### PR TITLE
[char.rb] migrate global functions to Char module

### DIFF
--- a/lib/attributes/char.rb
+++ b/lib/attributes/char.rb
@@ -126,7 +126,7 @@ class Char
       percent >= num.to_i
     end
   end
-  
+
   def Char.dump_info
     echo "Char.dump_info is no longer used. Update or fix your script."
   end

--- a/lib/attributes/char.rb
+++ b/lib/attributes/char.rb
@@ -37,6 +37,37 @@ class Char
     end
   end
 
+  def Char.percentstance(num = nil)
+    if num.nil?
+      XMLData.stance_value
+    else
+      XMLData.stance_value >= num.to_i
+    end
+  end
+
+  def Char.checkencumbrance(string = nil)
+    if string.nil?
+      XMLData.encumbrance_text
+    elsif (string.class == Integer) or (string =~ /^[0-9]+$/ and (string = string.to_i))
+      string <= XMLData.encumbrance_value
+    else
+      # fixme
+      if string =~ /#{XMLData.encumbrance_text}/i
+        true
+      else
+        false
+      end
+    end
+  end
+
+  def Char.percentencumbrance(num = nil)
+    if num.nil?
+      XMLData.encumbrance_value
+    else
+      num.to_i <= XMLData.encumbrance_value
+    end
+  end
+
   def Char.health(num = nil)
     if num.nil?
       XMLData.health

--- a/lib/attributes/char.rb
+++ b/lib/attributes/char.rb
@@ -37,38 +37,96 @@ class Char
     end
   end
 
-  def Char.health(*args)
-    checkhealth(*args)
+  def Char.health(num = nil)
+    if num.nil?
+      XMLData.health
+    else
+      XMLData.health >= num.to_i
+    end
   end
 
-  def Char.mana(*args)
-    checkmana(*args)
+  def Char.mana(num = nil)
+    if num.nil?
+      XMLData.mana
+    else
+      XMLData.mana >= num.to_i
+    end
   end
 
-  def Char.spirit(*args)
-    checkspirit(*args)
+  def Char.spirit(num = nil)
+    if num.nil?
+      XMLData.spirit
+    else
+      XMLData.spirit >= num.to_i
+    end
+  end
+
+  def Char.stamina(num = nil)
+    if num.nil?
+      XMLData.stamina
+    else
+      XMLData.stamina >= num.to_i
+    end
   end
 
   def Char.maxhealth
-    Object.module_eval { maxhealth }
+    Object.module_eval { XMLData.max_health }
   end
 
   def Char.maxmana
-    Object.module_eval { maxmana }
+    Object.module_eval { XMLData.max_mana }
   end
 
   def Char.maxspirit
-    Object.module_eval { maxspirit }
-  end
-
-  def Char.stamina(*args)
-    checkstamina(*args)
+    Object.module_eval { XMLData.max_spirit }
   end
 
   def Char.maxstamina
-    Object.module_eval { maxstamina }
+    Object.module_eval { XMLData.max_stamina }
   end
 
+  def Char.percenthealth(num = nil)
+    if num.nil?
+      ((XMLData.health.to_f / XMLData.max_health.to_f) * 100).to_i
+    else
+      ((XMLData.health.to_f / XMLData.max_health.to_f) * 100).to_i >= num.to_i
+    end
+  end
+
+  def Char.percentmana(num = nil)
+    if XMLData.max_mana == 0
+      percent = 100
+    else
+      percent = ((XMLData.mana.to_f / XMLData.max_mana.to_f) * 100).to_i
+    end
+    if num.nil?
+      percent
+    else
+      percent >= num.to_i
+    end
+  end
+
+  def Char.percentspirit(num = nil)
+    if num.nil?
+      ((XMLData.spirit.to_f / XMLData.max_spirit.to_f) * 100).to_i
+    else
+      ((XMLData.spirit.to_f / XMLData.max_spirit.to_f) * 100).to_i >= num.to_i
+    end
+  end
+
+  def Char.percentstamina(num = nil)
+    if XMLData.max_stamina == 0
+      percent = 100
+    else
+      percent = ((XMLData.stamina.to_f / XMLData.max_stamina.to_f) * 100).to_i
+    end
+    if num.nil?
+      percent
+    else
+      percent >= num.to_i
+    end
+  end
+  
   def Char.dump_info
     echo "Char.dump_info is no longer used. Update or fix your script."
   end

--- a/lib/attributes/char.rb
+++ b/lib/attributes/char.rb
@@ -9,8 +9,32 @@ class Char
     XMLData.name
   end
 
