### PR TITLE
[lich.rbw][xmlparser.rb] Remove NAV tag rewrites, fix in xmlparser instead

### DIFF
--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -236,17 +236,6 @@ class XMLParser
         end
       end
 
-      if name == 'compass' and $nav_seen
-        $nav_seen = false
-        @second_compass = true
-      end
-
-      if name == 'compass' and @second_compass
-        @second_compass = false
-        @room_count += 1
-        $room_count += 1
-      end
-
       if name =~ /^(?:a|right|left)$/
         @obj_exist = attributes['exist']
         @obj_noun = attributes['noun']
@@ -729,6 +718,18 @@ class XMLParser
 
   def tag_end(name)
     begin
+
+      if name == 'compass' and $nav_seen
+        $nav_seen = false
+        @second_compass = true
+      end
+
+      if name == 'compass' and @second_compass
+        @second_compass = false
+        @room_count += 1
+        $room_count += 1
+      end
+
       if name == 'inv'
         if @obj_exist == @obj_location
           if @obj_after_name == 'is closed.'

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -722,9 +722,7 @@ class XMLParser
       if name == 'compass' and $nav_seen
         $nav_seen = false
         @second_compass = true
-      end
-
-      if name == 'compass' and @second_compass
+      elsif name == 'compass' and @second_compass
         @second_compass = false
         @room_count += 1
         $room_count += 1

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -222,7 +222,6 @@ class XMLParser
       @active_ids.push(attributes['id'].to_s)
 
       if name == 'nav'
-        Lich.log("01 NAV detected!")
         @previous_nav_rm = @room_id
         @room_id = attributes['rm'].to_i
         $nav_seen = true
@@ -230,7 +229,6 @@ class XMLParser
       end
 
       if name == 'compass'
-        Lich.log("02 COMPASS detected!")
         if @current_stream == 'familiar'
           @fam_mode = String.new
         elsif @room_window_disabled
@@ -239,13 +237,11 @@ class XMLParser
       end
 
       if name == 'compass' and $nav_seen
-        Lich.log("03 COMPASS & NAV SEEN")
         $nav_seen = false
         @second_compass = true
       end
 
       if name == 'compass' and @second_compass
-        Lich.log("04 COMPASS & SECOND COMPASS")
         @second_compass = false
         @room_count += 1
         $room_count += 1

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -220,6 +220,37 @@ class XMLParser
     begin
       @active_tags.push(name)
       @active_ids.push(attributes['id'].to_s)
+
+      if name == 'nav'
+        Lich.log("01 NAV detected!")
+        @previous_nav_rm = @room_id
+        @room_id = attributes['rm'].to_i
+        $nav_seen = true
+        Map.last_seen_objects = nil if Map.method_defined?(:last_seen_objects); # DR Only
+      end
+
+      if name == 'compass'
+        Lich.log("02 COMPASS detected!")
+        if @current_stream == 'familiar'
+          @fam_mode = String.new
+        elsif @room_window_disabled
+          @room_exits = Array.new
+        end
+      end
+
+      if name == 'compass' and $nav_seen
+        Lich.log("03 COMPASS & NAV SEEN")
+        $nav_seen = false
+        @second_compass = true
+      end
+
+      if name == 'compass' and @second_compass
+        Lich.log("04 COMPASS & SECOND COMPASS")
+        @second_compass = false
+        @room_count += 1
+        $room_count += 1
+      end
+
       if name =~ /^(?:a|right|left)$/
         @obj_exist = attributes['exist']
         @obj_noun = attributes['noun']
@@ -241,11 +272,6 @@ class XMLParser
         @process_spell_durations = true
       elsif name == 'resource'
         nil
-      elsif name == 'nav'
-        @previous_nav_rm = @room_id
-        @room_id = attributes['rm'].to_i
-        $nav_seen = true
-        Map.last_seen_objects = nil if Map.method_defined?(:last_seen_objects); # DR Only
       elsif name == 'pushStream'
         @in_stream = true
         @current_stream = attributes['id'].to_s
@@ -734,13 +760,6 @@ class XMLParser
         @room_exits.each { |exit| gsl_exits.concat(DIRMAP[SHORTDIR[exit]].to_s) }
         $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
         gsl_exits = nil
-        @room_count += 1
-        $room_count += 1
-      elsif name == 'compass' and $nav_seen
-        $nav_seen = false
-        @second_compass = true
-      elsif name == 'compass' and @second_compass
-        @second_compass = false
         @room_count += 1
         $room_count += 1
       end

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -480,12 +480,6 @@ class XMLParser
           end
         end
         $_CLIENT_.puts "\034GSV#{sprintf('%010d%010d%010d%010d%010d%010d%010d%010d', @max_health.to_i, @health.to_i, @max_spirit.to_i, @spirit.to_i, @max_mana.to_i, @mana.to_i, make_wound_gsl, make_scar_gsl)}\r\n" if @send_fake_tags
-      elsif name == 'compass'
-        if @current_stream == 'familiar'
-          @fam_mode = String.new
-        elsif @room_window_disabled
-          @room_exits = Array.new
-        end
       elsif @room_window_disabled and (name == 'dir') and @active_tags.include?('compass')
         @room_exits.push(LONGDIR[attributes['value']])
       elsif name == 'radio'
@@ -749,7 +743,6 @@ class XMLParser
         $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
         gsl_exits = nil
       elsif @room_window_disabled and (name == 'compass')
-        #            @room_window_disabled = false
         @room_description = @room_description.strip
         @room_exits_string.concat " #{@room_exits.join(', ')}" unless @room_exits.empty?
         gsl_exits = String.new

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -719,13 +719,16 @@ class XMLParser
   def tag_end(name)
     begin
 
-      if name == 'compass' and $nav_seen
-        $nav_seen = false
-        @second_compass = true
-      elsif name == 'compass' and @second_compass
-        @second_compass = false
-        @room_count += 1
-        $room_count += 1
+      if @game =~ /^DR/
+        if name == 'compass' and $nav_seen
+          $nav_seen = false
+          @second_compass = true
+        end
+        if name == 'compass' and @second_compass
+          @second_compass = false
+          @room_count += 1
+          $room_count += 1
+        end
       end
 
       if name == 'inv'

--- a/lich.rbw
+++ b/lich.rbw
@@ -1058,23 +1058,6 @@ module Games
         server_string = server_string.gsub("<pushStream id=\"combat\" /><component id=", "<component id=")
         # server_string = server_string.gsub("<pushStream id=\"combat\" /><prompt ","<prompt ")
 
-        ## Fix for nested/non-solo nav tags.
-        ## DR needs the <nav/> tag to be in its own line to properly detect movement
-        ## These two fixes make it so room movement can be detected reliably
-        if server_string =~ /^<nav\/>/
-          unless server_string.chomp == "<nav\/>"
-            Lich.log "NAV tag detected in nested line: #{server_string.inspect}"
-            server_string.gsub!("<nav\/>", "<nav\/>\n").chomp!
-            Lich.log "NAV tag fixed to: #{server_string.inspect}"
-          end
-        end
-
-        if server_string =~ /(?!^)<nav\/>/
-          Lich.log "NAV tag detected not at start of line: #{server_string.inspect}"
-          server_string.gsub!("<nav\/>", "\n<nav\/>").chomp!
-          Lich.log "NAV tag fixed to: #{server_string.inspect}"
-        end
-
         # Fixes xml with \r\n in the middle of it like:
         # <component id='room exits'>Obvious paths: clockwise, widdershins.\r\n
         # <compass></compass></component>\r\n


### PR DESCRIPTION
Allows xmlparser to parse nav tags when nested in the same line as other attributes.