### PR TITLE
[lich.rbw] Allow other frontends to benefit from detached-mode

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -2527,6 +2527,8 @@ if (arg = ARGV.find { |a| (a == '-g') or (a == '--game') })
     $frontend = 'avalon'
   elsif ARGV.any? { |arg| arg == '--frostbite' }
     $frontend = 'frostbite'
+  elsif ARGV.any? { |arg| arg == '--genie' }
+    $frontend = 'genie'
   else
     $frontend = 'unknown'
   end

--- a/lich.rbw
+++ b/lich.rbw
@@ -3319,7 +3319,9 @@ main_thread = Thread.new {
         end
         if $_DETACHABLE_CLIENT_
           begin
+            Lich.log("01 Front end is #{$frontend}")
             $frontend = 'profanity' unless $frontend
+            Lich.log("02 Front end is #{$frontend}")
             Thread.new {
               if $frontend == 'profanity'
                 100.times { sleep 0.1; break if XMLData.indicator['IconJOINED'] }
@@ -3343,8 +3345,10 @@ main_thread = Thread.new {
                     init_str.concat "<image id=\"#{area}\" name=\"Scar#{Scars.send(area)}\"/>"
                   end
                 end
+                init_str.concat '<compass>'
               end
-              init_str.concat '<compass>'
+
+              init_str = '<compass>' unless $frontend == 'profanity'
               shorten_dir = { 'north' => 'n', 'northeast' => 'ne', 'east' => 'e', 'southeast' => 'se', 'south' => 's', 'southwest' => 'sw', 'west' => 'w', 'northwest' => 'nw', 'up' => 'up', 'down' => 'down', 'out' => 'out' }
               for dir in XMLData.room_exits
                 if (short_dir = shorten_dir[dir])

--- a/lich.rbw
+++ b/lich.rbw
@@ -3319,9 +3319,9 @@ main_thread = Thread.new {
         end
         if $_DETACHABLE_CLIENT_
           begin
-            unless ARGV.include?('--genie')
-              $frontend = 'profanity'
-              Thread.new {
+            $frontend = 'profanity' unless $frontend
+            Thread.new {
+              if $frontend == 'profanity'
                 100.times { sleep 0.1; break if XMLData.indicator['IconJOINED'] }
                 init_str = "<progressBar id='mana' value='0' text='mana #{XMLData.mana}/#{XMLData.max_mana}'/>"
                 init_str.concat "<progressBar id='health' value='0' text='health #{XMLData.health}/#{XMLData.max_health}'/>"
@@ -3343,18 +3343,18 @@ main_thread = Thread.new {
                     init_str.concat "<image id=\"#{area}\" name=\"Scar#{Scars.send(area)}\"/>"
                   end
                 end
-                init_str.concat '<compass>'
-                shorten_dir = { 'north' => 'n', 'northeast' => 'ne', 'east' => 'e', 'southeast' => 'se', 'south' => 's', 'southwest' => 'sw', 'west' => 'w', 'northwest' => 'nw', 'up' => 'up', 'down' => 'down', 'out' => 'out' }
-                for dir in XMLData.room_exits
-                  if (short_dir = shorten_dir[dir])
-                    init_str.concat "<dir value='#{short_dir}'/>"
-                  end
+              end
+              init_str.concat '<compass>'
+              shorten_dir = { 'north' => 'n', 'northeast' => 'ne', 'east' => 'e', 'southeast' => 'se', 'south' => 's', 'southwest' => 'sw', 'west' => 'w', 'northwest' => 'nw', 'up' => 'up', 'down' => 'down', 'out' => 'out' }
+              for dir in XMLData.room_exits
+                if (short_dir = shorten_dir[dir])
+                  init_str.concat "<dir value='#{short_dir}'/>"
                 end
-                init_str.concat '</compass>'
-                $_DETACHABLE_CLIENT_.puts init_str
-                init_str = nil
-              }
-            end
+              end
+              init_str.concat '</compass>'
+              $_DETACHABLE_CLIENT_.puts init_str
+              init_str = nil
+            }
             while (client_string = $_DETACHABLE_CLIENT_.gets)
               client_string = "#{$cmd_prefix}#{client_string}" # if $frontend =~ /^(?:wizard|avalon)$/
               begin

--- a/lich.rbw
+++ b/lich.rbw
@@ -3319,9 +3319,7 @@ main_thread = Thread.new {
         end
         if $_DETACHABLE_CLIENT_
           begin
-            Lich.log("01 Front end is #{$frontend}")
             $frontend = 'profanity' unless $frontend
-            Lich.log("02 Front end is #{$frontend}")
             Thread.new {
               if $frontend == 'profanity'
                 100.times { sleep 0.1; break if XMLData.indicator['IconJOINED'] }


### PR DESCRIPTION
This sends the Profanity bits only if we use Profanity, and allows other FEs to benefit from the shortened directions.

The attempt here is to allow the faster movement from the shortened dir to benefit other clients.

There is a theory that this should be applied to every client, no matter what. We're exploring that now.