### PR TITLE
[all][global_defs.rb] update monsterbold methods

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2020,10 +2020,8 @@ end
 def monsterbold_start
   if $frontend =~ /^(?:wizard|avalon)$/
     "\034GSL\r\n"
-  elsif $frontend =~ /^(?:stormfront|frostbite)$/
+  elsif $frontend =~ /^(?:stormfront|frostbite|wrayth|profanity)$/
     '<pushBold/>'
-  elsif $frontend == 'profanity'
-    '<b>'
   else
     ''
   end
@@ -2032,10 +2030,8 @@ end
 def monsterbold_end
   if $frontend =~ /^(?:wizard|avalon)$/
     "\034GSM\r\n"
-  elsif $frontend =~ /^(?:stormfront|frostbite)$/
+  elsif $frontend =~ /^(?:stormfront|frostbite|wrayth|profanity)$/
     '<popBold/>'
-  elsif $frontend == 'profanity'
-    '</b>'
   else
     ''
   end

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2020,7 +2020,7 @@ end
 def monsterbold_start
   if $frontend =~ /^(?:wizard|avalon)$/
     "\034GSL\r\n"
-  elsif $frontend =~ /^(?:stormfront|frostbite|wrayth|profanity)$/
+  elsif $frontend =~ /^(?:stormfront|frostbite|wrayth|profanity|genie)$/
     '<pushBold/>'
   else
     ''
@@ -2030,7 +2030,7 @@ end
 def monsterbold_end
   if $frontend =~ /^(?:wizard|avalon)$/
     "\034GSM\r\n"
-  elsif $frontend =~ /^(?:stormfront|frostbite|wrayth|profanity)$/
+  elsif $frontend =~ /^(?:stormfront|frostbite|wrayth|profanity|genie)$/
     '<popBold/>'
   else
     ''


### PR DESCRIPTION
Remove standalone `<b>`/`</b>` for profanity as Profanity supports pushBold/popBold without issue.