### PR TITLE
chore: InnoSetup changes

### DIFF
--- a/R4LGTK3.iss
+++ b/R4LGTK3.iss
@@ -34,6 +34,7 @@ DisableStartupPrompt=Yes
 DisableProgramGroupPage=Yes
 DisableWelcomePage=Yes
 DisableReadyPage=Yes
+UsePreviousAppDir=No
 ;DisableFinishedPage=Yes
 
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)


### PR DESCRIPTION
- Add a "Lich Only" option to installer
- Add selection option for where to place Lich5 folder (desktop or Ruby4Lich5 subfolder)
- Hide the Ruby4Lich5\R4LInstall subfolder so makes harder to accidentally use