### PR TITLE
chore: add individual PSM skill methods for short/long names

### DIFF
--- a/lib/psms/armor.rb
+++ b/lib/psms/armor.rb
@@ -118,7 +118,6 @@ module Armor
     usage_result
   end
 
-
   Armor.armor_lookups.each { |armor|
     self.define_singleton_method(armor[:short_name]) do
       Armor[armor[:short_name]]

--- a/lib/psms/armor.rb
+++ b/lib/psms/armor.rb
@@ -117,4 +117,15 @@ module Armor
     }
     usage_result
   end
+
+
+  Armor.armor_lookups.each { |armor|
+    self.define_singleton_method(armor[:short_name]) do
+      Armor[armor[:short_name]]
+    end
+
+    self.define_singleton_method(armor[:long_name]) do
+      Armor[armor[:short_name]]
+    end
+  }
 end

--- a/lib/psms/ascension.rb
+++ b/lib/psms/ascension.rb
@@ -94,4 +94,14 @@ module Ascension
   def Ascension.available?(name)
     Ascension.known?(name) and Ascension.affordable?(name) and !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
   end
+  
+  Ascension.ascension_lookups.each { |ascension|
+    self.define_singleton_method(ascension[:short_name]) do
+      Ascension[ascension[:short_name]]
+    end
+
+    self.define_singleton_method(ascension[:long_name]) do
+      Ascension[ascension[:short_name]]
+    end
+  }
 end

--- a/lib/psms/cman.rb
+++ b/lib/psms/cman.rb
@@ -100,4 +100,14 @@ module CMan
   def CMan.available?(name)
     CMan.known?(name) and CMan.affordable?(name) and !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
   end
+
+  CMan.cman_lookups.each { |cman|
+    self.define_singleton_method(cman[:short_name]) do
+      CMan[cman[:short_name]]
+    end
+
+    self.define_singleton_method(cman[:long_name]) do
+      CMan[cman[:short_name]]
+    end
+  }
 end

--- a/lib/psms/feat.rb
+++ b/lib/psms/feat.rb
@@ -44,4 +44,14 @@ module Feat
   def Feat.available?(name)
     Feat.known?(name) and Feat.affordable?(name) and !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
   end
+
+  Feat.feat_lookups.each { |feat|
+    self.define_singleton_method(feat[:short_name]) do
+      Feat[feat[:short_name]]
+    end
+
+    self.define_singleton_method(feat[:long_name]) do
+      Feat[feat[:short_name]]
+    end
+  }
 end

--- a/lib/psms/shield.rb
+++ b/lib/psms/shield.rb
@@ -256,4 +256,14 @@ module Shield
     }
     usage_result
   end
+
+  Shield.shield_lookups.each { |shield|
+    self.define_singleton_method(shield[:short_name]) do
+      Shield[shield[:short_name]]
+    end
+
+    self.define_singleton_method(shield[:long_name]) do
+      Shield[shield[:short_name]]
+    end
+  }
 end

--- a/lib/psms/warcry.rb
+++ b/lib/psms/warcry.rb
@@ -88,4 +88,14 @@ class Warcry
     end
     usage_result
   end
+
+  Warcry.warcry_lookups.each { |warcry|
+    self.define_singleton_method(warcry[:short_name]) do
+      Warcry[warcry[:short_name]]
+    end
+
+    self.define_singleton_method(warcry[:long_name]) do
+      Warcry[warcry[:short_name]]
+    end
+  }
 end

--- a/lib/psms/weapon.rb
+++ b/lib/psms/weapon.rb
@@ -200,4 +200,14 @@ module Weapon
     end
     usage_result
   end
+
+  Weapon.weapon_lookups.each { |weapon|
+    self.define_singleton_method(weapon[:short_name]) do
+      Weapon[weapon[:short_name]]
+    end
+
+    self.define_singleton_method(weapon[:long_name]) do
+      Weapon[weapon[:short_name]]
+    end
+  }
 end


### PR DESCRIPTION
Allows for checking current skill rank by doing: `CMan.berserk` vs the current `CMan['berserk']` that currently existed.