### PR TITLE
Adding boolean calls and gui fixes back

### DIFF
--- a/lib/gui-login.rb
+++ b/lib/gui-login.rb
@@ -10,7 +10,7 @@ def gui_login
   if File.exists?("#{DATA_DIR}/entry.dat")
     @entry_data = File.open("#{DATA_DIR}/entry.dat", 'r') { |file|
       begin
-        if @autosort_state == 'on'
+        if @autosort_state == true
         # Sort in list by instance name, account name, and then character name
         Marshal.load(file.read.unpack('m').first).sort do |a, b|
           [a[:game_name], a[:user_id], a[:char_name]] <=> [b[:game_name], b[:user_id], b[:char_name]]
@@ -52,9 +52,9 @@ def gui_login
     #
     # put it together and show the window
     #
-    silver = Gdk::RGBA::parse("#d3d3d3")
+    lightgrey = Gdk::RGBA::parse("#d3d3d3")
     @notebook = Gtk::Notebook.new
-    @notebook.override_background_color(:normal, silver) if @theme_state == 'off'
+    @notebook.override_background_color(:normal, lightgrey) unless @theme_state == true
     @notebook.append_page(@quick_game_entry_tab, Gtk::Label.new('Saved Entry'))
     @notebook.append_page(@game_entry_tab, Gtk::Label.new('Manual Entry'))
 

--- a/lib/gui-saved-login.rb
+++ b/lib/gui-saved-login.rb
@@ -4,7 +4,7 @@
 # this file is intended to load as part of the loginGUI Gtk queue block method
 # it is a sequential stream presently, so do not (yet) modify to class / module
 
-Gtk::Settings.default.gtk_application_prefer_dark_theme = true if @theme_state == 'on'
+Gtk::Settings.default.gtk_application_prefer_dark_theme = true if @theme_state == true
 
 if @entry_data.empty?
   box = Gtk::Box.new(:horizontal)
@@ -16,13 +16,13 @@ else
   last_user_id = nil
   account_array = []
 
-  if @tab_layout_state == 'on'
+  if @tab_layout_state == true
 
     @account_book = Gtk::Notebook.new
     @account_book.set_tab_pos(:left)
     @account_book.show_border = true
 
-    if @theme_state != 'on'
+    unless @theme_state == true
       lightgrey = Gdk::RGBA::parse("#d3d3d3")
       @account_book.override_background_color(:normal, lightgrey)
 
@@ -89,7 +89,7 @@ else
 
         @remove_button.style_context.add_provider(@button_provider, Gtk::StyleProvider::PRIORITY_USER)
         @play_button.style_context.add_provider(@button_provider, Gtk::StyleProvider::PRIORITY_USER)
-        @account_book.style_context.add_provider(@tab_provider, Gtk::StyleProvider::PRIORITY_USER) if @theme_state != 'on'
+        @account_book.style_context.add_provider(@tab_provider, Gtk::StyleProvider::PRIORITY_USER) unless @theme_state == true
 
         char_box = Gtk::Box.new(:horizontal)
         char_box.pack_end(@remove_button, :expand => true, :fill => false, :padding => 0)
@@ -335,9 +335,9 @@ else
     theme_select_label = Gtk::Label.new('Dark Theme')
     tab_select_label = Gtk::Label.new('Tab Layout')
     sort_select_label = Gtk::Label.new(' AutoSort   ')
-    theme_select.set_active(true) if @theme_state == 'on'
-    tab_select.set_active(true) if @tab_layout_state == 'on'
-    sort_select.set_active(true) if @autosort_state == 'on'
+    theme_select.set_active(true) if @theme_state == true
+    tab_select.set_active(true) if @tab_layout_state == true
+    sort_select.set_active(true) if @autosort_state == true
 
     @slider_box.pack_start(theme_select, :expand => true, :fill => false, :padding => 0)
     @slider_box.pack_start(theme_select_label, :expand => true, :fill => false, :padding => 0)
@@ -358,41 +358,28 @@ else
     }
 
     theme_select.signal_connect('notify::active') { |s|
-      @theme_state = theme_select.active? ? 'on' : 'off'
-      if @theme_state == 'on'
+      if theme_select.active?
         Gtk::Settings.default.gtk_application_prefer_dark_theme = true
         @play_button.style_context.remove_provider(@button_provider) if defined?(@button_provider)
         @account_book.style_context.remove_provider(@tab_provider) if defined?(@tab_provider)
         @account_book.override_background_color(:normal, Gdk::RGBA::parse("rgba(0,0,0,0)"))
         @notebook.override_background_color(:normal, Gdk::RGBA::parse("rgba(0,0,0,0)"))
-        Lich.track_dark_mode = 'on'
+        Lich.track_dark_mode = true
       else
         Gtk::Settings.default.gtk_application_prefer_dark_theme = false
         lightgrey = Gdk::RGBA::parse("#d3d3d3")
         @account_book.override_background_color(:normal, lightgrey)
         @notebook.override_background_color(:normal, lightgrey)
-        Lich.track_dark_mode = 'off'
+        Lich.track_dark_mode = false
       end
     }
 
     tab_select.signal_connect('notify::active') { |s|
-      @tab_layout_state = tab_select.active? ? 'on' : 'off'
-      if @tab_layout_state == 'on'
-        Lich.track_layout_state = 'on'
-      else
-        Lich.track_layout_state = 'off'
-      end
-
+      Lich.track_layout_state = tab_select.active? ? true : false
     }
 
     sort_select.signal_connect('notify::active') { |s|
-      @autosort_state = sort_select.active? ? 'on' : 'off'
-      if @autosort_state == 'on'
-        Lich.track_autosort_state = 'on'
-      else
-        Lich.track_autosort_state = 'off'
-      end
-
+      Lich.track_autosort_state = sort_select.active? ? true : false
     }
 
 end #if

