### PR TITLE
[all][init.rb] bugfix: error for Windows DISPLAY variable

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -517,7 +517,7 @@ rescue LoadError
   exit
 end
 
-unless ARGV.grep(/^--no-(?:gtk|gui)$/).any? || (ENV['DISPLAY'].nil? && !ARGV.include?('--gtk'))
+unless (ARGV.grep(/^--no-(?:gtk|gui)$/).any? || RUBY_PLATFORM !~ /mingw/ && (ENV['DISPLAY'].nil? && !ARGV.include?('--gtk')))
   begin
     require 'gtk3'
     HAVE_GTK = true


### PR DESCRIPTION
Windows `ENV['DISPLAY']` is nil by default, this corrects the logic