### PR TITLE
[all] [lich.rbw] [lib/sessionvars.lib] Add new module SessionVars to be used for non-persistent variable storage

### DIFF
--- a/lib/sessionvars.rb
+++ b/lib/sessionvars.rb
@@ -1,0 +1,35 @@
+# New module SessionVars for variables needed by more than one script but do not need to be saved to the sqlite db
+#   (should this be in settings path?)
+# 2024-09-05
+
+module SessionVars
+  @@svars = Hash.new
+
+  def SessionVars.[](name)
+    @@svars[name]
+  end
+
+  def SessionVars.[]=(name, val)
+    if val.nil?
+      @@svars.delete(name)
+    else
+      @@svars[name] = val
+    end
+  end
+
+  def SessionVars.list
+    @@svars.dup
+  end
+
+  def SessionVars.method_missing(arg1, arg2 = '')
+    if arg1[-1, 1] == '='
+      if arg2.nil?
+        @@svars.delete(arg1.to_s.chop)
+      else
+        @@svars[arg1.to_s.chop] = arg2
+      end
+    else
+      @@svars[arg1.to_s]
+    end
+  end
+end

--- a/lich.rbw
+++ b/lich.rbw
@@ -100,6 +100,7 @@ require File.join(LIB_DIR, 'settings', 'settings.rb')
 require File.join(LIB_DIR, 'settings', 'gamesettings.rb')
 require File.join(LIB_DIR, 'settings', 'charsettings.rb')
 require File.join(LIB_DIR, 'vars.rb')
+require File.join(LIB_DIR, 'sessionvars.rb')
 
 # Script classes move to lib 230305
 require File.join(LIB_DIR, 'script.rb')


### PR DESCRIPTION
To be used for variables that do not need to persist across sessions, so no need to hit the SQLiteDB Possible Examples:
 - goback for `go2`
 - DR moonwatch data

This is taking a stab at providing a way to move data out of the SQLite DB that doesn't need to be there, but without polluting the global variable space (https://github.com/elanthia-online/scripts/pull/1537)