### PR TITLE
[all][main.rb] fix: Mudlet support

### DIFF
--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -592,6 +592,20 @@ reconnect_if_wanted = proc {
           Game._puts(client_string)
         end
       else
+        if launcher_cmd =~ /mudlet/
+          Game._puts(game_key)
+          game_key = nil
+
+          client_string = "/FE:WIZARD /VERSION:1.0.1.22 /P:#{RUBY_PLATFORM} /XML"
+          $_CLIENTBUFFER_.push(client_string.dup)
+          Game._puts(client_string)
+
+          2.times {
+            sleep 0.3
+            $_CLIENTBUFFER_.push("<c>\r\n")
+            Game._puts("<c>")
+          }
+        end
         inv_off_proc = proc { |server_string|
           if server_string =~ /^<(?:container|clearContainer|exposeContainer)/
             server_string.gsub!(/<(?:container|clearContainer|exposeContainer)[^>]*>|<inv.+\/inv>/, '')


### PR DESCRIPTION
Mudlet doesn't support real Simutronics integration, so force it if launcher_cmd contains it