### PR TITLE
[gs][stash.rb] bugfix: wear code improvement

### DIFF
--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -142,7 +142,7 @@ module Lich
         if (left_hand.noun =~ /shield|buckler|targe|heater|parma|aegis|scutum|greatshield|mantlet|pavis|arbalest|bow|crossbow|yumi|arbalest/)\
           and Lich::Stash::wear_to_inv(left_hand)
           actions.unshift proc {
-            dothistimeout "remove ##{left_hand.id}", 3, /^You (?:remove|sling|unsling)|^With a slight roll of your shoulder, you|^You .*#{left_hand.noun}|^Remove what\?/
+            fput "remove ##{left_hand.id}"
             20.times { break if GameObj.left_hand.id == left_hand.id or GameObj.right_hand.id == left_hand.id; sleep 0.1 }
 
             if GameObj.right_hand.id == left_hand.id


### PR DESCRIPTION
Update `wear` coding to validate on GameObj no longer being in hand/in inventory instead of ingame FE response lines.