### PR TITLE
[specs] Refactor some things to significantly improve rspec run time

### DIFF
--- a/lib/game-loader.rb
+++ b/lib/game-loader.rb
@@ -13,6 +13,7 @@ module GameLoader
     require 'lib/infomon/status'
     require 'lib/experience'
     require 'lib/infomon/activespell'
+    ActiveSpell.watch!
     # PSMS (armor, cman, feat, shield, weapon) have moved
     # to ./lib/psms and are now called by psms.rb
     require 'lib/psms'

--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -110,5 +110,4 @@ module ActiveSpell
       end
     end
   end
-  ActiveSpell.watch!
 end

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -24,10 +24,16 @@ require 'rexml/document'
 require 'rexml/streamlistener'
 require 'open-uri'
 require "spell"
-download = URI.open('https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/effect-list.xml').read
-FileUtils.mkdir_p('/home/runner/work/lich-5/lich-5/data')
-File.write('/home/runner/work/lich-5/lich-5/data/effect-list.xml', download)
-Games::Gemstone::Spell.load('/home/runner/work/lich-5/lich-5/data/effect-list.xml')
+require 'tmpdir'
+
+Dir.mktmpdir do |dir|
+  local_filename = File.join(dir, "effect-list.xml")
+  print "Downloading effect-list.xml..."
+  download = URI.open('https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/effect-list.xml').read
+  File.write(local_filename, download)
+  Games::Gemstone::Spell.load(local_filename)
+  puts " Done!"
+end
 
 require "infomon/infomon"
 require "attributes/stats"

--- a/spec/psms_spec.rb
+++ b/spec/psms_spec.rb
@@ -27,7 +27,7 @@ require "spell"
 require 'tmpdir'
 
 Dir.mktmpdir do |dir|
-  local_filename = File.join(dir, "eefect-list.xml")
+  local_filename = File.join(dir, "effect-list.xml")
   print "Downloading effect-list.xml..."
   download = URI.open('https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/effect-list.xml').read
   File.write(local_filename, download)

--- a/spec/psms_spec.rb
+++ b/spec/psms_spec.rb
@@ -24,10 +24,16 @@ require 'rexml/document'
 require 'rexml/streamlistener'
 require 'open-uri'
 require "spell"
-download = URI.open('https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/effect-list.xml').read
-FileUtils.mkdir_p('/home/runner/work/lich-5/lich-5/data')
-File.write('/home/runner/work/lich-5/lich-5/data/effect-list.xml', download)
-Games::Gemstone::Spell.load('/home/runner/work/lich-5/lich-5/data/effect-list.xml')
+require 'tmpdir'
+
+Dir.mktmpdir do |dir|
+  local_filename = File.join(dir, "eefect-list.xml")
+  print "Downloading effect-list.xml..."
+  download = URI.open('https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/effect-list.xml').read
+  File.write(local_filename, download)
+  Games::Gemstone::Spell.load(local_filename)
+  puts " Done!"
+end
 
 require "psms"
 require "infomon/infomon"


### PR DESCRIPTION
I wasn't able to run the specs locally after some recent changes, so I dug into what was going on. I made a few changes here to get things working locally and to vastly improve the spec run time.  It is also probably not ideal that we download `spell-effect.xml` multiple times per spec run but things happen reasonably fast for me locally that I didn't tackle that.

### Before
[3 minutes](https://github.com/elanthia-online/lich-5/actions/runs/5687307741)

### After
[20s](https://github.com/elanthia-online/lich-5/actions/runs/5687369839)
