### PR TITLE
[gs][games.rb] bugfix: RealID update

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -207,10 +207,12 @@ module Games
                   #                           Buffer.update(alt_string, Buffer::DOWNSTREAM_MOD)
                   if (Lich.display_lichid == true or Lich.display_uid == true) and XMLData.game =~ /^GS/ and alt_string =~ /^<resource picture=.*roomName/
                     if (Lich.display_lichid == true and Lich.display_uid == true)
+                      alt_string.sub!(/] \(\d+\)/) { "]" }
                       alt_string.sub!(']') { " - #{Map.current.id}] (u#{XMLData.room_id})" }
                     elsif Lich.display_lichid == true
                       alt_string.sub!(']') { " - #{Map.current.id}]" }
                     elsif Lich.display_uid == true
+                      alt_string.sub!(/] \(\d+\)/) { "]" }
                       alt_string.sub!(']') { "] (u#{XMLData.room_id})" }
                     end
                   end


### PR DESCRIPTION
Update to show Lich's UID if enabled instead of the game feed real ID when flag is turned on as well.

Changes:
```
[The Garden Shack - 31978] (u8086350) (8086350)
```
Back to:
```
[The Garden Shack - 31978] (u8086350)
```
When both `SET ShowRoomID ON` and `;display uid true`