### PR TITLE
[experience.rb] add rpa?, lumnis? and percent API calls

### DIFF
--- a/lib/experience.rb
+++ b/lib/experience.rb
@@ -50,10 +50,10 @@ module Experience
   end
 
   def self.rpa?
-    Infomon.get("experience.rpa")
+    Infomon.get_bool("experience.rpa")
   end
 
   def self.lumnis?
-    Infomon.get("experience.lumnis")
+    Infomon.get_bool("experience.lumnis")
   end
 end

--- a/lib/experience.rb
+++ b/lib/experience.rb
@@ -25,6 +25,18 @@ module Experience
     Infomon.get("experience.total_experience")
   end
 
+  def self.percent_fxp
+    (fxp_current.to_f / fxp_max.to_f) * 100
+  end
+
+  def self.percent_axp
+    (axp.to_f / txp.to_f) * 100
+  end
+
+  def self.percent_exp
+    (exp.to_f / txp.to_f) * 100
+  end
+
   def self.lte
     Infomon.get("experience.long_term_experience")
   end
@@ -35,5 +47,13 @@ module Experience
 
   def self.deaths_sting
     Infomon.get("experience.deaths_sting")
+  end
+
+  def self.rpa?
+    Infomon.get("experience.rpa")
+  end
+
+  def self.lumnis?
+    Infomon.get("experience.lumnis")
   end
 end

--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -56,7 +56,7 @@ module Infomon
       WealthSilver = /^You have (?<silver>no silver|but one|[\d,]+) coins? with you\.$/.freeze
       WealthSilverContainer = /^You are carrying (?<silver>[\d,]+) coins? stored within your /.freeze
       RPAActive = /^Your recent adventures echo powerfully in your mind\.$|^You take a deep breath, and look around with renewed vigor\.  It is good to be alive, and an adventurer in this land\.$|^With a sudden flash of insight, you realize you now understand more of what you have experienced\.\.\.\.\.$|^An old memory bubbles up from your past, and causes you to reflect a moment\.  With a flash of insight, you realize you understand yourself a bit better than you did a moment ago\.  The sudden feeling of self-knowledge is a pleasant one\.$/.freeze
-      LumnisActive = /^A soft feeling of serenity touches your mind, providing you with a clearer understanding of recent events\.$|^You feel a strange sense of serenity and find you are able to reflect on recent events with uncommon clarity and understanding\.$/.freeze
+      LumnisActive = /^A soft feeling of serenity touches your mind, providing you with a clearer understanding of recent events\.$|^You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding\.$/.freeze
       LumnisDeactive = /^The soft feeling of serenity slowly dissipates from your mind\.$/.freeze
 
       # TODO: refactor / streamline?

--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -55,6 +55,9 @@ module Infomon
       TicketRaikhen = /^\s*Rumor Woods - (?<raikhen>[\d,]+) raikhen\.$/.freeze
       WealthSilver = /^You have (?<silver>no silver|but one|[\d,]+) coins? with you\.$/.freeze
       WealthSilverContainer = /^You are carrying (?<silver>[\d,]+) coins? stored within your /.freeze
+      RPAActive = /^Your recent adventures echo powerfully in your mind\.$|^You take a deep breath, and look around with renewed vigor\.  It is good to be alive, and an adventurer in this land\.$|^With a sudden flash of insight, you realize you now understand more of what you have experienced\.\.\.\.\.$|^An old memory bubbles up from your past, and causes you to reflect a moment\.  With a flash of insight, you realize you understand yourself a bit better than you did a moment ago\.  The sudden feeling of self-knowledge is a pleasant one\.$/.freeze
+      LumnisActive = /^A soft feeling of serenity touches your mind, providing you with a clearer understanding of recent events\.$|^You feel a strange sense of serenity, and find you are able to reflect on recent events with uncommon clarity and understanding\.$/.freeze
+      LumnisDeactive = /^The soft feeling of serenity slowly dissipates from your mind\.$/.freeze
 
       # TODO: refactor / streamline?
       SleepActive = /^Your mind goes completely blank\.$|^You close your eyes and slowly drift off to sleep\.$|^You slump to the ground and immediately fall asleep\.  You must have been exhausted!$/.freeze
@@ -80,7 +83,7 @@ module Infomon
                          SocietyResign, LearnPSM, UnlearnPSM, LostTechnique, LearnTechnique, UnlearnTechnique,
                          Resource, Suffused, GigasArtifactFragments, RedsteelMarks, TicketGeneral, TicketBlackscrip,
                          TicketBloodscrip, TicketEtherealScrip, TicketSoulShards, TicketRaikhen,
-                         WealthSilver, WealthSilverContainer, GoalsDetected, GoalsEnded)
+                         WealthSilver, WealthSilverContainer, GoalsDetected, GoalsEnded, RPAActive, LumnisActive, LumnisDeactive)
     end
 
     def self.parse(line)
