### PR TITLE
[global_defs.rb] at feet handling to move method

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -603,6 +603,11 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
     elsif line =~ /^You dive into the fast-moving river, but the current catches you and whips you back to shore, wet and battered\.$|^Running through the swampy terrain, you notice a wet patch in the bog|^You flounder around in the water.$|^You blunder around in the water, barely able|^You struggle against the swift current to swim|^You slap at the water in a sad failure to swim|^You work against the swift current to swim/
       waitrt?
       put_dir.call
+    elsif line =~ /^You notice.* at your feet, and do not wish to leave it behind/
+      fput "lift"
+      fput "stow"
+      sleep 1
+      put_dir.call
     elsif line == "You don't seem to be able to move to do that."
       30.times {
         break if clear.include?('You regain control of your senses!')

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -603,9 +603,8 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
     elsif line =~ /^You dive into the fast-moving river, but the current catches you and whips you back to shore, wet and battered\.$|^Running through the swampy terrain, you notice a wet patch in the bog|^You flounder around in the water.$|^You blunder around in the water, barely able|^You struggle against the swift current to swim|^You slap at the water in a sad failure to swim|^You work against the swift current to swim/
       waitrt?
       put_dir.call
-    elsif line =~ /^You notice.* at your feet, and do not wish to leave it behind/
-      fput "lift"
-      fput "stow"
+    elsif line =~ /^You notice .* at your feet, and do not wish to leave it behind|As you prepare to move away, you remember/
+      fput "stow feet"
       sleep 1
       put_dir.call
     elsif line == "You don't seem to be able to move to do that."

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -603,7 +603,7 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
     elsif line =~ /^You dive into the fast-moving river, but the current catches you and whips you back to shore, wet and battered\.$|^Running through the swampy terrain, you notice a wet patch in the bog|^You flounder around in the water.$|^You blunder around in the water, barely able|^You struggle against the swift current to swim|^You slap at the water in a sad failure to swim|^You work against the swift current to swim/
       waitrt?
       put_dir.call
-    elsif line =~ /^You notice .* at your feet, and do not wish to leave it behind|As you prepare to move away, you remember/
+    elsif line =~ /^(You notice .* at your feet, and do not wish to leave it behind|As you prepare to move away, you remember)/
       fput "stow feet"
       sleep 1
       put_dir.call


### PR DESCRIPTION
Like to add a few lines to global_defs, dealing with move method and items at your feet:
```ruby

    elsif line =~ /^You notice.* at your feet, and do not wish to leave it behind/
      fput "lift"
      fput "stow"
      sleep 1
      put_dir.call
```
inside move method.
```
>;go2 pond
--- Lich: go2 active.
[go2: ETA: 0:00:02 (12 rooms to move through)]
[go2]>south
You notice some ojhenik potion at your feet, and do not wish to leave it behind.
>
[go2]>lift
You pick up the potion lying at your feet.
>
[go2]>stow
You put your potion in your entangling brambles.
>
[go2]>south
You notice some sufil sap at your feet, and do not wish to leave it behind.
>
[go2]>lift
You pick up the sap lying at your feet.
>
[go2]>stow
You put your sap in your entangling brambles.
>
[go2]>south
```
With the new lift verb, this doesn't require anything special wrt commands or methods, and will sort most (if not all) issues of moving with items at your feet. 