### PR TITLE
[scripts] [autostart] Skip dependency in autostarts, and instructions on how to remove it.

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -138,7 +138,7 @@ if script.vars.empty?
         if script_info[:name] == 'infomon' || script_info[:name] == 'repository'
           next
         elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
-          respond "\n--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with ';autostart remove --global dependency'"
+          respond "\n--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with '#{$clean_lich_char}autostart remove --global dependency'"
           temp_script_list = Settings['scripts']
           if (temp_script_list.class == Array) and (temp_script_info = temp_script_list.find { |s| s[:name] == script_info[:name] })
             temp_script_list.delete(temp_script_info)

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -138,7 +138,19 @@ if script.vars.empty?
         if script_info[:name] == 'infomon' || script_info[:name] == 'repository'
           next
         elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
-          respond "\n--- dependency found in autostart list. It can be removed from here, as it's no longer used. It can be safely removed with ';autostart remove --global dependency'"
+          respond "\n--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with ';autostart remove --global dependency'"
+          temp_script_list = Settings['scripts']
+          if (temp_script_list.class == Array) and (temp_script_info = temp_script_list.find { |s| s[:name] == script_info[:name] })
+            temp_script_list.delete(temp_script_info)
+            Settings['scripts'] = temp_script_list
+            respond "\n--- #{script_info[:name]} was removed from the global autostart list\n\n"
+          end
+          temp_script_list = CharSettings['scripts']
+          if (temp_script_list.class == Array) and (temp_script_info = temp_script_list.find { |s| s[:name] == script_info[:name] })
+            temp_script_list.delete(temp_script_info)
+            CharSettings['scripts'] = temp_script_list
+            respond "\n--- #{script_info[:name]} was removed from #{XMLData.name}'s autostart list\n\n"
+          end
           next
         else
           Script.start(script_info[:name], :args => script_info[:args])

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -138,7 +138,7 @@ if script.vars.empty?
         if script_info[:name] == 'infomon' || script_info[:name] == 'repository'
           next
         elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
-          respond "\n--- dependency found in autostart list. It can be removed from here, as it's no longer used.\n\n---"
+          respond "\n--- dependency found in autostart list. It can be removed from here, as it's no longer used. It can be safely removed with ';autostart remove --global dependency'"
           next
         else
           Script.start(script_info[:name], :args => script_info[:args])

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.54
+       version: 0.55
       required: Lich >= 4.6.58
 
   changelog:
+    0.55 (2022-03-23):
+      Adding check for dependency, with note.
     0.54 (2022-03-15):
       Added logic to welcome Dragonrealms.
       DragonRealms/GemstoneIV infomon detection
@@ -134,6 +136,9 @@ if script.vars.empty?
       # Loop through list
       for script_info in script_list
         if script_info[:name] == 'infomon' || script_info[:name] == 'repository'
+          next
+        elsif script_info[:name] == 'dependency' && XMLData.game =~ /^DR/
+          respond "\n--- dependency found in autostart list. It can be removed from here, as it's no longer used.\n\n---"
           next
         else
           Script.start(script_info[:name], :args => script_info[:args])


### PR DESCRIPTION
Simple as anything. Just skips dependency if it's additionally listed as an autostart script, and prints a note on how to remove it from the autostart liss.

```
--- dependency found in autostart list. Attempting to remove it now. If unsuccessful, it can be safely removed with ';autostart remove --global dependency'                                                                                   
                                                                                                                                                                                                                                              
--- dependency was removed from the global autostart list         
```