### PR TITLE
[all][init.rb] expand debug log files include milliseconds

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -680,7 +680,7 @@ Lich.init_db
 # only keep the last 20 debug files
 #
 
-DELETE_CANDIDATES = %r[^debug-\d+-\d+-\d+-\d+-\d+-\d+(?:-\d+)?\.log$]
+DELETE_CANDIDATES = %r[^debug(?:-\d+)+\.log$]
 if Dir.entries(TEMP_DIR).find_all { |fn| fn =~ DELETE_CANDIDATES }.length > 20 # avoid NIL response
   Dir.entries(TEMP_DIR).find_all { |fn| fn =~ DELETE_CANDIDATES }.sort.reverse[20..-1].each { |oldfile|
     begin


### PR DESCRIPTION
Add `%L` to debug filenames due to rapid lich launcher launch within a single second causing issues with debug files not being created.