### PR TITLE
Resolves hang on connect issue on Ruby 3.2.1 on windows

### DIFF
--- a/lib/gui-manual-login.rb
+++ b/lib/gui-manual-login.rb
@@ -118,7 +118,7 @@ connect_button.signal_connect('clicked') {
         legacy: true
       )
     end
-    if login_info =~ /error/i
+    if login_info.to_s =~ /error/i
       @msgbox.call "\nSomething went wrong... probably invalid \nuser id and / or password.\n\nserver response: #{login_info}"
       connect_button.sensitive = true
       disconnect_button.sensitive = false


### PR DESCRIPTION
 - Caused by Invalid use of pattern-matching operator from an array

Closes Connect hangs trying to get character list on Ruby 3.2.1 on Windows. #290 