@@ -122,7 +125,9 @@ module Infomon
           @expr_hold = []
           Infomon.mutex_lock
           match = Regexp.last_match
-          @expr_hold.push(['experience.fame', match[:fame].delete(',').to_i])
+          @expr_hold.push(['experience.fame', match[:fame].delete(',').to_i],
+                          ['experience.rpa', false],
+                          ['experience.lumnis', false])
           :ok
         when Pattern::RealExp
           match = Regexp.last_match
@@ -220,6 +225,15 @@ module Infomon
                                 ['psm.horlands_holler', 0]])
           :ok
         # end of blob saves
+        when Pattern::RPAActive
+          Infomon.set('experience.rpa', true)
+          :ok
+        when Pattern::LumnisActive
+          Infomon.set('experience.lumnis', true)
+          :ok
+        when Pattern::LumnisDeactive
+          Infomon.set('experience.lumnis', false)
+          :ok
         when Pattern::Warcries
           match = Regexp.last_match
           Infomon.set('psm.%s' % match[:name].split(' ')[1], 1)

--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -56,7 +56,7 @@ module Infomon
       WealthSilver = /^You have (?<silver>no silver|but one|[\d,]+) coins? with you\.$/.freeze
       WealthSilverContainer = /^You are carrying (?<silver>[\d,]+) coins? stored within your /.freeze
       RPAActive = /^Your recent adventures echo powerfully in your mind\.$|^You take a deep breath, and look around with renewed vigor\.  It is good to be alive, and an adventurer in this land\.$|^With a sudden flash of insight, you realize you now understand more of what you have experienced\.\.\.\.\.$|^An old memory bubbles up from your past, and causes you to reflect a moment\.  With a flash of insight, you realize you understand yourself a bit better than you did a moment ago\.  The sudden feeling of self-knowledge is a pleasant one\.$/.freeze
-      LumnisActive = /^A soft feeling of serenity touches your mind, providing you with a clearer understanding of recent events\.$|^You feel a strange sense of serenity, and find you are able to reflect on recent events with uncommon clarity and understanding\.$/.freeze
+      LumnisActive = /^A soft feeling of serenity touches your mind, providing you with a clearer understanding of recent events\.$|^You feel a strange sense of serenity and find you are able to reflect on recent events with uncommon clarity and understanding\.$/.freeze
       LumnisDeactive = /^The soft feeling of serenity slowly dissipates from your mind\.$/.freeze
 
       # TODO: refactor / streamline?

--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -125,9 +125,7 @@ module Infomon
           @expr_hold = []
           Infomon.mutex_lock
           match = Regexp.last_match
-          @expr_hold.push(['experience.fame', match[:fame].delete(',').to_i],
-                          ['experience.rpa', false],
-                          ['experience.lumnis', false])
+          @expr_hold.push(['experience.fame', match[:fame].delete(',').to_i])
           :ok
         when Pattern::RealExp
           match = Regexp.last_match
@@ -151,6 +149,8 @@ module Infomon
         when Pattern::ExprEnd
           Infomon.upsert_batch(@expr_hold)
           Infomon.mutex_unlock
+          Infomon.set('experience.rpa', false)
+          Infomon.set('experience.lumnis', false)
           :ok
         when Pattern::SkillStart
           @skills_hold = []

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -228,7 +228,6 @@ describe Infomon::Parser, ".parse" do
       expect(Infomon.get_bool("experience.lumnis")).to eq(false)
       expect(Experience.rpa?).to eq(true)
       expect(Experience.lumnis?).to eq(true)
-
     end
   end
 

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -224,7 +224,7 @@ describe Infomon::Parser, ".parse" do
       Infomon::Parser.parse %[Your recent adventures echo powerfully in your mind.]
       expect(Infomon.get_bool("experience.rpa")).to eq(true)
       expect(Experience.rpa?).to eq(true)
-      
+
       Infomon::Parser.parse %[You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding.]
       expect(Infomon.get_bool("experience.lumnis")).to eq(true)
       expect(Experience.lumnis?).to eq(true)

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -207,8 +207,8 @@ describe Infomon::Parser, ".parse" do
       expect(Infomon.get("experience.long_term_experience")).to eq(26_266)
       expect(Infomon.get("experience.deeds")).to eq(20)
       expect(Infomon.get("experience.deaths_sting")).to eq("None")
-      expect(Infomon.get_bool("experience.rpa")).to eq(false)
-      expect(Infomon.get_bool("experience.lumnis")).to eq(false)
+      expect(Infomon.get_bool("experience.rpa")).to be(false)
+      expect(Infomon.get_bool("experience.lumnis")).to be(false)
 
       expect(Experience.fame).to eq(4_804_958)
       expect(Experience.fxp_current).to eq(1_350)
@@ -218,16 +218,16 @@ describe Infomon::Parser, ".parse" do
       expect(Experience.lte).to eq(26_266)
       expect(Experience.deeds).to eq(20)
       expect(Experience.deaths_sting).to eq("None")
