### PR TITLE
[lich.rbw] Clean lich char comma or semi-colon

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -7569,13 +7569,6 @@ main_thread = Thread.new {
 
   listener = timeout_thr = nil
 
-=begin
-########
-#
-# Removing as no longer necessary
-#
-########
-
   # 
   # drop superuser privileges
   # OSXLich-Doug - this section causes problems on too many systems.
@@ -7600,7 +7593,6 @@ main_thread = Thread.new {
        end
     end
   end
-=end
       
   # backward compatibility
   if $frontend =~ /^(?:wizard|avalon)$/

--- a/lich.rbw
+++ b/lich.rbw
@@ -7125,8 +7125,6 @@ main_thread = Thread.new {
   $SEND_CHARACTER = '>'
   $cmd_prefix = '<c>'
   $clean_lich_char = $frontend == 'genie' ? ',' : ';'
-  # for backwards compatibility, we keep $lich_char defined and matching
-  # since since scripts expect this to be the case.
   $lich_char = Regexp.escape($clean_lich_char)
   $lich_char_regex = Regexp.union(',', ';')
 

--- a/lich.rbw
+++ b/lich.rbw
@@ -7131,7 +7131,7 @@ main_thread = Thread.new {
     $clean_lich_char = ';'
     $clean_lich_char_alt = ','
   end
-  $lich_char = Regexp.union(Regexp.escape($clean_lich_char), Regexp.escape($clean_lich_char_alt))
+  $lich_char = Regexp.union($clean_lich_char, $clean_lich_char_alt)
 
 
   @launch_data = nil

--- a/lich.rbw
+++ b/lich.rbw
@@ -3930,7 +3930,7 @@ def do_client(client_string)
   #   Buffer.update(client_string, Buffer::UPSTREAM_MOD)
   return nil if client_string.nil?
 
-  if client_string =~ /^(?:<c>)?#{$lich_cmd_char}(.+)$/
+  if client_string =~ /^(?:<c>)?#{$lich_cmd_char_regex}(.+)$/
     cmd = $1
     if cmd =~ /^k$|^kill$|^stop$/
       if Script.running.empty?
@@ -7131,8 +7131,10 @@ main_thread = Thread.new {
     $clean_lich_char = ';'
     $clean_lich_char_alt = ','
   end
+  # for backwards compatibility, we keep $lich_char defined and matching
+  # since since scripts expect this to be the case.
   $lich_char = $clean_lich_char
-  $lich_cmd_char = Regexp.union($clean_lich_char, $clean_lich_char_alt)
+  $lich_cmd_char_regex = Regexp.union($clean_lich_char, $clean_lich_char_alt)
 
   @launch_data = nil
   require_relative("./lib/eaccess.rb")

--- a/lich.rbw
+++ b/lich.rbw
@@ -3930,7 +3930,7 @@ def do_client(client_string)
   #   Buffer.update(client_string, Buffer::UPSTREAM_MOD)
   return nil if client_string.nil?
 
-  if client_string =~ /^(?:<c>)?#{$lich_cmd_char_regex}(.+)$/
+  if client_string =~ /^(?:<c>)?#{$lich_char_regex}(.+)$/
     cmd = $1
     if cmd =~ /^k$|^kill$|^stop$/
       if Script.running.empty?
@@ -7134,7 +7134,7 @@ main_thread = Thread.new {
   # for backwards compatibility, we keep $lich_char defined and matching
   # since since scripts expect this to be the case.
   $lich_char = $clean_lich_char
-  $lich_cmd_char_regex = Regexp.union($clean_lich_char, $clean_lich_char_alt)
+  $lich_char_regex = Regexp.union($clean_lich_char, $clean_lich_char_alt)
 
   @launch_data = nil
   require_relative("./lib/eaccess.rb")

--- a/lich.rbw
+++ b/lich.rbw
@@ -7124,8 +7124,15 @@ main_thread = Thread.new {
   test_mode = false
   $SEND_CHARACTER = '>'
   $cmd_prefix = '<c>'
-  $clean_lich_char = $frontend == 'genie' ? ',' : ';'
-  $lich_char = Regexp.escape($clean_lich_char)
+  if $frontend == 'genie'
+    $clean_lich_char = ','
+    $clean_lich_char_alt = ';'
+  else
+    $clean_lich_char = ';'
+    $clean_lich_char_alt = ','
+  end
+  $lich_char = Regexp.union(Regexp.escape($clean_lich_char), Regexp.escape($clean_lich_char_alt))
+
 
   @launch_data = nil
   require_relative("./lib/eaccess.rb")
@@ -7562,6 +7569,13 @@ main_thread = Thread.new {
 
   listener = timeout_thr = nil
 
+=begin
+########
+#
+# Removing as no longer necessary
+#
+########
+
   # 
   # drop superuser privileges
   # OSXLich-Doug - this section causes problems on too many systems.
@@ -7586,6 +7600,7 @@ main_thread = Thread.new {
        end
     end
   end
+=end
       
   # backward compatibility
   if $frontend =~ /^(?:wizard|avalon)$/

--- a/lich.rbw
+++ b/lich.rbw
@@ -7127,7 +7127,7 @@ main_thread = Thread.new {
   $clean_lich_char = $frontend == 'genie' ? ',' : ';'
   # for backwards compatibility, we keep $lich_char defined and matching
   # since since scripts expect this to be the case.
-  $lich_char = $clean_lich_char
+  $lich_char = Regexp.escape($clean_lich_char)
   $lich_char_regex = Regexp.union(',', ';')
 
   @launch_data = nil

--- a/lich.rbw
+++ b/lich.rbw
@@ -3930,7 +3930,7 @@ def do_client(client_string)
   #   Buffer.update(client_string, Buffer::UPSTREAM_MOD)
   return nil if client_string.nil?
 
-  if client_string =~ /^(?:<c>)?#{$lich_cmd}(.+)$/
+  if client_string =~ /^(?:<c>)?#{$lich_cmd_char}(.+)$/
     cmd = $1
     if cmd =~ /^k$|^kill$|^stop$/
       if Script.running.empty?
@@ -7132,7 +7132,7 @@ main_thread = Thread.new {
     $clean_lich_char_alt = ','
   end
   $lich_char = $clean_lich_char
-  $lich_cmd = Regexp.union($clean_lich_char, $clean_lich_char_alt)
+  $lich_cmd_char = Regexp.union($clean_lich_char, $clean_lich_char_alt)
 
   @launch_data = nil
   require_relative("./lib/eaccess.rb")

--- a/lich.rbw
+++ b/lich.rbw
@@ -7124,17 +7124,11 @@ main_thread = Thread.new {
   test_mode = false
   $SEND_CHARACTER = '>'
   $cmd_prefix = '<c>'
-  if $frontend == 'genie'
-    $clean_lich_char = ','
-    $clean_lich_char_alt = ';'
-  else
-    $clean_lich_char = ';'
-    $clean_lich_char_alt = ','
-  end
+  $clean_lich_char = $frontend == 'genie' ? ',' : ';'
   # for backwards compatibility, we keep $lich_char defined and matching
   # since since scripts expect this to be the case.
   $lich_char = $clean_lich_char
-  $lich_char_regex = Regexp.union($clean_lich_char, $clean_lich_char_alt)
+  $lich_char_regex = Regexp.union(',', ';')
 
   @launch_data = nil
   require_relative("./lib/eaccess.rb")

--- a/lich.rbw
+++ b/lich.rbw
@@ -3930,7 +3930,7 @@ def do_client(client_string)
   #   Buffer.update(client_string, Buffer::UPSTREAM_MOD)
   return nil if client_string.nil?
 
-  if client_string =~ /^(?:<c>)?#{$lich_char}(.+)$/
+  if client_string =~ /^(?:<c>)?#{$lich_cmd}(.+)$/
     cmd = $1
     if cmd =~ /^k$|^kill$|^stop$/
       if Script.running.empty?
@@ -7131,8 +7131,8 @@ main_thread = Thread.new {
     $clean_lich_char = ';'
     $clean_lich_char_alt = ','
   end
-  $lich_char = Regexp.union($clean_lich_char, $clean_lich_char_alt)
-
+  $lich_char = $clean_lich_char
+  $lich_cmd = Regexp.union($clean_lich_char, $clean_lich_char_alt)
 
   @launch_data = nil
   require_relative("./lib/eaccess.rb")


### PR DESCRIPTION
Allows usage of a comma, or the semi-colon as the lich char. In the past, Genie couldn't handle semi-colons, but that's no longer the case.

I don't believe adding the comma as a second command character breaks anything...