### PR TITLE
[messaging.rb] bugfix stream_window

### DIFF
--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -50,11 +50,11 @@ module Lich
       stream_window_after_txt = ""
       if $frontend =~ /stormfront|profanity/i && allowed_streams.include?(window)
         stream_window_before_txt = "<pushStream id=\"#{window}\" ifClosedStyle=\"watching\"/>"
-        stream_window_after_txt = "<popStream/>\r\n"
+        stream_window_after_txt = "\r\n<popStream/>\r\n"
       else
         if window =~ /familiar/i
           stream_window_before_txt = "\034GSe\r\n"
-          stream_window_after_txt = "\034GSf\r\n"
+          stream_window_after_txt = "\r\n\034GSf\r\n"
         elsif window =~ /thoughts/i
           stream_window_before_txt = "You hear the faint thoughts of LICH-MESSAGE echo in your mind:\r\n"
           stream_window_after_txt = ""


### PR DESCRIPTION
Missing a `\r\n` at the end of the msg to force new line for stream window