### PR TITLE
[infomon.rb] context! change to use underscore instead of decimal

### DIFF
--- a/lib/infomon/infomon.rb
+++ b/lib/infomon/infomon.rb
@@ -40,7 +40,7 @@ module Infomon
 
   def self.table_name
     self.context!
-    ("%s.%s" % [XMLData.game, XMLData.name]).to_sym
+    ("%s_%s" % [XMLData.game, XMLData.name]).to_sym
   end
 
   def self.reset!


### PR DESCRIPTION
SQLite naming conventions use alphanumeric and underscore for naming, using a dot notation requires quoting the name.

Dots are for identifying objects, usually in the database.schema.table.column pattern.

Would be better to do this before shipping.