--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -1,7 +1,14 @@
 module Lich
-  @@hosts_file = nil
-  @@lich_db    = nil
+  @@hosts_file           = nil
+  @@lich_db              = nil
   @@last_warn_deprecated = 0
+
+  # settings
+  @@display_lichid       = nil # boolean
+  @@display_uid          = nil # boolean
+  @@track_autosort_state = nil # boolean
+  @@track_dark_mode      = nil # boolean
+  @@track_layout_state   = nil # boolean
 
   def Lich.method_missing(arg1, arg2 = '')
     if (Time.now.to_i - @@last_warn_deprecated) > 300
@@ -566,124 +573,150 @@ module Lich
 
 # new feature GUI / internal settings states
 
-  def Lich.track_autosort_state
+  def Lich.debug_messaging
+    if @@debug_messaging.nil?
     begin
-      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_autosort_state';")
+        val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='debug_messaging';")
     rescue SQLite3::BusyException
       sleep 0.1
       retry
     end
-    val
+      @@debug_messaging = (val.to_s =~ /on|true|yes/ ? true : false)
+      Lich.debug_messaging = @@debug_messaging
+  end
+    return @@debug_messaging
   end
 
-  def Lich.track_autosort_state=(val)
+  def Lich.debug_messaging=(val)
+    @@debug_messaging = (val.to_s =~ /on|true|yes/ ? true : false)
     begin
-      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_autosort_state',?);", val.to_s.encode('UTF-8'))
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('debug_messaging',?);", @@debug_messaging.to_s.encode('UTF-8'))
     rescue SQLite3::BusyException
       sleep 0.1
       retry
     end
-    nil
-  end
-
-  def Lich.track_layout_state
-    begin
-      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_layout_state';")
-    rescue SQLite3::BusyException
-      sleep 0.1
-      retry
-    end
-    val
-  end
-
-  def Lich.track_layout_state=(val)
-    begin
-      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_layout_state',?);", val.to_s.encode('UTF-8'))
-    rescue SQLite3::BusyException
-      sleep 0.1
-      retry
-    end
-    nil
-  end
-
-  def Lich.track_dark_mode
-    begin
-      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_dark_mode';")
-    rescue SQLite3::BusyException
-      sleep 0.1
-      retry
-    end
-    val
-  end
-
-  def Lich.track_dark_mode=(val)
-    begin
-      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_dark_mode',?);", val.to_s.encode('UTF-8'))
-    rescue SQLite3::BusyException
-      sleep 0.1
-      retry
-    end
-    nil
+    return nil
   end
 
   def Lich.display_lichid
+    if @@display_lichid.nil?
     begin
-      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_lichid';")
+        val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_lichid';")
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+      val = (XMLData.game =~ /^GS/ ? true : false) if val.nil? and XMLData.game != ""; # default false if DR, otherwise default true
+      @@display_lichid = (val.to_s =~ /on|true|yes/ ? true : false) if !val.nil?;
+  end
+    return @@display_lichid
+  end
+
+  def Lich.display_lichid=(val)
+    @@display_lichid = (val.to_s =~ /on|true|yes/ ? true : false)
+    begin
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_lichid',?);", @@display_lichid.to_s.encode('UTF-8'))
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+    return nil
+  end
+
+  def Lich.display_uid
+    if @@display_uid.nil?
+    begin
+        val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_uid';")
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+      val = (XMLData.game =~ /^GS/ ? true : false) if val.nil? and XMLData.game != ""; # default false if DR, otherwise default true
+      @@display_uid = (val.to_s =~ /on|true|yes/ ? true : false) if !val.nil?;
+  end
+    return @@display_uid
+  end
+
+  def Lich.display_uid=(val)
+    @@display_uid = (val.to_s =~ /on|true|yes/ ? true : false)
+    begin
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_uid',?);", @@display_uid.to_s.encode('UTF-8'))
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+    return nil
+  end
+
+  def Lich.track_autosort_state
+    if @@track_autosort_state.nil?
+    begin
+        val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_autosort_state';")
     rescue SQLite3::BusyException
       sleep 0.1
       retry
 end
