### PR TITLE
[lich.rbw] Remove nested double-quotes from inside subtitle tags

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -2304,7 +2304,7 @@ module Games
                 if $_SERVERSTRING_ =~ /<compDef id='room text'><\/compDef>/
                   $_SERVERSTRING_.sub!(/(.*)\s\s<compDef id='room text'><\/compDef>/) { "<compDef id='room desc'>#{$1}</compDef>" }
                 end
-                if $_SERVERSTRING_ =~ /(?:subtitle=".*\[)(.*")(?:\]")/
+                if $_SERVERSTRING_ =~ /^<streamWindow.*subtitle=".*\[.*"\]"/
                   $_SERVERSTRING_.gsub!(/(?<!=)(?<!\])"/, '&quote;')
                 end
                 if atmospherics

--- a/lich.rbw
+++ b/lich.rbw
@@ -2304,6 +2304,9 @@ module Games
                 if $_SERVERSTRING_ =~ /<compDef id='room text'><\/compDef>/
                   $_SERVERSTRING_.sub!(/(.*)\s\s<compDef id='room text'><\/compDef>/) { "<compDef id='room desc'>#{$1}</compDef>" }
                 end
+                if $_SERVERSTRING_ =~ /(?:subtitle=".*\[)(.*")(?:\]")/
+                  $_SERVERSTRING_.gsub!(/(?<!=)(?<!\])"/, '&quote;')
+                end
                 if atmospherics
                   atmospherics = false
                   $_SERVERSTRING.prepend('<popStream id="atmospherics" \/>') unless $_SERVERSTRING =~ /<popStream id="atmospherics" \/>/


### PR DESCRIPTION
Turns
```xml
<streamWindow id='room' title='Room' subtitle=" - ["Kertigen's Honor"]" location='center' target='drop' ifClosed='' resident='true'/>
```
into
```xml
<streamWindow id='room' title='Room' subtitle=" - [&quote;Kertigen's Honor&quote;]" location='center' target='drop' ifClosed='' resident='true'/>
```