### PR TITLE
[messaging.rb] mono API fix for \n AVALON bug

### DIFF
--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -141,7 +141,7 @@ module Lich
       if $frontend =~ /^(?:stormfront|wrayth|genie)$/i
         _respond "<output class=\"mono\"/>\n" + msg + "\n<output class=\"\"/>"
       else
-        _respond msg
+        _respond msg.split("\n")
       end
     end
   end


### PR DESCRIPTION
Fix Lich::Messaging.mono API to correct for Avalon's \n handling being bugged.