### PR TITLE
[lib/gui-manual-login.rb] Fixes issue of using wrong variable for custom_launch_dir during save

### DIFF
--- a/lib/gui-manual-login.rb
+++ b/lib/gui-manual-login.rb
@@ -195,11 +195,11 @@ play_button.signal_connect('clicked') {
       if @custom_launch_dir.child.text.empty? or @custom_launch_dir.child.text == "(enter working directory for command)"
         custom_launch_dir = nil
       else
-        @custom_launch_dir = @custom_launch_dir.child.text
+        custom_launch_dir = @custom_launch_dir.child.text
       end
     else
       custom_launch = nil
-      @custom_launch_dir = nil
+      custom_launch_dir = nil
     end
     @entry_data.push h = { :char_name => treeview.selection.selected[3], :game_code => treeview.selection.selected[0], :game_name => treeview.selection.selected[1], :user_id => user_id_entry.text, :password => pass_entry.text, :frontend => frontend, :custom_launch => custom_launch, :custom_launch_dir => custom_launch_dir }
     @save_entry_data = true


### PR DESCRIPTION
The text of the @custom_launch_dir combo box is incorrectly being used to overwrite the whole object itself when being saved, instead of fetching that text and saving it to a new local variable which is actually used during the save

Until PR #285 is merged, this won't have much effect, as setting custom launch commands aren't currently accessible from the gui.