### PR TITLE
chore: breakouts for Spell and XMLParser

### DIFF
--- a/lib/spell.rb
+++ b/lib/spell.rb
@@ -1,0 +1,734 @@
+# Lich5 Carve out for class Spell
+# intended for use beyond 5.0.19
+# needs: DRY, and LIB header scheme
+
+module Games
+  module Gemstone
+
+  class Spell
+    @@list ||= Array.new
+    @@loaded ||= false
+    @@cast_lock ||= Array.new
+    @@bonus_list ||= Array.new
+    @@cost_list ||= Array.new
+    @@load_mutex = Mutex.new
+    @@elevated_load = proc { Spell.load }
+    @@after_stance = nil
+    attr_reader :num, :name, :timestamp, :msgup, :msgdn, :circle, :active, :type, :cast_proc, :real_time, :persist_on_death, :availability, :no_incant
+    attr_accessor :stance, :channel
+
+    def initialize(xml_spell)
+      @num = xml_spell.attributes['number'].to_i
+      @name = xml_spell.attributes['name']
+      @type = xml_spell.attributes['type']
+      @no_incant = ((xml_spell.attributes['incant'] == 'no') ? true : false)
+      if xml_spell.attributes['availability'] == 'all'
+        @availability = 'all'
+      elsif xml_spell.attributes['availability'] == 'group'
+        @availability = 'group'
+      else
+        @availability = 'self-cast'
+      end
+      @bonus = Hash.new
+      xml_spell.elements.find_all { |e| e.name == 'bonus' }.each { |e|
+        @bonus[e.attributes['type']] = e.text
+        @bonus[e.attributes['type']].untaint
+      }
+      @msgup = xml_spell.elements.find_all { |e| (e.name == 'message') and (e.attributes['type'].downcase == 'start') }.collect { |e| e.text }.join('$|^')
+      @msgup = nil if @msgup.empty?
+      @msgdn = xml_spell.elements.find_all { |e| (e.name == 'message') and (e.attributes['type'].downcase == 'end') }.collect { |e| e.text }.join('$|^')
+      @msgdn = nil if @msgdn.empty?
+      @stance = ((xml_spell.attributes['stance'] =~ /^(yes|true)$/i) ? true : false)
+      @channel = ((xml_spell.attributes['channel'] =~ /^(yes|true)$/i) ? true : false)
+      @cost = Hash.new
+      xml_spell.elements.find_all { |e| e.name == 'cost' }.each { |xml_cost|
+        @cost[xml_cost.attributes['type'].downcase] ||= Hash.new
+        if xml_cost.attributes['cast-type'].downcase == 'target'
+          @cost[xml_cost.attributes['type'].downcase]['target'] = xml_cost.text
+        else
+          @cost[xml_cost.attributes['type'].downcase]['self'] = xml_cost.text
+        end
+      }
+      @duration = Hash.new
+      xml_spell.elements.find_all { |e| e.name == 'duration' }.each { |xml_duration|
+        if xml_duration.attributes['cast-type'].downcase == 'target'
+          cast_type = 'target'
+        else
+          cast_type = 'self'
+          if xml_duration.attributes['real-time'] =~ /^(yes|true)$/i
+            @real_time = true
+          else
+            @real_time = false
+          end
+        end
+        @duration[cast_type] = Hash.new
+        @duration[cast_type][:duration] = xml_duration.text
+        @duration[cast_type][:stackable] = (xml_duration.attributes['span'].downcase == 'stackable')
+        @duration[cast_type][:refreshable] = (xml_duration.attributes['span'].downcase == 'refreshable')
+        if xml_duration.attributes['multicastable'] =~ /^(yes|true)$/i
+          @duration[cast_type][:multicastable] = true
+        else
+          @duration[cast_type][:multicastable] = false
+        end
+        if xml_duration.attributes['persist-on-death'] =~ /^(yes|true)$/i
+          @persist_on_death = true
+        else
+          @persist_on_death = false
+        end
+        if xml_duration.attributes['max']
+          @duration[cast_type][:max_duration] = xml_duration.attributes['max'].to_f
+        else
+          @duration[cast_type][:max_duration] = 250.0
+        end
+      }
+      @cast_proc = xml_spell.elements['cast-proc'].text
+      @cast_proc.untaint
+      @timestamp = Time.now
+      @timeleft = 0
+      @active = false
+      @circle = (num.to_s.length == 3 ? num.to_s[0..0] : num.to_s[0..1])
+      @@list.push(self) unless @@list.find { |spell| spell.num == @num }
+      self
+    end
+    def Spell.after_stance=(val)
+      @@after_stance = val
+    end
+    def Spell.load(filename=nil)
+      if $SAFE == 0
+        if filename.nil?
+          if File.exists?("#{DATA_DIR}/spell-list.xml")
+            filename = "#{DATA_DIR}/spell-list.xml"
+          elsif File.exists?("#{SCRIPT_DIR}/spell-list.xml") # deprecated
+            filename = "#{SCRIPT_DIR}/spell-list.xml"
+          else
+            filename = "#{DATA_DIR}/spell-list.xml"
+          end
+        end
+        script = Script.current
+        @@load_mutex.synchronize {
+          return true if @loaded
+          begin
+            spell_times = Hash.new
+            # reloading spell data should not reset spell tracking...
+            unless @@list.empty?
+              @@list.each { |spell| spell_times[spell.num] = spell.timeleft if spell.active? }
+              @@list.clear
+            end
+            File.open(filename) { |file|
+              xml_doc = REXML::Document.new(file)
+              xml_root = xml_doc.root
+              xml_root.elements.each { |xml_spell| Spell.new(xml_spell) }
+            }
+            @@list.each { |spell|
+              if spell_times[spell.num]
+                spell.timeleft = spell_times[spell.num]
+                spell.active = true
+              end
+            }
+            @@bonus_list = @@list.collect { |spell| spell._bonus.keys }.flatten
+            @@bonus_list = @@bonus_list | @@bonus_list
+            @@cost_list = @@list.collect { |spell| spell._cost.keys }.flatten
+            @@cost_list = @@cost_list | @@cost_list
+            @@loaded = true
+            return true
+          rescue
+            respond "--- Lich: error: Spell.load: #{$!}"
+            Lich.log "error: Spell.load: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+            @@loaded = false
+            return false
+          end
+        }
+      else
+        @@elevated_load.call
+      end
+    end
+    def Spell.[](val)
+      Spell.load unless @@loaded
+      if val.class == Spell
+        val
+      elsif (val.class == Integer) or (val.class == String and val =~ /^[0-9]+$/)
+        @@list.find { |spell| spell.num == val.to_i }
+      else
+        val = Regexp.escape(val)
+        (@@list.find { |s| s.name =~ /^#{val}$/i } || @@list.find { |s| s.name =~ /^#{val}/i } || @@list.find { |s| s.msgup =~ /#{val}/i or s.msgdn =~ /#{val}/i })
+      end
+    end
+    def Spell.active
+      Spell.load unless @@loaded
+      active = Array.new
+      @@list.each { |spell| active.push(spell) if spell.active? }
+      active
+    end
+    def Spell.active?(val)
+      Spell.load unless @@loaded
+      Spell[val].active?
+    end
+    def Spell.list
+      Spell.load unless @@loaded
+      @@list
+    end
+    def Spell.upmsgs
+      Spell.load unless @@loaded
+      @@list.collect { |spell| spell.msgup }.compact
+    end
+    def Spell.dnmsgs
+      Spell.load unless @@loaded
+      @@list.collect { |spell| spell.msgdn }.compact
+    end
+    def time_per_formula(options={})
+      activator_modifier = { 'tap' => 0.5, 'rub' => 1, 'wave' => 1, 'raise' => 1.33, 'drink' => 0, 'bite' => 0, 'eat' => 0, 'gobble' => 0 }
+      can_haz_spell_ranks = /Spells\.(?:minorelemental|majorelemental|minorspiritual|majorspiritual|wizard|sorcerer|ranger|paladin|empath|cleric|bard|minormental)/
+      skills = [ 'Spells.minorelemental', 'Spells.majorelemental', 'Spells.minorspiritual', 'Spells.majorspiritual', 'Spells.wizard', 'Spells.sorcerer', 'Spells.ranger', 'Spells.paladin', 'Spells.empath', 'Spells.cleric', 'Spells.bard', 'Spells.minormental', 'Skills.magicitemuse', 'Skills.arcanesymbols' ]
+      if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
+        if options[:target] and (options[:target].downcase == options[:caster].downcase)
+          formula = @duration['self'][:duration].to_s.dup
+        else
+          formula = @duration['target'][:duration].dup || @duration['self'][:duration].to_s.dup
+        end
+        if options[:activator] =~ /^(#{activator_modifier.keys.join('|')})$/i
+          if formula =~ can_haz_spell_ranks
+            skills.each { |skill_name| formula.gsub!(skill_name, "(SpellRanks['#{options[:caster]}'].magicitemuse * #{activator_modifier[options[:activator]]}).to_i") }
+            formula = "(#{formula})/2.0"
+          elsif formula =~ /Skills\.(?:magicitemuse|arcanesymbols)/
+            skills.each { |skill_name| formula.gsub!(skill_name, "(SpellRanks['#{options[:caster]}'].magicitemuse * #{activator_modifier[options[:activator]]}).to_i") }
+          end
+        elsif options[:activator] =~ /^(invoke|scroll)$/i
+          if formula =~ can_haz_spell_ranks
+            skills.each { |skill_name| formula.gsub!(skill_name, "SpellRanks['#{options[:caster]}'].arcanesymbols.to_i") }
+            formula = "(#{formula})/2.0"
+          elsif formula =~ /Skills\.(?:magicitemuse|arcanesymbols)/
+            skills.each { |skill_name| formula.gsub!(skill_name, "SpellRanks['#{options[:caster]}'].arcanesymbols.to_i") }
+          end
+        else
+          skills.each { |skill_name| formula.gsub!(skill_name, "SpellRanks[#{options[:caster].to_s.inspect}].#{skill_name.sub(/^(?:Spells|Skills)\./, '')}.to_i") }
+        end
+      else
+        if options[:target] and (options[:target] !~ /^(?:self|#{XMLData.name})$/i)
+          formula = @duration['target'][:duration].dup || @duration['self'][:duration].to_s.dup
+        else
+          formula = @duration['self'][:duration].to_s.dup
+        end
+        if options[:activator] =~ /^(#{activator_modifier.keys.join('|')})$/i
+          if formula =~ can_haz_spell_ranks
+            skills.each { |skill_name| formula.gsub!(skill_name, "(Skills.magicitemuse * #{activator_modifier[options[:activator]]}).to_i") }
+            formula = "(#{formula})/2.0"
+          elsif formula =~ /Skills\.(?:magicitemuse|arcanesymbols)/
+            skills.each { |skill_name| formula.gsub!(skill_name, "(Skills.magicitemuse * #{activator_modifier[options[:activator]]}).to_i") }
+          end
+        elsif options[:activator] =~ /^(invoke|scroll)$/i
+          if formula =~ can_haz_spell_ranks
+            skills.each { |skill_name| formula.gsub!(skill_name, "Skills.arcanesymbols.to_i") }
+            formula = "(#{formula})/2.0"
+          elsif formula =~ /Skills\.(?:magicitemuse|arcanesymbols)/
+            skills.each { |skill_name| formula.gsub!(skill_name, "Skills.arcanesymbols.to_i") }
+          end
+        end
+      end
+      formula.untaint
+      formula
+    end
+    def time_per(options={})
+      formula = self.time_per_formula(options)
+      if options[:line]
+        line = options[:line]
+      end
+      proc { begin; $SAFE = 3; rescue; nil; end; eval(formula) }.call.to_f
+    end
+    def timeleft=(val)
+      @timeleft = val
+      @timestamp = Time.now
+    end
+    def timeleft
+      if self.time_per_formula.to_s == 'Spellsong.timeleft'
+        @timeleft = Spellsong.timeleft
+      else
+        @timeleft = @timeleft - ((Time.now - @timestamp) / 60.to_f)
+        if @timeleft <= 0
+          self.putdown
+          return 0.to_f
+        end
+      end
+      @timestamp = Time.now
+      @timeleft
+    end
+    def minsleft
+      self.timeleft
+    end
+    def secsleft
+      self.timeleft * 60
+    end
+    def active=(val)
+      @active = val
+    end
+    def active?
+      (self.timeleft > 0) and @active
+    end
+    def stackable?(options={})
+      if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
+        if options[:target] and (options[:target].downcase == options[:caster].downcase)
+          @duration['self'][:stackable]
+        else
+          if @duration['target'][:stackable].nil?
+            @duration['self'][:stackable]
+          else
+            @duration['target'][:stackable]
+          end
+        end
+      else
+        if options[:target] and (options[:target] !~ /^(?:self|#{XMLData.name})$/i)
+          if @duration['target'][:stackable].nil?
+            @duration['self'][:stackable]
+          else
+            @duration['target'][:stackable]
+          end
+        else
+          @duration['self'][:stackable]
+        end
+      end
+    end
+    def refreshable?(options={})
+      if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
+        if options[:target] and (options[:target].downcase == options[:caster].downcase)
+          @duration['self'][:refreshable]
+        else
+          if @duration['target'][:refreshable].nil?
+            @duration['self'][:refreshable]
+          else
+            @duration['target'][:refreshable]
+          end
+        end
+      else
+        if options[:target] and (options[:target] !~ /^(?:self|#{XMLData.name})$/i)
+          if @duration['target'][:refreshable].nil?
+            @duration['self'][:refreshable]
+          else
+            @duration['target'][:refreshable]
+          end
+        else
+          @duration['self'][:refreshable]
+        end
+      end
+    end
+    def multicastable?(options={})
+      if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
+        if options[:target] and (options[:target].downcase == options[:caster].downcase)
+          @duration['self'][:multicastable]
+        else
+          if @duration['target'][:multicastable].nil?
+            @duration['self'][:multicastable]
+          else
+            @duration['target'][:multicastable]
+          end
+        end
+      else
+        if options[:target] and (options[:target] !~ /^(?:self|#{XMLData.name})$/i)
+          if @duration['target'][:multicastable].nil?
+            @duration['self'][:multicastable]
+          else
+            @duration['target'][:multicastable]
+          end
+        else
+          @duration['self'][:multicastable]
+        end
+      end
+    end
+    def known?
+      if @num.to_s.length == 3
+        circle_num = @num.to_s[0..0].to_i
+      elsif @num.to_s.length == 4
+        circle_num = @num.to_s[0..1].to_i
+      else
+        return false
+      end
+      if circle_num == 1
+        ranks = [ Spells.minorspiritual, XMLData.level ].min
+      elsif circle_num == 2
+        ranks = [ Spells.majorspiritual, XMLData.level ].min
+      elsif circle_num == 3
+        ranks = [ Spells.cleric, XMLData.level ].min
+      elsif circle_num == 4
+        ranks = [ Spells.minorelemental, XMLData.level ].min
+      elsif circle_num == 5
+        ranks = [ Spells.majorelemental, XMLData.level ].min
+      elsif circle_num == 6
+        ranks = [ Spells.ranger, XMLData.level ].min
+      elsif circle_num == 7
+        ranks = [ Spells.sorcerer, XMLData.level ].min
+      elsif circle_num == 9
+        ranks = [ Spells.wizard, XMLData.level ].min
+      elsif circle_num == 10
+        ranks = [ Spells.bard, XMLData.level ].min
+      elsif circle_num == 11
+        ranks = [ Spells.empath, XMLData.level ].min
+      elsif circle_num == 12
+        ranks = [ Spells.minormental, XMLData.level ].min
+      elsif circle_num == 16
+        ranks = [ Spells.paladin, XMLData.level ].min
+      elsif circle_num == 17
+        if (@num == 1700) and (Char.prof =~ /^(?:Wizard|Cleric|Empath|Sorcerer|Savant)$/)
+          return true
+        else
+          return false
+        end
+      elsif (circle_num == 97) and (Society.status == 'Guardians of Sunfist')
+        ranks = Society.rank
+      elsif (circle_num == 98) and (Society.status == 'Order of Voln')
+        ranks = Society.rank
+      elsif (circle_num == 99) and (Society.status == 'Council of Light')
+        ranks = Society.rank
+      elsif (circle_num == 96)
+        return false
+
+#          deprecate CMan from Spell class .known?
+#          See CMan, CMan.known? and CMan.available? methods in CMan class
+
+      else
+        return false
+      end
+      if (@num % 100) <= ranks
+        return true
+      else
+        return false
+      end
+    end
+    def available?(options={})
+      if self.known?
+        if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
+          if options[:target] and (options[:target].downcase == options[:caster].downcase)
+            true
+          else
+            @availability == 'all'
+          end
+        else
+          if options[:target] and (options[:target] !~ /^(?:self|#{XMLData.name})$/i)
+            @availability == 'all'
+          else
+            true
+          end
+        end
+      else
+        false
+      end
+    end
+    def incant?
+      !@no_incant
+    end
+    def incant=(val)
+      @no_incant = !val
+    end
+    def to_s
+      @name.to_s
+    end
+    def max_duration(options={})
+      if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
+        if options[:target] and (options[:target].downcase == options[:caster].downcase)
+          @duration['self'][:max_duration]
+        else
+          @duration['target'][:max_duration] || @duration['self'][:max_duration]
+        end
+      else
+        if options[:target] and (options[:target] !~ /^(?:self|#{XMLData.name})$/i)
+          @duration['target'][:max_duration] || @duration['self'][:max_duration]
+        else
+          @duration['self'][:max_duration]
+        end
+      end
+    end
+    def putup(options={})
+      if stackable?(options)
+        self.timeleft = [ self.timeleft + self.time_per(options), self.max_duration(options) ].min
+      else
+        self.timeleft = [ self.time_per(options), self.max_duration(options) ].min
+      end
+      @active = true
+    end
+    def putdown
+      self.timeleft = 0
+      @active = false
+    end
+    def remaining
+      self.timeleft.as_time
+    end
+
+    def affordable?(options={})
+      # fixme: deal with them dirty bards!
+      release_options = options.dup
+      release_options[:multicast] = nil
+      if (self.stamina_cost(options) > 0) and (Spell[9699].active? or not checkstamina(self.stamina_cost(options)))
+        false
+      elsif (self.spirit_cost(options) > 0) and not checkspirit(self.spirit_cost(options) + 1 + [ 9912, 9913, 9914, 9916, 9916, 9916 ].delete_if { |num| !Spell[num].active? }.length)
+        false
+      elsif (self.mana_cost(options) > 0)
+        ## convert Spell[9699].active? to Effects::Debuffs test (if Debuffs is where it shows)
+        if Feat.known?(:mental_acuity) and (Spell[9699].active? or not checkstamina(self.mana_cost(options)*2))
+          false
+        elsif ( !Feat.known?(:mental_acuity) ) && ( !checkmana(self.mana_cost(options)) or (Spell[515].active? and !checkmana(self.mana_cost(options) + [self.mana_cost(release_options)/4, 1].max))  )
+          false
+        else
+          true
+        end
+      else
+        true
+      end
+    end
+
+    def Spell.lock_cast
+      script = Script.current
+      @@cast_lock.push(script)
+      until (@@cast_lock.first == script) or @@cast_lock.empty?
+        sleep 0.1
+        Script.current # allows this loop to be paused
+        @@cast_lock.delete_if { |s| s.paused or not Script.list.include?(s) }
+      end
+    end
+    def Spell.unlock_cast
+      @@cast_lock.delete(Script.current)
+    end
+    def cast(target=nil, results_of_interest=nil)
+      # fixme: find multicast in target and check mana for it
+      check_energy = proc {
+        if Feat.known?(:mental_acuity)
+          unless (self.mana_cost <= 0) or checkstamina(self.mana_cost*2)
+            echo 'cast: not enough stamina there, Monk!'
+            sleep 0.1
+            return false
+          end
+        else
+          unless (self.mana_cost <= 0) or checkmana(self.mana_cost)
+            echo 'cast: not enough mana'
+            sleep 0.1
+            return false
+          end
+        end
+        unless (self.spirit_cost > 0) or checkspirit(self.spirit_cost + 1 + [ 9912, 9913, 9914, 9916, 9916, 9916 ].delete_if { |num| !Spell[num].active? }.length)
+          echo 'cast: not enough spirit'
+          sleep 0.1
+          return false
+        end
+        unless (self.stamina_cost <= 0) or checkstamina(self.stamina_cost)
+          echo 'cast: not enough stamina'
+          sleep 0.1
+          return false
+        end
+      }
+      script = Script.current
+      if @type.nil?
+        echo "cast: spell missing type (#{@name})"
+        sleep 0.1
+        return false
+      end
+      check_energy.call
+      begin
+        save_want_downstream = script.want_downstream
+        save_want_downstream_xml = script.want_downstream_xml
+        script.want_downstream = true
+        script.want_downstream_xml = false
+        @@cast_lock.push(script)
+        until (@@cast_lock.first == script) or @@cast_lock.empty?
+          sleep 0.1
+          Script.current # allows this loop to be paused
+          @@cast_lock.delete_if { |s| s.paused or not Script.list.include?(s) }
+        end
+        check_energy.call
+        if @cast_proc
+          waitrt?
+          waitcastrt?
+          check_energy.call
+          begin
+            proc { begin; $SAFE = 3; rescue; nil; end; eval(@cast_proc) }.call
+          rescue
+            echo "cast: error: #{$!}"
+            respond $!.backtrace[0..2]
+            return false
+          end
+        else
+          if @channel
+            cast_cmd = 'channel'
+          else
+            cast_cmd = 'cast'
+          end
+          if (target.nil? or target.to_s.empty?) and not @no_incant
+            cast_cmd = "incant #{@num}"
+          elsif (target.nil? or target.to_s.empty?) and (@type =~ /attack/i) and not [410,435,525,912,909,609].include?(@num)
+            cast_cmd += ' target'
+          elsif target.class == GameObj
+            cast_cmd += " ##{target.id}"
+          elsif target.class == Integer
+            cast_cmd += " ##{target}"
+          else
+            cast_cmd += " #{target}"
+          end
+          cast_result = nil
+          loop {
+            waitrt?
+            if cast_cmd =~ /^incant/
+              if (checkprep != @name) and (checkprep != 'None')
+                dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
+              end
+            else
+              unless checkprep == @name
+                unless checkprep == 'None'
+                  dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
+                  unless (self.mana_cost <= 0) or checkmana(self.mana_cost)
+                    echo 'cast: not enough mana'
+                    sleep 0.1
+                    return false
+                  end
+                  unless (self.spirit_cost <= 0) or checkspirit(self.spirit_cost + 1 + (if checkspell(9912) then 1 else 0 end) + (if checkspell(9913) then 1 else 0 end) + (if checkspell(9914) then 1 else 0 end) + (if checkspell(9916) then 5 else 0 end))
+                    echo 'cast: not enough spirit'
+                    sleep 0.1
+                    return false
+                  end
+                  unless (self.stamina_cost <= 0) or checkstamina(self.stamina_cost)
+                    echo 'cast: not enough stamina'
+                    sleep 0.1
+                    return false
+                  end
+                end
+                loop {
+                  waitrt?
+                  waitcastrt?
+                  prepare_result = dothistimeout "prepare #{@num}", 8, /^You already have a spell readied!  You must RELEASE it if you wish to prepare another!$|^Your spell(?:song)? is ready\.|^You can't think clearly enough to prepare a spell!$|^You are concentrating too intently .*?to prepare a spell\.$|^You are too injured to make that dextrous of a movement|^The searing pain in your throat makes that impossible|^But you don't have any mana!\.$|^You can't make that dextrous of a move!$|^As you begin to prepare the spell the wind blows small objects at you thwarting your attempt\.$|^You do not know that spell!$|^All you manage to do is cough up some blood\.$|The incantations of countless spells swirl through your mind as a golden light flashes before your eyes\./
+                  if prepare_result =~ /^Your spell(?:song)? is ready\./
+                    break
+                  elsif prepare_result == 'You already have a spell readied!  You must RELEASE it if you wish to prepare another!'
+                    dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
+                    unless (self.mana_cost <= 0) or checkmana(self.mana_cost)
+                      echo 'cast: not enough mana'
+                      sleep 0.1
+                      return false
+                    end
+                  elsif prepare_result =~ /^You can't think clearly enough to prepare a spell!$|^You are concentrating too intently .*?to prepare a spell\.$|^You are too injured to make that dextrous of a movement|^The searing pain in your throat makes that impossible|^But you don't have any mana!\.$|^You can't make that dextrous of a move!$|^As you begin to prepare the spell the wind blows small objects at you thwarting your attempt\.$|^You do not know that spell!$|^All you manage to do is cough up some blood\.$|The incantations of countless spells swirl through your mind as a golden light flashes before your eyes\./
+                    sleep 0.1
+                    return prepare_result
+                  end
+                }
+              end
+            end
+            waitcastrt?
+            if @stance and checkstance != 'offensive'
+              put 'stance offensive'
+              # dothistimeout 'stance offensive', 5, /^You (?:are now in|move into) an? offensive stance|^You are unable to change your stance\.$/
+            end
+            if results_of_interest.class == Regexp
+              results_regex = /^(?:Cast|Sing) Roundtime [0-9]+ Seconds?\.$|^Cast at what\?$|^But you don't have any mana!$|^\[Spell Hindrance for|^You don't have a spell prepared!$|keeps? the spell from working\.|^Be at peace my child, there is no need for spells of war in here\.$|Spells of War cannot be cast|^As you focus on your magic, your vision swims with a swirling haze of crimson\.$|^Your magic fizzles ineffectually\.$|^All you manage to do is cough up some blood\.$|^And give yourself away!  Never!$|^You are unable to do that right now\.$|^You feel a sudden rush of power as you absorb [0-9]+ mana!$|^You are unable to drain it!$|leaving you casting at nothing but thin air!$|^You don't seem to be able to move to do that\.$|^Provoking a GameMaster is not such a good idea\.$|^You can't think clearly enough to prepare a spell!$|^You do not currently have a target\.$|The incantations of countless spells swirl through your mind as a golden light flashes before your eyes\.|#{results_of_interest.to_s}/
+            else
+              results_regex = /^(?:Cast|Sing) Roundtime [0-9]+ Seconds?\.$|^Cast at what\?$|^But you don't have any mana!$|^\[Spell Hindrance for|^You don't have a spell prepared!$|keeps? the spell from working\.|^Be at peace my child, there is no need for spells of war in here\.$|Spells of War cannot be cast|^As you focus on your magic, your vision swims with a swirling haze of crimson\.$|^Your magic fizzles ineffectually\.$|^All you manage to do is cough up some blood\.$|^And give yourself away!  Never!$|^You are unable to do that right now\.$|^You feel a sudden rush of power as you absorb [0-9]+ mana!$|^You are unable to drain it!$|leaving you casting at nothing but thin air!$|^You don't seem to be able to move to do that\.$|^Provoking a GameMaster is not such a good idea\.$|^You can't think clearly enough to prepare a spell!$|^You do not currently have a target\.$|The incantations of countless spells swirl through your mind as a golden light flashes before your eyes\./
+            end
+            cast_result = dothistimeout cast_cmd, 5, results_regex
+            if cast_result == "You don't seem to be able to move to do that."
+              100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+              cast_result = dothistimeout cast_cmd, 5, results_regex
+            end
+            if @stance
+              if @@after_stance
+                if checkstance !~ /#{@@after_stance}/
+                  waitrt?
+                  dothistimeout "stance #{@@after_stance}", 3, /^You (?:are now in|move into) an? \w+ stance|^You are unable to change your stance\.$/
+                end
+              elsif checkstance !~ /^guarded$|^defensive$/
+                waitrt?
+                if checkcastrt > 0
+                  dothistimeout 'stance guarded', 3, /^You (?:are now in|move into) an? \w+ stance|^You are unable to change your stance\.$/
+                else
+                  dothistimeout 'stance defensive', 3, /^You (?:are now in|move into) an? \w+ stance|^You are unable to change your stance\.$/
+                end
+              end
+            end
+            if cast_result =~ /^Cast at what\?$|^Be at peace my child, there is no need for spells of war in here\.$|^Provoking a GameMaster is not such a good idea\.$/
+              dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
+            end
+            break unless (@circle.to_i == 10) and (cast_result =~ /^\[Spell Hindrance for/)
+            }
+          cast_result
+        end
+      ensure
+        script.want_downstream = save_want_downstream
+        script.want_downstream_xml = save_want_downstream_xml
+        @@cast_lock.delete(script)
+      end
+    end
+    def _bonus
+      @bonus.dup
+    end
+    def _cost
+      @cost.dup
+    end
+    def method_missing(*args)
+      if @@bonus_list.include?(args[0].to_s.gsub('_', '-'))
+        if @bonus[args[0].to_s.gsub('_', '-')]
+          proc { begin; $SAFE = 3; rescue; nil; end; eval(@bonus[args[0].to_s.gsub('_', '-')]) }.call.to_i
+        else
+          0
+        end
+      elsif @@bonus_list.include?(args[0].to_s.sub(/_formula$/, '').gsub('_', '-'))
+        @bonus[args[0].to_s.sub(/_formula$/, '').gsub('_', '-')].dup
+      elsif (args[0].to_s =~ /_cost(?:_formula)?$/) and @@cost_list.include?(args[0].to_s.sub(/_formula$/, '').sub(/_cost$/, ''))
+        options = args[1].to_hash
+        if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
+          if options[:target] and (options[:target].downcase == options[:caster].downcase)
+            formula = @cost[args[0].to_s.sub(/_formula$/, '').sub(/_cost$/, '')]['self'].dup
+          else
+            formula = @cost[args[0].to_s.sub(/_formula$/, '').sub(/_cost$/, '')]['target'].dup || @cost[args[0].to_s.gsub('_', '-')]['self'].dup
+          end
+          skills = { 'Spells.minorelemental' => "SpellRanks['#{options[:caster]}'].minorelemental.to_i", 'Spells.majorelemental' => "SpellRanks['#{options[:caster]}'].majorelemental.to_i", 'Spells.minorspiritual' => "SpellRanks['#{options[:caster]}'].minorspiritual.to_i", 'Spells.majorspiritual' => "SpellRanks['#{options[:caster]}'].majorspiritual.to_i", 'Spells.wizard' => "SpellRanks['#{options[:caster]}'].wizard.to_i", 'Spells.sorcerer' => "SpellRanks['#{options[:caster]}'].sorcerer.to_i", 'Spells.ranger' => "SpellRanks['#{options[:caster]}'].ranger.to_i", 'Spells.paladin' => "SpellRanks['#{options[:caster]}'].paladin.to_i", 'Spells.empath' => "SpellRanks['#{options[:caster]}'].empath.to_i", 'Spells.cleric' => "SpellRanks['#{options[:caster]}'].cleric.to_i", 'Spells.bard' => "SpellRanks['#{options[:caster]}'].bard.to_i", 'Stats.level' => '100' }
+          skills.each_pair { |a, b| formula.gsub!(a, b) }
+        else
+          if options[:target] and (options[:target] !~ /^(?:self|#{XMLData.name})$/i)
+            formula = @cost[args[0].to_s.sub(/_formula$/, '').sub(/_cost$/, '')]['target'].dup || @cost[args[0].to_s.gsub('_', '-')]['self'].dup
+          else
+            formula = @cost[args[0].to_s.sub(/_formula$/, '').sub(/_cost$/, '')]['self'].dup
+          end
+        end
+        if args[0].to_s =~ /mana/ and Spell[597].active? # Rapid Fire Penalty
+          formula = "#{formula}+5"
+        end
+        if options[:multicast].to_i > 1
+          formula = "(#{formula})*#{options[:multicast].to_i}"
+        end
+        if args[0].to_s =~ /_formula$/
+          formula.dup
+        else
+          if formula
+            formula.untaint if formula.tainted?
+            proc { begin; $SAFE = 3; rescue; nil; end; eval(formula) }.call.to_i
+          else
+            0
+          end
+        end
+      else
+        respond 'missing method: ' + args.inspect.to_s
+        raise NoMethodError
+      end
+    end
+    def circle_name
+      Spells.get_circle_name(@circle)
+    end
+    def clear_on_death
+      !@persist_on_death
+    end
+    # for backwards compatiblity
+    def duration;      self.time_per_formula;            end
+    def cost;          self.mana_cost_formula    || '0'; end
+    def manaCost;      self.mana_cost_formula    || '0'; end
+    def spiritCost;    self.spirit_cost_formula  || '0'; end
+    def staminaCost;   self.stamina_cost_formula || '0'; end
+    def boltAS;        self.bolt_as_formula;             end
+    def physicalAS;    self.physical_as_formula;         end
+    def boltDS;        self.bolt_ds_formula;             end
+    def physicalDS;    self.physical_ds_formula;         end
+    def elementalCS;   self.elemental_cs_formula;        end
+    def mentalCS;      self.mental_cs_formula;           end
+    def spiritCS;      self.spirit_cs_formula;           end
+    def sorcererCS;    self.sorcerer_cs_formula;         end
+    def elementalTD;   self.elemental_td_formula;        end
+    def mentalTD;      self.mental_td_formula;           end
+    def spiritTD;      self.spirit_td_formula;           end
+    def sorcererTD;    self.sorcerer_td_formula;         end
+    def castProc;      @cast_proc;                       end
+    def stacks;        self.stackable?                   end
+    def command;       nil;                              end
+    def circlename;    self.circle_name;                 end
+    def selfonly;      @availability != 'all';           end
+  end
+end

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -1,0 +1,719 @@
+# Lich5 Carve out for class XMLParser
+# intended for use beyond 5.0.19
+# needs: DRY, and LIB header scheme
+
+class XMLParser
+  attr_reader :mana, :max_mana, :health, :max_health, :spirit, :max_spirit, :last_spirit,
+              :stamina, :max_stamina, :stance_text, :stance_value, :mind_text, :mind_value,
+              :prepared_spell, :encumbrance_text, :encumbrance_full_text, :encumbrance_value,
+              :indicator, :injuries, :injury_mode, :room_count, :room_title, :room_description,
+              :room_exits, :room_exits_string, :familiar_room_title, :familiar_room_description,
+              :familiar_room_exits, :bounty_task, :injury_mode, :server_time, :server_time_offset,
+              :roundtime_end, :cast_roundtime_end, :last_pulse, :level, :next_level_value,
+              :next_level_text, :society_task, :stow_container_id, :name, :game, :in_stream,
+              :player_id, :prompt, :current_target_ids, :current_target_id, :room_window_disabled,
+              :dialogs, :room_id
+  attr_accessor :send_fake_tags
+
+  @@warned_deprecated_spellfront = 0
+
+  include REXML::StreamListener
+
+  def initialize
+    @buffer = String.new
+    @unescape = { 'lt' => '<', 'gt' => '>', 'quot' => '"', 'apos' => "'", 'amp' => '&' }
+    @bold = false
+    @active_tags = Array.new
+    @active_ids = Array.new
+    @last_tag = String.new
+    @last_id = String.new
+    @current_stream = String.new
+    @current_style = String.new
+    @stow_container_id = nil
+    @obj_location = nil
+    @obj_exist = nil
+    @obj_noun = nil
+    @obj_before_name = nil
+    @obj_name = nil
+    @obj_after_name = nil
+    @pc = nil
+    @last_obj = nil
+    @in_stream = false
+    @player_status = nil
+    @fam_mode = String.new
+    @room_window_disabled = false
+    @wound_gsl = String.new
+    @scar_gsl = String.new
+    @send_fake_tags = false
+    @prompt = String.new
+    @nerve_tracker_num = 0
+    @nerve_tracker_active = 'no'
+    @server_time = Time.now.to_i
+    @server_time_offset = 0
+    @roundtime_end = 0
+    @cast_roundtime_end = 0
+    @last_pulse = Time.now.to_i
+    @level = 0
+    @next_level_value = 0
+    @next_level_text = String.new
+    @current_target_ids = Array.new
+
+    @room_count = 0
+    @room_title = String.new
+    @room_description = String.new
+    @room_exits = Array.new
+    @room_exits_string = String.new
+
+    @familiar_room_title = String.new
+    @familiar_room_description = String.new
+    @familiar_room_exits = Array.new
+
+    @bounty_task = String.new
+    @society_task = String.new
+
+    @name = String.new
+    @game = String.new
+    @player_id = String.new
+    @mana = 0
+    @max_mana = 0
+    @health = 0
+    @max_health = 0
+    @spirit = 0
+    @max_spirit = 0
+    @last_spirit = nil
+    @stamina = 0
+    @max_stamina = 0
+    @stance_text = String.new
+    @stance_value = 0
+    @mind_text = String.new
+    @mind_value = 0
+    @prepared_spell = 'None'
+    @encumbrance_text = String.new
+    @encumbrance_full_text = String.new
+    @encumbrance_value = 0
+    @indicator = Hash.new
+    @injuries = { 'back' => { 'scar' => 0, 'wound' => 0 }, 'leftHand' => { 'scar' => 0, 'wound' => 0 }, 'rightHand' => { 'scar' => 0, 'wound' => 0 }, 'head' => { 'scar' => 0, 'wound' => 0 }, 'rightArm' => { 'scar' => 0, 'wound' => 0 }, 'abdomen' => { 'scar' => 0, 'wound' => 0 }, 'leftEye' => { 'scar' => 0, 'wound' => 0 }, 'leftArm' => { 'scar' => 0, 'wound' => 0 }, 'chest' => { 'scar' => 0, 'wound' => 0 }, 'leftFoot' => { 'scar' => 0, 'wound' => 0 }, 'rightFoot' => { 'scar' => 0, 'wound' => 0 }, 'rightLeg' => { 'scar' => 0, 'wound' => 0 }, 'neck' => { 'scar' => 0, 'wound' => 0 }, 'leftLeg' => { 'scar' => 0, 'wound' => 0 }, 'nsys' => { 'scar' => 0, 'wound' => 0 }, 'rightEye' => { 'scar' => 0, 'wound' => 0 } }
+    @injury_mode = 0
+
+    # psm 3.0 dialogdata updates
+    @dialogs = {}
+
+    # real id updates
+    @room_id = nil
+  end
+
+  # for backwards compatability
+  def active_spells
+    z = {}
+    XMLData.dialogs.sort.each do |a, b|
+      b.each do |k, v|
+        case a
+        when /Active Spells|Buffs/
+          z.merge!(k => v) if k.instance_of?(String)
+        when /Cooldowns/
+          z.merge!("CD - #{k}" => v) if k.instance_of?(String)
+        when /Debuffs/
+          z.merge!("DB - #{k}" => v) if k.instance_of?(String)
+        end
+      end
+    end
+    z
+  end
+
+  def reset
+    @active_tags = Array.new
+    @active_ids = Array.new
+    @current_stream = String.new
+    @current_style = String.new
+  end
+
+  def make_wound_gsl
+    @wound_gsl = sprintf("0b0%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b", @injuries['nsys']['wound'], @injuries['leftEye']['wound'], @injuries['rightEye']['wound'], @injuries['back']['wound'], @injuries['abdomen']['wound'], @injuries['chest']['wound'], @injuries['leftHand']['wound'], @injuries['rightHand']['wound'], @injuries['leftLeg']['wound'], @injuries['rightLeg']['wound'], @injuries['leftArm']['wound'], @injuries['rightArm']['wound'], @injuries['neck']['wound'], @injuries['head']['wound'])
+  end
+
+  def make_scar_gsl
+    @scar_gsl = sprintf("0b0%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b%02b", @injuries['nsys']['scar'], @injuries['leftEye']['scar'], @injuries['rightEye']['scar'], @injuries['back']['scar'], @injuries['abdomen']['scar'], @injuries['chest']['scar'], @injuries['leftHand']['scar'], @injuries['rightHand']['scar'], @injuries['leftLeg']['scar'], @injuries['rightLeg']['scar'], @injuries['leftArm']['scar'], @injuries['rightArm']['scar'], @injuries['neck']['scar'], @injuries['head']['scar'])
+  end
+
+  def parse(line)
+    @buffer.concat(line)
+    loop {
+      if str = @buffer.slice!(/^[^<]+/)
+        text(str.gsub(/&(lt|gt|quot|apos|amp)/) { @unescape[$1] })
+      elsif str = @buffer.slice!(/^<\/[^<]+>/)
+        element = /^<\/([^\s>\/]+)/.match(str).captures.first
+        tag_end(element)
+      elsif str = @buffer.slice!(/^<[^<]+>/)
+        element = /^<([^\s>\/]+)/.match(str).captures.first
+        attributes = Hash.new
+        str.scan(/([A-z][A-z0-9_\-]*)=(["'])(.*?)\2/).each { |attr| attributes[attr[0]] = attr[2] }
+        tag_start(element, attributes)
+        tag_end(element) if str =~ /\/>$/
+      else
+        break
+      end
+    }
+  end
+
+  DECADE = 10 * 31_536_000
+
+  def parse_psm3_progressbar(kind, attributes)
+    @dialogs[kind] ||= {}
+    id = attributes["id"].to_i
+    name = attributes["text"]
+    value = attributes["time"]
+    return unless name && value
+    # set the expiry for a decade for infinite duration effects
+    return @dialogs[kind][name] = @dialogs[kind][id] = Time.now + DECADE if value.downcase.eql?("indefinite")
+
+    # in psm 3.0 progress bars now have second precision!
+    hour, minute, second = value.split(':')
+    @dialogs[kind][name] = @dialogs[kind][id] = Time.now + (hour.to_i * 3600) + (minute.to_i * 60) + second.to_i
+  end
+
+  PSM_3_DIALOG_IDS = ["Buffs", "Active Spells", "Debuffs", "Cooldowns"]
+
+  def tag_start(name, attributes)
+    begin
+      @active_tags.push(name)
+      @active_ids.push(attributes['id'].to_s)
+      if name =~ /^(?:a|right|left)$/
+        @obj_exist = attributes['exist']
+        @obj_noun = attributes['noun']
+      elsif name == 'inv'
+        if attributes['id'] == 'stow'
+          @obj_location = @stow_container_id
+        else
+          @obj_location = attributes['id']
+        end
+        @obj_exist = nil
+        @obj_noun = nil
+        @obj_name = nil
+        @obj_before_name = nil
+        @obj_after_name = nil
+      elsif name == 'dialogData' and attributes['clear'] == 't' and PSM_3_DIALOG_IDS.include?(attributes["id"])
+        @dialogs[attributes["id"]] ||= {}
+        @dialogs[attributes["id"]].clear
+      elsif name == 'resource'
+        nil
+      elsif name == 'nav'
+        @room_id = attributes['rm'].to_i
+      elsif name == 'pushStream'
+        @in_stream = true
+        @current_stream = attributes['id'].to_s
+        GameObj.clear_inv if attributes['id'].to_s == 'inv'
+      elsif name == 'popStream'
+        if attributes['id'] == 'room'
+          unless @room_window_disabled
+            @room_count += 1
+            $room_count += 1
+          end
+        end
+        @in_stream = false
+        if attributes['id'] == 'bounty'
+          @bounty_task.strip!
+        end
+        @current_stream = String.new
+      elsif name == 'pushBold'
+        @bold = true
+      elsif name == 'popBold'
+        @bold = false
+      elsif (name == 'streamWindow')
+        if (attributes['id'] == 'main') and attributes['subtitle']
+          @room_title = '[' + attributes['subtitle'][3..-1] + ']'
+        end
+      elsif name == 'style'
+        @current_style = attributes['id']
+      elsif name == 'prompt'
+        @server_time = attributes['time'].to_i
+        @server_time_offset = (Time.now.to_i - @server_time)
+        $_CLIENT_.puts "\034GSq#{sprintf('%010d', @server_time)}\r\n" if @send_fake_tags
+      elsif (name == 'compDef') or (name == 'component')
+        if attributes['id'] == 'room objs'
+          GameObj.clear_loot
+          GameObj.clear_npcs
+        elsif attributes['id'] == 'room players'
+          GameObj.clear_pcs
+        elsif attributes['id'] == 'room exits'
+          @room_exits = Array.new
+          @room_exits_string = String.new
+        elsif attributes['id'] == 'room desc'
+          @room_description = String.new
+          GameObj.clear_room_desc
+        elsif attributes['id'] == 'room extra' # DragonRealms
+          @room_count += 1
+          $room_count += 1
+          # elsif attributes['id'] == 'sprite'
+        end
+      elsif name == 'clearContainer'
+        if attributes['id'] == 'stow'
+          GameObj.clear_container(@stow_container_id)
+        else
+          GameObj.clear_container(attributes['id'])
+        end
+      elsif name == 'deleteContainer'
+        GameObj.delete_container(attributes['id'])
+      elsif name == 'progressBar'
+        if attributes['id'] == 'pbarStance'
+          @stance_text = attributes['text'].split.first
+          @stance_value = attributes['value'].to_i
+          $_CLIENT_.puts "\034GSg#{sprintf('%010d', @stance_value)}\r\n" if @send_fake_tags
+        elsif attributes['id'] == 'mana'
+          last_mana = @mana
+          @mana, @max_mana = attributes['text'].scan(/-?\d+/).collect { |num| num.to_i }
+          difference = @mana - last_mana
+          # fixme: enhancives screw this up
+          if (difference == noded_pulse) or (difference == unnoded_pulse) or ((@mana == @max_mana) and (last_mana + noded_pulse > @max_mana))
+            @last_pulse = Time.now.to_i
+            if @send_fake_tags
+              $_CLIENT_.puts "\034GSZ#{sprintf('%010d', (@mana + 1))}\n"
+              $_CLIENT_.puts "\034GSZ#{sprintf('%010d', @mana)}\n"
+            end
+          end
+          if @send_fake_tags
+            $_CLIENT_.puts "\034GSV#{sprintf('%010d%010d%010d%010d%010d%010d%010d%010d', @max_health.to_i, @health.to_i, @max_spirit.to_i, @spirit.to_i, @max_mana.to_i, @mana.to_i, @wound_gsl, @scar_gsl)}\r\n"
+          end
+        elsif attributes['id'] == 'stamina'
+          @stamina, @max_stamina = attributes['text'].scan(/-?\d+/).collect { |num| num.to_i }
+        elsif attributes['id'] == 'mindState'
+          @mind_text = attributes['text']
+          @mind_value = attributes['value'].to_i
+          $_CLIENT_.puts "\034GSr#{MINDMAP[@mind_text]}\r\n" if @send_fake_tags
+        elsif attributes['id'] == 'health'
+          @health, @max_health = attributes['text'].scan(/-?\d+/).collect { |num| num.to_i }
+          $_CLIENT_.puts "\034GSV#{sprintf('%010d%010d%010d%010d%010d%010d%010d%010d', @max_health.to_i, @health.to_i, @max_spirit.to_i, @spirit.to_i, @max_mana.to_i, @mana.to_i, @wound_gsl, @scar_gsl)}\r\n" if @send_fake_tags
+        elsif attributes['id'] == 'spirit'
+          @last_spirit = @spirit if @last_spirit
+          @spirit, @max_spirit = attributes['text'].scan(/-?\d+/).collect { |num| num.to_i }
+          @last_spirit = @spirit unless @last_spirit
+          $_CLIENT_.puts "\034GSV#{sprintf('%010d%010d%010d%010d%010d%010d%010d%010d', @max_health.to_i, @health.to_i, @max_spirit.to_i, @spirit.to_i, @max_mana.to_i, @mana.to_i, @wound_gsl, @scar_gsl)}\r\n" if @send_fake_tags
+        elsif attributes['id'] == 'nextLvlPB'
+          Gift.pulse unless @next_level_text == attributes['text']
+          @next_level_value = attributes['value'].to_i
+          @next_level_text = attributes['text']
+        elsif attributes['id'] == 'encumlevel'
+          @encumbrance_value = attributes['value'].to_i
+          @encumbrance_text = attributes['text']
+        elsif PSM_3_DIALOG_IDS.include?(@active_ids[-2])
+          # puts "kind=(%s) name=%s attributes=%s" % [@active_ids[-2], name, attributes]
+          self.parse_psm3_progressbar(@active_ids[-2], attributes)
+        end
+      elsif name == 'roundTime'
+        @roundtime_end = attributes['value'].to_i
+        $_CLIENT_.puts "\034GSQ#{sprintf('%010d', @roundtime_end)}\r\n" if @send_fake_tags
+      elsif name == 'castTime'
+        @cast_roundtime_end = attributes['value'].to_i
+      elsif name == 'dropDownBox'
+        if attributes['id'] == 'dDBTarget'
+          @current_target_ids.clear
+          attributes['content_value'].split(',').each { |t|
+            if t =~ /^\#(\-?\d+)(?:,|$)/
+              @current_target_ids.push($1)
+            end
+          }
+          if attributes['content_value'] =~ /^\#(\-?\d+)(?:,|$)/
+            @current_target_id = $1
+          else
+            @current_target_id = nil
+          end
+        end
+      elsif name == 'indicator'
+        @indicator[attributes['id']] = attributes['visible']
+        if @send_fake_tags
+          if attributes['id'] == 'IconPOISONED'
+            if attributes['visible'] == 'y'
+              $_CLIENT_.puts "\034GSJ0000000000000000000100000000001\r\n"
+            else
+              $_CLIENT_.puts "\034GSJ0000000000000000000000000000000\r\n"
+            end
+          elsif attributes['id'] == 'IconDISEASED'
+            if attributes['visible'] == 'y'
+              $_CLIENT_.puts "\034GSK0000000000000000000100000000001\r\n"
+            else
+              $_CLIENT_.puts "\034GSK0000000000000000000000000000000\r\n"
+            end
+          else
+            gsl_prompt = String.new; ICONMAP.keys.each { |icon| gsl_prompt += ICONMAP[icon] if @indicator[icon] == 'y' }
+            $_CLIENT_.puts "\034GSP#{sprintf('%-30s', gsl_prompt)}\r\n"
+          end
+        end
+      elsif (name == 'image') and @active_ids.include?('injuries')
+        if @injuries.keys.include?(attributes['id'])
+          if attributes['name'] =~ /Injury/i
+            @injuries[attributes['id']]['wound'] = attributes['name'].slice(/\d/).to_i
+          elsif attributes['name'] =~ /Scar/i
+            @injuries[attributes['id']]['wound'] = 0
+            @injuries[attributes['id']]['scar'] = attributes['name'].slice(/\d/).to_i
+          elsif attributes['name'] =~ /Nsys/i
+            rank = attributes['name'].slice(/\d/).to_i
+            if rank == 0
+              @injuries['nsys']['wound'] = 0
+              @injuries['nsys']['scar'] = 0
+            else
+              Thread.new {
+                wait_while { dead? }
+                action = proc { |server_string|
+                  if (@nerve_tracker_active == 'maybe')
+                    if @nerve_tracker_active == 'maybe'
+                      if server_string =~ /^You/
+                        @nerve_tracker_active = 'yes'
+                        @injuries['nsys']['wound'] = 0
+                        @injuries['nsys']['scar'] = 0
+                      else
+                        @nerve_tracker_active = 'no'
+                      end
+                    end
+                  end
+                  if @nerve_tracker_active == 'yes'
+                    if server_string =~ /<output class=['"]['"]\/>/
+                      @nerve_tracker_active = 'no'
+                      @nerve_tracker_num -= 1
+                      DownstreamHook.remove('nerve_tracker') if @nerve_tracker_num < 1
+                      $_CLIENT_.puts "\034GSV#{sprintf('%010d%010d%010d%010d%010d%010d%010d%010d', @max_health.to_i, @health.to_i, @max_spirit.to_i, @spirit.to_i, @max_mana.to_i, @mana.to_i, make_wound_gsl, make_scar_gsl)}\r\n" if @send_fake_tags
+                      server_string
+                    elsif server_string =~ /a case of uncontrollable convulsions/
+                      @injuries['nsys']['wound'] = 3
+                      nil
+                    elsif server_string =~ /a case of sporadic convulsions/
+                      @injuries['nsys']['wound'] = 2
+                      nil
+                    elsif server_string =~ /a strange case of muscle twitching/
+                      @injuries['nsys']['wound'] = 1
+                      nil
+                    elsif server_string =~ /a very difficult time with muscle control/
+                      @injuries['nsys']['scar'] = 3
+                      nil
+                    elsif server_string =~ /constant muscle spasms/
+                      @injuries['nsys']['scar'] = 2
+                      nil
+                    elsif server_string =~ /developed slurred speech/
+                      @injuries['nsys']['scar'] = 1
+                      nil
+                    end
+                  else
+                    if server_string =~ /<output class=['"]mono['"]\/>/
+                      @nerve_tracker_active = 'maybe'
+                    end
+                    server_string
+                  end
+                }
+                @nerve_tracker_num += 1
+                DownstreamHook.add('nerve_tracker', action)
+                Game._puts "#{$cmd_prefix}health"
+              }
+            end
+          else
+            @injuries[attributes['id']]['wound'] = 0
+            @injuries[attributes['id']]['scar'] = 0
+          end
+        end
+        $_CLIENT_.puts "\034GSV#{sprintf('%010d%010d%010d%010d%010d%010d%010d%010d', @max_health.to_i, @health.to_i, @max_spirit.to_i, @spirit.to_i, @max_mana.to_i, @mana.to_i, make_wound_gsl, make_scar_gsl)}\r\n" if @send_fake_tags
+      elsif name == 'compass'
+        if @current_stream == 'familiar'
+          @fam_mode = String.new
+        elsif @room_window_disabled
+          @room_exits = Array.new
+        end
+      elsif @room_window_disabled and (name == 'dir') and @active_tags.include?('compass')
+        @room_exits.push(LONGDIR[attributes['value']])
+      elsif name == 'radio'
+        if attributes['id'] == 'injrRad'
+          @injury_mode = 0 if attributes['value'] == '1'
+        elsif attributes['id'] == 'scarRad'
+          @injury_mode = 1 if attributes['value'] == '1'
+        elsif attributes['id'] == 'bothRad'
+          @injury_mode = 2 if attributes['value'] == '1'
+        end
+      elsif name == 'label'
+        if attributes['id'] == 'yourLvl'
+          @level = Stats.level = attributes['value'].slice(/\d+/).to_i
+        elsif attributes['id'] == 'encumblurb'
+          @encumbrance_full_text = attributes['value']
+        elsif @active_tags[-2] == 'dialogData' and PSM_3_DIALOG_IDS.include?(@active_ids[-2])
+          # deprecated: labels do not have the required data in psm 3.0 dialogdata
+          #             instead we must parse the <progressBar/> element
+        end
+      elsif (name == 'container') and (attributes['id'] == 'stow')
+        @stow_container_id = attributes['target'].sub('#', '')
+      elsif (name == 'clearStream')
+        if attributes['id'] == 'bounty'
+          @bounty_task = String.new
+        end
+      elsif (name == 'playerID')
+        @player_id = attributes['id']
+        unless $frontend =~ /^(?:wizard|avalon)$/
+          if Lich.inventory_boxes(@player_id)
+            DownstreamHook.remove('inventory_boxes_off')
+          end
+        end
+      elsif name == 'settingsInfo'
+        if game = attributes['instance']
+          if game == 'GS4'
+            @game = 'GSIV'
+          elsif (game == 'GSX') or (game == 'GS4X')
+            @game = 'GSPlat'
+          else
+            @game = game
+          end
+        end
+      elsif (name == 'app') and (@name = attributes['char'])
+        if @game.nil? or @game.empty?
+          @game = 'unknown'
+        end
+        unless File.exists?("#{DATA_DIR}/#{@game}")
+          Dir.mkdir("#{DATA_DIR}/#{@game}")
+        end
+        unless File.exists?("#{DATA_DIR}/#{@game}/#{@name}")
+          Dir.mkdir("#{DATA_DIR}/#{@game}/#{@name}")
+        end
+        if $frontend =~ /^(?:wizard|avalon)$/
+          Game._puts "#{$cmd_prefix}_flag Display Dialog Boxes 0"
+          sleep 0.05
+          Game._puts "#{$cmd_prefix}_injury 2"
+          sleep 0.05
+          # fixme: game name hardcoded as Gemstone IV; maybe doesn't make any difference to the client
+          $_CLIENT_.puts "\034GSB0000000000#{attributes['char']}\r\n\034GSA#{Time.now.to_i.to_s}GemStone IV\034GSD\r\n"
+          # Sending fake GSL tags to the Wizard FE is disabled until now, because it doesn't accept the tags and just gives errors until initialized with the above line
+          @send_fake_tags = true
+          # Send all the tags we missed out on
+          $_CLIENT_.puts "\034GSV#{sprintf('%010d%010d%010d%010d%010d%010d%010d%010d', @max_health.to_i, @health.to_i, @max_spirit.to_i, @spirit.to_i, @max_mana.to_i, @mana.to_i, make_wound_gsl, make_scar_gsl)}\r\n"
+          $_CLIENT_.puts "\034GSg#{sprintf('%010d', @stance_value)}\r\n"
+          $_CLIENT_.puts "\034GSr#{MINDMAP[@mind_text]}\r\n"
+          gsl_prompt = String.new
+          @indicator.keys.each { |icon| gsl_prompt += ICONMAP[icon] if @indicator[icon] == 'y' }
+          $_CLIENT_.puts "\034GSP#{sprintf('%-30s', gsl_prompt)}\r\n"
+          gsl_prompt = nil
+          gsl_exits = String.new
+          @room_exits.each { |exit| gsl_exits.concat(DIRMAP[SHORTDIR[exit]].to_s) }
+          $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
+          gsl_exits = nil
+          $_CLIENT_.puts "\034GSn#{sprintf('%-14s', @prepared_spell)}\r\n"
+          $_CLIENT_.puts "\034GSm#{sprintf('%-45s', GameObj.right_hand.name)}\r\n"
+          $_CLIENT_.puts "\034GSl#{sprintf('%-45s', GameObj.left_hand.name)}\r\n"
+          $_CLIENT_.puts "\034GSq#{sprintf('%010d', @server_time)}\r\n"
+          $_CLIENT_.puts "\034GSQ#{sprintf('%010d', @roundtime_end)}\r\n" if @roundtime_end > 0
+        end
+        Game._puts("#{$cmd_prefix}_flag Display Inventory Boxes 1")
+        Script.start('autostart') if Script.exists?('autostart')
+        if arg = ARGV.find { |a| a =~ /^\-\-start\-scripts=/ }
+          for script_name in arg.sub('--start-scripts=', '').split(',')
+            Script.start(script_name)
+          end
+        end
+      end
+    rescue
+      $stdout.puts "--- error: XMLParser.tag_start: #{$!}"
+      Lich.log "error: XMLParser.tag_start: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+      sleep 0.1
+      reset
+    end
+  end
+
+  def text(text_string)
+    begin
+      # fixme: /<stream id="Spells">.*?<\/stream>/m
+      # $_CLIENT_.write(text_string) unless ($frontend != 'suks') or (@current_stream =~ /^(?:spellfront|inv|bounty|society)$/) or @active_tags.any? { |tag| tag =~ /^(?:compDef|inv|component|right|left|spell)$/ } or (@active_tags.include?('stream') and @active_ids.include?('Spells')) or (text_string == "\n" and (@last_tag =~ /^(?:popStream|prompt|compDef|dialogData|openDialog|switchQuickBar|component)$/))
+      if @active_tags.include?('inv')
+        if @active_tags[-1] == 'a'
+          @obj_name = text_string
+        elsif @obj_name.nil?
+          @obj_before_name = text_string.strip
+        else
+          @obj_after_name = text_string.strip
+        end
+      elsif @active_tags.last == 'prompt'
+        @prompt = text_string
+      elsif @active_tags.include?('right')
+        GameObj.new_right_hand(@obj_exist, @obj_noun, text_string)
+        $_CLIENT_.puts "\034GSm#{sprintf('%-45s', text_string)}\r\n" if @send_fake_tags
+      elsif @active_tags.include?('left')
+        GameObj.new_left_hand(@obj_exist, @obj_noun, text_string)
+        $_CLIENT_.puts "\034GSl#{sprintf('%-45s', text_string)}\r\n" if @send_fake_tags
+      elsif @active_tags.include?('spell')
+        @prepared_spell = text_string
+        $_CLIENT_.puts "\034GSn#{sprintf('%-14s', text_string)}\r\n" if @send_fake_tags
+      elsif @active_tags.include?('compDef') or @active_tags.include?('component')
+        if @active_ids.include?('room objs')
+          if @active_tags.include?('a')
+            if @bold
+              GameObj.new_npc(@obj_exist, @obj_noun, text_string)
+            else
+              GameObj.new_loot(@obj_exist, @obj_noun, text_string)
+            end
+          elsif (text_string =~ /that (?:is|appears) ([\w\s]+)(?:,| and|\.)/) or (text_string =~ / \(([^\(]+)\)/)
+            GameObj.npcs[-1].status = $1
+          end
+        elsif @active_ids.include?('room players')
+          if @active_tags.include?('a')
+            @pc = GameObj.new_pc(@obj_exist, @obj_noun, "#{@player_title}#{text_string}", @player_status)
+            @player_status = nil
+          else
+            if @game =~ /^DR/
+              GameObj.clear_pcs
+              text_string.sub(/^Also here\: /, '').sub(/ and ([^,]+)\./) { ", #{$1}" }.split(', ').each { |player|
+                if player =~ / who is (.+)/
+                  status = $1
+                  player.sub!(/ who is .+/, '')
+                elsif player =~ / \((.+)\)/
+                  status = $1
+                  player.sub!(/ \(.+\)/, '')
+                else
+                  status = nil
+                end
+                noun = player.slice(/\b[A-Z][a-z]+$/)
+                if player =~ /the body of /
+                  player.sub!('the body of ', '')
+                  if status
+                    status.concat ' dead'
+                  else
+                    status = 'dead'
+                  end
+                end
+                if player =~ /a stunned /
+                  player.sub!('a stunned ', '')
+                  if status
+                    status.concat ' stunned'
+                  else
+                    status = 'stunned'
+                  end
+                end
+                GameObj.new_pc(nil, noun, player, status)
+              }
+            else
+              if (text_string =~ /^ who (?:is|appears) ([\w\s]+)(?:,| and|\.|$)/) or (text_string =~ / \(([\w\s]+)\)(?: \(([\w\s]+)\))?/)
+                if @pc.status
+                  @pc.status.concat " #{$1}"
+                else
+                  @pc.status = $1
+                end
+                @pc.status.concat " #{$2}" if $2
+              end
+              if text_string =~ /(?:^Also here: |, )(?:a )?([a-z\s]+)?([\w\s\-!\?',]+)?$/
+                @player_status = ($1.strip.gsub('the body of', 'dead')) if $1
+                @player_title = $2
+              end
+            end
+          end
+        elsif @active_ids.include?('room desc')
+          if text_string == '[Room window disabled at this location.]'
+            @room_window_disabled = true
+          else
+            @room_window_disabled = false
+            @room_description.concat(text_string)
+            if @active_tags.include?('a')
+              GameObj.new_room_desc(@obj_exist, @obj_noun, text_string)
+            end
+          end
+        elsif @active_ids.include?('room exits')
+          @room_exits_string.concat(text_string)
+          @room_exits.push(text_string) if @active_tags.include?('d')
+        end
+      elsif @current_stream == 'bounty'
+        @bounty_task += text_string
+      elsif @current_stream == 'society'
+        @society_task = text_string
+      elsif (@current_stream == 'inv') and @active_tags.include?('a')
+        GameObj.new_inv(@obj_exist, @obj_noun, text_string, nil)
+      elsif @current_stream == 'familiar'
+        # fixme: familiar room tracking does not (can not?) auto update, status of pcs and npcs isn't tracked at all, titles of pcs aren't tracked
+        if @current_style == 'roomName'
+          @familiar_room_title = text_string
+          @familiar_room_description = String.new
+          @familiar_room_exits = Array.new
+          GameObj.clear_fam_room_desc
+          GameObj.clear_fam_loot
+          GameObj.clear_fam_npcs
+          GameObj.clear_fam_pcs
+          @fam_mode = String.new
+        elsif @current_style == 'roomDesc'
+          @familiar_room_description.concat(text_string)
+          if @active_tags.include?('a')
+            GameObj.new_fam_room_desc(@obj_exist, @obj_noun, text_string)
+          end
+        elsif text_string =~ /^You also see/
+          @fam_mode = 'things'
+        elsif text_string =~ /^Also here/
+          @fam_mode = 'people'
+        elsif text_string =~ /Obvious (?:paths|exits)/
+          @fam_mode = 'paths'
+        elsif @fam_mode == 'things'
+          if @active_tags.include?('a')
+            if @bold
+              GameObj.new_fam_npc(@obj_exist, @obj_noun, text_string)
+            else
+              GameObj.new_fam_loot(@obj_exist, @obj_noun, text_string)
+            end
+          end
+          # puts 'things: ' + text_string
+        elsif @fam_mode == 'people' and @active_tags.include?('a')
+          GameObj.new_fam_pc(@obj_exist, @obj_noun, text_string)
+          # puts 'people: ' + text_string
+        elsif (@fam_mode == 'paths') and @active_tags.include?('a')
+          @familiar_room_exits.push(text_string)
+        end
+      elsif @room_window_disabled
+        if @current_style == 'roomDesc'
+          @room_description.concat(text_string)
+          if @active_tags.include?('a')
+            GameObj.new_room_desc(@obj_exist, @obj_noun, text_string)
+          end
+        elsif text_string =~ /^Obvious (?:paths|exits): (?:none)?$/
+          @room_exits_string = text_string.strip
+        end
+      end
+    rescue
+      $stdout.puts "--- error: XMLParser.text: #{$!}"
+      Lich.log "error: XMLParser.text: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+      sleep 0.1
+      reset
+    end
+  end
+
+  def tag_end(name)
+    begin
+      if name == 'inv'
+        if @obj_exist == @obj_location
+          if @obj_after_name == 'is closed.'
+            GameObj.delete_container(@stow_container_id)
+          end
+        elsif @obj_exist
+          GameObj.new_inv(@obj_exist, @obj_noun, @obj_name, @obj_location, @obj_before_name, @obj_after_name)
+        end
+      elsif @send_fake_tags and (@active_ids.last == 'room exits')
+        gsl_exits = String.new
+        @room_exits.each { |exit| gsl_exits.concat(DIRMAP[SHORTDIR[exit]].to_s) }
+        $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
+        gsl_exits = nil
+      elsif @room_window_disabled and (name == 'compass')
+        #            @room_window_disabled = false
+        @room_description = @room_description.strip
+        @room_exits_string.concat " #{@room_exits.join(', ')}" unless @room_exits.empty?
+        gsl_exits = String.new
+        @room_exits.each { |exit| gsl_exits.concat(DIRMAP[SHORTDIR[exit]].to_s) }
+        $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
+        gsl_exits = nil
+        @room_count += 1
+        $room_count += 1
+      end
+      @last_tag = @active_tags.pop
+      @last_id = @active_ids.pop
+    rescue
+      $stdout.puts "--- error: XMLParser.tag_end: #{$!}"
+      Lich.log "error: XMLParser.tag_end: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+      sleep 0.1
+      reset
+    end
+  end
+
+  # here for backwards compatibility, but spellfront xml isn't sent by the game anymore
+  def spellfront
+    if (Time.now.to_i - @@warned_deprecated_spellfront) > 300
+      @@warned_deprecated_spellfront = Time.now.to_i
+      unless script_name = Script.current.name
+        script_name = 'unknown script'
+      end
+      respond "--- warning: #{script_name} is using deprecated method XMLData.spellfront; this method will be removed in a future version of Lich"
+    end
+    @active_spells.keys
+  end
+end


### PR DESCRIPTION
Closes issue #37 

Note - not active in Lich.rbw.  To activate, bump version per semver and include

`require_relative("./lib/<classfile>.rb") `

in place of the entire class definition.

Will sort out order of relative loads later, but for now simply places the class defs in the same location as original.