### PR TITLE
chore: front-end.rb update to add client and name methods

### DIFF
--- a/lib/front-end.rb
+++ b/lib/front-end.rb
@@ -21,4 +21,13 @@ module Frontend
     return if @session_file.nil?
     File.delete(@session_file) if File.exist? @session_file
   end
+
+  def self.client
+    return $_CLIENT_ if $_CLIENT_
+    return $_DETACHABLE_CLIENT_ if $_DETACHABLE_CLIENT_
+  end
+
+  def self.name
+    return $frontend
+  end
 end

--- a/lib/front-end.rb
+++ b/lib/front-end.rb
@@ -1,4 +1,3 @@
-
 require 'tempfile'
 require 'json'
 require 'fileutils'
@@ -10,7 +9,7 @@ module Frontend
   def self.create_session_file(name, host, port)
     FileUtils.mkdir_p @tmp_session_dir
     @session_file = File.join(@tmp_session_dir, "%s.session" % name.downcase.capitalize)
-    session_descriptor = {name: name, host: host, port: port}.to_json
+    session_descriptor = { name: name, host: host, port: port }.to_json
     puts "writing session descriptor to %s\n%s" % [@session_file, session_descriptor]
     File.open(@session_file, "w") do |fd|
       fd << session_descriptor

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -128,8 +128,7 @@ module Lich
           respond 'Please confirm your participation:  ;send Y or ;send N'
           # we are only going to get the next client-input line, and if it does not confirm, we bail
           # we are doing this to prevent hanging the client with various other inputs by the user
-          sync_thread = $_CLIENT_ || $_DETACHABLE_CLIENT_
-          line = sync_thread.gets until line.strip =~ /^;send |^;s /i
+          line = Frontend.client.gets until line.strip =~ /^;send |^;s /i
           if line =~ /send Y|s Y/i
             @beta_response = 'accepted'
             respond 'Beta test installation accepted.  Thank you for considering!'


### PR DESCRIPTION
Adds `Frontend.client` method that returns either `$_CLIENT_` or `$_DETACHABLE_CLIENT_` depending on which is active. Also adds `Frontend.name` to return `$frontend` to give a better API for future updates to replace the global variable.