### PR TITLE
[update.rb] change method to pull asset tar file

### DIFF
--- a/lib/update.rb
+++ b/lib/update.rb
@@ -171,7 +171,7 @@ module Lich
 
         JSON::parse(update_info).each { |entry, value|
           if entry.include? 'tag_name'
-            @update_to = entry[1].sub('v', '')
+            @update_to = value.sub('v', '')
           elsif entry.include? 'assets'
             @holder = value
           elsif entry.include? 'body'

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -172,12 +172,14 @@ module Lich
         JSON::parse(update_info).each { |entry|
           if entry.include? 'tag_name'
             @update_to = entry[1].sub('v', '')
-          elsif entry.include? 'tarball_url'
-            @zipfile = entry[1]
+          elsif entry.include? 'assets'
+            @holder = value
           elsif entry.include? 'body'
-            @new_features = entry[1].gsub(/\#\# What's Changed.+$/m, '')
+            @new_features = value.gsub(/\#\# What's Changed.+$/m, '')
           end
         }
+        beta_asset = @holder.find { |x| x['name'] =~ /lich-5.tar.gz/ }
+        @zipfile = beta_asset.fetch('browser_download_url')
       end
 
       def self.download_update

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -178,8 +178,8 @@ module Lich
             @new_features = value.gsub(/\#\# What's Changed.+$/m, '')
           end
         }
-        beta_asset = @holder.find { |x| x['name'] =~ /lich-5.tar.gz/ }
-        @zipfile = beta_asset.fetch('browser_download_url')
+        release_asset = @holder.find { |x| x['name'] =~ /lich-5.tar.gz/ }
+        @zipfile = release_asset.fetch('browser_download_url')
       end
 
       def self.download_update

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -169,7 +169,7 @@ module Lich
         filename = "https://api.github.com/repos/elanthia-online/lich-5/releases/latest"
         update_info = URI.parse(filename).open.read
 
-        JSON::parse(update_info).each { |entry|
+        JSON::parse(update_info).each { |entry, value|
           if entry.include? 'tag_name'
             @update_to = entry[1].sub('v', '')
           elsif entry.include? 'assets'


### PR DESCRIPTION
Changed prod tar retrieval based on suggestion to match beta file fetch method.  Change supports workflow change to delete data files from Lich repo and build EO scripts repo data files into build.