### PR TITLE
[infomon] Refactor ActiveSpell watcher to use queue

### DIFF
--- a/lib/game-loader.rb
+++ b/lib/game-loader.rb
@@ -13,7 +13,6 @@ module GameLoader
     require 'lib/infomon/status'
     require 'lib/experience'
     require 'lib/infomon/activespell'
-    ActiveSpell.watch!
     # PSMS (armor, cman, feat, shield, weapon) have moved
     # to ./lib/psms and are now called by psms.rb
     require 'lib/psms'

--- a/lib/game-loader.rb
+++ b/lib/game-loader.rb
@@ -13,6 +13,7 @@ module GameLoader
     require 'lib/infomon/status'
     require 'lib/experience'
     require 'lib/infomon/activespell'
+    ActiveSpell.watch!
     # PSMS (armor, cman, feat, shield, weapon) have moved
     # to ./lib/psms and are now called by psms.rb
     require 'lib/psms'

--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -117,10 +117,10 @@ module ActiveSpell
   def self.update_in_background?
     @update_in_background
   end
- 
+
   def self.request_update
     if update_in_background?
-      enqueue_update 
+      enqueue_update
     else
       update_spell_durations
     end
@@ -141,7 +141,7 @@ module ActiveSpell
   end
 
   def self.watch!
-    Thread.new do |thread|
+    Thread.new do
       loop do
         block_until_update_requested
         update_spell_durations

--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -109,29 +109,12 @@ module ActiveSpell
     end
   end
 
-  def self.update_in_background=(val)
-    @update_in_background = val
-  end
-  self.update_in_background = true
-
-  def self.update_in_background?
-    @update_in_background
-  end
-
   def self.request_update
-    if update_in_background?
-      enqueue_update
-    else
-      update_spell_durations
-    end
+    queue << Time.now
   end
 
   def self.queue
     @queue ||= Queue.new
-  end
-
-  def self.enqueue_update
-    queue << Time.now
   end
 
   def self.block_until_update_requested

--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -141,15 +141,13 @@ module ActiveSpell
   end
 
   def self.watch!
-    Thread.new do
+    @thread ||= Thread.new do
       loop do
         block_until_update_requested
         update_spell_durations
       rescue StandardError => e
-        if $infomon_debug
-          respond 'Error in spell durations thread'
-          respond e.inspect
-        end
+        respond 'Error in spell durations thread'
+        respond e.inspect
       end
     end
   end

--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -70,43 +70,41 @@ module ActiveSpell
     [update_spell_names, update_spell_durations]
   end
 
-  def self.watch!
-    Thread.new do
-      loop do
-        begin
-          sleep 0.01 until XMLData.process_spell_durations
-          update_spell_names, update_spell_durations = ActiveSpell.get_spell_info
-          puts "#{update_spell_names}\r\n" if $infomon_debug
-          puts "#{update_spell_durations}\r\n" if $infomon_debug
+  def self.update_spell_durations
+    begin
+      respond "[infomon] updating spell durations..." if $infomon_debug
+      update_spell_names, update_spell_durations = ActiveSpell.get_spell_info
+      puts "#{update_spell_names}\r\n" if $infomon_debug
+      puts "#{update_spell_durations}\r\n" if $infomon_debug
 
-          existing_spell_names = []
-          ignore_spells = ["Berserk", "Council Task", "Council Punishment", "Briar Betrayer"]
-          Spell.active.each { |s| existing_spell_names << s.name }
-          inactive_spells = existing_spell_names - ignore_spells - update_spell_names
-          inactive_spells.reject! do |s|
-            s =~ /^Aspect of the \w+ Cooldown|^[\w\s]+ Recovery/
-          end
-          inactive_spells.each do |s|
-            badspell = Spell[s].num
-            Spell[badspell].putdown if Spell[s].active?
-          end
+      existing_spell_names = []
+      ignore_spells = ["Berserk", "Council Task", "Council Punishment", "Briar Betrayer"]
+      Spell.active.each { |s| existing_spell_names << s.name }
+      inactive_spells = existing_spell_names - ignore_spells - update_spell_names
+      inactive_spells.reject! do |s|
+        s =~ /^Aspect of the \w+ Cooldown|^[\w\s]+ Recovery/
+      end
+      inactive_spells.each do |s|
+        badspell = Spell[s].num
+        Spell[badspell].putdown if Spell[s].active?
+      end
 
