### PR TITLE
[spell.rb] fix for #273

### DIFF
--- a/lib/spell.rb
+++ b/lib/spell.rb
@@ -611,7 +611,7 @@ module Games
               return false
             end
           end
-          unless (self.spirit_cost > 0) or checkspirit(self.spirit_cost + 1 + [9912, 9913, 9914, 9916, 9916, 9916].delete_if { |num| !Spell[num].active? }.length)
+          unless (self.spirit_cost <= 0) or checkspirit(self.spirit_cost + 1 + [9912, 9913, 9914, 9916, 9916, 9916].delete_if { |num| !Spell[num].active? }.length)
             echo 'cast: not enough spirit'
             sleep 0.1
             return false


### PR DESCRIPTION
fix for #273

reproduce as col sorcerer: 
reduce spirit to 1 and have spirit draining sign active (e.g. sign of swords), try Spell[401].cast and get 'not enough spirit' error. 

fix: skip spirit check if the spell doesn't require spirit.