### PR TITLE
Remove 5 minute timeout

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -5313,19 +5313,6 @@ module Games
         end
         @@socket.sync = true
 
-        Thread.new {
-          @@last_recv = Time.now
-          loop {
-            if (@@last_recv + 300) < Time.now
-              Lich.log "#{Time.now}: error: nothing recieved from game server in 5 minutes"
-              @@thread.kill rescue nil
-              break
-            end
-            sleep (300 - (Time.now - @@last_recv))
-            sleep 1
-          }
-        }
-
         @@thread = Thread.new {
           begin
             atmospherics = false


### PR DESCRIPTION
Recent XML frequency changes and increased time in allowing characters to remain inactive have led to an increase in firing of the legacy lich method of timing out after 5 minutes of no server messages.

Removes the thread that watched for 5 minutes and then logged out.  