### PR TITLE
[update.rb] bug in order of options parsing

### DIFF
--- a/lib/update.rb
+++ b/lib/update.rb
@@ -85,15 +85,15 @@ module Lich
         _respond; _respond 'You may also wish to copy your entire Lich5 folder to'
         _respond 'another location for additional safety, after any'
         _respond 'additional requested updates are completed.'
-        snapshot_subdir = "#{BACKUP_DIR}/L5-snapshot-#{Time.now.strftime("%Y-%m-%d-%H-%M-%S")}"
+        snapshot_subdir = File.join(BACKUP_DIR, "L5-snapshot-#{Time.now.strftime("%Y-%m-%d-%H-%M-%S")}")
         unless File.exists?(snapshot_subdir)
           Dir.mkdir(snapshot_subdir)
         end
-        filename = "#{$lich_dir}#{File.basename($PROGRAM_NAME)}"
-        copyfilename = "#{snapshot_subdir}/#{File.basename($PROGRAM_NAME)}"
+        filename = File.join(LICH_DIR, File.basename($PROGRAM_NAME))
+        copyfilename = File.join(snapshot_subdir, File.basename($PROGRAM_NAME))
         File.open(filename, 'rb') { |r| File.open(copyfilename, 'wb') { |w| w.write(r.read) } }
 
-        snapshot_lib_subdir = "#{snapshot_subdir}/lib"
+        snapshot_lib_subdir = File.join(snapshot_subdir, "lib")
         unless File.exists?(snapshot_lib_subdir)
           Dir.mkdir(snapshot_lib_subdir)
         end