-          update_spell_durations.uniq.each do |k, v|
-            if (spell = Spell.list.find { |s| (s.name.downcase == k.strip.downcase) || (s.num.to_s == k.strip) })
-              spell.active = true
-              spell.timeleft = if v - Time.now > 300 * 60
-                                 600.01
-                               else
-                                 ((v - Time.now) / 60)
-                               end
-            elsif $infomon_debug
-              respond "no spell matches #{k}"
-            end
-          end
-        rescue StandardError
-          respond 'Error in spell durations thread' if $infomon_debug
+      update_spell_durations.uniq.each do |k, v|
+        if (spell = Spell.list.find { |s| (s.name.downcase == k.strip.downcase) || (s.num.to_s == k.strip) })
+          spell.active = true
+          spell.timeleft = if v - Time.now > 300 * 60
+                            600.01
+                          else
+                            ((v - Time.now) / 60)
+                          end
+        elsif $infomon_debug
+          respond "no spell matches #{k}"
         end
-        XMLData.process_spell_durations = false
+      end
+    rescue StandardError => e
+      if $infomon_debug
+        respond 'Error in spell durations thread'
+        respond e.inspect
       end
     end
   end

--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -93,10 +93,10 @@ module ActiveSpell
         if (spell = Spell.list.find { |s| (s.name.downcase == k.strip.downcase) || (s.num.to_s == k.strip) })
           spell.active = true
           spell.timeleft = if v - Time.now > 300 * 60
-                            600.01
-                          else
-                            ((v - Time.now) / 60)
-                          end
+                             600.01
+                           else
+                             ((v - Time.now) / 60)
+                           end
         elsif $infomon_debug
           respond "no spell matches #{k}"
         end

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -251,7 +251,7 @@ class XMLParser
         @dialogs[attributes["id"]] ||= {}
         @dialogs[attributes["id"]].clear
         # detect a clear board request for effects, and send to activespell
-        ActiveSpell.update_spell_durations
+        ActiveSpell.request_update
       elsif name == 'resource'
         nil
       elsif name == 'pushStream'
@@ -354,7 +354,7 @@ class XMLParser
           # puts "kind=(%s) name=%s attributes=%s" % [@active_ids[-2], name, attributes]
           self.parse_psm3_progressbar(@active_ids[-2], attributes)
           # since we received an updated spell duration, let's signal infomon to update
-          ActiveSpell.update_spell_durations
+          ActiveSpell.request_update
         end
       elsif name == 'roundTime'
         @roundtime_end = attributes['value'].to_i

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -32,7 +32,7 @@ class XMLParser
               :next_level_text, :society_task, :stow_container_id, :name, :game, :in_stream,
               :player_id, :prompt, :current_target_ids, :current_target_id, :room_window_disabled,
               :dialogs, :room_id, :previous_nav_rm, :room_objects, :concentration, :max_concentration
-  attr_accessor :send_fake_tags, :process_spell_durations
+  attr_accessor :send_fake_tags
 
   @@warned_deprecated_spellfront = 0
 
@@ -123,9 +123,6 @@ class XMLParser
     # real id updates
     @room_id = nil
     @previous_nav_rm = nil
-
-    # infomon rewrite (activespells)
-    @process_spell_durations = false
   end
 
   # for backwards compatibility
@@ -254,7 +251,7 @@ class XMLParser
         @dialogs[attributes["id"]] ||= {}
         @dialogs[attributes["id"]].clear
         # detect a clear board request for effects, and send to activespell
-        @process_spell_durations = true
+        ActiveSpell.update_spell_durations
       elsif name == 'resource'
         nil
       elsif name == 'pushStream'
