### PR TITLE
[dr][games.rb] bugfix: Genie FE real ID#s not supported, hide by default

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -222,6 +222,9 @@ module Games
                     end
                     @@room_number_after_ready = true
                   end
+                  if $frontend =~ /genie/i && alt_string =~ /^<streamWindow id='room' title='Room' subtitle=" - \[.*\] \((?:\d+|\*\*)\)"/
+                    alt_string.sub!(/] \((?:\d+|\*\*)\)/) { "]" }
+                  end
                   if @@room_number_after_ready && alt_string =~ /<prompt /
                     if XMLData.game =~ /^DR/
                       room_number = ""


### PR DESCRIPTION
Due to real ID#s being an option and now being required for future Lich5 release on DragonRealms, but GenieFE not supporting them for mapping function, hide real ID#s until client updated.