### PR TITLE
[claim.rb] feat: add new claim module and associated changes to xmlparser

### DIFF
--- a/lib/claim.rb
+++ b/lib/claim.rb
@@ -84,7 +84,11 @@ module Claim
       @mine = true
       self.claim_room nav_rm unless nav_rm.nil?
     rescue StandardError => e
-      Log.out(e)
+      if defined?(Log)
+        Log.out(e)
+      else
+        respond("Claim Parser Error: #{e}")
+      end
     ensure
       Lock.unlock if Lock.owned?
     end

--- a/lib/claim.rb
+++ b/lib/claim.rb
@@ -49,7 +49,7 @@ module Claim
     info_table = Terminal::Table.new :headings => ['Property', 'Value', 'Description'],
                                      :rows => rows,
                                      :style => {:all_separators => true}
-    _respond "<output class=\"mono\"/>\n" + info_table.to_s + "\n<output class=\"\"/>")
+    Lich::Messaging.mono(info_table.to_s)
   end
 
   def self.mine?

--- a/lib/claim.rb
+++ b/lib/claim.rb
@@ -1,0 +1,93 @@
+
+module Claim
+  Lock            = Mutex.new
+  @claimed_room   ||= nil
+  @last_room      ||= nil
+  @mine           ||= false
+  @buffer         = []
+  @others         = []
+  @timestamp      = Time.now
+
+  def self.claim_room(id)
+    @claimed_room = id.to_i
+    @timestamp    = Time.now
+    Log.out("claimed #{@claimed_room}", label: %i(claim room)) if defined? Log
+    Lock.unlock
+  end
+
+  def self.claimed_room
+    @claimed_room
+  end
+
+  def self.last_room
+    @last_room
+  end
+
+  def self.lock
+    Lock.lock if !Lock.owned?
+  end
+
+  def self.unlock
+    Lock.unlock if Lock.owned?
+  end
+
+  def self.current?
+    Lock.synchronize { @mine.eql?(true) }
+  end
+
+  def self.checked?(room = nil)
+    Lock.synchronize { XMLData.room_id == (room || @last_room) }
+  end
+
+  def self.info
+    info = {'Current Room' => XMLData.room_id,
+            'Mine' => Claim.mine?,
+            'Claimed Room' => Claim.claimed_room,
+            'Checked' => Claim.checked?,
+            'Last Room' => Claim.last_room,
+            'Others' => Claim.others}
+    respond JSON.pretty_generate(info)
+  end
+
+  def self.mine?
+    self.current?
+  end
+
+  def self.others
+    @others
+  end
+
+  def self.members
+    return [] unless defined? Group
+
+    if Group.checked?
+      Group.members.map(&:noun)
+    else
+      []
+    end
+  end
+
+  def self.clustered
+    return [] unless defined? Cluster 
+    Cluster.connected
+  end
+
+  def self.parser_handle(nav_rm, pcs)
+    echo "Claim handled #{nav_rm} with xmlparser" if $claim_debug
+    begin
+      @others = pcs - self.clustered - self.members
+      @last_room = nav_rm
+      unless @others.empty?
+        @mine = false
+        return
+      end
+      @mine = true
+      self.claim_room nav_rm unless nav_rm.nil?
+    rescue StandardError => e
+      Log.out(e)
+    ensure
+      Lock.unlock if Lock.owned?
+    end
+  end
+
+end

--- a/lib/claim.rb
+++ b/lib/claim.rb
@@ -1,108 +1,110 @@
 
-module Claim
-  Lock            = Mutex.new
-  @claimed_room   ||= nil
-  @last_room      ||= nil
-  @mine           ||= false
-  @buffer         = []
-  @others         = []
-  @timestamp      = Time.now
+module Lich
+  module Claim
+    Lock            = Mutex.new
+    @claimed_room   ||= nil
+    @last_room      ||= nil
+    @mine           ||= false
+    @buffer         = []
+    @others         = []
+    @timestamp      = Time.now
 