-    val
+      @@track_autosort_state = (val.to_s =~ /on|true|yes/ ? true : false)
+  end
+    return @@track_autosort_state
   end
 
-  def Lich.display_lichid=(val)
+  def Lich.track_autosort_state=(val)
+    @@track_autosort_state = (val.to_s =~ /on|true|yes/ ? true : false)
     begin
-      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_lichid',?);", val.to_s.encode('UTF-8'))
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_autosort_state',?);", @@track_autosort_state.to_s.encode('UTF-8'))
     rescue SQLite3::BusyException
       sleep 0.1
       retry
     end
-    nil
+    return nil
   end
 
-  def Lich.display_uid
+  def Lich.track_dark_mode
+    if @@track_dark_mode.nil?
     begin
-      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_uid';")
+        val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_dark_mode';")
     rescue SQLite3::BusyException
       sleep 0.1
       retry
     end
-    val
+      @@track_dark_mode = (val.to_s =~ /on|true|yes/ ? true : false)
+  end
+    return @@track_dark_mode
   end
 
-  def Lich.display_uid=(val)
+  def Lich.track_dark_mode=(val)
+    @@track_dark_mode = (val.to_s =~ /on|true|yes/ ? true : false)
     begin
-      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_uid',?);", val.to_s.encode('UTF-8'))
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_dark_mode',?);", @@track_dark_mode.to_s.encode('UTF-8'))
     rescue SQLite3::BusyException
       sleep 0.1
       retry
     end
-    nil
+    return nil
   end
 
-  def Lich.debug_messaging
+  def Lich.track_layout_state
+    if @@track_layout_state.nil?
     begin
-      val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='debug_messaging';")
+        val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_layout_state';")
     rescue SQLite3::BusyException
       sleep 0.1
       retry
     end
-    val
+      @@track_layout_state = (val.to_s =~ /on|true|yes/ ? true : false)
+  end
+    return @@track_layout_state
   end
 
-  def Lich.debug_messaging=(val)
+  def Lich.track_layout_state=(val)
+    @@track_layout_state = (val.to_s =~ /on|true|yes/ ? true : false)
     begin
-      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('debug_messaging',?);", val.to_s.encode('UTF-8'))
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_layout_state',?);", @@track_layout_state.to_s.encode('UTF-8'))
     rescue SQLite3::BusyException
       sleep 0.1
       retry
     end
-    nil
+    return nil
   end
-
 end

--- a/lich.rbw
+++ b/lich.rbw
@@ -2337,17 +2337,15 @@ module Games
 
                 if alt_string = DownstreamHook.run($_SERVERSTRING_)
                   #                           Buffer.update(alt_string, Buffer::DOWNSTREAM_MOD)
-                  if alt_string =~ /<resource picture=.*roomName/
-                    unless XMLData.game =~ /^DR/
-                      if (Lich.display_lichid =~ /on|true|yes/ && Lich.display_uid =~ /on|true|yes/) || (Lich.display_lichid.nil? && Lich.display_uid.nil?) #default on
-                        alt_string.sub!(']') { " - #{Room.current.id}] (u#{XMLData.room_id})" }
-                      elsif Lich.display_lichid =~ /on|true|yes/ || (Lich.display_lichid.nil?) # don't force an entry
-                        alt_string.sub!(']') { " - #{Room.current.id}]" }
-                      elsif Lich.display_uid =~ /on|true|yes/ || (Lich.display_uid.nil?) # don't force an entry
-                        alt_string.sub!(']') { "] (u#{XMLData.room_id})" }
+                  if (Lich.display_lichid == true or Lich.display_uid == true) and XMLData.game =~ /^GS/ and alt_string =~ /<resource picture=.*roomName/
+                    if (Lich.display_lichid == true and Lich.display_uid == true)
+                      alt_string.sub!(']') {" - #{Map.current.id}] (u#{XMLData.room_id})"}
+                    elsif Lich.display_lichid == true
+                      alt_string.sub!(']') {" - #{Map.current.id}]"}
+                    elsif Lich.display_uid == true
+                      alt_string.sub!(']') {"] (u#{XMLData.room_id})"}
                       end
                     end
-                  end
                   if $frontend =~ /^(?:wizard|avalon)$/
                     alt_string = sf_to_wiz(alt_string)
                   end


### PR DESCRIPTION
After resetting staging to master, bringing these two ROWO variable initialization fixes back - 

one on displaying lichid / uid that was calling lich.db3 at room transition / look (and sometimes multiple times), and for each character.   Imagine go2 at full speed, with an army following, all hitting the same local lich.db3 at room transition. 

two is the same change for like lich variables stored in the db3 file - not nearly as beneficial from a performance perspective, but consistency was the goal for that change.