@@ -101,12 +101,12 @@ module Lich
 
         snapshot_lib_files = Dir.children(LIB_DIR)
         snapshot_lib_files.each { |file|
-          File.open("#{$lich_dir}/lib/#{file}", 'rb') { |r|
-            File.open("#{snapshot_lib_subdir}/#{file}", 'wb') { |w| w.write(r.read) }
+          File.open(File.join(LICH_DIR, "lib", file), 'rb') { |r|
+            File.open(File.join(snapshot_lib_subdir, file), 'wb') { |w| w.write(r.read) }
           }
         }
 
-        snapshot_script_subdir = "#{snapshot_subdir}/scripts"
+        snapshot_script_subdir = File.join(snapshot_subdir, "scripts")
         unless File.exists?(snapshot_script_subdir)
           Dir.mkdir(snapshot_script_subdir)
         end
@@ -114,9 +114,9 @@ module Lich
         ## we need to find a better way without hving to maintain this list
 
         @snapshot_core_script.each { |file|
-          if File.exist?("#{$lich_dir}/scripts/#{file}")
-            File.open("#{$lich_dir}/scripts/#{file}", 'rb') { |r|
-              File.open("#{snapshot_script_subdir}/#{file}", 'wb') { |w| w.write(r.read) }
+          if File.exist?(File.join(LICH_DIR, "scripts", file))
+            File.open(File.join(LICH_DIR, "scripts", file), 'rb') { |r|
+              File.open(File.join(snapshot_script_subdir, file), 'wb') { |w| w.write(r.read) }
             }
           else
             next
@@ -157,33 +157,33 @@ module Lich
         else
           _respond; _respond "Downloading Lich5 version #{@update_to}"; _respond
           filename = "lich5-#{@update_to}"
-          File.open("#{TEMP_DIR}/#{filename}.zip", "wb") do |file|
+          File.open(File.join(TEMP_DIR, "#{filename}.zip"), "wb") do |file|
             file.write open("#{@zipfile}").read
           end
 
           if defined?(Win32)
-            Dir.chdir("#{TEMP_DIR}")
-            system("tar -xf #{TEMP_DIR}/#{filename}.zip")
+            Dir.chdir(TEMP_DIR)
+            system("tar -xf #{File.join(TEMP_DIR, filename)}.zip")
             sleep 2
             system("move elanthia-online-lich* #{filename}")
             sleep 2
           else
-            finish = spawn "unzip #{TEMP_DIR}/#{filename}.zip -d #{TEMP_DIR}/#{filename}"
+            finish = spawn "unzip #{File.join(TEMP_DIR, filename)}.zip -d #{File.join(TEMP_DIR, filename)}"
           end
           unless defined?(Win32)
             50.times { break unless (Process.waitpid(finish, Process::WNOHANG)).nil?; sleep 0.1 }
 
-            new_target = Dir.children("#{TEMP_DIR}/#{filename}")
-            FileUtils.cp_r("#{TEMP_DIR}/#{filename}/#{new_target[0]}", "#{TEMP_DIR}")
-            FileUtils.remove_dir("#{TEMP_DIR}/#{filename}")
-            FileUtils.mv("#{TEMP_DIR}/#{new_target[0]}", "#{TEMP_DIR}/#{filename}")
+            new_target = Dir.children(File.join(TEMP_DIR, filename))
+            FileUtils.cp_r(File.join(TEMP_DIR, filename, new_target[0]), TEMP_DIR)
+            FileUtils.remove_dir(File.join(TEMP_DIR, filename))
+            FileUtils.mv(File.join(TEMP_DIR, new_target[0]), File.join(TEMP_DIR, filename))
           end
           ## These five lines may be deleted after zipfiles are created with .gitattributes
-          cleanup_dir = Dir.children("#{TEMP_DIR}/#{filename}")
-          FileUtils.remove_dir("#{TEMP_DIR}/#{filename}/lich") if cleanup_dir.include?("lich")
-          FileUtils.rm("#{TEMP_DIR}/#{filename}/netlify.toml") if cleanup_dir.include?("netlify.toml")
-          FileUtils.rm("#{TEMP_DIR}/#{filename}/README.adoc") if cleanup_dir.include?("README.adoc")
-          FileUtils.rm("#{TEMP_DIR}/#{filename}/data/update-lich5.json") if Dir.children("#{TEMP_DIR}/#{filename}/data").include?("update-lich5.json")
+          cleanup_dir = Dir.children(File.join(TEMP_DIR, filename))
+          FileUtils.remove_dir(File.join(TEMP_DIR, filename, "lich")) if cleanup_dir.include?("lich")
+          FileUtils.rm(File.join(TEMP_DIR, filename, "netlify.toml")) if cleanup_dir.include?("netlify.toml")
+          FileUtils.rm(File.join(TEMP_DIR, filename, "README.adoc")) if cleanup_dir.include?("README.adoc")
+          FileUtils.rm(File.join(TEMP_DIR, filename, "data", "update-lich5.json")) if Dir.children(File.join(TEMP_DIR, filename, "data")).include?("update-lich5.json")
 
           _respond; _respond 'Copying updated lich files to their locations.'
 
@@ -201,11 +201,11 @@ module Lich
           ## We do not care about local edits from players to the Lich5 / script location
           ## for CORE scripts (those required to run Lich5 properly)
 
-          core_update = Dir.children("#{TEMP_DIR}/#{filename}/scripts")
+          core_update = Dir.children(File.join(TEMP_DIR, filename, "scripts"))
           core_update.each { |file|
-            File.delete("#{SCRIPT_DIR}/#{file}") if File.exist?("#{SCRIPT_DIR}/#{file}")
-            File.open("#{TEMP_DIR}/#{filename}/scripts/#{file}", 'rb') { |r|
-              File.open("#{SCRIPT_DIR}/#{file}", 'wb') { |w| w.write(r.read) }
+            File.delete(File.join(SCRIPT_DIR, file)) if File.exist?(File.join(SCRIPT_DIR, file))
+            File.open(File.join(TEMP_DIR, filename, "scripts", file), 'rb') { |r|
+              File.open(File.join(SCRIPT_DIR, file), 'wb') { |w| w.write(r.read) }
             }
             _respond "script #{file} has been updated."
           }
@@ -214,14 +214,14 @@ module Lich
           ## specifically gameobj-data.xml and spell-list.xml.
           ## Let's be a little more purposeful and gentle with these two files.
 
-          data_update = Dir.children("#{TEMP_DIR}/#{filename}/data")
+          data_update = Dir.children(File.join(TEMP_DIR, filename, "data"))
           data_update.each { |file|
             transition_filename = "#{file}".sub(".xml", '')
-            newfilename = "#{DATA_DIR}/#{transition_filename}-#{rand(100000000)}.xml"
-            File.open("#{DATA_DIR}/#{file}", 'rb') { |r| File.open(newfilename, 'wb') { |w| w.write(r.read) } }
-            File.delete("#{DATA_DIR}/#{file}") if File.exist?("#{DATA_DIR}/#{file}")
-            File.open("#{TEMP_DIR}/#{filename}/data/#{file}", 'rb') { |r|
-              File.open("#{DATA_DIR}/#{file}", 'wb') { |w| w.write(r.read) }
+            newfilename = File.join(DATA_DIR, "#{transition_filename}-#{Time.now.to_i}.xml")
+            File.open(File.join(DATA_DIR, file), 'rb') { |r| File.open(newfilename, 'wb') { |w| w.write(r.read) } }
+            File.delete(File.join(DATA_DIR, file)) if File.exist?(File.join(DATA_DIR, file))
+            File.open(File.join(TEMP_DIR, filename, "data", file), 'rb') { |r|
+              File.open(File.join(DATA_DIR, file), 'wb') { |w| w.write(r.read) }
             }
             _respond "data #{file} has been updated. The prior version was renamed to #{newfilename}."
           }
@@ -230,18 +230,18 @@ module Lich
           ## not need to save a copy of this in the TEMP_DIR as previously done, since we
           ## took the snapshot at the beginning.
 
-          lich_to_update = "#{LICH_DIR}/#{File.basename($PROGRAM_NAME)}"
-          update_to_lich = "#{TEMP_DIR}/#{filename}/lich.rbw"
+          lich_to_update = File.join(LICH_DIR, File.basename($PROGRAM_NAME))
+          update_to_lich = File.join(TEMP_DIR, filename, "lich.rbw")
           File.open(update_to_lich, 'rb') { |r| File.open(lich_to_update, 'wb') { |w| w.write(r.read) } }
 
           ## And we clen up after ourselves
 
-          FileUtils.remove_dir("#{TEMP_DIR}/#{filename}")   # we know these exist because
-          FileUtils.rm("#{TEMP_DIR}/#{filename}.zip")       # we just processed them
+          FileUtils.remove_dir(File.join(TEMP_DIR, filename))   # we know these exist because
+          FileUtils.rm(File.join(TEMP_DIR, "#{filename}.zip"))       # we just processed them
 
           _respond; _respond "Lich5 has been updated to Lich5 version #{@update_to}"
-          _respond 'You should exit the game, then log back in.  This will start the game'
-          _respond 'with your updated Lich.  Enjoy!'
+          _respond "You should exit the game, then log back in.  This will start the game"
+          _respond "with your updated Lich.  Enjoy!"
         end
       end
 
@@ -251,78 +251,81 @@ module Lich
         ## that can be reinstalled with the lich5-update --update command
 
         _respond; _respond 'Reverting Lich5 to previously installed version.'
-        revert_array = Dir.glob("#{BACKUP_DIR}/*").sort.reverse
+        revert_array = Dir.glob(File.join(BACKUP_DIR, "*")).sort.reverse
         restore_snapshot = revert_array[0]
         if restore_snapshot.empty? or /L5-snapshot/ !~ restore_snapshot
           _respond "No prior Lich5 version found. Seek assistance."
         else
           # delete all lib files
-          FileUtils.rm_f Dir.glob("#{LIB_DIR}/*")
+          FileUtils.rm_f(Dir.glob(File.join(LIB_DIR, "*")))
           # copy all backed up lib files
-          FileUtils.cp_r "#{restore_snapshot}/lib/.", "#{LIB_DIR}"
+          FileUtils.cp_r(File.join(restore_snapshot, "lib", "."), LIB_DIR)
           # delete array of core scripts
           @snapshot_core_script.each { |file|
-            File.delete("#{SCRIPT_DIR}/#{file}") if File.exist?("#{SCRIPT_DIR}/#{file}")
+            File.delete(File.join(SCRIPT_DIR, file)) if File.exist?(File.join(SCRIPT_DIR, file))
           }
           # copy all backed up core scripts (array to save, only array files in backup)
-          FileUtils.cp_r "#{restore_snapshot}/scripts/.", "#{SCRIPT_DIR}"
+          FileUtils.cp_r(File.join(restore_snapshot, "scripts", "."), SCRIPT_DIR)
 
           # skip gameobj-data and spell-list (non-functional logically, previous versions
           # already present and current files may contain local edits)
 
           # update lich.rbw in stream because it is active (we hope)
-          lich_to_update = "#{LICH_DIR}/#{File.basename($PROGRAM_NAME)}"
-          update_to_lich = "#{restore_snapshot}/lich.rbw"
+          lich_to_update = File.join(LICH_DIR, File.basename($PROGRAM_NAME))
+          update_to_lich = File.join(restore_snapshot, "lich.rbw")
           File.open(update_to_lich, 'rb') { |r| File.open(lich_to_update, 'wb') { |w| w.write(r.read) } }
 
           # as a courtesy to the player, remind which version they were rev'd back to
           targetversion = ''
-          targetfile = File.open("#{LIB_DIR}/version.rb").read
+          targetfile = File.open(File.join(LIB_DIR, "version.rb")).read
           targetfile.each_line do |line|
             if line =~ /LICH_VERSION\s+?=\s+?/
               targetversion = line.sub(/LICH_VERSION\s+?=\s+?/, '').sub('"', '')
             end
           end
-          _respond; _respond "Lich5 has been reverted to Lich5 version #{targetversion}"
-          _respond 'You should exit the game, then log back in.  This will start the game'
-          _respond 'with your previous version of Lich.  Enjoy!'
+          _respond
+          _respond "Lich5 has been reverted to Lich5 version #{targetversion}"
+          _respond "You should exit the game, then log back in.  This will start the game"
+          _respond "with your previous version of Lich.  Enjoy!"
         end
       end
 
       def self.update_file(type, rf)
         requested_file = rf
-        requested_file_name = requested_file.sub(/(?:.lic|.rb|.xml|.ui)$/, '')
+        requested_file_name = requested_file.sub(/\.(?:lic|rb|xml|ui)$/, '')
         case type
-        when 'script'
-          location = "#{SCRIPT_DIR}"
+        when "script"
+          location = SCRIPT_DIR
           remote_repo = "https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts"
-          requested_file =~ /.lic$/ ? requested_file_ext = '.lic' : requested_file_ext = "bad extension"
-        when 'library'
-          location = "#{LIB_DIR}"
+          requested_file =~ /\.lic$/ ? requested_file_ext = ".lic" : requested_file_ext = "bad extension"
+        when "library"
+          location = LIB_DIR
           remote_repo = "https://raw.githubusercontent.com/elanthia-online/lich-5/master/lib"
-          requested_file =~ /.rb$/ ? requested_file_ext = '.rb' : requested_file_ext = "bad extension"
-        when 'data'
-          location = "#{DATA_DIR}"
+          requested_file =~ /\.rb$/ ? requested_file_ext = ".rb" : requested_file_ext = "bad extension"
+        when "data"
+          location = DATA_DIR
           remote_repo = "https://raw.githubusercontent.com/elanthia-online/lich-5/master/data"
-          requested_file =~ /((?:.xml$|.ui$))/ ? requested_file_ext = $1.dup : requested_file_ext = "bad extension"
+          requested_file =~ /(\.(?:xml|ui))$/ ? requested_file_ext = $1.dup : requested_file_ext = "bad extension"
         end
-        unless requested_file_ext == 'bad extension'
-          File.delete("#{location}/#{requested_file_name}#{requested_file_ext}") if File.exists?("#{location}/#{requested_file_name}#{requested_file_ext}")
+        unless requested_file_ext == "bad extension"
+          File.delete(File.join(location, requested_file)) if File.exists?(File.join(location, requested_file))
           begin
-            File.open("#{location}/#{requested_file_name}#{requested_file_ext}", "wb") do |file|
-              file.write open("#{remote_repo}/#{requested_file_name}#{requested_file_ext}").read
+            File.open(File.join(location, requested_file), "wb") do |file|
+              file.write open(File.join(remote_repo, requested_file)).read
             end
-            _respond; _respond "#{requested_file} has been updated."
+            _respond
+            _respond "#{requested_file} has been updated."
           rescue
             # we created a garbage file (zero bytes filename) so let's clean it up and inform.
             sleep 1
-            File.delete("#{location}/#{requested_file_name}#{requested_file_ext}") if File.exists?("#{location}/#{requested_file_name}#{requested_file_ext}")
-            _respond; _respond "The filename #{requested_file_name}#{requested_file_ext} is not available via lich5-update."
+            File.delete(File.join(location, requested_file)) if File.exists?(File.join(location, requested_file))
+            _respond; _respond "The filename #{requested_file} is not available via lich5-update."
             _respond "Check the spelling of your requested file, or use ';jinx' to"
             _respond "to download #{requested_file} from another respository."
           end
         else
-          _respond; _respond "The requested file #{requested_file} has an incorrect extension."
+          _respond
+          _respond "The requested file #{requested_file} has an incorrect extension."
           _respond "Valid extensions are '.lic' for scripts, '.rb' for library files,"
           _respond "and '.xml' or '.ui' for data files. Please correct and try again."
         end

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -259,20 +259,20 @@ module Lich
           # delete all lib files
           FileUtils.rm_f Dir.glob("#{LIB_DIR}/*")
           # copy all backed up lib files
-          FileUtils.cp_r "#{BACKUP_DIR}/#{restore_snapshot}/lib/.", "#{LIB_DIR}"
+          FileUtils.cp_r "#{restore_snapshot}/lib/.", "#{LIB_DIR}"
           # delete array of core scripts
           @snapshot_core_script.each { |file|
             File.delete("#{SCRIPT_DIR}/#{file}") if File.exist?("#{SCRIPT_DIR}/#{file}")
           }
           # copy all backed up core scripts (array to save, only array files in backup)
-          FileUtils.cp_r "#{BACKUP_DIR}/#{restore_snapshot}/scripts/.", "#{SCRIPT_DIR}"
+          FileUtils.cp_r "#{restore_snapshot}/scripts/.", "#{SCRIPT_DIR}"
 
           # skip gameobj-data and spell-list (non-functional logically, previous versions
           # already present and current files may contain local edits)
 
           # update lich.rbw in stream because it is active (we hope)
           lich_to_update = "#{LICH_DIR}/#{File.basename($PROGRAM_NAME)}"
-          update_to_lich = "#{BACKUP_DIR}/#{restore_snapshot}/lich.rbw"
+          update_to_lich = "#{restore_snapshot}/lich.rbw"
           File.open(update_to_lich, 'rb') { |r| File.open(lich_to_update, 'wb') { |w| w.write(r.read) } }
 
           # as a courtesy to the player, remind which version they were rev'd back to

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -19,14 +19,14 @@ module Lich
           self.help # Ok, that's just wrong.
         when /--update|-u/
           self.download_update
+        when /--refresh/
+          _respond; _respond "This command has been removed."
         when /--revert|-r/
           self.revert
         when /--(?:(script|library|data))=(.*)/
           self.update_file($1.dup, $2.dup)
         when /--snapshot|-s/ # this one needs to be after --script
           self.snapshot
-        when /--refresh/
-          _respond; _respond "This command has been removed."
         else
           _respond; _respond "Command '#{type}' unknown, illegitimate and ignored.  Exiting . . ."; _respond
         end


### PR DESCRIPTION
Needed to place --refresh before the --revert CASE statement due to regex matching `-r` for revert before it could ever get to `--refresh`