### PR TITLE
[cli.rb] save last Infomon.sync to db

### DIFF
--- a/lib/infomon/cli.rb
+++ b/lib/infomon/cli.rb
@@ -26,6 +26,7 @@ module Infomon
       respond "Did #{command}." if $infomon_debug
     end
     respond 'Requested Infomon sync complete.'
+    Infomon.set('infomon.last_sync', Time.now.to_i)
   end
 
   def self.redo!


### PR DESCRIPTION
Save the last time `Infomon.sync` was ran to the db to have a valid check for first run sync and for other debugging needs by setting `Infomon.set('infomon.last_sync', Time.now.to_i)`