### PR TITLE
[all][games.rb]Bugfix - correct for missing room info in some cases

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -204,7 +204,7 @@ module Games
                   @@infomon_loaded = true
                 end
 
-                if @@autostarted and !@@cli_scripts and $_SERVERSTRING_ =~ /roomDesc/
+                if @@autostarted and !@@cli_scripts and defined? XMLData.game
                   if (arg = ARGV.find { |a| a =~ /^\-\-start\-scripts=/ })
                     for script_name in arg.sub('--start-scripts=', '').split(',')
                       Script.start(script_name)


### PR DESCRIPTION
This fixes a bug wherein an edgecase could cause a CLI user not to be able to use the `--start-scripts` feature.