### PR TITLE
Script CLASS empty array initializing bugfix

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -1237,6 +1237,8 @@ class Script
       unless (args[:args].nil? || args[:args].empty?)
         @vars = [ args[:args].join(" ") ]
         @vars.concat args[:args]
+      else
+        @vars = Array.new
       end
     else
       @vars = Array.new

--- a/lich.rbw
+++ b/lich.rbw
@@ -722,9 +722,7 @@ class Script
           end
         elsif args[1].class == Hash
           options = args[1]
-          unless options[:args].nil? or options[:args].empty?
-            script_args = options[:args]
-          end
+          script_args = (options[:args] || String.new)
         else
           # fixme: error
           next nil
@@ -740,9 +738,7 @@ class Script
         # fixme: error
         next nil
       end
-      unless options[:args].nil? or options[:args].empty?
-        script_args = options[:args]
-      end
+      script_args = (options[:args] || String.new)
     end
 
     # fixme: look in wizard script directory
@@ -1238,8 +1234,10 @@ class Script
         @vars.concat args[:args].scan(/[^\s"]*(?<!\\)"(?:\\"|[^"])+(?<!\\)"[^\s]*|(?:\\"|[^"\s])+/).collect { |s| s.gsub(/(?<!\\)"/, '').gsub('\\"', '"') }
       end
     elsif args[:args].class == Array
-      @vars = [ args[:args].join(" ") ]
-      @vars.concat args[:args]
+      unless (args[:args].nil? || args[:args].empty?)
+        @vars = [ args[:args].join(" ") ]
+        @vars.concat args[:args]
+      end
     else
       @vars = Array.new
     end

--- a/lich.rbw
+++ b/lich.rbw
@@ -722,7 +722,9 @@ class Script
           end
         elsif args[1].class == Hash
           options = args[1]
-          script_args = (options[:args] || String.new)
+          unless options[:args].nil? or options[:args].empty?
+            script_args = options[:args]
+          end
         else
           # fixme: error
           next nil
@@ -738,7 +740,9 @@ class Script
         # fixme: error
         next nil
       end
-      script_args = (options[:args] || String.new)
+      unless options[:args].nil? or options[:args].empty?
+        script_args = options[:args]
+      end
     end
 
     # fixme: look in wizard script directory


### PR DESCRIPTION
Preventing class Script from pushing empty arguments to scripts being loaded

This change modifies class Script to prevent empty or nil arguments being passed to scripts as they're being loaded.  Scripts that do not accept arguments were unaffected by recent Lich 5.4.x changes, but those scripts that did accept arguments, but did not intend to catch NIL or EMPTY arguments showed erratic behavior.

edited for spelling