-      expect(Experience.rpa?).to eq(false)
-      expect(Experience.lumnis?).to eq(false)
+      expect(Experience.rpa?).to be(false)
+      expect(Experience.lumnis?).to be(false)
 
       Infomon::Parser.parse %[^Your recent adventures echo powerfully in your mind\.$]
-      expect(Infomon.get_bool("experience.rpa")).to eq(true)
-      expect(Experience.rpa?).to eq(true)
+      expect(Infomon.get_bool("experience.rpa")).to be(true)
+      expect(Experience.rpa?).to be(true)
 
       Infomon::Parser.parse %[^You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding\.$]
-      expect(Infomon.get_bool("experience.lumnis")).to eq(true)
-      expect(Experience.lumnis?).to eq(true)
+      expect(Infomon.get_bool("experience.lumnis")).to be(true)
+      expect(Experience.lumnis?).to be(true)
     end
   end
 

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -221,11 +221,11 @@ describe Infomon::Parser, ".parse" do
       expect(Experience.rpa?).to eq(false)
       expect(Experience.lumnis?).to eq(false)
 
-      Infomon::Parser.parse %[Your recent adventures echo powerfully in your mind.]
+      Infomon::Parser.parse %[^Your recent adventures echo powerfully in your mind\.$]
       expect(Infomon.get_bool("experience.rpa")).to eq(true)
       expect(Experience.rpa?).to eq(true)
 
-      Infomon::Parser.parse %[You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding.]
+      Infomon::Parser.parse %[^You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding\.$]
       expect(Infomon.get_bool("experience.lumnis")).to eq(true)
       expect(Experience.lumnis?).to eq(true)
     end

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -207,6 +207,8 @@ describe Infomon::Parser, ".parse" do
       expect(Infomon.get("experience.long_term_experience")).to eq(26_266)
       expect(Infomon.get("experience.deeds")).to eq(20)
       expect(Infomon.get("experience.deaths_sting")).to eq("None")
+      expect(Infomon.get_bool("experience.rpa")).to eq(false)
+      expect(Infomon.get_bool("experience.lumnis")).to eq(false)
 
       expect(Experience.fame).to eq(4_804_958)
       expect(Experience.fxp_current).to eq(1_350)
@@ -216,6 +218,17 @@ describe Infomon::Parser, ".parse" do
       expect(Experience.lte).to eq(26_266)
       expect(Experience.deeds).to eq(20)
       expect(Experience.deaths_sting).to eq("None")
+      expect(Experience.rpa?).to eq(false)
+      expect(Experience.lumnis?).to eq(false)
+
+      Infomon::Parser.parse %[Your recent adventures echo powerfully in your mind.]
+      Infomon::Parser.parse %[You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding.]
+
+      expect(Infomon.get_bool("experience.rpa")).to eq(true)
+      expect(Infomon.get_bool("experience.lumnis")).to eq(false)
+      expect(Experience.rpa?).to eq(true)
+      expect(Experience.lumnis?).to eq(true)
+
     end
   end
 

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -221,11 +221,11 @@ describe Infomon::Parser, ".parse" do
       expect(Experience.rpa?).to be(false)
       expect(Experience.lumnis?).to be(false)
 
-      Infomon::Parser.parse %[^Your recent adventures echo powerfully in your mind\.$]
+      Infomon::Parser.parse %[Your recent adventures echo powerfully in your mind.]
       expect(Infomon.get_bool("experience.rpa")).to be(true)
       expect(Experience.rpa?).to be(true)
 
-      Infomon::Parser.parse %[^You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding\.$]
+      Infomon::Parser.parse %[You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding.]
       expect(Infomon.get_bool("experience.lumnis")).to be(true)
       expect(Experience.lumnis?).to be(true)
     end

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -222,11 +222,11 @@ describe Infomon::Parser, ".parse" do
       expect(Experience.lumnis?).to eq(false)
 
       Infomon::Parser.parse %[Your recent adventures echo powerfully in your mind.]
-      Infomon::Parser.parse %[You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding.]
-
       expect(Infomon.get_bool("experience.rpa")).to eq(true)
-      expect(Infomon.get_bool("experience.lumnis")).to eq(false)
       expect(Experience.rpa?).to eq(true)
+      
+      Infomon::Parser.parse %[You feel a strange sense of serenity and find that you are able to reflect on recent events with uncommon clarity and understanding.]
+      expect(Infomon.get_bool("experience.lumnis")).to eq(true)
       expect(Experience.lumnis?).to eq(true)
     end
   end


### PR DESCRIPTION
Adds the tracking of RPA and Lumnis to infomon and retrievable via `Experience.rpa?` and `Experience.lumnis?`. Also adds percent experience calls for field experience, ascension experience, and regular experience via `Experience.percent_fxp`, `Experience.percent_axp`, and `Experience.percent_exp`. Resolves #449 issue