### PR TITLE
Update infomon to track spell durations accurately

### DIFF
--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -310,6 +310,8 @@ class XMLParser
         elsif PSM_3_DIALOG_IDS.include?(@active_ids[-2])
           # puts "kind=(%s) name=%s attributes=%s" % [@active_ids[-2], name, attributes]
           self.parse_psm3_progressbar(@active_ids[-2], attributes)
+          # since we received an updated spell duration, let's signal infomon to update
+          $process_legacy_spell_durations = true
         end
       elsif name == 'roundTime'
         @roundtime_end = attributes['value'].to_i

--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -8,14 +8,17 @@
   contributers: Tillmen, Shaelun, Athias
           game: Gemstone
           tags: core
-      required: Lich > 4.6.10
-       version: 1.18.11
+      required: Lich > 5.0.16
+       version: 1.18.12
         Source: https://github.com/elanthia-online/jinx
     Alt Source: https://github.com/elanthia-online/lich-5
 
   Version Control:
     Major_change.feature_addition.bugfix
 
+  1.18.12 (2022-02-04):
+    Bugfix for syncing up invoker spells / sk spells in infomon
+    Added 'Test' as acceptable instance for loading
   1.18.11 (2021-12-03):
     Bugfix for duplicate names between Spell and Cooldown
   1.18.10 (2021-09-10):
@@ -44,10 +47,12 @@
     Typo for infomon_bound with envelopes should be envelop
 =end
 
-unless XMLData.game =~ /^(?:GSF|GSIV|GSPlat|GST)$/
+unless XMLData.game =~ /^(?:GSF|GSIV|GSPlat|GST|Test)$/
   echo "This script is meant for Gemstone Prime, Platinum, or Shattered.  It will likely cause problems on whatever game you're trying to run it on..."
   exit
 end
+
+$infomon_debug = false
 
 hide_me
 setpriority(1)
@@ -351,26 +356,101 @@ Thread.new {
 }
 
 #
-# Another workaround for Simu fail
+# Spell timing true-up (Invoker and SK item spells do not have proper durations)
+# this needs to be addressed in class Spell rewrite
+# in the meantime, this should mean no spell is more than 1 second off from
+# Simu's time calculations
 #
