### PR TITLE
Update map_gs.rb

### DIFF
--- a/lib/map_gs.rb
+++ b/lib/map_gs.rb
@@ -251,7 +251,7 @@ class Map
       foggy_exits = (XMLData.room_exits_string =~ /^Obvious (?:exits|paths): obscured by a thick fog$/)
       if (room = @@list.find { |r|
             r.title.include?(XMLData.room_title) and
-     rescription.include?(XMLData.room_description.strip) and
+     description.include?(XMLData.room_description.strip) and
      (unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
      (ggy_exits or r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
      (t r.check_location or r.location == Map.get_location)

--- a/lib/map_gs.rb
+++ b/lib/map_gs.rb
@@ -2,6 +2,8 @@ class Map
   @@loaded                   = false
   @@load_mutex               = Mutex.new
   @@list                   ||= Array.new
+  @@images                 ||= Array.new
+  @@locations              ||= Array.new
   @@tags                   ||= Array.new
   @@current_room_mutex       = Mutex.new
   @@current_room_id        ||= nil
@@ -14,53 +16,59 @@ class Map
   @@previous_room_id       ||= nil
   @@uids                     = {}
   attr_reader :id
-  attr_accessor :title, :description, :paths, :uid, :location, :climate, :terrain, :wayto, :timeto, :image, :image_coords, :tags, :check_location, :unique_loot, :uid
-  def initialize(id, title, description, paths, uid = [], location=nil, climate=nil, terrain=nil, wayto={}, timeto={}, image=nil, image_coords=nil, tags=[], check_location=nil, unique_loot=nil)
+  attr_accessor :title, :description, :paths, :uid, :location, :climate, :terrain, :wayto, :timeto, :image, :image_coords, :tags, :check_location, :unique_loot
+
+  def initialize(id, title, description, paths, uid = [], location = nil, climate = nil, terrain = nil, wayto = {}, timeto = {}, image = nil, image_coords = nil, tags = [], check_location = nil, unique_loot = nil)
     @id, @title, @description, @paths, @uid, @location, @climate, @terrain, @wayto, @timeto, @image, @image_coords, @tags, @check_location, @unique_loot = id, title, description, paths, uid, location, climate, terrain, wayto, timeto, image, image_coords, tags, check_location, unique_loot
     @@list[@id] = self
   end
-  def Map.current_room_id;return @@current_room_id;end
-  def Map.current_room_id=(id);return @@current_room_id = id;end
-  def fuzzy_room_id;return @@current_room_id;end
-  def outside?
-    @paths.first =~ /^Obvious paths:/ ? true : false
-  end
-  def to_i
-    @id
-  end
+
+  def Map.current_room_id; return @@current_room_id; end
+  def Map.current_room_id=(id); return @@current_room_id = id; end
+  def Map.loaded; return @@loaded; end
+  def Map.previous_room_id; return @@previous_room_id; end
+  def Map.previous_room_id=(id); return @@previous_room_id = id; end
+  def fuzzy_room_id; return @@current_room_id; end
+  def outside?; return @paths.first =~ /^Obvious paths:/ ? true : false; end
+  def to_i; return @id; end
+
   def to_s
-    "##{@id} (u#{@uid[-1]}):\n#{@title[-1]} (#{@location})\n#{@description[-1]}\n#{@paths[-1]}"
+    return "##{@id} (u#{@uid.first}):\n#{@title.first} (#{@location})\n#{@description.first}\n#{@paths.first}"
   end
+
   def inspect
-    self.instance_variables.collect { |var| var.to_s + "=" + self.instance_variable_get(var).inspect }.join("\n")
+    return self.instance_variables.collect { |var| var.to_s + "=" + self.instance_variable_get(var).inspect }.join("\n")
   end
-  def Map.fuzzy_room_id()
-    return @@fuzzy_room_id
-  end
+
+  def Map.fuzzy_room_id; return @@fuzzy_room_id; end
+
   def Map.get_free_id
     Map.load unless @@loaded
-    return @@list.compact.max_by{ |r| r.id}.id + 1
+    return @@list.compact.max_by { |r| r.id }.id + 1
   end
+
   def Map.list
     Map.load unless @@loaded
-    @@list
+    return @@list
   end
+
   def Map.[](val)
     Map.load unless @@loaded
-    if (val.class == Integer) or val =~ /^[0-9]+$/
-      @@list[val.to_i]
+    if (val.class == Integer or val =~ /^[0-9]+$/)
+      return @@list[val.to_i]
     elsif val =~ /^u(-?\d+)$/i
       uid_request = $1.dup.to_i
-      @@list[(Map.ids_from_uid(uid_request)[0]).to_i]
+      return @@list[(Map.ids_from_uid(uid_request)[0]).to_i]
     else
       chkre = /#{val.strip.sub(/\.$/, '').gsub(/\.(?:\.\.)?/, '|')}/i
       chk = /#{Regexp.escape(val.strip)}/i
-      @@list.find { |room| room.title.find { |title| title =~ chk } } || @@list.find { |room| room.description.find { |desc| desc =~ chk } } || @@list.find { |room| room.description.find { |desc| desc =~ chkre } }
+      return @@list.find { |room| room.title.find { |title| title =~ chk } } || @@list.find { |room| room.description.find { |desc| desc =~ chk } } || @@list.find { |room| room.description.find { |desc| desc =~ chkre } }
     end
   end
+
   def Map.get_location
     unless XMLData.room_count == @@current_location_count
-      if script = Script.current
+      if (script = Script.current)
         save_want_downstream = script.want_downstream
         script.want_downstream = true
         waitrt?
@@ -76,53 +84,61 @@ class Map
         nil
       end
     end
-    @@current_location
+    return @@current_location
   end
+
   def Map.previous
     return nil if @@previous_room_id.nil?
     return @@list[@@previous_room_id]
   end
+
   def Map.previous_uid
     return XMLData.previous_nav_rm
   end
+
   def Map.current # returns Map/Room
     Map.load unless @@loaded
-    if script = Script.current
+    if Script.current
       return @@list[@@current_room_id] if XMLData.room_count == @@current_room_count and !@@current_room_id.nil?;
     else
       return @@list[@@current_room_id] if XMLData.room_count == @@fuzzy_room_count and !@@current_room_id.nil?;
     end
     ids = Map.ids_from_uid(XMLData.room_id);
     return Map.set_current(ids[0]) if ids.size == 1;
-    if ids.size > 1 and !@@current_room_id.nil? and id = Map.match_multi_ids(ids)
+    if ids.size > 1 and !@@current_room_id.nil? and (id = Map.match_multi_ids(ids))
       return Map.set_current(id)
     end
     return Map.match_no_uid()
   end
+
   def Map.set_current(id) # returns Map/Room
     @@previous_room_id = @@current_room_id if id != @@current_room_id;
     @@current_room_id  = id
     return nil if id.nil?
     return @@list[id]
   end
-  def Map.set_fuzzy(id)  # returns Map/Room
+
+  def Map.set_fuzzy(id) # returns Map/Room
     @@previous_room_id = @@current_room_id if !id.nil? and id != @@current_room_id;
     @@current_room_id  = id
     return nil if id.nil?
     return @@list[id]
   end
+
   def Map.match_multi_ids(ids) # returns id
-    matches = ids.find_all { |s| @@list[@@current_room_id].wayto.keys.include?(s.to_s)}
+    matches = ids.find_all { |s| @@list[@@current_room_id].wayto.keys.include?(s.to_s) }
     return matches[0] if matches.size == 1;
     return nil;
   end
+
   def Map.match_no_uid() # returns Map/Room
-    if script = Script.current;
+    if (script = Script.current);
       return Map.set_current(Map.match_current(script))
     else
       return Map.set_fuzzy(Map.match_fuzzy())
     end
   end
+
   def Map.match_current(script) # returns id
     @@current_room_mutex.synchronize {
       peer_history = Hash.new
@@ -131,13 +147,13 @@ class Map
         begin
           script.ignore_pause = true
           peer_room_count = XMLData.room_count
-          if peer_tag = r.tags.find { |tag| tag =~ /^(set desc on; )?peer [a-z]+ =~ \/.+\/$/ }
+          if (peer_tag = r.tags.find { |tag| tag =~ /^(set desc on; )?peer [a-z]+ =~ \/.+\/$/ })
             good = false
             need_desc, peer_direction, peer_requirement = /^(set desc on; )?peer ([a-z]+) =~ \/(.+)\/$/.match(peer_tag).captures
             need_desc = need_desc ? true : false
             if peer_history[peer_room_count][peer_direction][need_desc].nil?
               if need_desc
-                unless last_roomdesc = $_SERVERBUFFER_.reverse.find { |line| line =~ /<style id="roomDesc"\/>/ } and (last_roomdesc =~ /<style id="roomDesc"\/>[^<]/)
+                unless (last_roomdesc = $_SERVERBUFFER_.reverse.find { |line| line =~ /<style id="roomDesc"\/>/ }) and (last_roomdesc =~ /<style id="roomDesc"\/>[^<]/)
                   put 'set description on'
                   need_set_desc_off = true
                 end
@@ -163,7 +179,7 @@ class Map
               if result =~ /^You peer/
                 peer_results = Array.new
                 5.times {
-                  if line = get?
+                  if (line = get?)
                     peer_results.push line
                     break if line =~ /^Obvious/
                   end
@@ -195,50 +211,67 @@ class Map
         good
       }
       begin
-        1.times {
-          @@current_room_count = XMLData.room_count
-          foggy_exits = (XMLData.room_exits_string =~ /^Obvious (?:exits|paths): obscured by a thick fog$/)
-          if room = @@list.find { |r| r.title.include?(XMLData.room_title) and
+        @@current_room_count = XMLData.room_count
+        foggy_exits = (XMLData.room_exits_string =~ /^Obvious (?:exits|paths): obscured by a thick fog$/)
+        if (room = @@list.find { |r|
+              r.title.include?(XMLData.room_title) and
               r.description.include?(XMLData.room_description.strip) and
               (r.unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
               (foggy_exits or r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
               (not r.check_location or r.location == Map.get_location) and check_peer_tag.call(r)
-            }
-            redo unless @@current_room_count == XMLData.room_count
-            return room.id
-          else
-            redo unless @@current_room_count == XMLData.room_count
-            desc_regex = /#{Regexp.escape(XMLData.room_description.strip.sub(/\.+$/, '')).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
-            if room = @@list.find { |r| r.title.include?(XMLData.room_title) and
+            })
+          redo unless @@current_room_count == XMLData.room_count
+          return room.id
+        else
+          redo unless @@current_room_count == XMLData.room_count
+          desc_regex = /#{Regexp.escape(XMLData.room_description.strip.sub(/\.+$/, '')).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
+          if (room = @@list.find { |r|
+                r.title.include?(XMLData.room_title) and
                 (foggy_exits or r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
                 (XMLData.room_window_disabled or r.description.any? { |desc| desc =~ desc_regex }) and
                 (r.unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
                 (not r.check_location or r.location == Map.get_location) and check_peer_tag.call(r)
-              }
-              redo unless @@current_room_count == XMLData.room_count
-              return room.id
-            else
-              redo unless @@current_room_count == XMLData.room_count
-              return nil
-            end
+              })
+            redo unless @@current_room_count == XMLData.room_count
+            return room.id
+          else
+            redo unless @@current_room_count == XMLData.room_count
+            return nil
           end
-        }
+        end
       ensure
         put 'set description off' if need_set_desc_off
       end
     }
   end
+
   def Map.match_fuzzy() # returns id
     @@fuzzy_room_mutex.synchronize {
       @@fuzzy_room_count = XMLData.room_count
-      1.times {
-        foggy_exits = (XMLData.room_exits_string =~ /^Obvious (?:exits|paths): obscured by a thick fog$/)
-        if (room = @@list.find { |r| r.title.include?(XMLData.room_title) and
-            r.description.include?(XMLData.room_description.strip) and
-            (r.unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
-            (foggy_exits or r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
-            (not r.check_location or r.location == Map.get_location)
+      foggy_exits = (XMLData.room_exits_string =~ /^Obvious (?:exits|paths): obscured by a thick fog$/)
+      if (room = @@list.find { |r|
+            r.title.include?(XMLData.room_title) and
+     rescription.include?(XMLData.room_description.strip) and
+     (unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
+     (ggy_exits or r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
+     (t r.check_location or r.location == Map.get_location)
           })
+        redo unless @@fuzzy_room_count == XMLData.room_count
+        if room.tags.any? { |tag| tag =~ /^(set desc on; )?peer [a-z]+ =~ \/.+\/$/ }
+          return nil
+        else
+          return room.id
+        end
+      else
+        redo unless @@fuzzy_room_count == XMLData.room_count
+        desc_regex = /#{Regexp.escape(XMLData.room_description.strip.sub(/\.+$/, '')).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
+        if (room = @@list.find { |r|
+              r.title.include?(XMLData.room_title) and
+              (foggy_exits or r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
+              (XMLData.room_window_disabled or r.description.any? { |desc| desc =~ desc_regex }) and
+              (r.unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
+              (not r.check_location or r.location == Map.get_location)
+            })
           redo unless @@fuzzy_room_count == XMLData.room_count
           if room.tags.any? { |tag| tag =~ /^(set desc on; )?peer [a-z]+ =~ \/.+\/$/ }
             return nil
@@ -247,27 +280,12 @@ class Map
           end
         else
           redo unless @@fuzzy_room_count == XMLData.room_count
-          desc_regex = /#{Regexp.escape(XMLData.room_description.strip.sub(/\.+$/, '')).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
-          if room = @@list.find { |r| r.title.include?(XMLData.room_title) and
-              (foggy_exits or r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
-              (XMLData.room_window_disabled or r.description.any? { |desc| desc =~ desc_regex }) and
-              (r.unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
-              (not r.check_location or r.location == Map.get_location)
-            }
-            redo unless @@fuzzy_room_count == XMLData.room_count
-            if room.tags.any? { |tag| tag =~ /^(set desc on; )?peer [a-z]+ =~ \/.+\/$/ }
-              return nil
-            else
-              return room.id
-            end
-          else
-            redo unless @@fuzzy_room_count == XMLData.room_count
-            return nil
-          end
+          return nil
         end
-      }
+      end
     }
   end
+
   def Map.current_or_new # returns Map/Room
     return nil unless Script.current
     Map.load unless @@loaded
@@ -275,51 +293,79 @@ class Map
     room = nil
     id = ids[0] if ids.size == 1;
     id = Map.match_multi_ids(ids) if ids.size > 1;
-    id = Map.match_current(Script.current) if id.nil?;
+    if id.nil?
+      id = Map.match_current(Script.current)
+      # prevent loading uids into existing rooms with a single id unless tagged meta:map:multi-uid
+      if !id.nil? and Map[id].uid.size == 1 and !Map[id].tags.include?('meta:map:multi-uid')
+        id = nil
+      end
+    end
     if !id.nil? # existing room
       room = Map[id]
       if !room.uid.include?(XMLData.room_id)
         room.uid << XMLData.room_id
-        Map.uids_add(XMLData.room_id,room.id)
+        Map.uids_add(XMLData.room_id, room.id)
         echo "Map: Adding new uid for #{room.id}: #{XMLData.room_id}"
       end
-      if !room.title.include?(XMLData.room_title)
-        room.title.unshift(XMLData.room_title)
-        echo "Map: Adding new title for #{room.id}: '#{XMLData.room_title}'"
-      end
-      if !room.description.include?(XMLData.room_description.strip)
-        room.description.unshift(XMLData.room_description.strip)
-        echo "Map: Adding new description for #{room.id}: '#{XMLData.room_description.strip}'"
-      end
-      if !room.paths.include?(XMLData.room_exits_string.strip)
-        room.paths.unshift(XMLData.room_exits_string.strip)
-        echo "Map: Adding new paths for #{room.id}: '#{XMLData.room_exits_string.strip}'"
-      end
-      if (room.location.nil? or room.location == false)
-        current_location = Map.get_location
-        room.location    = current_location
-        echo "Map: Updating location for #{room.id}: '#{current_location}'"
+      if (room.tags & ['meta:map:latest-only', 'meta:playershop']).empty?
+        # update room if not meta:playershop or meta:map:latest-only
+        if !room.title.include?(XMLData.room_title)
+          room.title.unshift(XMLData.room_title)
+          echo "Map: Adding new title for #{room.id}: '#{XMLData.room_title}'"
+        end
+        if !room.description.include?(XMLData.room_description.strip)
+          room.description.unshift(XMLData.room_description.strip)
+          echo "Map: Adding new description for #{room.id} : #{XMLData.room_description.strip.inspect}"
+        end
+        if !room.paths.include?(XMLData.room_exits_string.strip)
+          room.paths.unshift(XMLData.room_exits_string.strip)
+          echo "Map: Adding new path for #{room.id}: #{XMLData.room_exits_string.strip.inspect}"
+        end
+        if (room.location.nil? or room.location == false or room.location == '')
+          current_location = Map.get_location
+          room.location    = current_location
+          echo "Map: Updating location for #{room.id}: #{current_location.inspect}"
+        end
+      elsif !(room.tags & ['meta:map:latest-only', 'meta:playershop']).empty?
+        # update rooms tagged meta:playershop or meta:map:latest-only
+        if room.title != [XMLData.room_title]
+          room.title = [XMLData.room_title]
+          echo "Map: Updating title for #{room.id}: #{XMLData.room_title.inspect}"
+        end
+        if room.description != XMLData.room_description.strip
+          room.description = [XMLData.room_description.strip]
+          echo "Map: Updating description for #{room.id}: #{XMLData.room_description.strip.inspect}"
+        end
+        if room.paths != [XMLData.room_exits_string.strip]
+          room.paths = [XMLData.room_exits_string.strip]
+          echo "Map: Updating path for #{room.id}: #{XMLData.room_exits_string.strip.inspect}"
+        end
+        if (room.location.nil? or room.location == false or room.location == '')
+          current_location = Map.get_location
+          room.location    = current_location
+          echo "Map: Updating location for #{room.id}: #{current_location.inspect}"
+        end
       end
       return Map.set_current(room.id)
     end
     # new room
     current_location = Map.get_location
-    foggy_exits      = (XMLData.room_exits_string =~ /^Obvious (?:exits|paths): obscured by a thick fog$/)
     id               = Map.get_free_id
-    title            = [ XMLData.room_title ]
-    description      = [ XMLData.room_description.strip ]
-    paths            = [ XMLData.room_exits_string.strip ]
-    uid              = [ XMLData.room_id ]
+    title            = [XMLData.room_title]
+    description      = [XMLData.room_description.strip]
+    paths            = [XMLData.room_exits_string.strip]
+    uid              = [XMLData.room_id]
     room             = Map.new(Map.get_free_id, title, description, paths, uid, current_location)
     Map.uids_add(XMLData.room_id, room.id)
     # flag identical rooms with different locations
-    identical_rooms = @@list.find_all { |r| (r.location != current_location) and
+    identical_rooms = @@list.find_all { |r|
+      (r.location != current_location) and
         r.title.include?(XMLData.room_title) and
         r.description.include?(XMLData.room_description.strip) and
         (r.unique_loot.nil? or (r.unique_loot.to_a - GameObj.loot.to_a.collect { |obj| obj.name }).empty?) and
         (r.paths.include?(XMLData.room_exits_string.strip) or r.tags.include?('random-paths')) and
         !r.uid.include?(XMLData.room_id)
-      }
+    }
     if identical_rooms.length > 0
       room.check_location = true
       identical_rooms.each { |r| r.check_location = true }
@@ -327,61 +373,73 @@ class Map
     echo "mapped new room, set current room to #{room.id}"
     return Map.set_current(id)
   end
+
+  def Map.locations
+    Map.load unless @@loaded
+    @@locations = @@list.each_with_object({}) { |r, h| h[r.location] = nil if !h.key?(r.location) }.keys if @@locations.empty?;
+    return @@locations.dup
+  end
+
+  def Map.images
+    Map.load unless @@loaded
+    @@images = @@list.each_with_object({}) { |r, h| h[r.image] = nil if !h.key?(r.image) }.keys if @@images.empty?;
+    return @@images.dup
+  end
+
   def Map.tags
     Map.load unless @@loaded
-    if @@tags.empty?
-      @@list.each { |r|
-        r.tags.each { |t|
-          @@tags.push(t) unless @@tags.include?(t)
-        }
-      }
-    end
-    @@tags.dup
+    @@tags = @@list.each_with_object({}) { |r, h| r.tags.each { |t| h[t] = nil if !h.key?(t) } }.keys if @@tags.empty?;
+    return @@tags.dup
   end
-  def Map.uids_add(uid,id)
-    if @@uids[uid].nil?
-      @@uids[uid] = [ id ]
+
+  def Map.uids(); return @@uids.dup; end
+
+  def Map.ids_from_uid(n); return (@@uids[n].nil? ? [] : @@uids[n].dup); end
+
+  def Map.uids_add(uid, id)
+    if !@@uids.key?(uid)
+      @@uids[uid] = [id]
     else
       @@uids[uid] << id if !@@uids[uid].include?(id)
     end
   end
+
   def Map.load_uids()
     Map.load unless @@loaded
     @@uids.clear
     @@list.each { |r|
-      r.uid.each { |u| Map.uids_add(u,r.id) }
+      r.uid.each { |u| Map.uids_add(u, r.id) }
     }
   end
-  def Map.ids_from_uid(n)
-    return (@@uids[n].nil? ? [] : @@uids[n])
-  end
-  def Map.uids()
-    return @@uids
-  end
+
   def Map.clear
     @@load_mutex.synchronize {
       @@list.clear
       @@tags.clear
+      @@locations.clear
+      @@images.clear
       @@loaded = false
       GC.start
     }
-    true
+    return true
   end
+
   def Map.reload
     Map.clear
     Map.load
   end
-  def Map.load(filename=nil)
+
+  def Map.load(filename = nil)
     if filename.nil?
-      file_list = Dir.entries("#{DATA_DIR}/#{XMLData.game}").find_all { |filename| filename =~ /^map\-[0-9]+\.(?:dat|xml|json)$/i }.collect { |filename| "#{DATA_DIR}/#{XMLData.game}/#{filename}" }.sort.reverse
+      file_list = Dir.entries("#{DATA_DIR}/#{XMLData.game}").find_all { |fn| fn =~ /^map\-[0-9]+\.(?:dat|xml|json)$/i }.collect { |fn| "#{DATA_DIR}/#{XMLData.game}/#{fn}" }.sort.reverse
     else
-      file_list = [ filename ]
+      file_list = [filename]
     end
     if file_list.empty?
       respond "--- Lich: error: no map database found"
       return false
     end
-    while filename = file_list.shift
+    while (filename = file_list.shift)
       if filename =~ /\.json$/i
         if Map.load_json(filename)
           return true
@@ -398,28 +456,26 @@ class Map
     end
     return false
   end
-  def Map.load_json(filename=nil)
+
+  def Map.load_json(filename = nil)
     @@load_mutex.synchronize {
       if @@loaded
         return true
       else
         if filename
-          file_list = [ filename ]
-          #respond "--- loading #{filename}" #if error
+          file_list = [filename]
         else
-          file_list = Dir.entries("#{DATA_DIR}/#{XMLData.game}").find_all { |filename|
-            filename =~ /^map\-[0-9]+\.json$/i
-          }.collect { |filename|
-            "#{DATA_DIR}/#{XMLData.game}/#{filename}"
+          file_list = Dir.entries("#{DATA_DIR}/#{XMLData.game}").find_all { |fn|
+            fn =~ /^map\-[0-9]+\.json$/i
+          }.collect { |fn|
+            "#{DATA_DIR}/#{XMLData.game}/#{fn}"
           }.sort.reverse
-          #respond "--- loading #{filename}" #if error
         end
         if file_list.empty?
           respond "--- Lich: error: no map database found"
           return false
         end
-        error = false
-        while filename = file_list.shift
+        while (filename = file_list.shift)
           if File.exist?(filename)
             File.open(filename) { |f|
               JSON.parse(f.read).each { |room|
@@ -433,13 +489,17 @@ class Map
                     room['timeto'][k] = StringProc.new(room['timeto'][k][3..-1])
                   end
                 }
-                room['tags'] ||= []
-                room['uid'] ||= []
+                room['wayto'] ||= {}
+                room['timeto'] ||= {}
+                room['title'] ||= []
+                room['description'] ||= []
+                room['tags']  ||= []
+                room['uid']   ||= []
                 Map.new(room['id'], room['title'], room['description'], room['paths'], room['uid'], room['location'], room['climate'], room['terrain'], room['wayto'], room['timeto'], room['image'], room['image_coords'], room['tags'], room['check_location'], room['unique_loot'])
               }
             }
             @@tags.clear
-            respond "--- Map loaded #{filename}" #if error
+            respond "--- #{Script.current.name} Map loaded #{filename}"
             @@loaded = true
             Map.load_uids
             return true
@@ -449,32 +509,29 @@ class Map
     }
   end
 
-  def Map.load_dat(filename=nil)
+  def Map.load_dat(filename = nil)
     @@load_mutex.synchronize {
       if @@loaded
         return true
       else
         if filename.nil?
-          file_list = Dir.entries("#{DATA_DIR}/#{XMLData.game}").find_all { |filename| filename =~ /^map\-[0-9]+\.dat$/ }.collect { |filename| "#{DATA_DIR}/#{XMLData.game}/#{filename}" }.sort.reverse
+          file_list = Dir.entries("#{DATA_DIR}/#{XMLData.game}").find_all { |fn| fn =~ /^map\-[0-9]+\.dat$/ }.collect { |fn| "#{DATA_DIR}/#{XMLData.game}/#{fn}" }.sort.reverse
         else
-          file_list = [ filename ]
+          file_list = [filename]
           respond "--- file_list = #{filename.inspect}"
         end
         if file_list.empty?
           respond "--- Lich: error: no map database found"
           return false
         end
-        error = false
-        while filename = file_list.shift
+        while (filename = file_list.shift)
           begin
             @@list = File.open(filename, 'rb') { |f| Marshal.load(f.read) }
-            respond "--- Map loaded #{filename}" #if error
-
+            respond "--- Map loaded #{filename}" # if error
             @@loaded = true
             Map.load_uids
             return true
           rescue
-            error = true
             if file_list.empty?
               respond "--- Lich: error: failed to load #{filename}: #{$!}"
             else
@@ -487,7 +544,7 @@ class Map
     }
   end
 
-  def Map.load_xml(filename="#{DATA_DIR}/#{XMLData.game}/map.xml")
+  def Map.load_xml(filename = "#{DATA_DIR}/#{XMLData.game}/map.xml")
     @@load_mutex.synchronize {
       if @@loaded
         return true
@@ -501,7 +558,7 @@ class Map
         room = nil
         buffer = String.new
         unescape = { 'lt' => '<', 'gt' => '>', 'quot' => '"', 'apos' => "'", 'amp' => '&' }
-        tag_start = proc { |element,attributes|
+        tag_start = proc { |element, attributes|
           current_tag = element
           current_attributes = attributes
           if element == 'room'
@@ -520,7 +577,7 @@ class Map
             room['uid'] = Array.new
           elsif element =~ /^(?:image|tsoran)$/ and attributes['name'] and attributes['x'] and attributes['y'] and attributes['size']
             room['image'] = attributes['name']
-            room['image_coords'] = [ (attributes['x'].to_i - (attributes['size']/2.0).round), (attributes['y'].to_i - (attributes['size']/2.0).round), (attributes['x'].to_i + (attributes['size']/2.0).round), (attributes['y'].to_i + (attributes['size']/2.0).round) ]
+            room['image_coords'] = [(attributes['x'].to_i - (attributes['size'] / 2.0).round), (attributes['y'].to_i - (attributes['size'] / 2.0).round), (attributes['x'].to_i + (attributes['size'] / 2.0).round), (attributes['y'].to_i + (attributes['size'] / 2.0).round)]
           elsif (element == 'image') and attributes['name'] and attributes['coords'] and (attributes['coords'] =~ /[0-9]+,[0-9]+,[0-9]+,[0-9]+/)
             room['image'] = attributes['name']
             room['image_coords'] = attributes['coords'].split(',').collect { |num| num.to_i }
@@ -538,8 +595,6 @@ class Map
           elsif current_tag == 'exit' and current_attributes['target']
             if current_attributes['type'].downcase == 'string'
               room['wayto'][current_attributes['target']] = text_string
-            elsif
-              room['wayto'][current_attributes['target']] = StringProc.new(text_string)
             end
             if current_attributes['cost'] =~ /^[0-9\.]+$/
               room['timeto'][current_attributes['target']] = current_attributes['cost'].to_f
@@ -561,12 +616,12 @@ class Map
         }
         begin
           File.open(filename) { |file|
-            while line = file.gets
+            while (line = file.gets)
               buffer.concat(line)
               # fixme: remove   (?=<)   ?
-              while str = buffer.slice!(/^<([^>]+)><\/\1>|^[^<]+(?=<)|^<[^<]+>/)
-                if str[0,1] == '<'
-                  if str[1,1] == '/'
+              while (str = buffer.slice!(/^<([^>]+)><\/\1>|^[^<]+(?=<)|^<[^<]+>/))
+                if str[0, 1] == '<'
+                  if str[1, 1] == '/'
                     element = /^<\/([^\s>\/]+)/.match(str).captures.first
                     tag_end.call(element)
                   else
@@ -580,7 +635,7 @@ class Map
                       attributes = Hash.new
                       str.scan(/([A-z][A-z0-9_\-]*)=(["'])(.*?)\2/).each { |attr| attributes[attr[0]] = attr[2].gsub(/&(#{unescape.keys.join('|')});/) { unescape[$1] } }
                       tag_start.call(element, attributes)
-                      tag_end.call(element) if str[-2,1] == '/'
+                      tag_end.call(element) if str[-2, 1] == '/'
                     end
                   end
                 else
@@ -605,7 +660,7 @@ class Map
     }
   end
 
-  def Map.save(filename="#{DATA_DIR}/#{XMLData.game}/map-#{Time.now.to_i}.dat")
+  def Map.save(filename = "#{DATA_DIR}/#{XMLData.game}/map-#{Time.now.to_i}.dat")
     if File.exist?(filename)
       respond "--- Backing up map database"
       begin
@@ -632,27 +687,30 @@ class Map
     @@list.delete_if { |r| r.nil? }
     @@list.to_json(args)
   end
-  def to_json(*args)
+
+  def to_json(*_args)
     mapjson = ({
-      :id => @id,
-      :title => @title,
-      :description => @description,
-      :paths => @paths,
-      :location => @location,
-      :climate => @climate,
-      :terrain => @terrain,
-      :wayto => @wayto,
-      :timeto => @timeto,
-      :image => @image,
-      :image_coords => @image_coords,
-      :tags => @tags,
+      :id             => @id,
+      :title          => @title,
+      :description    => @description,
+      :paths          => @paths,
+      :location       => @location,
+      :climate        => @climate,
+      :terrain        => @terrain,
+      :wayto          => @wayto,
+      :timeto         => @timeto,
+      :image          => @image,
+      :image_coords   => @image_coords,
+      :tags           => @tags,
       :check_location => @check_location,
-      :unique_loot => @unique_loot,
-      :uid => @uid,
-    }).delete_if { |a,b| b.nil? or (b.class == Array and b.empty?) };
+      :unique_loot    => @unique_loot,
+      :uid            => @uid,
+    }).delete_if { |_a, b| b.nil? or (b.class == Array and b.empty?) };
+    # can't remove empty wayto and timeto, fails test on repository server side
     JSON.pretty_generate(mapjson);
   end
-  def Map.save_json(filename="#{DATA_DIR}/#{XMLData.game}/map-#{Time.now.to_i}.json")
+
+  def Map.save_json(filename = "#{DATA_DIR}/#{XMLData.game}/map-#{Time.now.to_i}.json")
     if File.exist?(filename)
       respond "File exists!  Backing it up before proceeding..."
       begin
@@ -670,8 +728,10 @@ class Map
       file.write(Map.to_json)
     }
     respond "#{filename} saved"
+    Map.reload if Map[-1].id != Map[Map[-1].id].id
   end
-  def Map.save_xml(filename="#{DATA_DIR}/#{XMLData.game}/map-#{Time.now.to_i}.xml")
+
+  def Map.save_xml(filename = "#{DATA_DIR}/#{XMLData.game}/map-#{Time.now.to_i}.xml")
     if File.exist?(filename)
       respond "File exists!  Backing it up before proceeding..."
       begin
@@ -748,7 +808,7 @@ class Map
     time = 0.to_f
     until array.length < 2
       room = array.shift
-      if t = Map[room].timeto[array.first.to_s]
+      if (t = Map[room].timeto[array.first.to_s])
         if t.class == Proc
           time += t.call.to_f
         else
@@ -758,26 +818,28 @@ class Map
         time += "0.2".to_f
       end
     end
-    time
+    return time
   end
-  def Map.dijkstra(source, destination=nil)
+
+  def Map.dijkstra(source, destination = nil)
     if source.class == Map
-      source.dijkstra(destination)
-    elsif room = Map[source]
-      room.dijkstra(destination)
+      return source.dijkstra(destination)
+    elsif (room = Map[source])
+      return room.dijkstra(destination)
     else
       echo "Map.dijkstra: error: invalid source room"
-      nil
+      return nil
     end
   end
-  def dijkstra(destination=nil)
+
+  def dijkstra(destination = nil)
     begin
       Map.load unless @@loaded
       source = @id
       visited = Array.new
       shortest_distances = Array.new
       previous = Array.new
-      pq = [ source ]
+      pq = [source]
       pq_push = proc { |val|
         for i in 0...pq.size
           if shortest_distances[val] <= shortest_distances[pq[i]]
@@ -785,7 +847,7 @@ class Map
             break
           end
         end
-        pq.push(val) if i.nil? or (i == pq.size-1)
+        pq.push(val) if i.nil? or (i == pq.size - 1)
       }
       visited[source] = true
       shortest_distances[source] = 0
@@ -869,56 +931,61 @@ class Map
       nil
     end
   end
+
   def Map.findpath(source, destination)
     if source.class == Map
       source.path_to(destination)
-    elsif room = Map[source]
+    elsif (room = Map[source])
       room.path_to(destination)
     else
       echo "Map.findpath: error: invalid source room"
       nil
     end
   end
+
   def path_to(destination)
     Map.load unless @@loaded
     destination = destination.to_i
-    previous, shortest_distances = dijkstra(destination)
+    previous, _shortest_distances = dijkstra(destination)
     return nil unless previous[destination]
-    path = [ destination ]
+    path = [destination]
     path.push(previous[path[-1]]) until previous[path[-1]] == @id
     path.reverse!
     path.pop
     return path
   end
+
   def find_nearest_by_tag(tag_name)
     target_list = Array.new
     @@list.each { |room| target_list.push(room.id) if room.tags.include?(tag_name) }
-    previous, shortest_distances = Map.dijkstra(@id, target_list)
+    _previous, shortest_distances = Map.dijkstra(@id, target_list)
     if target_list.include?(@id)
       @id
     else
       target_list.delete_if { |room_num| shortest_distances[room_num].nil? }
-      target_list.sort { |a,b| shortest_distances[a] <=> shortest_distances[b] }.first
+      target_list.sort { |a, b| shortest_distances[a] <=> shortest_distances[b] }.first
     end
   end
+
   def find_all_nearest_by_tag(tag_name)
     target_list = Array.new
     @@list.each { |room| target_list.push(room.id) if room.tags.include?(tag_name) }
-    previous, shortest_distances = Map.dijkstra(@id)
+    _previous, shortest_distances = Map.dijkstra(@id)
     target_list.delete_if { |room_num| shortest_distances[room_num].nil? }
-    target_list.sort { |a,b| shortest_distances[a] <=> shortest_distances[b] }
+    target_list.sort { |a, b| shortest_distances[a] <=> shortest_distances[b] }
   end
+
   def find_nearest(target_list)
     target_list = target_list.collect { |num| num.to_i }
     if target_list.include?(@id)
       @id
     else
-      previous, shortest_distances = Map.dijkstra(@id, target_list)
+      _previous, shortest_distances = Map.dijkstra(@id, target_list)
       target_list.delete_if { |room_num| shortest_distances[room_num].nil? }
-      target_list.sort { |a,b| shortest_distances[a] <=> shortest_distances[b] }.first
+      target_list.sort { |a, b| shortest_distances[a] <=> shortest_distances[b] }.first
     end
   end
-end
+end # end class Map
 
 class Room < Map
   def Room.method_missing(*args)
@@ -928,34 +995,10 @@ end
 
 # deprecated
 class Map
-  def desc
-    @description
-  end
-  def map_name
-    @image
-  end
-  def map_x
-    if @image_coords.nil?
-      nil
-    else
-      ((image_coords[0] + image_coords[2])/2.0).round
-    end
-  end
-  def map_y
-    if @image_coords.nil?
-      nil
-    else
-      ((image_coords[1] + image_coords[3])/2.0).round
-    end
-  end
-  def map_roomsize
-    if @image_coords.nil?
-      nil
-    else
-      image_coords[2] - image_coords[0]
-    end
-  end
-  def geo
-    nil
-  end
+  def desc; return @description; end
+  def map_name; return @image; end
+  def map_x; return @image_coords.nil? ? nil : ((image_coords[0] + image_coords[2]) / 2.0).round; end
+  def map_y; return @image_coords.nil? ? nil : ((image_coords[1] + image_coords[3]) / 2.0).round; end
+  def map_roomsize; return @image_coords.nil? ? nil : image_coords[2] - image_coords[0]; end
+  def geo; return nil; end
 end


### PR DESCRIPTION
rubocop
- update logic to not add multiple uids to the same room unless tagged meta:map:multi-uid
- updated Map.current_or_new to strip down rooms to just their current values for rooms tagged meta:map:latest-only or meta:playershop
- adds Map.images and Map.locations, similar to Map.tags.  Switched to use a hash to build the tags array faster.