### PR TITLE
[lib/gui-saved-login.rb] Fix mismatch on tabbed GUI and instance names

### DIFF
--- a/lib/gui-saved-login.rb
+++ b/lib/gui-saved-login.rb
@@ -46,14 +46,24 @@ else
 
       realm = ''
 
-      if login_info[:game_code] =~ /GSX/
-        realm = 'Platinum'
-      elsif login_info[:game_code] =~ /GST/
-        realm = 'Test'
-      elsif login_info[:game_code] =~ /GSF/
-        realm = 'Shattered'
+      if login_info[:game_code]  =~ /^GS3$/
+        realm = 'GS Prime'
+      elsif login_info[:game_code] =~ /^GSX$/
+        realm = 'GS Platinum'
+      elsif login_info[:game_code] =~ /^GST$/
+        realm = 'GS Test'
+      elsif login_info[:game_code] =~ /^GSF$/
+        realm = 'GS Shattered'
+      elsif login_info[:game_code] =~ /^DR$/
+        realm = 'DR Prime'
+      elsif login_info[:game_code] =~ /^DRX$/
+        realm = 'DR Platinum'
+      elsif login_info[:game_code] =~ /^DRT$/
+        realm = 'DR Test'
+      elsif login_info[:game_code] =~ /^DRF$/
+        realm = 'DR Fallen'
       else
-        realm = 'Prime'
+        realm = 'Unknown'
       end
 
         @button_provider = Gtk::CssProvider.new


### PR DESCRIPTION
 - Add all DR game codes for tabbed layout gui
 - Add specific code for GS3 instead of relying on falling through to else
 - Add unknown in case not matching any current known gamecodes.