### PR TITLE
[experience.rb] percent experience options

### DIFF
--- a/lib/experience.rb
+++ b/lib/experience.rb
@@ -25,6 +25,18 @@ module Experience
     Infomon.get("experience.total_experience")
   end
 
+  def self.percent_fxp
+    (fxp_current.to_f / fxp_max.to_f) * 100
+  end
+
+  def self.percent_axp
+    (axp.to_f / txp.to_f) * 100
+  end
+
+  def self.percent_exp
+    (exp.to_f / txp.to_f) * 100
+  end
+
   def self.lte
     Infomon.get("experience.long_term_experience")
   end


### PR DESCRIPTION
Adds percent experience calls for field experience, ascension experience, and regular experience via `Experience.percent_fxp`, `Experience.percent_axp`, and `Experience.percent_exp`. Partially resolves issue #449 