### PR TITLE
[gs][spell.rb] add Spell.after_stance

### DIFF
--- a/lib/spell.rb
+++ b/lib/spell.rb
@@ -136,6 +136,10 @@ module Games
         @@after_stance = val
       end
 
+      def Spell.after_stance
+        @@after_stance
+      end
+
       def Spell.load(filename = nil)
         if filename.nil?
           filename = File.join(DATA_DIR, 'effect-list.xml')


### PR DESCRIPTION
Allow for checking current `@@after_stance` setting as currently you can set it via `Spell.after_stance = <VAL>` but there's no way to pull it other than using `Spell.class_variable_get(:@@after_stance)`. This is used to stance dance back into designated stance if spell supports stancing (bolts) instead of going back to guarded/defensive in the `Spell.cast` logic here:

```ruby
              if @stance
                if @@after_stance
                  if Char.stance !~ /#{@@after_stance}/
                    waitrt?
                    dothistimeout "stance #{@@after_stance}", 3, /^You (?:are now in|move into) an? \w+ stance|^You are unable to change your stance\.$/
                  end
                elsif Char.stance !~ /^guarded$|^defensive$/
                  waitrt?
                  if checkcastrt > 0
                    dothistimeout 'stance guarded', 3, /^You (?:are now in|move into) an? \w+ stance|^You are unable to change your stance\.$/
                  else
                    dothistimeout 'stance defensive', 3, /^You (?:are now in|move into) an? \w+ stance|^You are unable to change your stance\.$/
                  end
                end
              end
```