### PR TITLE
[psms.rb] stop clobbering with PSMS.name_normal, account for apostrophes

### DIFF
--- a/lib/psms.rb
+++ b/lib/psms.rb
@@ -12,10 +12,13 @@ module PSMS
   def self.name_normal(name)
     # there are five cases to normalize
     # "vault_kick", "vault kick", "vault-kick", :vault_kick, :vaultkick
+    # "predator's eye"
     # if present, convert spaces to underscore; convert all to downcase string
-    name.gsub!(' ', '_') if name =~ (/\s/)
-    name.gsub!('-', '_') if name =~ (/-/)
-    name.to_s.downcase
+    normal_name = name.to_s.downcase
+    normal_name.gsub!(' ', '_') if name =~ (/\s/)
+    normal_name.gsub!('-', '_') if name =~ (/-/)
+    normal_name.gsub!("'", '') if name =~ (/'/)
+    normal_name
   end
 
   def self.find_name(name, type)


### PR DESCRIPTION
- apostrophes were not accounted for in `PSMS.name_normal` (Predator's Eye)
- stop clobbering the passed argument in name_normal by operating on a different object. the `gsubs!` were changing the passed name all the way up the stack causing unintended side effects