### PR TITLE
[infomon.rb] dash space fix for naming keys

### DIFF
--- a/lib/infomon/infomon.rb
+++ b/lib/infomon/infomon.rb
@@ -64,7 +64,7 @@ module Infomon
 
   def self._key(key)
     key = key.to_s.downcase
-    key.gsub!(' ', '_').gsub!('_-_', '').gsub!('-', '_') if key =~ /\s|-/
+    key.gsub!(' ', '_').gsub!('_-_', '_').gsub!('-', '_') if key =~ /\s|-/
     return key
   end
 


### PR DESCRIPTION
Currently keys should be automatically replacing spacing with `_` characters. But in regards to lore skills, this is currently having an issue due to the `.gsub('_-_', '')` removing the underline as shown via:
```ruby
;e echo Infomon._key('sorcerous lore - necromancy')
[exec1: sorcerous_lorenecromancy] 
```
Replacing the previous to be `.gsub('_-_', '_')` instead now corrects this and has the naming to be:
```ruby
;e echo Infomon._key('sorcerous lore - necromancy')
[exec1: sorcerous_lore_necromancy] 
```
Which matches skills.rb module for returning proper values.