### PR TITLE
[lich.rbw] Add sub for bad apostrophe encoding string

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -1073,6 +1073,16 @@ module Games
         server_string = server_string.gsub("<pushStream id=\"combat\" /><popStream id=\"combat\" />", "")
         server_string = server_string.gsub("<popStream id=\"combat\" /><pushStream id=\"combat\" />", "")
 
+        # DR occasionally has poor encoding in text, which causes parsing errors.
+        # One example of this is in the discern text for the spell Membrach's Greed
+        # which gets sent as Membrach\x92s Greed. This fixes the bad encoding until
+        # Simu fixes it.
+        if server_string =~ /\x92/
+          Lich.log "Detected poorly encoded apostrophe: #{server_string.inspect}"
+          server_string.gsub!("\x92", "'")
+          Lich.log "Changed poorly encoded apostrophe to: #{server_string.inspect}"
+        end
+
         ## Fix combat wrapping components - Why, DR, Why?
         server_string = server_string.gsub("<pushStream id=\"combat\" /><component id=", "<component id=")
         # server_string = server_string.gsub("<pushStream id=\"combat\" /><prompt ","<prompt ")


### PR DESCRIPTION
DR occasionally has poor encoding in text, which causes parsing errors. One example of this is in the discern text for the spell Membrach's Greed which gets sent as Membrach\x92s Greed. This fixes the bad encoding until Simu fixes it.

Results in:
```
2023-07-14 10:11:02: Detected poorly encoded apostrophe: "<roundTime value='1689286271'/>Named for the Dwarven warlord whose lust for wealth and power propelled his kingdom into disastrous war, certain moralists decry the teaching of Memb
rach\x92s Greed.  Their objections are largely dismissed though, for rather than perverting its target's mentality as commonly believed, the spell pattern selectively hones the natural thought processes related to avidity and discernment,
 allowing those under its elegant effect to more easily locate and collect valuable raw resources.  A versatile spell, knowledge of Membrach\x92s Greed will prove beneficial to furriers, woodcutters, herbalists, and prospectors alike.\r\n
"
```
to
```
2023-07-14 10:11:02: Changed poorly encoded apostrophe to: "<roundTime value='1689286271'/>Named for the Dwarven warlord whose lust for wealth and power propelled his kingdom into disastrous war, certain moralists decry the teaching of Me
mbrach's Greed.  Their objections are largely dismissed though, for rather than perverting its target's mentality as commonly believed, the spell pattern selectively hones the natural thought processes related to avidity and discernment, 
allowing those under its elegant effect to more easily locate and collect valuable raw resources.  A versatile spell, knowledge of Membrach's Greed will prove beneficial to furriers, woodcutters, herbalists, and prospectors alike.\r\n"
```