### PR TITLE
[rubocop.yml] add Layout/FirstHashElementIndentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,16 +13,19 @@ Naming:
 Style:
   Enabled: false
 
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
 
 Layout/EndOfLine:
   Enabled: false
 
-Layout/LineLength:
-  Enabled: false
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
 
-Layout/EmptyLineAfterGuardClause:
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+
+Layout/LineLength:
   Enabled: false
 
 Metrics/AbcSize:
@@ -55,3 +58,5 @@ Metrics/ParameterLists:
 Security/Eval:
   Enabled: false
   
+Security/MarshalLoad:
+  Enabled: false


### PR DESCRIPTION
Add Layout/FirstHashElementIndentation EnforcedStyle consistent

Will cause hash elements to be indented properly.

Instead of:
```ruby
@locker_items.push({
                     :id          => id,
                     :location_id => location_id.to_i,
                     :level       => level.to_i,
                   })
```
We'd get
```ruby
@locker_items.push({
  :id          => id,
  :location_id => location_id.to_i,
  :level       => level.to_i,
})```