### PR TITLE
[messaging.rb] 1.2.0 mono spaced output

### DIFF
--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -137,7 +137,7 @@ module Lich
     end
 
     def self.mono(msg)
-      return raise StandardError.new 'Lich::Messaging.mono only works with String paremeters!' if msg.is_a?(String)
+      return raise StandardError.new 'Lich::Messaging.mono only works with String paremeters!' unless msg.is_a?(String)
       if $frontend =~ /^(?:wizard|avalon)$/i
         _respond msg
       else

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -137,7 +137,7 @@ module Lich
     end
 
     def self.mono(msg)
-      return raise StandardError.new 'Lich::Messaging.mono only works with String paremeters!' if msg.class != String
+      return raise StandardError.new 'Lich::Messaging.mono only works with String paremeters!' if msg.is_a?(String)
       if $frontend =~ /^(?:wizard|avalon)$/i
         _respond msg
       else

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -138,10 +138,10 @@ module Lich
 
     def self.mono(msg)
       return raise StandardError.new 'Lich::Messaging.mono only works with String paremeters!' unless msg.is_a?(String)
-      if $frontend =~ /^(?:wizard|avalon)$/i
-        _respond msg
-      else
+      if $frontend =~ /^(?:stormfront|wrayth)$/i
         _respond "<output class=\"mono\"/>\n" + msg + "\n<output class=\"\"/>"
+      else
+        _respond msg
       end
     end
   end

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -138,7 +138,7 @@ module Lich
 
     def self.mono(msg)
       return raise StandardError.new 'Lich::Messaging.mono only works with String paremeters!' unless msg.is_a?(String)
-      if $frontend =~ /^(?:stormfront|wrayth)$/i
+      if $frontend =~ /^(?:stormfront|wrayth|genie)$/i
         _respond "<output class=\"mono\"/>\n" + msg + "\n<output class=\"\"/>"
       else
         _respond msg

--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -7,9 +7,12 @@ Entries added here should always be accessible from Lich::Messaging.feature name
     game: Gemstone
     tags: CORE, util, utilities
     required: Lich > 5.4.0
-    version: 1.1.0
+    version: 1.2.0
 
   changelog:
+    v1.2.0 (2023-08-02)
+      Add Lich::Messaging.mono(msg) to send msg as mono spaced text
+      Robocop code cleanup
     v1.1.0 (2022-10-28)
       Add loot window as an option
     v1.0.2 (2022-11-19)
@@ -28,7 +31,6 @@ Entries added here should always be accessible from Lich::Messaging.feature name
 
 module Lich
   module Messaging
-  
     def self.xml_encode(msg)
       msg.encode(:xml => :text)
     end
@@ -36,15 +38,14 @@ module Lich
     def self.monsterbold(msg)
       return monsterbold_start + self.xml_encode(msg) + monsterbold_end
     end
-    
+
     def self.stream_window(msg, window = "familiar")
-      
       if XMLData.game =~ /^GS/
         allowed_streams = ["familiar", "speech", "thoughts", "loot"]
       elsif XMLData.game =~ /^DR/
         allowed_streams = ["familiar", "speech", "thoughts", "combat"]
       end
-      
+
       stream_window_before_txt = ""
       stream_window_after_txt = ""
       if $frontend =~ /stormfront|profanity/i && allowed_streams.include?(window)
@@ -59,19 +60,18 @@ module Lich
           stream_window_after_txt = ""
         end
       end
-      
+
       _respond stream_window_before_txt + self.xml_encode(msg) + stream_window_after_txt
     end
-  
+
     def self.msg_format(type = "info", msg = "")
-      
       preset_color_before = ""
       preset_color_after = ""
-      
-      wizard_color = {"white"=>128, "black"=>129, "dark blue"=>130, "dark green"=>131, "dark teal"=>132,
-        "dark red"=>133, "purple"=>134, "gold"=>135, "light grey"=>136, "blue"=>137,
-        "bright green"=>138, "teal"=>139, "red"=>140, "pink"=>141, "yellow"=>142}
-      
+
+      wizard_color = { "white" => 128, "black" => 129, "dark blue" => 130, "dark green" => 131, "dark teal" => 132,
+        "dark red" => 133, "purple" => 134, "gold" => 135, "light grey" => 136, "blue" => 137,
+        "bright green" => 138, "teal" => 139, "red" => 140, "pink" => 141, "yellow" => 142 }
+
       if $frontend =~ /^(?:stormfront|frostbite|profanity)$/
         case type
         when "error", "yellow", "bold", "monster", "creature"
@@ -87,7 +87,8 @@ module Lich
           preset_color_before = "<preset id='speech'>"
           preset_color_after = "</preset>"
         when "link", "command", "selectedLink", "watching", "roomName"
-          
+          preset_color_before = ""
+          preset_color_after = ""
         end
       elsif $frontend =~ /^(?:wizard)$/
         case type
@@ -104,7 +105,8 @@ module Lich
           preset_color_before = wizard_color["bright green"].chr.force_encoding(Encoding::ASCII_8BIT)
           preset_color_after = "\217".force_encoding(Encoding::ASCII_8BIT)
         when "link", "command", "selectedLink", "watching", "roomName"
-        
+          preset_color_before = ""
+          preset_color_after = ""
         end
       else
         case type
@@ -121,20 +123,26 @@ module Lich
           preset_color_before = ">> "
           preset_color_after = ""
         when "link", "command", "selectedLink", "watching", "roomName"
-        
+          preset_color_before = ""
+          preset_color_after = ""
         end
       end
-    
+
       return (preset_color_before + xml_encode(msg) + preset_color_after)
-    
     end
 
     def self.msg(type = "info", msg = "")
-      
       return if type == "debug" && (Lich.debug_messaging.nil? || Lich.debug_messaging == "false")
       _respond msg_format(type, msg)
-      
     end
-    
+
+    def self.mono(msg)
+      return raise StandardError.new 'Lich::Messaging.mono only works with String paremeters!' if msg.class != String
+      if $frontend =~ /^(?:wizard|avalon)$/i
+        _respond msg
+      else
+        _respond "<output class=\"mono\"/>\n" + msg + "\n<output class=\"\"/>"
+      end
+    end
   end
 end

--- a/lich.rbw
+++ b/lich.rbw
@@ -1677,7 +1677,7 @@ module Games
           end
           effect_out.add_separator unless title == 'Debuffs'
         }
-        _respond "<output class=\"mono\"/>\n" + effect_out.to_s + "\n<output class=\"\"/>"
+        Lich::Messaging.mono(effect_out.to_s)
       end
     end
 


### PR DESCRIPTION
Add Lich::Messaging.mono(msg) to send msg as mono spaced text and rubocop code cleanup