-  def Char.stance(*args)
-    checkstance(*args)
+  def Char.stance(num = nil)
+    if num.nil?
+      XMLData.stance_text
+    elsif (num.class == String) and (num.to_i == 0)
+      if num =~ /off/i
+        XMLData.stance_value == 0
+      elsif num =~ /adv/i
+        XMLData.stance_value.between?(01, 20)
+      elsif num =~ /for/i
+        XMLData.stance_value.between?(21, 40)
+      elsif num =~ /neu/i
+        XMLData.stance_value.between?(41, 60)
+      elsif num =~ /gua/i
+        XMLData.stance_value.between?(61, 80)
+      elsif num =~ /def/i
+        XMLData.stance_value == 100
+      else
+        echo "Char.stance: invalid argument (#{num}).  Must be off/adv/for/neu/gua/def or 0-100"
+        nil
+      end
+    elsif (num.class == Integer) or (num =~ /^[0-9]+$/ and (num = num.to_i))
+      XMLData.stance_value == num.to_i
+    else
+      echo "Char.stance: invalid argument (#{num}).  Must be off/adv/for/neu/gua/def or 0-100"
+      nil
+    end
   end
 
   def Char.health(*args)

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -919,32 +919,8 @@ def percentconcentration(num = nil)
   end
 end
 
-def checkstance(num = nil)
-  if num.nil?
-    XMLData.stance_text
-  elsif (num.class == String) and (num.to_i == 0)
-    if num =~ /off/i
-      XMLData.stance_value == 0
-    elsif num =~ /adv/i
-      XMLData.stance_value.between?(01, 20)
-    elsif num =~ /for/i
-      XMLData.stance_value.between?(21, 40)
-    elsif num =~ /neu/i
-      XMLData.stance_value.between?(41, 60)
-    elsif num =~ /gua/i
-      XMLData.stance_value.between?(61, 80)
-    elsif num =~ /def/i
-      XMLData.stance_value == 100
-    else
-      echo "checkstance: invalid argument (#{num}).  Must be off/adv/for/neu/gua/def or 0-100"
-      nil
-    end
-  elsif (num.class == Integer) or (num =~ /^[0-9]+$/ and (num = num.to_i))
-    XMLData.stance_value == num.to_i
-  else
-    echo "checkstance: invalid argument (#{num}).  Must be off/adv/for/neu/gua/def or 0-100"
-    nil
-  end
+def checkstance(*args)
+  Char.stance(*args)
 end
 
 def percentstance(num = nil)

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -894,35 +894,19 @@ def checkstance(*args)
   Char.stance(*args)
 end
 
-def percentstance(num = nil)
-  if num.nil?
-    XMLData.stance_value
-  else
-    XMLData.stance_value >= num.to_i
-  end
+def percentstance(*args)
+  Lich.depreciated('percentstance', 'Char.percentstance')
+  Char.percentstance(*args)
 end
 
-def checkencumbrance(string = nil)
-  if string.nil?
-    XMLData.encumbrance_text
-  elsif (string.class == Integer) or (string =~ /^[0-9]+$/ and (string = string.to_i))
-    string <= XMLData.encumbrance_value
-  else
-    # fixme
-    if string =~ /#{XMLData.encumbrance_text}/i
-      true
-    else
-      false
-    end
-  end
+def checkencumbrance(*args)
+  Lich.depreciated('checkencumbrance', 'Char.checkencumbrance')
+  Char.checkencumbrance(*args)
 end
 
-def percentencumbrance(num = nil)
-  if num.nil?
-    XMLData.encumbrance_value
-  else
-    num.to_i <= XMLData.encumbrance_value
-  end
+def percentencumbrance(*args)
+  Lich.depreciated('percentencumbrance', 'Char.percentencumbrance')
+  Char.percentencumbrance(*args)
 end
 
 def checkarea(*strings)

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -920,7 +920,7 @@ def percentconcentration(num = nil)
 end
 
 def checkstance(*args)
-  Lich.log("Depreciated method used - checkstance - Script: #{Script.current.name} - Change to use Char.stance instead!")
+  Lich.depreciated('checkstance', 'Char.stance')
   Char.stance(*args)
 end
 

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -812,94 +812,64 @@ def checksaturated
   end
 end
 
-def checkmana(num = nil)
-  if num.nil?
-    XMLData.mana
-  else
-    XMLData.mana >= num.to_i
-  end
+def checkmana(*args)
+  Lich.depreciated('checkmana', 'Char.mana')
+  Char.mana(*args)
 end
 
 def maxmana
-  XMLData.max_mana
+  Lich.depreciated('maxmana', 'Char.maxmana')
+  Char.maxmana
 end
 
-def percentmana(num = nil)
-  if XMLData.max_mana == 0
-    percent = 100
-  else
-    percent = ((XMLData.mana.to_f / XMLData.max_mana.to_f) * 100).to_i
-  end
-  if num.nil?
-    percent
-  else
-    percent >= num.to_i
-  end
+def percentmana(*args)
+  Lich.depreciated('percentmana', 'Char.percentmana')
+  Char.percentmana(*args)
 end
 
