### PR TITLE
[all][init.rb] fix: update required ruby check messaging

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -13,7 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(REQUIRED_RUBY)
   if (RUBY_PLATFORM =~ /mingw|win/) and (RUBY_PLATFORM !~ /darwin/i)
     require 'win32ole'
     shell = WIN32OLE.new('WScript.Shell')
-    message = "!!ALERT!!\nYour version of Ruby is too old!\nUpgrade Ruby to version #{REQUIRED_RUBY} or newer!\nClick OK to launch browser to go to documentation now!"
+    message = "!!ALERT!!\nYour version #{RUBY_VERSION} of Ruby is too old!\nUpgrade Ruby to version #{REQUIRED_RUBY} or newer!\nClick OK to launch browser to go to documentation now!"
     title = "Lich v#{LICH_VERSION}"
     type = 1 + 64  # OK/Cancel buttons + Information icon
     result = shell.Popup(message, 0, title, type)
@@ -23,7 +23,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(REQUIRED_RUBY)
     end
   else
     puts "!!ALERT!!"
-    puts "Your version of Ruby is too old!"
+    puts "Your version #{RUBY_VERSION} of Ruby is too old!"
     puts "Upgrade Ruby to version #{REQUIRED_RUBY} or newer!"
     puts "Go to https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich for more info!"
   end


### PR DESCRIPTION
Updated win32 code to use `win32ole` instead of `fiddle`