### PR TITLE
[lich.rbw] avoid stomping exits because of doorknobs

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -3105,6 +3105,8 @@ def move(dir='none', giveup_seconds=10, giveup_lines=30)
       put_dir.call
     elsif (line =~ /^You (?:take a few steps toward|trudge up to|limp towards|march up to|sashay gracefully up to|skip happily towards|sneak up to|stumble toward) a rusty doorknob/) and (dir =~ /door/)
       which = [ 'first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eight', 'ninth', 'tenth', 'eleventh', 'twelfth' ]
+      # avoid stomping the room for the entire session due to a transient failure
+      dir = dir.to_s
       if dir =~ /\b#{which.join('|')}\b/
         dir.sub!(/\b(#{which.join('|')})\b/) { "#{which[which.index($1)+1]}" }
       else


### PR DESCRIPTION
if a rusty doorknob is in a room, and a mundane "go door" wayto fails because of it code changes the exit to "go second door" (or third, fourth. it tries to iterate based on the exit). However, it changes the entire room in memory not just the command issued to the game while issuing that movement so it persists for the entire session. If the doorknob is then removed, the exit is now broken until the player logs out or reloads the mapdb.

by casting the "dir" var to a string first, we avoid this issue by manipulating a temporary string var and not a reference to the map DB in memory itself.

example:
```
>drop doork
You drop a rusty doorknob.
--- Lich: go2 active.
[go2: ETA: 0:00:00 (1 rooms to move through)]
>;go2 13198
[go2]>go door
You take a few steps toward a rusty doorknob.
[go2]>go second door
[Lyeonia Hall, Vault (the Adventurer's Guild) - 13198]
You notice Treasure Master Relton.
Obvious exits: out
[go2: travel time: 0:00:00]
```
this exit is now broken if the doorknob is removed for me until i reload the mapdb / relog:
```
>o
[Lyeonia Hall, Corridor (the Adventurer's Guild) - 12803]
You notice a rusty doorknob and a steel-banded door with a golden plaque on it.
Obvious exits: south
>get doork
You pick up a rusty doorknob.
--- Lich: go2 active.
>;go2 13198
[go2: ETA: 0:00:00 (1 rooms to move through)]
[go2]>go second door
Where are you trying to go?
[go2: move: failed]
[go2: restarting script...]
[go2: ETA: 0:00:00 (1 rooms to move through)]
[go2]>go second door
Where are you trying to go?
[go2: move: failed]
[go2: restarting script...]
[go2]>help lag-check
No help files matching that entry were found.
[go2: ETA: 0:00:00 (1 rooms to move through)]
[go2]>go second door
Where are you trying to go?
[go2: move: failed]
[go2: changing Room[12803].timeto['13198'] to nil]
[go2: reverting Room[12803].timeto['13198'] back to 0.2]
--- Lich: go2 has exited.
```

and now changing dir away from a reference value:
```
>;go2 13198
[go2]>go door
You take a few steps toward a rusty doorknob.
[go2]>go second door
[Lyeonia Hall, Vault (the Adventurer's Guild) - 13198]
You notice Treasure Master Relton.
Obvious exits: out
[go2: travel time: 0:00:00]
--- Lich: go2 has exited.
>o
[Lyeonia Hall, Corridor (the Adventurer's Guild) - 12803]
You notice a rusty doorknob and a steel-banded door with a golden plaque on it.
Obvious exits: south
>get doork
You pick up a rusty doorknob.
--- Lich: go2 active.
[go2: ETA: 0:00:00 (1 rooms to move through)]
>;go2 13198
[go2]>go door
[Lyeonia Hall, Vault (the Adventurer's Guild) - 13198]
You notice Treasure Master Relton.
Obvious exits: out
[go2: travel time: 0:00:00]
```
