### PR TITLE
[activespell.rb] add duration change messaging

### DIFF
--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -79,11 +79,11 @@ module ActiveSpell
       active_durations += effect_type.to_h.keys
       effect_type.to_h.each do |effect, end_time|
         next unless effect.is_a?(String)
-        effect, end_time = ActiveSpell.get_spell_info({effect=>end_time})
+        effect, end_time = ActiveSpell.get_spell_info({ effect=>end_time })
         effect = effect.join
         end_time = end_time[effect]
-        next unless spell = Spell.list.find { |s| s.num == effect.to_i || s.name =~ /#{effect}/ }
-        if effect_type.to_h.find { |k, v| k == spell.num }
+        next unless (spell = Spell.list.find { |s| s.num == effect.to_i || s.name =~ /#{effect}/ })
+        if effect_type.to_h.find { |k, _v| k == spell.num }
           effect_key = spell.num
         else
           effect_key = spell.name


### PR DESCRIPTION
Add duration change messaging when casting spells as well as for when an effect ends.

```
>incant 401 
A swirling cloud of shadow forms around your right hand as you prepare Elemental Defense I...
Your spell is ready.
You gesture.
A silvery luminescence surrounds you.
Cast Roundtime 3 Seconds.
[ 401 Elemental Defense I: +1:34:59, 1:34:59 ]

>stop 401
With a moment's concentration, you terminate the Elemental Defense I spell.
The silvery luminescence fades from around you.
[ 401 Elemental Defense I: Ended ]
```