### PR TITLE
[gs4][parser.rb] Lich::Messaging use of _respond

### DIFF
--- a/lib/infomon/parser.rb
+++ b/lib/infomon/parser.rb
@@ -184,7 +184,7 @@ module Infomon
           if @goals_detected
             @goals_detected = false
             respond
-            respond Lich::Messaging.monsterbold('You just trained your character.  Lich will gather your updated skills.')
+            _respond Lich::Messaging.monsterbold('You just trained your character.  Lich will gather your updated skills.')
             respond
             # temporary inform for users about command
             # fixme: update ExecCommand to consistently perform local API actions from lib files


### PR DESCRIPTION
Change to use `_respond` instead of `respond` as sending XML that needs to be interpreted correctly by FE