### PR TITLE
Adjusting autostart for DR to run dependency appropriately

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -101,6 +101,9 @@ if XMLData.game =~ /^DR/
       sleep 0.1
       retry
     end
+  else
+    Script.start('dependency')
+    sleep 1
   end
 end
 
@@ -116,9 +119,7 @@ if script.vars.empty?
     if script_list.class == Array
       if run_info == false
         # Run infomon
-        if XMLData.game =~ /^DR/
-          Script.start("drinfomon") if Script.exists?("drinfomon")
-        else
+        unless XMLData.game =~ /^DR/
           Script.start("infomon")
         end
         run_info = true


### PR DESCRIPTION
This change adds dependency start into autostart ahead of processing any other scripts, and does not start drinfomon - drinfomon is initiated by dependency.

Solves
1) dependency only starts on initial run
2) drinfomon tries to start before dependency is active
3) drinfomon would fail because dependency already starts it