### PR TITLE
[gs][effects.rb] remove slightly differing naming conventions

### DIFF
--- a/lib/effects.rb
+++ b/lib/effects.rb
@@ -74,7 +74,7 @@ module Games
                 circle = Spell[sn].circlename
               end
               effect_out.add_row [sn, title, stext, duration]
-              existing_spell_nums.delete_if { |s| Spell[s].name == stext || s == sn }
+              existing_spell_nums.delete_if { |s| Spell[s].name =~ /#{stext}/ || stext =~ /#{Spell[s].name}/ || s == sn }
             }
           end
           effect_out.add_separator unless title == 'Debuffs' && existing_spell_nums.empty?


### PR DESCRIPTION
Issue still arose where slightly different naming conventions still populated. Example:
```
+--------+-----------+-------------------------+----------+
| 3013   | Cooldowns | Symbol of Mana          | 0:04:58  |
| 20990  | Cooldowns | Next Bounty             | 0:08:15  |
| 200546 | Cooldowns | Mana Leech              | 0:05:25  |
+--------+-----------+-------------------------+----------+
| 515    | Buffs     | Rapid Fire              | 0:00:22  |
| 3011   | Buffs     | Symbol of Protection    | 0:07:01  |
| 5210   | Buffs     | Symbol of Courage       | 0:02:41  |
+--------+-----------+-------------------------+----------+
|        | Debuffs   | No debuffs found!       |          |
+--------+-----------+-------------------------+----------+
| 9048   | Other     | Symbol of Mana Cooldown | 0:04:58  |
| 9516   | Other     | Mana Leech Recovery     | 0:00:24  |
+--------+-----------+-------------------------+----------+
```