### PR TITLE
[all][log.rb] Enable/Disable with Filter

### DIFF
--- a/lib/log.rb
+++ b/lib/log.rb
@@ -4,7 +4,7 @@
 module Log
   @@log_enabled = nil
   @@log_filter  = nil
-  
+
   def self.on(filter = //)
     @@log_enabled = true
     @@log_filter = filter


### PR DESCRIPTION
Add the option to enable/disable Log output by doing either `Log.on` or `Log.off`. You can check if Log is currently enabled by doing `Log.on?` and you can also pass a filter to `Log.on` via regex by doing: `Log.on(/claim/)` and it will only show log msgs with claim in it. You can view the current filter via `Log.filter`