### PR TITLE
feat: ExecName - Named execs

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2228,6 +2228,7 @@ def do_client(client_string)
       respond "   #{$clean_lich_char}e <code>                  ''"
       respond "   #{$clean_lich_char}execq <code>              same as #{$clean_lich_char}exec but without the script active and exited messages"
       respond "   #{$clean_lich_char}eq <code>                 ''"
+      respond "   #{$clean_lich_char}execname <name> <code>    creates named exec (name#) and then executes the code as if it was in a script"
       respond
       if (RUBY_VERSION =~ /^2\.[012]\./)
         respond "   #{$clean_lich_char}trust <script name>       let the script do whatever it wants"

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2122,10 +2122,10 @@ def do_client(client_string)
           Script.new_downstream(msg)
         end
       end
-    elsif cmd =~ /^(?:exec|e)(q)?(n)? (.+)$/
-      cmd_data = $3
-      ExecScript.start(cmd_data, { :quiet => $1, :trusted => ($2.nil? and RUBY_VERSION =~ /^2\.[012]\./) })
-    elsif cmd =~ /^(?:execname) ([\w\d-]+) (.+)$/
+    elsif cmd =~ /^(?:exec|e)(q)? (.+)$/
+      cmd_data = $2
+      ExecScript.start(cmd_data, { :quiet => $1 })
+    elsif cmd =~ /^(?:execname|en) ([\w\d-]+) (.+)$/
       execname = $1
       cmd_data = $2
       ExecScript.start(cmd_data, { :name => execname })

--- a/lib/script.rb
+++ b/lib/script.rb
@@ -899,8 +899,13 @@ class ExecScript < Script
     @no_kill_all = false
     @match_stack_labels = Array.new
     @match_stack_strings = Array.new
-    num = '1'; num.succ! while @@running.any? { |s| s.name == "exec#{num}" }
-    @name = "exec#{num}"
+    if flags[:name].nil?
+      num = '1'; num.succ! while @@running.any? { |s| s.name == "exec#{num}" }
+      @name = "exec#{num}"
+    else
+      num = '1'; num.succ! while @@running.any? { |s| s.name == "#{flags[:name]}#{num}" }
+      @name = "#{flags[:name]}#{num}"
+    end
     @@running.push(self)
     self
   end


### PR DESCRIPTION
Allow for naming your exec by launching via following:
```
>;execname log echo '1'   
--- Lich: log1 active.    
[log1: 1]                 
--- Lich: log1 has exited.
```