### PR TITLE
Emergency blue button to include needed files

### DIFF
--- a/data/update-lich5.json
+++ b/data/update-lich5.json
@@ -2,7 +2,7 @@
   {
     "update_type":"current",
     "version_lich":"5.5.0",
-    "update_libs":["armor.rb", "cman.rb", "constants.rb", "eaccess.rb", "feat.rb", "front-end.rb", "gtk.rb", "gui-login.rb", "gui-manual-login.rb", "gui-saved-login.rb", "init.rb", "lich.rb", "map_dr.rb", "map_gs.rb", "messaging.rb", "shield.rb", "spell.rb", "stash.rb", "util.rb", "version.rb", "weapon.rb", "xmlparser.rb"],
+    "update_libs":["armor.rb", "cman.rb", "constants.rb", "eaccess.rb", "feat.rb", "front-end.rb", "global_defs.rb", "gtk.rb", "gui-login.rb", "gui-manual-login.rb", "gui-saved-login.rb", "init.rb", "lich.rb", "map.rb", "map_dr.rb", "map_gs.rb", "messaging.rb", "shield.rb", "spell.rb", "stash.rb", "update.rb", "util.rb", "version.rb", "weapon.rb", "xmlparser.rb"],
     "update_datas":["spell-list.xml", "gameobj-data.xml"],
     "update_core_scripts":["alias.lic", "autostart.lic", "go2.lic", "infomon.lic", "jinx.lic", "lich5-update.lic", "lnet.lic", "log.lic", "narost.lic", "repository.lic", "vars.lic", "version.lic", "xnarost.lic"],
     "recommend_update_scripts":{},
@@ -22,7 +22,7 @@
   {
     "update_type":"refresh",
     "version_lich":"5.5.0",
-    "update_libs":["armor.rb", "cman.rb", "constants.rb", "eaccess.rb", "feat.rb", "front-end.rb", "gtk.rb", "gui-login.rb", "gui-manual-login.rb", "gui-saved-login.rb", "init.rb", "lich.rb", "map_dr.rb", "map_gs.rb", "messaging.rb", "shield.rb", "spell.rb", "stash.rb", "util.rb", "version.rb", "weapon.rb", "xmlparser.rb"],
+    "update_libs":["armor.rb", "cman.rb", "constants.rb", "eaccess.rb", "feat.rb", "front-end.rb", "global_defs.rb", "gtk.rb", "gui-login.rb", "gui-manual-login.rb", "gui-saved-login.rb", "init.rb", "lich.rb", "map.rb", "map_dr.rb", "map_gs.rb", "messaging.rb", "shield.rb", "spell.rb", "stash.rb", "update.rb", "util.rb", "version.rb", "weapon.rb", "xmlparser.rb"],
     "update_datas":["spell-list.xml", "gameobj-data.xml"],
     "update_core_scripts":["alias.lic", "autostart.lic", "go2.lic", "infomon.lic", "jinx.lic", "lich5-update.lic", "lnet.lic", "log.lic", "narost.lic", "repository.lic", "vars.lic", "version.lic", "xnarost.lic"],
     "recommend_update_scripts":{},
@@ -32,7 +32,7 @@
   {
     "update_type":"snapshot",
     "version_lich":"5.5.0",
-    "update_libs":["armor.rb", "cman.rb", "constants.rb", "eaccess.rb", "feat.rb", "front-end.rb", "gtk.rb", "gui-login.rb", "gui-manual-login.rb", "gui-saved-login.rb", "init.rb", "lich.rb", "map_dr.rb", "map_gs.rb", "messaging.rb", "shield.rb", "spell.rb", "stash.rb", "util.rb", "version.rb", "weapon.rb", "xmlparser.rb"],
+    "update_libs":["armor.rb", "cman.rb", "constants.rb", "eaccess.rb", "feat.rb", "front-end.rb", "global_defs.rb", "gtk.rb", "gui-login.rb", "gui-manual-login.rb", "gui-saved-login.rb", "init.rb", "lich.rb", "map.rb", "map_dr.rb", "map_gs.rb", "messaging.rb", "shield.rb", "spell.rb", "stash.rb", "update.rb", "util.rb", "version.rb", "weapon.rb", "xmlparser.rb"],
     "update_datas":["spell-list.xml", "gameobj-data.xml"],
     "update_core_scripts":["alias.lic", "autostart.lic", "go2.lic", "infomon.lic", "jinx.lic", "lich5-update.lic", "lnet.lic", "log.lic", "narost.lic", "repository.lic", "vars.lic", "version.lic", "xnarost.lic"],
     "recommend_update_scripts":{},


### PR DESCRIPTION
The old 5.5.0 spec didn't have update.rb, global_defs.rb and updated map.rb - these are added while we're preparing the 5.6 transition.