### PR TITLE
[dr][lich.rbw] Remove the exclusion of login/logoff/death messaging in downstream hook

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -1162,14 +1162,7 @@ module Games
                       Map.last_seen_objects = $1 # DR only: copy loot line to Map.last_seen_objects
                     end
 
-                    if !line.empty?
-                      if XMLData.game =~ /^GS/
-                        Script.new_downstream(line)
-                      else
-                        unless line =~ /^\s\*\s[A-Z][a-z]+ (?:returns home from a hard day of adventuring\.|joins the adventure\.|(?:is off to a rough start!  (?:H|She) )?just bit the dust!|was just incinerated!|was just vaporized!|has been vaporized!|has disconnected\.)$|^ \* The death cry of [A-Z][a-z]+ echoes in your mind!$|^\r*\n*$/
-                          Script.new_downstream(line)
-                        end
-                      end
+                    Script.new_downstream(line) if !line.empty?
                     end
                   }
                 end

--- a/lich.rbw
+++ b/lich.rbw
@@ -1163,7 +1163,6 @@ module Games
                     end
 
                     Script.new_downstream(line) if !line.empty?
-                    end
                   }
                 end
               rescue


### PR DESCRIPTION
Remove the exclusion of login/logoff/death messaging.

It's not a complete list, and it would be painful to update (players can get custom messaging unique to themselves) with no apparent reason to be excluded.