### PR TITLE
[lich.rbw] Add support to specify IP to listen on in detachable client mode

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -4261,9 +4261,12 @@ else
   hosts_dir = nil
 end
 
+detachable_client_host = '127.0.0.1'
 detachable_client_port = nil
 if arg = ARGV.find { |a| a =~ /^\-\-detachable\-client=[0-9]+$/ }
   detachable_client_port = /^\-\-detachable\-client=([0-9]+)$/.match(arg).captures.first
+elsif arg = ARGV.find { |a| a =~ /^\-\-detachable\-client=((?:\d{1,3}\.){3}\d{1,3}):([0-9]{1,5})$/ }
+  detachable_client_host, detachable_client_port = /^\-\-detachable\-client=((?:\d{1,3}\.){3}\d{1,3}):([0-9]{1,5})$/.match(arg).captures
 end
 
 if argv_options[:sal]
@@ -5080,7 +5083,7 @@ main_thread = Thread.new {
     detachable_client_thread = Thread.new {
       loop {
         begin
-          server = TCPServer.new('127.0.0.1', detachable_client_port)
+          server = TCPServer.new(detachable_client_host, detachable_client_port)
           char_name = ARGV[ARGV.index('--login')+1].capitalize
           Frontend.create_session_file(char_name, server.addr[2], server.addr[1])
 


### PR DESCRIPTION
Enables greater flexibility in detached client mode, especially where this is deployed via docker or other containers.  No need to mess with iptables / firewalld / etc within the container.

