### PR TITLE
[task.rb] fix to :heirloom_found for guard?

### DIFF
--- a/lib/bounty/task.rb
+++ b/lib/bounty/task.rb
@@ -105,7 +105,7 @@ class Bounty
     def guard?
       [
         :guard,
-        :bandit_assignment, :creature_assignment, :heirloom_assignment, :rescue_assignment
+        :bandit_assignment, :creature_assignment, :heirloom_assignment, :heirloom_found, :rescue_assignment
       ].include?(type)
     end
 

--- a/lib/bounty/task.rb
+++ b/lib/bounty/task.rb
@@ -1,6 +1,6 @@
 class Bounty
   class Task
-    def initialize(options={})
+    def initialize(options = {})
       @description    = options[:description]
       @type           = options[:type]
       @requirements   = options[:requirements] || {}
@@ -123,19 +123,25 @@ class Bounty
     def help?
       description.start_with?("You have been tasked to help")
     end
-    def assist?; help?; end
-    def group?; help? ;end
+
+    def assist?
+      help?
+    end
+
+    def group?
+      help?
+    end
 
     def method_missing(symbol, *args, &blk)
-      if requirements&.keys.include?(symbol)
+      if requirements&.keys&.include?(symbol)
         requirements[symbol]
       else
         super
       end
     end
 
-    def respond_to_missing?(symbol, include_private=false)
-      requirements&.keys.include?(symbol) || super
+    def respond_to_missing?(symbol, include_private = false)
+      requirements&.keys&.include?(symbol) || super
     end
   end
 end

--- a/spec/bounty/task_spec.rb
+++ b/spec/bounty/task_spec.rb
@@ -132,7 +132,7 @@ class Bounty
 
     describe "#guard?" do
       let(:predicate) { :guard? }
-      let(:truthy_types) { [:guard, :bandit_assignment, :creature_assignment, :heirloom_assignment, :rescue_assignment] }
+      let(:truthy_types) { [:guard, :bandit_assignment, :creature_assignment, :heirloom_assignment, :heirloom_found, :rescue_assignment] }
 
       include_examples "task predicate examples"
     end


### PR DESCRIPTION
Need to add `:heirloom_found` match for `guard?` method as you need to return to the guard first before going to the taskmaster.