### PR TITLE
[status.rb] typo for webbed using wrong indicator

### DIFF
--- a/lib/infomon/status.rb
+++ b/lib/infomon/status.rb
@@ -26,7 +26,7 @@ module Status
 
   # deprecate these in global_defs after warning, consider bringing other status maps over
   def self.webbed?
-    XMLData.indicator['IconDEAD'] == 'y'
+    XMLData.indicator['IconWEBBED'] == 'y'
   end
 
   def self.dead?


### PR DESCRIPTION
Had `self.webbed?` using `XMLData.indicator['IconDEAD']` instead of `XMLData.indicator['IconWEBBED']`