### PR TITLE
Fixing variable to instance variable for login dialog window

### DIFF
--- a/lib/gui-login.rb
+++ b/lib/gui-login.rb
@@ -36,8 +36,8 @@ def gui_login
     @window = nil
     install_tab_loaded = false
 
-    msgbox = proc { |msg|
-      dialog = Gtk::MessageDialog.new(:parent => window, :flags => Gtk::DialogFlags::DESTROY_WITH_PARENT, :type => Gtk::MessageType::ERROR, :buttons => Gtk::ButtonsType::CLOSE, :message => msg)
+    @msgbox = proc { |msg|
+      dialog = Gtk::MessageDialog.new(:parent => @window, :flags => Gtk::DialogFlags::DESTROY_WITH_PARENT, :type => Gtk::MessageType::ERROR, :buttons => Gtk::ButtonsType::CLOSE, :message => msg)
       #			dialog.set_icon(default_icon)
       dialog.run
       dialog.destroy

--- a/lib/gui-manual-login.rb
+++ b/lib/gui-manual-login.rb
@@ -119,7 +119,7 @@ connect_button.signal_connect('clicked') {
       )
     end
     if login_info =~ /error/i
-      msgbox.call "\nSomething went wrong... probably invalid \nuser id and / or password.\n\nserver response: #{login_info}"
+      @msgbox.call "\nSomething went wrong... probably invalid \nuser id and / or password.\n\nserver response: #{login_info}"
       connect_button.sensitive = true
       disconnect_button = false
       user_id_entry.sensitive = true


### PR DESCRIPTION
Reported by Athias - incorrectly entered account / password information in Lich 5 GUI errors, but does not present a modal dialog with explanation as intended.

Repairs this issue.