### PR TITLE
[R4LGTK3.iss] change final installer name include version

### DIFF
--- a/R4LGTK3.iss
+++ b/R4LGTK3.iss
@@ -41,7 +41,7 @@ DisableReadyPage=Yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 PrivilegesRequired=lowest
 ;PrivilegesRequiredOverridesAllowed=commandline dialog
-OutputBaseFilename=Ruby4Lich5
+OutputBaseFilename=Ruby4Lich{#MyAppVersion}
 SetupIconFile=.\fly64.ico
 Compression=lzma2/ultra64
 SolidCompression=yes


### PR DESCRIPTION
Change installer name to match version of Lich it's packaged with so instead of `Ruby4Lich5.exe` it's `Ruby4Lich5.7.0-rc.6.exe`