### PR TITLE
chore: include recent lich5-update.lic in release/package

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -34,11 +34,12 @@ jobs:
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/ewaggle.lic > lich5/scripts/ewaggle.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/go2.lic > lich5/scripts/go2.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/jinx.lic > lich5/scripts/jinx.lic
+          curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/lich5-update.lic > lich5/scripts/lich5-update.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/log.lic > lich5/scripts/log.lic
+          curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/map.lic > lich5/scripts/map.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/repository.lic > lich5/scripts/repository.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/vars.lic > lich5/scripts/vars.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/version.lic > lich5/scripts/version.lic
-          curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/map.lic > lich5/scripts/map.lic
           curl https://raw.githubusercontent.com/rpherbig/dr-scripts/master/dependency.lic > lich5/scripts/dependency.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/effect-list.xml > lich5/data/effect-list.xml
           cp lich.rbw Lich5/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,12 @@ jobs:
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/ewaggle.lic > lich5/scripts/ewaggle.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/go2.lic > lich5/scripts/go2.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/jinx.lic > lich5/scripts/jinx.lic
+          curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/lich5-update.lic > lich5/scripts/lich5-update.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/log.lic > lich5/scripts/log.lic
+          curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/map.lic > lich5/scripts/map.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/repository.lic > lich5/scripts/repository.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/vars.lic > lich5/scripts/vars.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/version.lic > lich5/scripts/version.lic
-          curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/map.lic > lich5/scripts/map.lic
           curl https://raw.githubusercontent.com/rpherbig/dr-scripts/master/dependency.lic > lich5/scripts/dependency.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/effect-list.xml > lich5/data/effect-list.xml
           cp lich.rbw lich5/


### PR DESCRIPTION
Update to include updated lich5-update.lic to force newest version of the script that if on Lich 5.7.0 will cause the script to use built in `update.rb` API library instead. This also allows for continued use of autostart to check if current version is up to date via the `--announce` option