### PR TITLE
Strained Muscles was renamed to Overexerted

### DIFF
--- a/lib/cman.rb
+++ b/lib/cman.rb
@@ -268,7 +268,7 @@ class CMan
 
   def CMan.available?(name)
     CMan.known?(name) and CMan.affordable?(name) and
-    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Strained Muscles')
+    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
   end
 
 end

--- a/lib/feat.rb
+++ b/lib/feat.rb
@@ -117,7 +117,7 @@ class Feat
 
   def Feat.available?(name)
     Feat.known?(name) and Feat.affordable?(name) and
-    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Strained Muscles')
+    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
   end
 
 end

--- a/lib/shield.rb
+++ b/lib/shield.rb
@@ -286,7 +286,7 @@ class Shield
 
   def Shield.available?(name)
     Shield.known?(name) and Shield.affordable?(name) and
-    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Strained Muscles')
+    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
   end
 
   def Shield.use(name, target = "")

--- a/lib/weapon.rb
+++ b/lib/weapon.rb
@@ -101,7 +101,7 @@ class Weapon
 
   def Weapon.available?(name)
     Weapon.known?(name) and Weapon.affordable?(name) and
-    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Strained Muscles')
+    !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
   end
 
 end


### PR DESCRIPTION
the `available?` check for cman and cman like abilities was using the old Strained Muscles debuff name. This was renamed to overexerted some time back.