-  def self.claim_room(id)
-    @claimed_room = id.to_i
-    @timestamp    = Time.now
-    Log.out("claimed #{@claimed_room}", label: %i(claim room)) if defined?(Log)
-    Lock.unlock
-  end
-
-  def self.claimed_room
-    @claimed_room
-  end
-
-  def self.last_room
-    @last_room
-  end
-
-  def self.lock
-    Lock.lock if !Lock.owned?
-  end
-
-  def self.unlock
-    Lock.unlock if Lock.owned?
-  end
-
-  def self.current?
-    Lock.synchronize { @mine.eql?(true) }
-  end
-
-  def self.checked?(room = nil)
-    Lock.synchronize { XMLData.room_id == (room || @last_room) }
-  end
-
-  def self.info
-    rows = [['XMLData.room_id', XMLData.room_id, 'Current room according to the XMLData'],
-            ['Claim.mine?', Claim.mine?, 'Claim status on the current room'],
-            ['Claim.claimed_room', Claim.claimed_room, 'Room id of the last claimed room'],
-            ['Claim.checked?', Claim.checked?, "Has Claim finished parsing ROOMID\ndefault: the current room"],
-            ['Claim.last_room', Claim.last_room, 'The last room checked by Claim, regardless of status'],
-            ['Claim.others', Claim.others.join("\n"), "Other characters in the room\npotentially less grouped characters"]]
-    info_table = Terminal::Table.new :headings => ['Property', 'Value', 'Description'],
-                                     :rows => rows,
-                                     :style => {:all_separators => true}
-    Lich::Messaging.mono(info_table.to_s)
-  end
-
-  def self.mine?
-    self.current?
-  end
-
-  def self.others
-    @others
-  end
-
-  def self.members
-    return [] unless defined? Group
-
-    begin
-      if Group.checked?
-        return Group.members.map(&:noun)
-      else
-        return []
-      end
-    rescue
-      return []
+    def self.claim_room(id)
+      @claimed_room = id.to_i
+      @timestamp    = Time.now
+      Log.out("claimed #{@claimed_room}", label: %i(claim room)) if defined?(Log)
+      Lock.unlock
     end
-  end
 
-  def self.clustered
-    begin
-      return [] unless defined? Cluster 
-      Cluster.connected
-    rescue
-      return []
+    def self.claimed_room
+      @claimed_room
     end
-  end
 
-  def self.parser_handle(nav_rm, pcs)
-    echo "Claim handled #{nav_rm} with xmlparser" if $claim_debug
-    begin
-      @others = pcs - self.clustered - self.members
-      @last_room = nav_rm
-      unless @others.empty?
-        @mine = false
-        return
-      end
-      @mine = true
-      self.claim_room nav_rm unless nav_rm.nil?
-    rescue StandardError => e
-      if defined?(Log)
-        Log.out(e)
-      else
-        respond("Claim Parser Error: #{e}")
-      end
-    ensure
+    def self.last_room
+      @last_room
+    end
+
+    def self.lock
+      Lock.lock if !Lock.owned?
+    end
+
+    def self.unlock
       Lock.unlock if Lock.owned?
     end
-  end
 
+    def self.current?
+      Lock.synchronize { @mine.eql?(true) }
+    end
+
+    def self.checked?(room = nil)
+      Lock.synchronize { XMLData.room_id == (room || @last_room) }
+    end
+
+    def self.info
+      rows = [['XMLData.room_id', XMLData.room_id, 'Current room according to the XMLData'],
+              ['Claim.mine?', Claim.mine?, 'Claim status on the current room'],
+              ['Claim.claimed_room', Claim.claimed_room, 'Room id of the last claimed room'],
+              ['Claim.checked?', Claim.checked?, "Has Claim finished parsing ROOMID\ndefault: the current room"],
+              ['Claim.last_room', Claim.last_room, 'The last room checked by Claim, regardless of status'],
+              ['Claim.others', Claim.others.join("\n"), "Other characters in the room\npotentially less grouped characters"]]
+      info_table = Terminal::Table.new :headings => ['Property', 'Value', 'Description'],
+                                      :rows => rows,
+                                      :style => {:all_separators => true}
+      Lich::Messaging.mono(info_table.to_s)
+    end
+
+    def self.mine?
+      self.current?
+    end
+
+    def self.others
+      @others
+    end
+
+    def self.members
+      return [] unless defined? Group
+
+      begin
+        if Group.checked?
+          return Group.members.map(&:noun)
+        else
+          return []
+        end
+      rescue
+        return []
+      end
+    end
+
+    def self.clustered
+      begin
+        return [] unless defined? Cluster 
+        Cluster.connected
+      rescue
+        return []
+      end
+    end
+
+    def self.parser_handle(nav_rm, pcs)
+      echo "Claim handled #{nav_rm} with xmlparser" if $claim_debug
+      begin
+        @others = pcs - self.clustered - self.members
+        @last_room = nav_rm
+        unless @others.empty?
+          @mine = false
+          return
+        end
+        @mine = true
+        self.claim_room nav_rm unless nav_rm.nil?
+      rescue StandardError => e
+        if defined?(Log)
+          Log.out(e)
+        else
+          respond("Claim Parser Error: #{e}")
+        end
+      ensure
+        Lock.unlock if Lock.owned?
+      end
+    end
+
+  end
 end

