### PR TITLE
bugfix:init.rb - detecting 20 files vs detecting 20 lich debug files;

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -844,7 +844,7 @@ DELETE_CANDIDATES = %r[^debug-\d+-\d+-\d+-\d+-\d+-\d+\.log$]
 if Dir.entries(TEMP_DIR).find_all { |fn| fn =~ DELETE_CANDIDATES }.length > 20 # avoid NIL response
   Dir.entries(TEMP_DIR).find_all { |fn| fn =~ DELETE_CANDIDATES }.sort.reverse[20..-1].each { |oldfile|
     begin
-      File.delete("#{TEMP_DIR}/#{oldfile}")
+      File.delete(File.join(TEMP_DIR, oldfile))
     rescue
       Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
     end

--- a/lib/init.rb
+++ b/lib/init.rb
@@ -839,8 +839,10 @@ Lich.init_db
 #
 # only keep the last 20 debug files
 #
-if Dir.entries(TEMP_DIR).length > 20 # avoid NIL response
-  Dir.entries(TEMP_DIR).find_all { |fn| fn =~ /^debug-\d+-\d+-\d+-\d+-\d+-\d+\.log$/ }.sort.reverse[20..-1].each { |oldfile|
+
+DELETE_CANDIDATES = %r[^debug-\d+-\d+-\d+-\d+-\d+-\d+\.log$]
+if Dir.entries(TEMP_DIR).find_all { |fn| fn =~ DELETE_CANDIDATES }.length > 20 # avoid NIL response
+  Dir.entries(TEMP_DIR).find_all { |fn| fn =~ DELETE_CANDIDATES }.sort.reverse[20..-1].each { |oldfile|
     begin
       File.delete("#{TEMP_DIR}/#{oldfile}")
     rescue
@@ -849,6 +851,7 @@ if Dir.entries(TEMP_DIR).length > 20 # avoid NIL response
   }
 end
 
+# todo: deprecate / remove for Ruby 3.2.1?
 if (RUBY_VERSION =~ /^2\.[012]\./)
   begin
     did_trusted_defaults = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='did_trusted_defaults';")


### PR DESCRIPTION
Current Lich will sometimes fail to run for a few attempts and then mysteriously start with no other changes.  The issue is current Lich detects more than 20 files in TEMP_DIR and tries to delete `debug<numbers.log` files over 20.  But many activities (like `;repository`) also save files to TEMP_DIR, leading to a `TRUE` result for more than 20 files, but potentially a `FALSE` result for 20 debug files. 

This change detects only debug files, and actions only debug files to prevent the intermittent failure.