@@ -357,7 +354,7 @@ class XMLParser
           # puts "kind=(%s) name=%s attributes=%s" % [@active_ids[-2], name, attributes]
           self.parse_psm3_progressbar(@active_ids[-2], attributes)
           # since we received an updated spell duration, let's signal infomon to update
-          @process_spell_durations = true
+          ActiveSpell.update_spell_durations
         end
       elsif name == 'roundTime'
         @roundtime_end = attributes['value'].to_i

--- a/spec/activespell_spec.rb
+++ b/spec/activespell_spec.rb
@@ -5,18 +5,11 @@
 
 require 'infomon/activespell'
 
-module XMLData
-  def self.process_spell_durations=(val)
-    val
-  end
-end
-
 describe ActiveSpell do
   context "updates spell information" do
     it "queries XMLData" do
       testbed = { "Bravery" => "2023-03-16 16:23:01.205027 -0400", "Heroism" => "2023-03-16 16:23:01.205062 -0400", "Elemental Defense I" => "2023-03-16 18:35:20.205097 -0400", "Elemental Defense II" => "2023-03-16 18:35:20.205133 -0400", "Elemental Defense III" => "2023-03-16 18:35:20.205167 -0400", "Elemental Targeting" => "2023-03-16 18:35:20.205202 -0400", "Elemental Barrier" => "2023-03-16 18:35:20.205238 -0400", "Thurfel's Ward" => "2023-03-16 18:35:20.205272 -0400", "Elemental Deflection" => "2023-03-16 18:35:20.205304 -0400", "Elemental Bias" => "2023-03-16 18:35:20.205339 -0400", "Strength" => "2023-03-16 18:35:20.205373 -0400", "Elemental Focus" => "2023-03-16 18:35:20.205405 -0400", "Mage Armor - Fire" => "2023-03-16 18:35:20.205442 -0400", "Haste" => "2023-03-16 18:35:20.205472 -0400", "Temporal Reversion" => "2023-03-16 18:35:20.205507 -0400", "Prismatic Guard" => "2023-03-16 18:35:20.205541 -0400", "Mass Blur" => "2023-03-16 18:35:20.205575 -0400", "Melgorehn's Aura" => "2023-03-16 18:35:20.205606 -0400" }
 
-      XMLData.process_spell_durations = true
       update_spell_names, update_spell_durations = ActiveSpell.get_spell_info(testbed)
 
       expect(update_spell_names).to eq(["Bravery", "Heroism", "Elemental Defense I", "Elemental Defense II", "Elemental Defense III", "Elemental Targeting", "Elemental Barrier", "Thurfel's Ward", "Elemental Deflection", "Elemental Bias", "Strength", "Elemental Focus", "Mage Armor", "Haste", "Temporal Reversion", "Prismatic Guard", "Mass Blur", "Melgorehn's Aura"])


### PR DESCRIPTION
When testing recent updates to lich, I noticed that my CPU usages was significantly higher (ie. redlining multiple CPUs on a modern machine).

After some investigation, it looks like the ActiveSpell watcher spawns a thread that repeatedly checks a new boolean value in the XMLData class.

I refactored this to try a couple of other approaches:

1) Invoke the ActiveSpell method directly instead of setting a boolean. This has greatly reduced CPU usage to less than 1% almost all the time. I understand the motivation for moving this to its own thread though, so I'm testing this especially with lots of scroll and spell updates to make sure it doesn't block processing in the main lich XML parsing routine. 

2) Continue to use the background thread but to switch to a [Queue](https://ruby-doc.org/core-2.5.0/Queue.html) instead of a busy loop to determine when there is work to pick up

To make testing easier, I also created a feature flag to swap between these behaviors without restarting Lich: `ActiveSpell.update_in_background = true / false`

Ran into a minor hiccup repeatedly spawning the watcher thread, but was able to solve this by memoizing the thread creation so that it only happens one time no matter how many times the code is loaded or the `watch!` method is called.

### Decision

After testing, the background thread version using a queue works well and won't block the main lich XML parsing thread. Removed the inline version and feature flag.