### PR TITLE
[core][parser] Add .to_i for integer match

### DIFF
--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -179,7 +179,7 @@ module Infomon
         when Pattern::Society
           match = Regexp.last_match
           Infomon.set('society.status', match[:society])
-          Infomon.set('society.rank', match[:rank])
+          Infomon.set('society.rank', match[:rank].to_i)
           case match[:standing] # if Master in society the rank match is nil
           when 'Master'
             if /Voln/.match?(match[:society])


### PR DESCRIPTION
This match was resulting in a string, not an integer.

https://discord.com/channels/690691823542206496/691485066659889212/1121762396583763988