### PR TITLE
[update.rb] - change prod update path to zipball

### DIFF
--- a/lib/update.rb
+++ b/lib/update.rb
@@ -172,7 +172,7 @@ module Lich
         JSON::parse(update_info).each { |entry|
           if entry.include? 'tag_name'
             @update_to = entry[1].sub('v', '')
-          elsif entry.include? 'tarball_url'
+          elsif entry.include? 'zipball_url'
             @zipfile = entry[1]
           elsif entry.include? 'body'
             @new_features = entry[1].gsub(/\#\# What's Changed.+$/m, '')


### PR DESCRIPTION
Correct `update.rb` default prod source from tarball to zipball to ensure proper files are downloaded at request.