### PR TITLE
[gs4][xmlparser.rb] bugfix: Simu XML breaking change RoomID

### DIFF
--- a/lib/xmlparser.rb
+++ b/lib/xmlparser.rb
@@ -320,7 +320,9 @@ class XMLParser
       end
       if (name == 'streamWindow')
         if (attributes['id'] == 'main') and attributes['subtitle']
-          @room_title = '[' + attributes['subtitle'][3..-1] + ']'
+          unless attributes['subtitle'].empty?
+            @room_title = '[' + attributes['subtitle'][3..-1] + ']'
+          end
         end
       end
       if name == 'style'


### PR DESCRIPTION
Simu has implemented roomID in the subtitle element of their XML, a change which caused a lich bug when `set roomname off` flag was engaged.