### PR TITLE
bugfix: Spellsong with Infomon

### DIFF
--- a/lib/infomon/activespell.rb
+++ b/lib/infomon/activespell.rb
@@ -97,6 +97,9 @@ module ActiveSpell
 
       update_spell_durations.uniq.each do |k, v|
         if (spell = Spell.list.find { |s| (s.name.downcase == k.strip.downcase) || (s.num.to_s == k.strip) })
+          if (spell.circle.to_i == 10) and not Spell.active.any? { |s| s.circle.to_i == 10 }
+            Spellsong.renewed
+          end
           spell.active = true
           spell.timeleft = if v - Time.now > 300 * 60
                              600.01

--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -71,6 +71,7 @@ module Infomon
       # Adding spell regexes.  Does not save to infomon.db.  Used by Spell and by ActiveSpells
       SpellUpMsgs = /^#{Games::Gemstone::Spell.upmsgs.join('$|^')}$/o.freeze
       SpellDnMsgs = /^#{Games::Gemstone::Spell.dnmsgs.join('$|^')}$/o.freeze
+      SpellsongRenewed = /^Your songs? renews?/.freeze
 
       All = Regexp.union(CharRaceProf, CharGenderAgeExpLevel, Stat, StatEnd, Fame, RealExp, AscExp, TotalExp, LTE,
                          ExprEnd, SkillStart, Skill, SpellRanks, SkillEnd, PSMStart, PSM, PSMEnd, Levelup, SpellsSolo,
@@ -80,7 +81,7 @@ module Infomon
                          SocietyResign, LearnPSM, UnlearnPSM, LostTechnique, LearnTechnique, UnlearnTechnique,
                          Resource, Suffused, GigasArtifactFragments, RedsteelMarks, TicketGeneral, TicketBlackscrip,
                          TicketBloodscrip, TicketEtherealScrip, TicketSoulShards, TicketRaikhen,
-                         WealthSilver, WealthSilverContainer, GoalsDetected, GoalsEnded)
+                         WealthSilver, WealthSilverContainer, GoalsDetected, GoalsEnded, SpellsongRenewed)
     end
 
     def self.parse(line)
@@ -420,6 +421,8 @@ module Infomon
           end
           spell.putdown if spell.active?
           :ok
+        when Pattern::SpellsongRenewed
+          Spellsong.renewed
         else
           :noop
         end

--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -423,6 +423,7 @@ module Infomon
           :ok
         when Pattern::SpellsongRenewed
           Spellsong.renewed
+          :ok
         else
           :noop
         end

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -124,7 +124,7 @@ module Games
       end
 
       def Spellsong.timeleft
-        ((@@renewed) / 60.to_f)
+        8
       end
     end
   end

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -35,12 +35,12 @@ Dir.mktmpdir do |dir|
   puts " Done!"
 end
 
+require "gameobj"
 require "infomon/infomon"
 require "attributes/stats"
 require "attributes/resources"
 require "infomon/currency"
 require "infomon/status"
-require "gameobj"
 require "experience"
 require "psms"
 module Infomon

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -35,7 +35,6 @@ Dir.mktmpdir do |dir|
   puts " Done!"
 end
 
-require "gameobj"
 require "infomon/infomon"
 require "attributes/stats"
 require "attributes/resources"
@@ -43,6 +42,7 @@ require "infomon/currency"
 require "infomon/status"
 require "experience"
 require "psms"
+
 module Infomon
   # cheat definition of `respond` to prevent having to load global_defs with dependenciesw
   def self.respond(msg)
@@ -129,6 +129,20 @@ module Games
       end
     end
   end
+end
+
+# fake GameObj to allow for passing.
+module Games
+  module Gemstone
+    class GameObj
+      @@npcs          = Array.new
+      def initialize(id, noun, name, before = nil, after = nil)
+        @id = id
+        @noun = noun
+        @name = name
+        @before_name = before
+        @after_name = after
+      end
 end
 
 describe Infomon, ".setup!" do

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -124,7 +124,7 @@ module Games
       end
 
       def Spellsong.timeleft
-        (@@renewed) / 60.to_f
+        ((@@renewed) / 60.to_f)
       end
     end
   end

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -122,6 +122,10 @@ module Games
       def Spellsong.renewed
         @@renewed = Time.now
       end
+
+      def Spellsong.timeleft
+        (@@renewed) / 60.to_f
+      end
     end
   end
 end

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -143,6 +143,8 @@ module Games
         @before_name = before
         @after_name = after
       end
+    end
+  end
 end
 
 describe Infomon, ".setup!" do

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -93,6 +93,20 @@ module Effects
     def each()
       to_h.each { |k, v| yield(k, v) }
     end
+
+    def active?(effect)
+      expiry = to_h.fetch(effect, 0)
+      expiry.to_f > Time.now.to_f
+    end
+
+    def time_left(effect)
+      expiry = to_h.fetch(effect, 0)
+      if to_h.fetch(effect, 0) != 0
+        ((expiry - Time.now) / 60.to_f)
+      else
+        expiry
+      end
+    end
   end
 
   Spells    = Registry.new("Active Spells")

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -95,7 +95,10 @@ module Effects
     end
   end
 
-  Debuffs = Registry.new("Debuffs")
+  Spells    = Registry.new("Active Spells")
+  Buffs     = Registry.new("Buffs")
+  Debuffs   = Registry.new("Debuffs")
+  Cooldowns = Registry.new("Cooldowns")
 end
 
 describe Infomon, ".setup!" do

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -141,6 +141,14 @@ class GameObj
     @before_name = before
     @after_name = after
   end
+
+  def GameObj.npcs
+    if @@npcs.empty?
+      nil
+    else
+      @@npcs.dup
+    end
+  end
 end
 
 describe Infomon, ".setup!" do

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -117,7 +117,7 @@ end
 
 module Games
   module Gemstone
-    module Spellsong
+    class Spellsong
       @@renewed ||= Time.at(Time.now.to_i - 1200)
       def Spellsong.renewed
         @@renewed = Time.now

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -132,18 +132,14 @@ module Games
 end
 
 # fake GameObj to allow for passing.
-module Games
-  module Gemstone
-    class GameObj
-      @@npcs          = Array.new
-      def initialize(id, noun, name, before = nil, after = nil)
-        @id = id
-        @noun = noun
-        @name = name
-        @before_name = before
-        @after_name = after
-      end
-    end
+class GameObj
+  @@npcs = Array.new
+  def initialize(id, noun, name, before = nil, after = nil)
+    @id = id
+    @noun = noun
+    @name = name
+    @before_name = before
+    @after_name = after
   end
 end
 

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -115,6 +115,17 @@ module Effects
   Cooldowns = Registry.new("Cooldowns")
 end
 
+module Games
+  module Gemstone
+    module Spellsong
+      @@renewed ||= Time.at(Time.now.to_i - 1200)
+      def Spellsong.renewed
+        @@renewed = Time.now
+      end
+    end
+  end
+end
+
 describe Infomon, ".setup!" do
   context "can set itself up" do
     it "creates a db" do

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -40,6 +40,7 @@ require "attributes/stats"
 require "attributes/resources"
 require "infomon/currency"
 require "infomon/status"
+require "gameobj"
 require "experience"
 require "psms"
 module Infomon


### PR DESCRIPTION
During rewrite of infomon, missed forcing Spellsong.renewed to be done when a song is sang or renewed. Also cleaned up spec-test to not throw as many internal errors on the spec run.