### PR TITLE
[.gitignore] Adding data/DR/ and scripts/ to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 backup/
 data/alias.db3
 data/GSIV
+data/DR
 data/entry.dat
 data/simu.pem
 logo.png
@@ -11,6 +12,7 @@ fly64.png
 jinxp
 logs/
 maps/
+scripts/
 temp/
 .pre-commit-config.yaml
 *.swp


### PR DESCRIPTION
Adds two folders to .gitignore.

`data/DR` to mirror the fact we already ignore `data/GSIV`
and
`scripts/` since no master copies of scripts live in this repo anyway, and this conflicts with folks who clone other repos and populate this directory.