### PR TITLE
[gs][effects.rb] show non-Effects in ;magic

### DIFF
--- a/lib/effects.rb
+++ b/lib/effects.rb
@@ -45,6 +45,9 @@ module Games
       def self.display
         effect_out = Terminal::Table.new :headings => ["ID", "Type", "Name", "Duration"]
         titles = ["Spells", "Cooldowns", "Buffs", "Debuffs"]
+        existing_spell_nums = []
+        active_spells = Spell.active
+        active_spells.each { |s| existing_spell_nums << s.num }
         circle = nil
         [Effects::Spells, Effects::Cooldowns, Effects::Buffs, Effects::Debuffs].each { |effect|
           title = titles.shift
@@ -71,9 +74,13 @@ module Games
                 circle = Spell[sn].circlename
               end
               effect_out.add_row [sn, title, stext, duration]
+              existing_spell_nums.delete_if { |s| Spell[s].name == stext || s == sn }
             }
           end
-          effect_out.add_separator unless title == 'Debuffs'
+          effect_out.add_separator unless title == 'Debuffs' && existing_spell_nums.empty?
+        }
+        existing_spell_nums.each { |sn|
+          effect_out.add_row [sn, "Other", Spell[sn].name, (Spell[sn].timeleft.as_time)]
         }
         Lich::Messaging.mono(effect_out.to_s)
       end


### PR DESCRIPTION
Current `;magic` output only shows known Effects, but is missing any custom effect-list.xml timers that aren't also in Effects. This PR allows output of those in a new section labeled "Other" and only displays if something exists.

Ex:
```
>;magic                                                 
+------+-----------+------------------------+----------+
| ID   | Type      | Name                   | Duration |
+------+-----------+------------------------+----------+
| 401  | Spells    | Elemental Defense I    | 3:15:10  |
| 406  | Spells    | Elemental Defense II   | 3:15:10  |
| 414  | Spells    | Elemental Defense III  | 3:15:10  |
| 425  | Spells    | Elemental Targeting    | 3:15:10  |
| 430  | Spells    | Elemental Barrier      | 3:15:10  |
| 503  | Spells    | Thurfel's Ward         | 3:15:10  |
| 507  | Spells    | Elemental Deflection   | 3:15:10  |
| 508  | Spells    | Elemental Bias         | 3:15:10  |
| 509  | Spells    | Strength               | 3:15:10  |
| 513  | Spells    | Elemental Focus        | 3:15:10  |
| 520  | Spells    | Mage Armor - Lightning | 3:15:10  |
| 535  | Spells    | Haste                  | 3:15:10  |
| 540  | Spells    | Temporal Reversion     | 3:15:10  |
| 905  | Spells    | Prismatic Guard        | 3:15:10  |
| 911  | Spells    | Mass Blur              | 3:15:10  |
| 913  | Spells    | Melgorehn's Aura       | 3:15:10  |
| 920  | Spells    | Call Familiar          | 3:15:14  |
+------+-----------+------------------------+----------+
|      | Cooldowns | No cooldowns found!    |          |
+------+-----------+------------------------+----------+
| 3011 | Buffs     | Symbol of Protection   | 0:00:07  |
+------+-----------+------------------------+----------+
|      | Debuffs   | No debuffs found!      |          |
+------+-----------+------------------------+----------+
| 9105 | Other     | Briar Betrayer         | 0:01:58  |
+------+-----------+------------------------+----------+
```