### PR TITLE
[society.rb] typo fix

### DIFF
--- a/lib/attributes/society.rb
+++ b/lib/attributes/society.rb
@@ -14,7 +14,7 @@ class Society
   end
 
   def self.member
-    self.stastus.dup
+    self.status.dup
   end
 
   def self.task


### PR DESCRIPTION
typo fix for `self.stastus.dup`