### PR TITLE
[all][main.rb] fix: create session file in regular connect method

### DIFF
--- a/lib/common/account.rb
+++ b/lib/common/account.rb
@@ -5,6 +5,7 @@ module Lich
       @@subscription ||= nil
       @@game_code ||= nil
       @@members ||= {}
+      @@character ||= nil
 
       def self.name
         @@name
@@ -12,6 +13,14 @@ module Lich
 
       def self.name=(value)
         @@name = value
+      end
+
+      def self.character
+        @@character
+      end
+
+      def self.character=(value)
+        @@character = value
       end
 
       def self.subscription

--- a/lib/common/eaccess.rb
+++ b/lib/common/eaccess.rb
@@ -54,6 +54,7 @@ module Lich
       def self.auth(password:, account:, character: nil, game_code: nil, legacy: false)
         Account.name = account
         Account.game_code = game_code
+        Account.character = character
         conn = EAccess.socket()
         # it is vitally important to verify self-signed certs
         # because there is no chain-of-trust for them

--- a/lib/common/front-end.rb
+++ b/lib/common/front-end.rb
@@ -8,18 +8,22 @@ module Lich
       @session_file = nil
       @tmp_session_dir = File.join Dir.tmpdir, "simutronics", "sessions"
 
-      def self.create_session_file(name, host, port)
+      def self.create_session_file(name, host, port, display_session: true)
         return if name.nil?
         FileUtils.mkdir_p @tmp_session_dir
         @session_file = File.join(@tmp_session_dir, "%s.session" % name.downcase.capitalize)
         session_descriptor = { name: name, host: host, port: port }.to_json
-        puts "writing session descriptor to %s\n%s" % [@session_file, session_descriptor]
+        puts "writing session descriptor to %s\n%s" % [@session_file, session_descriptor] if display_session
         File.open(@session_file, "w") do |fd|
           fd << session_descriptor
         end
       end
 
-      def self.cleanup_session_file()
+      def self.session_file_location
+        @session_file
+      end
+
+      def self.cleanup_session_file
         return if @session_file.nil?
         File.delete(@session_file) if File.exist? @session_file
       end

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -285,7 +285,7 @@ reconnect_if_wanted = proc {
       end
       accept_thread = Thread.new { $_CLIENT_ = SynchronizedSocket.new(listener.accept) }
       localport = listener.addr[1]
-      Frontend.create_session_file(Account.character, listener.addr[2], listener.addr[1])
+      Frontend.create_session_file(Account.character, listener.addr[2], listener.addr[1], display_session: false)
       if custom_launch
         sal_filename = nil
         launcher_cmd = custom_launch.sub(/\%port\%/, localport.to_s).sub(/\%key\%/, game_key.to_s)

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -285,6 +285,7 @@ reconnect_if_wanted = proc {
       end
       accept_thread = Thread.new { $_CLIENT_ = SynchronizedSocket.new(listener.accept) }
       localport = listener.addr[1]
+      Frontend.create_session_file(char_name, server.addr[2], server.addr[1])
       if custom_launch
         sal_filename = nil
         launcher_cmd = custom_launch.sub(/\%port\%/, localport.to_s).sub(/\%key\%/, game_key.to_s)
@@ -673,7 +674,7 @@ reconnect_if_wanted = proc {
     }
   end
 
-  if defined? @detachable_client_port
+  unless @detachable_client_port.nil?
     detachable_client_thread = Thread.new {
       loop {
         begin

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -285,7 +285,7 @@ reconnect_if_wanted = proc {
       end
       accept_thread = Thread.new { $_CLIENT_ = SynchronizedSocket.new(listener.accept) }
       localport = listener.addr[1]
-      Frontend.create_session_file(char_name, server.addr[2], server.addr[1])
+      Frontend.create_session_file(Account.character, server.addr[2], server.addr[1])
       if custom_launch
         sal_filename = nil
         launcher_cmd = custom_launch.sub(/\%port\%/, localport.to_s).sub(/\%key\%/, game_key.to_s)
@@ -669,6 +669,8 @@ reconnect_if_wanted = proc {
         Lich.log "error: client_thread: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
         sleep 0.2
         retry unless $_CLIENT_.closed? or Game.closed? or !Game.thread.alive? or ($!.to_s =~ /invalid argument|A connection attempt failed|An existing connection was forcibly closed/i)
+      ensure
+        Frontend.cleanup_session_file
       end
       Game.close
     }

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -285,7 +285,7 @@ reconnect_if_wanted = proc {
       end
       accept_thread = Thread.new { $_CLIENT_ = SynchronizedSocket.new(listener.accept) }
       localport = listener.addr[1]
-      Frontend.create_session_file(Account.character, server.addr[2], server.addr[1])
+      Frontend.create_session_file(Account.character, listener.addr[2], listener.addr[1])
       if custom_launch
         sal_filename = nil
         launcher_cmd = custom_launch.sub(/\%port\%/, localport.to_s).sub(/\%key\%/, game_key.to_s)


### PR DESCRIPTION
Currently we only create a session file in `File.join(Dir.tmpdir, "simutronics", "sessions")` if Lich is started with CLI arg of `--detachable-client=PORT`. This PR corrects a logic mistake in that detection as well as creates the same session file for launching from GUI that FEs can utilize if not able to take passed launch parameters to connect to a host/port. Namely Mudlet.

Also adds new `Account.character` api to allow for session file to be written properly.