### PR TITLE
Adding deprecated global dirs to constants.rb

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -12,3 +12,9 @@ TESTING = false
 # add this so that require statements can take the form 'lib/file'
 
 $LOAD_PATH << "#{LICH_DIR}"
+
+# deprecated
+$lich_dir = "#{LICH_DIR}/"
+$temp_dir = "#{TEMP_DIR}/"
+$script_dir = "#{SCRIPT_DIR}/"
+$data_dir = "#{DATA_DIR}/"


### PR DESCRIPTION
Did not include the deprecated global dir variables initially.  This corrects the oversight