### PR TITLE
Pulling forward small update to update.rb

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2164,6 +2164,9 @@ def do_client(client_string)
       update_parameter = $1.dup
       require 'lib/update.rb'
       Lich::Util::Update.request("#{update_parameter}")
+    elsif cmd =~ /^(?:lich5-update|l5u)/i
+      require 'lib/update.rb'
+      Lich::Util::Update.request("--help")
     elsif cmd =~ /^help$/i
       respond
       respond "Lich v#{LICH_VERSION}"

--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias
           game: any
           tags: core
-       version: 0.55
+       version: 0.56
       required: Lich >= 4.6.58
 
   changelog:
+    0.56 (2022-05-29):
+      Change default started scripts for fresh install
     0.55 (2022-03-31):
       Added messaging for DR users noting this script isn't normally used with DR-Scripts
       Adding check for dependency, with note.
@@ -57,7 +59,7 @@ end
 if Settings['scripts'].nil?
   Settings['scripts'] = Array.new
   Settings['scripts'].push(:name => 'alias', :args => [])
-  Settings['scripts'].push(:name => 'lnet', :args => [])
+  #Settings['scripts'].push(:name => 'lnet', :args => [])
 end
 
 # Let's go find out if we need to switch lich from updatable state


### PR DESCRIPTION
The logic for update.rb did not operate without a parameter.  This change detects no parameter provided and presents the --help information back to the user. Thanks, Tysong!