-def checkhealth(num = nil)
-  if num.nil?
-    XMLData.health
-  else
-    XMLData.health >= num.to_i
-  end
+def checkhealth(*args)
+  Lich.depreciated('checkhealth', 'Char.health')
+  Char.health(*args)
 end
 
 def maxhealth
-  XMLData.max_health
+  Lich.depreciated('maxhealth', 'Char.maxhealth')
+  Char.maxhealth
 end
 
-def percenthealth(num = nil)
-  if num.nil?
-    ((XMLData.health.to_f / XMLData.max_health.to_f) * 100).to_i
-  else
-    ((XMLData.health.to_f / XMLData.max_health.to_f) * 100).to_i >= num.to_i
-  end
+def percenthealth(*args)
+  Lich.depreciated('percenthealth', 'Char.percenthealth')
+  Char.percenthealth(*args)
 end
 
-def checkspirit(num = nil)
-  if num.nil?
-    XMLData.spirit
-  else
-    XMLData.spirit >= num.to_i
-  end
+def checkspirit(*args)
+  Lich.depreciated('checkspirit', 'Char.spirit')
+  Lich.spirit(*args)
 end
 
 def maxspirit
-  XMLData.max_spirit
+  Lich.depreciated('maxspirit', 'Char.maxspirit')
+  Char.maxspirit
 end
 
-def percentspirit(num = nil)
-  if num.nil?
-    ((XMLData.spirit.to_f / XMLData.max_spirit.to_f) * 100).to_i
-  else
-    ((XMLData.spirit.to_f / XMLData.max_spirit.to_f) * 100).to_i >= num.to_i
-  end
+def percentspirit(*args)
+  Lich.depreciated('percentspirit', 'Char.percentspirit')
+  Char.percentspirit(*args)
 end
 
-def checkstamina(num = nil)
-  if num.nil?
-    XMLData.stamina
-  else
-    XMLData.stamina >= num.to_i
-  end
+def checkstamina(*args)
+  Lich.depreciated('checkstamina', 'Char.stamina')
+  Char.stamina(*args)
 end
 
 def maxstamina()
-  XMLData.max_stamina
+  Lich.depreciated('maxstamina', 'Char.maxstamina')
+  Char.maxstamina
 end
 
-def percentstamina(num = nil)
-  if XMLData.max_stamina == 0
-    percent = 100
-  else
-    percent = ((XMLData.stamina.to_f / XMLData.max_stamina.to_f) * 100).to_i
-  end
-  if num.nil?
-    percent
-  else
-    percent >= num.to_i
-  end
+def percentstamina(*args)
+  Lich.depreciated('percentstamina', 'Char.percentstamina')
+  Char.percentstamina(*args)
 end
 
 def maxconcentration()
@@ -1663,7 +1633,7 @@ def noded_pulse
     else
       stats = [0, 0]
     end
-    return (maxmana * 25 / 100) + (stats.max / 10) + (stats.min / 20)
+    return (Char.maxmana * 25 / 100) + (stats.max / 10) + (stats.min / 20)
   else
     return 0 # this method is not used by DR
   end
@@ -1682,7 +1652,7 @@ def unnoded_pulse
     else
       stats = [0, 0]
     end
-    return (maxmana * 15 / 100) + (stats.max / 10) + (stats.min / 20)
+    return (Char.maxmana * 15 / 100) + (stats.max / 10) + (stats.min / 20)
   else
     return 0 # this method is not used by DR
   end

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -920,6 +920,7 @@ def percentconcentration(num = nil)
 end
 
 def checkstance(*args)
+  Lich.log("Depreciated method used - checkstance - Script: #{Script.current.name} - Change to use Char.stance instead!")
   Char.stance(*args)
 end
 

--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -58,6 +58,15 @@ module Lich
     $stderr.puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S")}: #{msg}"
   end
 
+  def Lich.depreciated(old_object = '', new_object = '')
+    msg = "Depreciated call to #{old_object} used"
+    unless Script.current.name == 'unknown script'
+      msg += " in #{Script.current.name}"
+    end
+    msg += ". Please change to #{new_object} instead!"
+    Lich.log(msg)
+  end
+
   def Lich.msgbox(args)
     if defined?(Win32)
       if args[:buttons] == :ok_cancel


### PR DESCRIPTION
Migrate global namespace lookups from `global_defs.rb` that relate to Char module and change global methods to reference them.

Created a new `Lich.depreciated` method to log usage of depreciated methods and to be able to point out references to functions that should no longer be used.

Used new depreciated method for global methods that are now usable from Char module. May need to comment out if too spammy as not sure just how much the global methods are used within core Lich functionality and don't want to overly spam the debug file.