### PR TITLE
[all][util.rb] bugfix: allow issue_command to use fput or put

### DIFF
--- a/lib/util.rb
+++ b/lib/util.rb
@@ -93,7 +93,7 @@ module Lich
               line
             end
           })
-          use_fput ? fput command : put command
+          use_fput ? fput(command) : put(command)
 
           until (line = get) =~ start_pattern; end
           result << line.rstrip


### PR DESCRIPTION
Sometimes you want to use an `fput` and sometimes you want to use a `put` command depending on the situation and to prevent race conditions of spammy additional scripts running causing a false RT detection. This allows to switch the command being sent to use `put` but defaults to usage of `fput`.