### PR TITLE
[infomon] updated messaging for bind

### DIFF
--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -59,8 +59,8 @@ module Infomon
       # TODO: refactor / streamline?
       SleepActive = /^Your mind goes completely blank\.$|^You close your eyes and slowly drift off to sleep\.$|^You slump to the ground and immediately fall asleep\.  You must have been exhausted!$/.freeze
       SleepNoActive = /^Your thoughts slowly come back to you as you find yourself lying on the ground\.  You must have been sleeping\.$|^You wake up from your slumber\.$|^You are awoken|^You awake|^You slowly come back to alertness and realize you must have been sleeping\.$/.freeze
-      BindActive = /^An unseen force envelops you, restricting all movement\./.freeze
-      BindNoActive = /^The restricting force that envelops you dissolves away\.|^You shake off the immobilization that was restricting your movements!/.freeze
+      BindActive = /^An unseen force (?:envelops|entangles) you, restricting (?:all|your) movement|^You are caught fast, the light of (?:Liabo|Lornon|Tilaok|Makiri|the moon) arresting your movements/.freeze
+      BindNoActive = /^The restricting force that envelops you dissolves away\.|^You shake off the immobilization that was restricting your movements!|^The restricting force enveloping you fades away\./.freeze
       SilenceActive = /^A pall of silence settles over you\.|^The pall of silence settles more heavily over you\./.freeze
       SilenceNoActive = /^The pall of silence leaves you\./.freeze
       CalmActive = /^A calm washes over you\./.freeze

--- a/lib/infomon/status.rb
+++ b/lib/infomon/status.rb
@@ -5,23 +5,23 @@ require "ostruct"
 
 module Status
   def self.bound?
-    Infomon.get_bool("status.bound") && Effects::Debuffs.to_h.has_key?('Bind')
+    Infomon.get_bool("status.bound") && Effects::Debuffs.active?('Bind')
   end
 
   def self.calmed?
-    Infomon.get_bool("status.calmed") && Effects::Debuffs.to_h.has_key?('Calm')
+    Infomon.get_bool("status.calmed") && Effects::Debuffs.active?('Calm')
   end
 
   def self.cutthroat?
-    Infomon.get_bool("status.cutthroat") && Effects::Debuffs.to_h.has_key?('Major Bleed')
+    Infomon.get_bool("status.cutthroat") && Effects::Debuffs.active?('Major Bleed')
   end
 
   def self.silenced?
-    Infomon.get_bool("status.silenced") && Effects::Debuffs.to_h.has_key?('Silenced')
+    Infomon.get_bool("status.silenced") && Effects::Debuffs.acitve?('Silenced')
   end
 
   def self.sleeping?
-    Infomon.get_bool("status.sleeping") && Effects::Debuffs.to_h.has_key?('Sleep')
+    Infomon.get_bool("status.sleeping") && Effects::Debuffs.active?('Sleep')
   end
 
   # deprecate these in global_defs after warning, consider bringing other status maps over


### PR DESCRIPTION
It appears Bind messaging slightly changed probably during the disabler review.
https://rubular.com/r/iGYS9uKNnOySc7 - matching all the permutations i've seen. Specifically moonbeam has variable moon messaging.

also a small update to the status module to use the actual active? call instead of converting to a hash + key lookup manually