### PR TITLE
[global_defs.rb] Adds another slip text match in the move function

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -593,7 +593,7 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
     elsif line == 'You are still stunned.'
       wait_while { stunned? }
       put_dir.call
-    elsif line =~ /you slip (?:on a patch of ice )?and flail uselessly as you land on your rear(?:\.|!)$|You wobble and stumble only for a moment before landing flat on your face!$/
+    elsif line =~ /you slip (?:on a patch of ice )?and flail uselessly as you land on your rear(?:\.|!)$|You wobble and stumble only for a moment before landing flat on your face!$|^You slip in the mud and fall flat on your back\!$/
       waitrt?
       fput 'stand' unless standing?
       waitrt?


### PR DESCRIPTION
In some rooms outside of Ratha (such as 5120), the `move` function in lib/global_defs.rb, called by go2.lic, was not catching slips:

```
[go2]>southwest
You slip in the mud and fall flat on your back!
>
[go2: move: no recognized response in 10 seconds.  giving up.]
[go2: restarting script...]
[go2: ETA: 0:00:10 (55 rooms to move through)]
[go2]>stand
You stand back up.
>
```

This PR adds a regex which catches this slip text, and go2 now seems to work as expected:

```
[go2]>southeast
You tramp southeast.
[Reshalia Trade Road, Farmland]
The road takes a sharp turn here at the corner of a field.  The ground underfoot is soft and squishy, with frequent stretches that are downright slippery.  The smell of healthy, wet slime gives you a clue as to why this piece of road is so hazardous -- it's very muddy and oozy.
Obvious paths: [southwest], [northwest].
Room Number: 5120
>
[go2]>southwest
You slip in the mud and fall flat on your back!
>
[go2]>stand
You stand back up.
```