### PR TITLE
Update go2.lic

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -9,10 +9,12 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.31
+           version: 1.32
           required: Lich >= 4.6.14
 
    changelog:
+      1.32 (2022-03-22):
+        For DR: add support for yaml-based map stringproc overrides
       1.31 (2022-03-10):
         Merged in DR changes from v1.22f by Sarvatt
       1.30 (2022-03-03):
@@ -160,6 +162,30 @@ show_help = proc {
    output.concat "\n"
    respond output
 }
+
+# For Dragonrealms only
+# A change in behavior from Lich4 to Lich5 caused certain ;go2 map wayto movements to fail.
+# This is because of the way the map stringprocs are structured, and the method used to evaluate
+# certain map moves, which involved an arguably dubious overloading of FalseClass on Lich4.
+# The transition to Lich5 makes it necessary to fix some stringprocs as an interim solution, at
+# least until the map can be divested from current owner control and handled appropriately. This code
+# also allows the flexibility to pull custom map wayto overrides from the standard yaml hierarchy.
+if XMLData.game =~ /^DR/
+  # Get yaml settings
+  settings = get_settings
+
+  # Get base and personal wayto overrides
+  base_wayto_overrides = settings.base_wayto_overrides
+  personal_wayto_overrides = settings.personal_wayto_overrides
+
+  # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
+  wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
+
+  # Iterate through the aggregated map wayto overrides from above and set new stringprocs
+  wayto_overrides.each do | key, values |
+    Map.list[values['start_room'].to_i].wayto["#{values['end_room']}"] = StringProc.new("#{values['str_proc']}")
+  end
+end
 
 change_map_vaalor_shortcut = proc { |use_shortcut|
    unless Map.list.any? { |room| room.timeto.any? { |adj_id,time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }


### PR DESCRIPTION
v1.32
For DR: add support for yaml-based map stringproc overrides
provided by @asechrest from https://github.com/elanthia-online/scripts/pull/634