### PR TITLE
[gs][games.rb] bugfix: support for pre/post room name txt

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -205,7 +205,7 @@ module Games
 
                 if (alt_string = DownstreamHook.run($_SERVERSTRING_))
                   #                           Buffer.update(alt_string, Buffer::DOWNSTREAM_MOD)
-                  if (Lich.display_lichid == true or Lich.display_uid == true) and XMLData.game =~ /^GS/ and alt_string =~ /^<resource picture=.*roomName/
+                  if (Lich.display_lichid == true or Lich.display_uid == true) and XMLData.game =~ /^GS/ and alt_string =~ /^(?:<resource picture="\d+"\/>|<popBold\/>)?<style id="roomName"\s+\/>/
                     if (Lich.display_lichid == true and Lich.display_uid == true)
                       alt_string.sub!(/] \(\d+\)/) { "]" }
                       alt_string.sub!(']') { " - #{Map.current.id}] (u#{XMLData.room_id})" }


### PR DESCRIPTION
As we look for `<resource picture="0"/>` to be prefacing the roomName tag, this fixes it so that it continues to work.
```xml
# NORMAL
<compDef id='room players'></compDef>
<compDef id='room exits'>Obvious paths: <d>north</d>, <d>east</d>, <d>south</d>, <d>west</d></compDef>
<compDef id='sprite'></compDef><popStream id='room'/>
<component id='room players'></component>
<resource picture="0"/><style id="roomName" />[Town Square, East]
<style id=""/><style id="roomDesc"/>Here in the center of a broad plaza near the commercial area of the bazaar stands the impressive facade of the slate-roofed <a exist="-321" noun="Hall">Moot Hall</a>, where the citizens of Wehnimer's Landing hold various official, religious and social functions.  Facing the square are some of the town's more prosperous and bustling shops.  <style id=""/>You also see a <a exist="58062" noun="barrel">large purple wooden barrel</a> and a <a exist="58059" noun="wagon">black imperial wagon</a> with a <a exist="58060" noun="pylon">glowing blue-white pylon</a> on it.
```
```xml
# with pre/post messaging
<compDef id='room players'></compDef>
<compDef id='room exits'>Obvious paths: <d>north</d>, <d>northeast</d>, <d>east</d>, <d>south</d>, <d>west</d></compDef>
<compDef id='sprite'></compDef><popStream id='room'/>
<component id='room players'></component>
<resource picture="0"/>This is pre messaging.
<style id="roomName" />[Town Square, Southwest]
<style id=""/>This is post messaging.
<style id="roomDesc"/>This corner of the square seems somewhat subdued.  Townsfolk pass through on their way to the shops, the bazaar, or the main well at the center of the square.  Others hurry past, anxious to get home or go on about their business.  <style id=""/>You also see <pushBold/><pushBold/>a <a exist="58184" noun="mutt">shaggy mutt</a><popBold/><popBold/>, <pushBold/><pushBold/>a <a exist="58217" noun="recruiter">dwarven recruiter</a><popBold/><popBold/>, a <a exist="-2262" noun="walkway">cobblestone walkway</a> leading up to a wrought iron gate and a <a exist="-60860" noun="shop">wood-sided shop</a>.
```

Room names can be displayed one of three ways I've been able to detect so far:
```
<resource picture="0"/><style id="roomName" />[Town Square, East]
<popBold/><style id="roomName" />[Town Square, Southeast]
<style id="roomName" />[Town Square, Southwest]
```