### PR TITLE
[rspec_tests.yml] cancel previous already running rspecs

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -1,6 +1,10 @@
 name: RSpec Tests
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
No reason to continue a previously still running rspec if another newer rspec action is started. Cancel previous in progress runs.