### PR TITLE
Add lich_char_regex back to do_client

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2015,7 +2015,7 @@ def do_client(client_string)
   #   Buffer.update(client_string, Buffer::UPSTREAM_MOD)
   return nil if client_string.nil?
 
-  if client_string =~ /^(?:<c>)?#{$lich_char}(.+)$/
+  if client_string =~ /^(?:<c>)?#{$lich_char_regex}(.+)$/
     cmd = $1
     if cmd =~ /^k$|^kill$|^stop$/
       if Script.running.empty?


### PR DESCRIPTION
In splitting global_defs.rb from lich.rbw, somehow managed to lose the `lich_char_regex` for `do_client` def.  This PR fixes that.