### PR TITLE
Update --snapshot lich5-update

### DIFF
--- a/scripts/lich5-update.lic
+++ b/scripts/lich5-update.lic
@@ -40,7 +40,7 @@ prep_update = proc { |type|
   filename = "https://raw.githubusercontent.com/elanthia-online/lich-5/master/data/update-lich5.json"
   update_info = open(filename).read
   JSON::parse(update_info).each { |entry|
-    if entry["update_type"]["#{type}"] && Gem::Version.new(entry["version_lich"]) > installed
+    if entry["update_type"]["#{type}"] && (Gem::Version.new(entry["version_lich"]) > installed || type = :refresh)
       @update_to = entry["version_lich"]
       @update_scripts = entry["update_core_scripts"] if !entry["update_core_scripts"].empty?
       @update_lib = entry["update_libs"] if !entry["update_libs"].empty?
@@ -192,14 +192,18 @@ Example usage:
   elsif arg == '--announce'
     prep_update.call(:current)
     if "#{LICH_VERSION}".chr == '5'
-      if !@new_features.empty?
-        _respond ''; _respond monsterbold_start()+"*** NEW VERSION AVAILABLE ***"+monsterbold_end()
-        _respond ''; _respond ''
-        @new_features.each { |line| _respond line.gsub(/[\"]/, '') }
-        _respond''; _respond "If you are interested in updating, run ';lich5-update --update' now."
-        _respond ''
+      if Gem::Version.new(@current) < Gem::Version.new(@update_to)
+        if !@new_features.empty?
+          _respond ''; _respond monsterbold_start()+"*** NEW VERSION AVAILABLE ***"+monsterbold_end()
+          _respond ''; _respond ''
+          @new_features.each { |line| _respond line.gsub(/[\"]/, '') }
+          _respond''; _respond "If you are interested in updating, run ';lich5-update --update' now."
+          _respond ''
+        end
+        # return nothing if @current >= @update_to
       end
     else
+      # lich version 4 - just say 'no'
       _respond "This script does not support Lich #{LICH_VERSION}."
     end
 


### PR DESCRIPTION
The --snapshot feature fails in certain test cases where the existing lich version is the same as the current json lich version.  These changes address validations and permit the --snapshot feature to function.  Adding directly to master branch to limit poor update experiences.