-fix_gameobj_status = proc { |server_string|
-  # false positive: shudders with sporadic convulsions as pearlescent ripples envelop .*? body
-#The earth elemental rumbles in agony as it teeters for a moment, then tumbles to the ground with a thundering crash!
-  if server_string =~ /^(?:The fire in the|With a surprised grunt, the|A sudden blue fire bursts over the hair of a|You hear a sound like a weeping child as a white glow separates itself from the|A low gurgling sound comes from deep within the chest of the|The|A|One last prolonged bovine moan escapes from the) (?:<pushBold\/>)?<a.*?exist=["'](\-?[0-9]+)["'].*?>.*?<\/a>(?:<popBold\/>)?(?:'s)? (?:body as it rises, disappearing into the heavens|falls to the ground and dies(?:, its feelers twitching)?|falls back into a heap and dies|body goes rigid and collapses to the ground, dead|body goes rigid and collapses to the floor, dead|slowly settles to the ground and begins to dissipate|falls to the ground motionless|body goes rigid and <pushBold\/><a.*?>\w+<\/a><popBold\/> eyes roll back into <pushBold\/><a.*?>\w+<\/a><popBold\/> head as <pushBold\/><a.*?>\w+<\/a><popBold\/> dies|growls one last time, and crumples to the ground in a heap|spins backwards and collapses dead|falls to the ground as the stillness of death overtakes <pushBold\/><a.*?>(?:him|her|it)<\/a><popBold\/>|crumples to the ground motionless|howls in agony one last time and dies|howls in agony while falling to the ground motionless|moans pitifully as <pushBold\/><a.*?>(?:he|she|it)<\/a><popBold\/> is released|careens to the ground and crumples in a heap|hisses one last time and dies|flutters its wings one last time and dies|slumps to the ground with a final snarl|horn dims as (?:his|her) lifeforce fades away|blinks in astonishment, then collapses in a motionless heap|collapses in a heap, its huge girth shaking the floor around it|goes limp and .*? falls over as the fire slowly fades from .*? eyes|eyes slowly fades|sputters violently, cascading flames all around as .*? collapses in a final fiery display|falls to the ground in a clattering, motionless heap|goes limp and .*? falls over as the fire slowly fades from .*? eyes|collapses to the ground and shudders once before finally going still|crumbles into a pile of rubble|shudders once before .*? finally goes still|totters for a moment and then falls to the ground like a pillar, breaking into pieces that fly out in every direction|collapses into a pile of rubble|rumbles in agony as .*? teeters for a moment, then falls directly at you|twists and coils violently in .*? death throes, finally going still|twitches one final time before falling still upon the floor|, consuming .*? form in the space of a breath|screams one last time and dies|breathes .*? last gasp and dies|rolls over and dies|as .*? falls (?:slack|still) against the (?:floor|ground)|collapses to the ground, emits a final squeal, and dies|cries out in pain one last time and dies|crumples to a heap on the ground and dies|collapses to the ground, emits a final sigh, and dies|crumples to the ground and dies|lets out a final caterwaul and dies|screams evilly one last time and goes still|gurgles eerily and collapses into a puddle of water|shudders, then topples to the ground|shudders one last time before lying still|violently for a moment, then goes still|grumbles in pain one last time before lying still|rumbles in agony and goes still|falls to the ground dead|collapses to the ground, emits a final bleat, and dies|topples to the ground motionless|shudders violently for a moment, then goes still|rumbles in agony as .*? teeters for a moment, then tumbles to the ground with a thundering crash)[\.!]\r?\n?$/
-    npc_id = $1
-    if npc = GameObj.npcs.find { |obj| obj.id == npc_id }
-      npc.status = 'dead'
-    end
-  elsif server_string =~ /^A calm washes over <pushBold\/>(?:a|an|the) <a exist="(.*?)" noun=".*?">.*?<\/a><popBold\/>\.\r?\n?$/
-    npc_id = $1
-    if npc = GameObj.npcs.find { |obj| obj.id == npc_id }
-      npc.status = 'calm'
-    end
-  end
-  server_string
-}
-before_dying { DownstreamHook.remove('fix_gameobj_status') }
-DownstreamHook.add('fix_gameobj_status', fix_gameobj_status)
+unless Gem::Version.new(LICH_VERSION) < Gem::Version.new('5.0.16')
+  Thread.new {
+    loop {
+      begin
+        until $process_legacy_spell_durations
+          sleep 0.01
+        end
+        update_spell_durations = XMLData.active_spells
+        update_spell_names = []
+        @makeychange = []
+        update_spell_durations.each do |k,v|
+          if k =~ /Mage Armor \- /
+            @makeychange << k
+            update_spell_names.push("Mage Armor")
+            next
+          elsif k =~ /CoS \- /
+            @makeychange << k
+            update_spell_names.push("Cloak of Shadows")
+            next
+          elsif k =~ /Enh\./
+            @makeychange << k
+            case k
+            when /Enh\. Strength/
+              update_spell_names.push("Surge of Strength")
+            when /Enh\. (?:Dexterity|Agility)/
+              update_spell_names.push("Burst of Swiftness")
+            end
+            next
+          elsif k =~ /Empowered/
+            @makeychange << k
+            update_spell_names.push("Shout")
+            next
+          elsif k =~ /Multi\-Strike/
+            @makeychange << k
+            update_spell_names.push("MStrike Cooldown")
+            next
+          elsif k =~ /Next Bounty Cooldown/
+            @makeychange << k
+            update_spell_names.push("Next Bounty")
+            next
+          end
+          update_spell_names << k
+        end
+        @makeychange.each do |changekey|
+          if update_spell_durations.key?(changekey)
+            case changekey
+            when /Mage Armor \- /
+              update_spell_durations['Mage Armor'] = update_spell_durations.delete changekey
+            when /CoS \- /
+              update_spell_durations['Cloak of Shadows'] = update_spell_durations.delete changekey
+            when /Enh\. Strength/
+              update_spell_durations['Surge of Strength'] = update_spell_durations.delete changekey
+            when /Enh\. (?:Dexterity|Agility)/
+              update_spell_durations['Burst of Swiftness'] = update_spell_durations.delete changekey
+            when /Empowered/
+              update_spell_durations['Shout'] = update_spell_durations.delete changekey
+            when /Multi\-Strike/
+              update_spell_durations['MStrike Cooldown'] = update_spell_durations.delete changekey
+            when /Next Bounty Cooldown/
+              update_spell_durations['Next Bounty'] = update_spell_durations.delete changekey
+            when /Next Group Bounty Cooldown/
+              update_spell_durations['Next Group Bounty'] = update_spell_durations.delete changekey
+            end
+          end
+        end
+
+        existing_spell_names = []
+        Spell.active.each { |s| existing_spell_names << s.name }
+        inactive_spells = existing_spell_names - update_spell_names
+        inactive_spells.each { |s| badspell = Spell[s].num; Spell[badspell].putdown if Spell[s].active?}
+
+        update_spell_durations.uniq.each do |k,v|
+          if spell = Spell.list.find { |s| s.name.downcase == k.strip().downcase or s.num.to_s == k.strip() }
+            spell.active = true
+            if v - Time.now > 300 * 60
+              spell.timeleft = 600.01
+            else
+              spell.timeleft = ((v - Time.now) / 60)
+            end
+          else
+            echo "no spell matches #{k}" if $infomon_debug
+          end
+        end
+      rescue
+        echo "Error in spell durations thread" if $infomon_debug
+      end
+      $process_legacy_spell_durations = false
+    }
+  }
+end
 
 #
 # Spell tracking
