### PR TITLE
[update.rb] bugfix for backing non-existent data files

### DIFF
--- a/lib/update.rb
+++ b/lib/update.rb
@@ -231,8 +231,10 @@ module Lich
           data_update.each { |file|
             transition_filename = "#{file}".sub(".xml", '')
             newfilename = File.join(DATA_DIR, "#{transition_filename}-#{Time.now.to_i}.xml")
-            File.open(File.join(DATA_DIR, file), 'rb') { |r| File.open(newfilename, 'wb') { |w| w.write(r.read) } }
-            File.delete(File.join(DATA_DIR, file)) if File.exist?(File.join(DATA_DIR, file))
+            if File.exist?(File.join(DATA_DIR, file))
+              File.open(File.join(DATA_DIR, file), 'rb') { |r| File.open(newfilename, 'wb') { |w| w.write(r.read) } }
+              File.delete(File.join(DATA_DIR, file))
+            end
             File.open(File.join(TEMP_DIR, filename, "data", file), 'rb') { |r|
               File.open(File.join(DATA_DIR, file), 'wb') { |w| w.write(r.read) }
             }


### PR DESCRIPTION
Resolves trying to backup a file that does not exist, like the new effect-list.xml

```
--- Lich: error: client_thread: No such file or directory @ rb_sysopen - D:/Lich5/data/effect-list.xml
D:/Lich5/lib/update.rb:234:in `initialize'
```