### PR TITLE
bug / spell.rb syntax error (missing end)

### DIFF
--- a/lib/spell.rb
+++ b/lib/spell.rb
@@ -744,5 +744,6 @@ module Games
     def command;       nil;                              end
     def circlename;    self.circle_name;                 end
     def selfonly;      @availability != 'all';           end
-  end
-end
+    end # class
+  end # mod
+end # mod


### PR DESCRIPTION
Detected at test - correction before launch

Added end statement for class that was missed in splitting code.  Merging in 30 minutes.