### PR TITLE
Removing drinfomon from starting in autostart

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -121,9 +121,7 @@ if script.vars.empty?
         # Run infomon
         unless XMLData.game =~ /^DR/
           Script.start("infomon")
-	else
-	  Start.script("drinfomon")  
-        end
+	end
         run_info = true
         sleep 0.5
       end


### PR DESCRIPTION
DR has the feature where drinfomon dynamically loads when required, so loading it in autostart is unnecessary.