### PR TITLE
[lib][stash.rb] Fix duration of Stash.add_to_bag

### DIFF
--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -43,7 +43,7 @@ module Lich
     def self.add_to_bag(bag, item)
       bag = container(bag)
       try_or_fail(command: "_drag ##{item.id} ##{bag.id}") do
-        4.times {
+        20.times {
           return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) and bag.contents.to_a.map(&:id).include?(item.id))
           return true if item.name =~ /^ethereal \w+$/ && ![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id)
           sleep 0.1


### PR DESCRIPTION
Presently `Stash.add_to_bag` attempts over 0.4 seconds to detect success in putting an item away without needing to check regex.

Most systems / network connections support a 0.2 to 0.4 second success for this method.  Some players report that after the item is stashed, containers are iterated and an attempt is made to place the item in each container or to prepare a spell.  This is the result of exceeding the 0.4 second threshold in detecting success even though the item is stowed as requested.

This change increases the time to detect success to 2 seconds, matching the `Stash.try_or_fail` method.  Since the `Stash.add_to_bag` method returns immediately on detecting success, this will allow the slower systems / network connections to detect success and process properly without adding blocking `sleep` commands to wait out the resulting success detection.  Most attempts will still succeed in the 0.2 to 0.4 second range, and no change will be noted.  Those players whose systems exceed that threshold should note improved performance and no errors.