@@ -1398,50 +1478,6 @@ while line = get
       $infomon_cutthroat = true
     elsif line =~ /^\s*The horrible pain in your vocal cords subsides as you spit out the last of the blood clogging your throat\.$/
       $infomon_cutthroat = false
-      #
-      # monitoring for spell active and true up spell durations
-      #
-    elsif line == "You currently have the following active effects:"
-      while (line = get)
-        case line
-        when /Spells:/
-          next
-        when /Cooldowns:/
-          cooldown_list = true
-          next
-        when /Buffs:/
-          cooldown_list = false
-          next
-        when /Debuffs:/
-          next
-        when /\s+([A-z0-9\s\'\(\)\-]+) \.* (([0-9]+)\:([0-9]+)\:([0-9]+)|Indefinite)$/
-          spell_name = $1.dup
-          spell_name = spell_name+' Cooldown' if cooldown_list
-          if $2.dup == 'Indefinite'
-            spell_time = 599.0
-          else
-            spell_time = ($3.dup.to_i * 60) + $4.dup.to_i + ($5.dup.to_i / 60.0)
-          end
-          if spell_name == 'Raise Dead Link'
-            spell_name = 'Raise Dead Cooldown'
-          elsif spell_name =~ /Mage Armor \- /
-            spell_name = 'Mage Armor'
-          elsif spell_name =~ /CoS \- /
-            spell_name = 'Cloak of Shadows'
-          end
-          if spell = Spell.list.find { |s| s.name.downcase == spell_name.strip().downcase or s.num.to_s == spell_name.strip() }
-            spell.active = true
-            spell.timeleft = spell_time
-          else
-            echo "no spell matches #{spell_name}" if $infomon_debug
-          end
-        when /^ [.]{40}|^  No (?:spells|cooldowns|buffs|debuffs) found\./
-          next
-        else
-          script.downstream_buffer.unshift(line) if line
-          break
-        end
-      end
     elsif line =~ /^You currently have .*? citizenship in (.*)\.$/
       Char.citizenship = $1
       CharSettings['citizenship'] = Char.citizenship


### PR DESCRIPTION
This is a significant change to Infomon that paves the direction for a future rewrite based on the Effects module. In short, it stops looking for up / down messages from spells and simply takes in the current xmlparser active_spells output. There are some names that are then transformed to conform with current naming conventions in spell-list.xml and various scripts to limit breaking changes.

Needs thorough testing.
