### PR TITLE
[gs][global_defs.rb] strip_xml multiline bugfix

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -1992,18 +1992,19 @@ def sf_to_wiz(line)
   end
 end
 
-def strip_xml(line)
+def strip_xml(line, type: 'main')
   return line if line == "\r\n"
 
-  if $strip_xml_multiline
-    $strip_xml_multiline = $strip_xml_multiline + line
-    line = $strip_xml_multiline
+  if $strip_xml_multiline[type]
+    $strip_xml_multiline[type] = $strip_xml_multiline[type] + line
+    line = $strip_xml_multiline[type]
   end
   if (line.scan(/<pushStream[^>]*\/>/).length > line.scan(/<popStream[^>]*\/>/).length)
-    $strip_xml_multiline = line
+    $strip_xml_multiline ||= {}
+    $strip_xml_multiline[type] = line
     return nil
   end
-  $strip_xml_multiline = nil
+  $strip_xml_multiline[type] = nil
 
   line = line.gsub(/<pushStream id=["'](?:spellfront|inv|bounty|society|speech|talk)["'][^>]*\/>.*?<popStream[^>]*>/m, '')
   line = line.gsub(/<stream id="Spells">.*?<\/stream>/m, '')

--- a/lich.rbw
+++ b/lich.rbw
@@ -1147,7 +1147,7 @@ module Games
                   if Module.const_defined?(:GameLoader) && XMLData.game =~ /^GS/
                     infomon_serverstring = $_SERVERSTRING_.dup
                     Infomon::XMLParser.parse(infomon_serverstring)
-                    stripped_infomon_serverstring = strip_xml(infomon_serverstring)
+                    stripped_infomon_serverstring = strip_xml(infomon_serverstring, type: 'infomon')
                     stripped_infomon_serverstring.split("\r\n").each { |line|
                       unless line.empty?
                         Infomon::Parser.parse(line)
@@ -1155,7 +1155,7 @@ module Games
                     }
                   end
                   Script.new_downstream_xml($_SERVERSTRING_)
-                  stripped_server = strip_xml($_SERVERSTRING_)
+                  stripped_server = strip_xml($_SERVERSTRING_, type: 'main')
                   stripped_server.split("\r\n").each { |line|
                     @@buffer.update(line) if TESTING
                     if defined?(Map) and Map.method_defined?(:last_seen_objects) and !Map.last_seen_objects and line =~ /(You also see .*)$/


### PR DESCRIPTION
Existed a bug when using `strip_xml` multiple times. Which happened when called for infomon parsing and then normal Script downstream pushing. This allows for separate multi-line detection in these situations and not cause double downstream buffer push.