### PR TITLE
Add toggles to display lichid and uid

### DIFF
--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -564,7 +564,7 @@ module Lich
     [gamehost, gameport]
   end
 
-# new feature GUI states
+# new feature GUI / internal settings states
 
   def Lich.track_autosort_state
     begin
@@ -625,4 +625,45 @@ module Lich
     end
     nil
   end
+
+  def Lich.display_lichid
+    begin
+      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_lichid';")
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+end
+    val
+  end
+
+  def Lich.display_lichid=(val)
+    begin
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_lichid',?);", val.to_s.encode('UTF-8'))
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+    nil
+  end
+
+  def Lich.display_uid
+    begin
+      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_uid';")
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+    val
+  end
+
+  def Lich.display_uid=(val)
+    begin
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_uid',?);", val.to_s.encode('UTF-8'))
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+    nil
+  end
+
 end

--- a/lich.rbw
+++ b/lich.rbw
@@ -5366,6 +5366,15 @@ module Games
                       Lich.log "error: client_thread: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
                     end
                   end
+                  if alt_string =~ /<resource picture=.*roomName/
+                    if (Lich.display_lichid =~ /on|true|yes/ && Lich.display_uid =~ /on|true|yes/) || (Lich.display_lichid.nil? && Lich.display_uid.nil?) #default on
+                      alt_string.sub!(']') { " - #{Room.current.id}] (u#{XMLData.room_id})" }
+                    elsif Lich.display_lichid =~ /on|true|yes/ || Lich.display_lichid.nil? # don't force an entry
+                      alt_string.sub!(']') { " - #{Room.current.id}]" }
+                    elsif Lich.display_uid =~ /on|true|yes/ || Lich.display_uid.nil? # don't force an entry
+                      alt_string.sub!(']') { "] (u#{XMLData.room_id})" }
+                    end
+                  end
                   if $frontend =~ /^(?:wizard|avalon)$/
                     alt_string = sf_to_wiz(alt_string)
                   end


### PR DESCRIPTION
Displays

`[Room Name - LichID] (uid)`

in the client, or permutations depending on setting for Lich.display_lichid and Lich.display.uid