### PR TITLE
Updating Lich5 LNet for Avalon

### DIFF
--- a/scripts/lnet.lic
+++ b/scripts/lnet.lic
@@ -303,7 +303,7 @@ class LNet
 					if @@options['fam_window']
 						$_CLIENT_.puts("\034GSe\r\n#{channel}#{aliased_from}: \"#{message}\"#{timestamp}\r\n\034GSf\r\n")
 					else
-						$_CLIENT_.puts("You hear the faint thoughts of #{channel}#{aliased_from} echo in your mind:\n\"#{message}\"#{timestamp}\r\n")
+						$_CLIENT_.puts("You hear the faint thoughts of #{channel}#{aliased_from} echo in your mind:\r\n\"#{message}\"#{timestamp}\r\n")
 					end
 					Script.new_downstream("#{channel}#{aliased_from}: \"#{message}\"#{timestamp}")
 				else


### PR DESCRIPTION
Very minor update to LNet to allow Mac Avalon users LNet thoughts to go the client thought window instead of the story window.  If no issues are noted and no feedback is provided by the team, will promote in 24 hours due to the minimal risk of impact.  Tested on SF, Wizard, Avalon and Illthorn (current rev).