### PR TITLE
[lich.rbw] Moving map-related require-relatives to accomodate Genie, and other direct-connect clients

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -7011,6 +7011,7 @@ if arg = ARGV.find { |a| (a == '-g') or (a == '--game') }
     $frontend = 'unknown'
   end
 elsif ARGV.include?('--gemstone')
+  require_relative("./lib/map_gs.rb")
   if ARGV.include?('--platinum')
     $platinum = true
     if ARGV.any? { |arg| (arg == '-s') or (arg == '--stormfront') }
@@ -7075,6 +7076,7 @@ elsif ARGV.include?('--fallen')
     exit
   end
 elsif ARGV.include?('--dragonrealms')
+  require_relative("./lib/map_dr.rb")
   if ARGV.include?('--platinum')
     $platinum = true
     if ARGV.any? { |arg| (arg == '-s') or (arg == '--stormfront') }
@@ -7243,10 +7245,8 @@ main_thread = Thread.new {
   if @launch_data
     if @launch_data.find { |opt| opt =~ /GAMECODE=DR/ }
       gamecodeshort = "DR"
-      require_relative("./lib/map_dr.rb")
     else
       gamecodeshort = "GS"
-      require_relative("./lib/map_gs.rb")
     end
     unless gamecode = @launch_data.find { |line| line =~ /GAMECODE=/ }
       $stdout.puts "error: launch_data contains no GAMECODE info"

--- a/lich.rbw
+++ b/lich.rbw
@@ -7081,7 +7081,6 @@ elsif ARGV.include?('--fallen')
     exit
   end
 elsif ARGV.include?('--dragonrealms')
-  require_relative("./lib/map_dr.rb")
   if ARGV.include?('--platinum')
     $platinum = true
     if ARGV.any? { |arg| (arg == '-s') or (arg == '--stormfront') }

--- a/lich.rbw
+++ b/lich.rbw
@@ -6996,6 +6996,12 @@ if argv_options[:sal]
   end
 end
 
+if ARGV.include?('--gemstone') || ARGV.include?('--shattered') || 
+  require_relative("./lib/map_gs.rb")
+elsif ARGV.include?('--dragonrealms') || ARGV.include?('--fallen') || 
+  require_relative("./lib/map_dr.rb")
+end
+
 if arg = ARGV.find { |a| (a == '-g') or (a == '--game') }
   game_host, game_port = ARGV[ARGV.index(arg) + 1].split(':')
   game_port = game_port.to_i
@@ -7011,7 +7017,6 @@ if arg = ARGV.find { |a| (a == '-g') or (a == '--game') }
     $frontend = 'unknown'
   end
 elsif ARGV.include?('--gemstone')
-  require_relative("./lib/map_gs.rb")
   if ARGV.include?('--platinum')
     $platinum = true
     if ARGV.any? { |arg| (arg == '-s') or (arg == '--stormfront') }
@@ -7242,11 +7247,13 @@ main_thread = Thread.new {
     end
   end
 
-  if @launch_data
+  if @launch_data && (!@launch_data.nil? || !@launch_data.empty?)
     if @launch_data.find { |opt| opt =~ /GAMECODE=DR/ }
       gamecodeshort = "DR"
+      require_relative("./lib/map_dr.rb")
     else
       gamecodeshort = "GS"
+      require_relative("./lib/map_gs.rb")
     end
     unless gamecode = @launch_data.find { |line| line =~ /GAMECODE=/ }
       $stdout.puts "error: launch_data contains no GAMECODE info"

--- a/lich.rbw
+++ b/lich.rbw
@@ -6996,9 +6996,9 @@ if argv_options[:sal]
   end
 end
 
-if ARGV.include?('--gemstone') || ARGV.include?('--shattered') || 
+if ARGV.include?('--gemstone') || ARGV.include?('--shattered')
   require_relative("./lib/map_gs.rb")
-elsif ARGV.include?('--dragonrealms') || ARGV.include?('--fallen') || 
+elsif ARGV.include?('--dragonrealms') || ARGV.include?('--fallen')
   require_relative("./lib/map_dr.rb")
 end
 

--- a/lich.rbw
+++ b/lich.rbw
@@ -6996,12 +6996,6 @@ if argv_options[:sal]
   end
 end
 
-if ARGV.include?('--gemstone') || ARGV.include?('--shattered')
-  require_relative("./lib/map_gs.rb")
-elsif ARGV.include?('--dragonrealms') || ARGV.include?('--fallen')
-  require_relative("./lib/map_dr.rb")
-end
-
 if arg = ARGV.find { |a| (a == '-g') or (a == '--game') }
   game_host, game_port = ARGV[ARGV.index(arg) + 1].split(':')
   game_port = game_port.to_i
@@ -7134,6 +7128,15 @@ main_thread = Thread.new {
   $lich_char = Regexp.escape($clean_lich_char)
 
   @launch_data = nil
+  if (@launch_data||{}).find { |opt| opt =~ /GAMECODE=DR/ } || ARGV.include?('--dragonrealms') || ARGV.include?('--fallen')
+    gamecodeshort = "DR"
+    require_relative("./lib/map_dr.rb")
+  elsif ARGV.include?('--gemstone') || ARGV.include?('--shattered') || (@launch_data && !@launch_data.empty?)
+    gamecodeshort = "GS"
+    require_relative("./lib/map_gs.rb")
+  else
+    raise error
+  end
   require_relative("./lib/eaccess.rb")
 
   if ARGV.include?('--login')
@@ -7246,14 +7249,7 @@ main_thread = Thread.new {
     end
   end
 
-  if @launch_data && (!@launch_data.nil? || !@launch_data.empty?)
-    if @launch_data.find { |opt| opt =~ /GAMECODE=DR/ }
-      gamecodeshort = "DR"
-      require_relative("./lib/map_dr.rb")
-    else
-      gamecodeshort = "GS"
-      require_relative("./lib/map_gs.rb")
-    end
+  if @launch_data && !@launch_data.empty?
     unless gamecode = @launch_data.find { |line| line =~ /GAMECODE=/ }
       $stdout.puts "error: launch_data contains no GAMECODE info"
       Lich.log "error: launch_data contains no GAMECODE info"

--- a/lich.rbw
+++ b/lich.rbw
@@ -7135,7 +7135,7 @@ main_thread = Thread.new {
     gamecodeshort = "GS"
     require_relative("./lib/map_gs.rb")
   else
-    raise error
+    echo "Could not determine game instance. Please report this as a bug."
   end
   require_relative("./lib/eaccess.rb")
 


### PR DESCRIPTION
Tested, no regressions. Gets rid of the problem where we don't detect the game without `--login` or via the launcher.

Note, with this change, lich5 works perfectly well with DR and Genie, using the existing process documented here https://github.com/GenieClient/Genie4/wiki/02.-Connecting-and-Profiles