--- a/lib/game-loader.rb
+++ b/lib/game-loader.rb
@@ -4,6 +4,7 @@ module GameLoader
     require 'lib/map/map_gs.rb'
     require 'lib/spell'
     require 'lib/bounty'
+    require 'lib/claim'
     require 'lib/infomon/infomon'
     require 'lib/attributes/resources'
     require 'lib/attributes/stats'

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -10,7 +10,7 @@ xmlparser.rb: Core lich file that defines the data extracted from SIMU's XML.
 
   changelog:
     v1.3.0 (2023-11-19)
-      Add usage of new Claim module
+      Add usage of new Lich::Claim module
     v1.2.1 (2022-05-29)
       Logic to avoid adding 'Cooldown' tag to any spell with text 'Recovery'
       (for 599, Rapid Fire Recovery) in XMLData.active_spells
@@ -127,7 +127,7 @@ class XMLParser
     @room_id = nil
     @previous_nav_rm = nil
 
-    # claim update
+    # Lich::Claim update
     @arrival_pcs = []
     @check_obvious_hiding = false
     @room_player_hidden = false
@@ -227,7 +227,7 @@ class XMLParser
       @active_ids.push(attributes['id'].to_s)
 
       if name == 'nav'
-        Claim.lock if defined?(Claim)
+        Lich::Claim.lock if defined?(Lich::Claim)
         @check_obvious_hiding = true
         @previous_nav_rm = @room_id
         @room_id = attributes['rm'].to_i
@@ -237,14 +237,14 @@ class XMLParser
       end
 
       if name == 'compass'
-        if defined?(Claim) && Claim::Lock.owned?
+        if defined?(Lich::Claim) && Lich::Claim::Lock.owned?
           if @room_player_hidden
             @arrival_pcs.push(:hidden)
             @check_obvious_hiding = false
             @room_player_hidden = false
           end
-          Claim.parser_handle(@room_id, @arrival_pcs)
-          Claim.unlock
+          Lich::Claim.parser_handle(@room_id, @arrival_pcs)
+          Lich::Claim.unlock
         end
         if @current_stream == 'familiar'
           @fam_mode = String.new
@@ -611,7 +611,7 @@ class XMLParser
           if @active_tags.include?('a')
             @pc = GameObj.new_pc(@obj_exist, @obj_noun, "#{@player_title}#{text_string}", @player_status)
             @player_status = nil
-            @arrival_pcs.push(@pc.noun) if (defined?(Claim) && Claim::Lock.owned?)
+            @arrival_pcs.push(@pc.noun) if (defined?(Lich::Claim) && Lich::Claim::Lock.owned?)
           else
             if @game =~ /^DR/
               GameObj.clear_pcs
@@ -765,14 +765,14 @@ class XMLParser
         $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
         gsl_exits = nil
       elsif @room_window_disabled and (name == 'compass')
-        if defined?(Claim) && Claim::Lock.owned?
+        if defined?(Lich::Claim) && Lich::Claim::Lock.owned?
           if @room_player_hidden
             @arrival_pcs.push(:hidden)
             @check_obvious_hiding = false
             @room_player_hidden = false
           end
-          Claim.parser_handle(@room_id, @arrival_pcs)
-          Claim.unlock
+          Lich::Claim.parser_handle(@room_id, @arrival_pcs)
+          Lich::Claim.unlock
         end
         @room_description = @room_description.strip
         @room_exits_string.concat " #{@room_exits.join(', ')}" unless @room_exits.empty?

--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -33,7 +33,8 @@ class XMLParser
               :roundtime_end, :cast_roundtime_end, :last_pulse, :level, :next_level_value,
               :next_level_text, :society_task, :stow_container_id, :name, :game, :in_stream,
               :player_id, :prompt, :current_target_ids, :current_target_id, :room_window_disabled,
-              :dialogs, :room_id, :previous_nav_rm, :room_objects, :concentration, :max_concentration
+              :dialogs, :room_id, :previous_nav_rm, :room_objects, :concentration, :max_concentration,
+              :arrival_pcs, :room_player_hidden
   attr_accessor :send_fake_tags
 
   @@warned_deprecated_spellfront = 0


### PR DESCRIPTION
the `Group` and `Clustered` callouts are kinda holdovers from O's original script not sure if that should just get taken out. but believe this is working. I'm still not running 5.7 as a daily driver but was fine in some impromptu testing and was a port of code i've been running in slightly older lich for months without issue. but there were some changes in xmlparser so might need extra verification.

This would expose `Claim.mine?` that could be use in bigshot et. all checks as well as letting other scripts block on `Claim.last_room == <target room>` to minimize race condition issues parsing room objects, etc.