### PR TITLE
[lich.rbw][init.rb]Add handling for no-gui on windows

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -653,7 +653,7 @@ rescue LoadError
   exit
 end
 
-if ((RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)) or ENV['DISPLAY']
+if ((RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i) and !ARGV.include?('--no-gui')) or ENV['DISPLAY']
   begin
     require 'gtk3'
     HAVE_GTK = true

--- a/lich.rbw
+++ b/lich.rbw
@@ -4209,6 +4209,8 @@ for arg in ARGV
     argv_options[:host] = { :domain => $1, :port => $2.to_i }
   elsif arg =~ /^--hosts-file=(.+)$/i
     argv_options[:hosts_file] = $1
+  elsif arg =~ /^--no-gui$/i
+    argv_options[:gui] = false
   elsif arg =~ /^--gui$/i
     argv_options[:gui] = true
   elsif arg =~ /^--game=(.+)$/i


### PR DESCRIPTION
Acts the same as `unset DISPLAY` on linux, but allows a windows instance to go gtk3-free