### PR TITLE
[scripts] [go2] Move from using lich_char to using clean_lich_char

### DIFF
--- a/scripts/go2.lic
+++ b/scripts/go2.lic
@@ -97,10 +97,10 @@ CharSettings['stop for dead']    = false if CharSettings['stop for dead'].nil?
 
 show_help = proc {
    output = "\n"
-   output.concat "   #{$lich_char}#{script.name} <target>                Takes you where you want to go using your saved options.\n"
-   output.concat "   #{$lich_char}#{script.name} <options> <target>      Takes you where you want to go, using the given options\n"
-   output.concat "   #{''.rjust($lich_char.length + script.name.length)}                          instead of your saved options.\n"
-   output.concat "   #{$lich_char}#{script.name} <options>               Saves the given options.\n"
+   output.concat "   #{$clean_lich_char}#{script.name} <target>                Takes you where you want to go using your saved options.\n"
+   output.concat "   #{$clean_lich_char}#{script.name} <options> <target>      Takes you where you want to go, using the given options\n"
+   output.concat "   #{''.rjust($clean_lich_char.length + script.name.length)}                          instead of your saved options.\n"
+   output.concat "   #{$clean_lich_char}#{script.name} <options>               Saves the given options.\n"
    output.concat "\n"
    output.concat "   target:\n"
    output.concat "\n"
@@ -152,11 +152,11 @@ show_help = proc {
    output.concat "\n"
    output.concat "   other commands:\n"
    output.concat "\n"
-   output.concat "      #{$lich_char}#{script.name} save <new name>=<target>      Saves a custom target.  <target> can be the same\n"
-   output.concat "      #{''.rjust($lich_char.length + script.name.length)}                                as before, or \"current\" for your current room\n"
-   output.concat "      #{$lich_char}#{script.name} delete <custom target>        Deletes a saved custom target.\n"
-   output.concat "      #{$lich_char}#{script.name} list                          Shows your settings and custom targets.\n"
-   output.concat "      #{$lich_char}#{script.name} targets                       Shows the built-in targets.\n"
+   output.concat "      #{$clean_lich_char}#{script.name} save <new name>=<target>      Saves a custom target.  <target> can be the same\n"
+   output.concat "      #{''.rjust($clean_lich_char.length + script.name.length)}                                as before, or \"current\" for your current room\n"
+   output.concat "      #{$clean_lich_char}#{script.name} delete <custom target>        Deletes a saved custom target.\n"
+   output.concat "      #{$clean_lich_char}#{script.name} list                          Shows your settings and custom targets.\n"
+   output.concat "      #{$clean_lich_char}#{script.name} targets                       Shows the built-in targets.\n"
    output.concat "\n"
    respond output
 }


### PR DESCRIPTION
In a world where `$lich_char` and `$clean_lich_char` are the same value, they can be used interchangeably. That isn't true if we want to support more than one `$lich_char` that's, I think, the original intent of separating the two. Anytime we want to reference/display the lich command character, use `$clean_lich_char` like this, and no issues arise. 