### PR TITLE
Add Linux WINE to direct FE launch methods

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -150,7 +150,7 @@ elsif defined?(Wine)
            'HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\WIZ32\\Directory']
 ## Needs improvement - iteration and such.  Quick slam test.
 #  $sf_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\STORM32\\Directory')
-#  $wiz_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\WIZ32\\Directory')
+$wiz_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\WIZ32\\Directory')
 $sf_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\STORM32\\Directory')
 end
 

--- a/lib/init.rb
+++ b/lib/init.rb
@@ -150,8 +150,16 @@ elsif defined?(Wine)
            'HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\WIZ32\\Directory']
 ## Needs improvement - iteration and such.  Quick slam test.
 #  $sf_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\STORM32\\Directory')
-$wiz_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\WIZ32\\Directory')
-$sf_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\STORM32\\Directory')
+  $wiz_fe_loc_temp = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\WIZ32\\Directory')
+  $sf_fe_loc_temp = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\STORM32\\Directory')
+
+  $wiz_fe_loc = $wiz_fe_loc_temp.gsub('\\', '/').gsub('C:', Wine::PREFIX + '/drive_c')
+  $sf_fe_loc = $sf_fe_loc_temp.gsub('\\', '/').gsub('C:', Wine::PREFIX + '/drive_c')
+
+  if !File.exist?($sf_fe_loc)
+    $sf_fe_loc =~ /SIMU/ ? $sf_fe_loc = $sf_fe_loc.gsub("SIMU", "Simu") : $sf_fe_loc = $sf_fe_loc.gsub("Simu", "SIMU")
+    Lich.log("Cannot find STORM equivalent FE to launch.") if !File.exist?($sf_fe_loc)
+  end
 end
 
 ## The following should be deprecated with the direct-frontend-launch-method


### PR DESCRIPTION
While not broken, the Linux | WINE method of FE launch still relies on SIMU Launcher or SIMU SGE -> SIMU Launcher.  This incorporates the method to determine where the FE is stored, for use by Lich without needing either Launcher or SGE