### PR TITLE
[gs][spell.rb] bugfix: Spell.affordable? 515 release

### DIFF
--- a/lib/spell.rb
+++ b/lib/spell.rb
@@ -538,7 +538,7 @@ module Games
           ## convert Spell[9699].active? to Effects::Debuffs test (if Debuffs is where it shows)
           if (Feat.known?(:mental_acuity) and self.num.between?(1201, 1220)) and (Spell[9699].active? or not Char.stamina >= (self.mana_cost(options) * 2) or Effects::Debuffs.active?("Overexerted"))
             false
-          elsif (!(Feat.known?(:mental_acuity) and self.num.between?(1201, 1220))) and (!(Char.mana >= self.mana_cost(options)) or (Spell[515].active? and !(Char.mana >= (self.mana_cost(options) + [self.mana_cost(release_options) / 4, 1].max))))
+          elsif (!(Feat.known?(:mental_acuity) and self.num.between?(1201, 1220))) and !(Char.mana >= self.mana_cost(options))
             false
           else
             true


### PR DESCRIPTION
Affordable check had a check for Rapid Fire 515 from before the revamp of the spell in 2015 that required releasing the spell as it would auto-reprepare it before then. Removing this code as it's no longer needed.