### PR TITLE
Stops lich crashing on load when wine is installed, but not used

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -149,7 +149,7 @@ elsif defined?(Wine)
   paths = ['HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\STORM32\\Directory',
            'HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\WIZ32\\Directory']
 ## Needs improvement - iteration and such.  Quick slam test.
-#  $sf_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\STORM32\\Directory')
+  $sf_fe_loc = Wine.registry_gets('HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Simutronics\\STORM32\\Directory') || ''
   $wiz_fe_loc_temp = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\WIZ32\\Directory')
   $sf_fe_loc_temp = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Simutronics\\STORM32\\Directory')
 


### PR DESCRIPTION
I have wine installed, but do not use it with lich. 

This is just a hack, to prevent lich crashing on load in this scenario. I can only assume this doesn't work anyway, since `$sf_fe_loc` is undefined, but it won't be an issue for most people. Linux being an edge case, and then having wine, but not using it for lich... Anyway, this let's me launch lich without crashing on linux.