### PR TITLE
[all][gui-saved-login.rb] fix: Wrayth display non-tabbed entries

### DIFF
--- a/lib/common/gui-saved-login.rb
+++ b/lib/common/gui-saved-login.rb
@@ -172,7 +172,7 @@ else
         quick_box.pack_start(Gtk::Label.new("Account: " + last_user_id), :expand => false, :fill => false, :padding => 6)
       end
 
-      label = Gtk::Label.new("#{login_info[:char_name]} (#{login_info[:game_name]}, #{login_info[:frontend]})")
+      label = Gtk::Label.new("#{login_info[:char_name]} (#{login_info[:game_name]}, #{login_info[:frontend].capitalize == 'Stormfront' ? 'Wrayth' : login_info[:frontend].capitalize}#{login_info[:custom_launch] ? ' custom' : ''})")
       play_button = Gtk::Button.new(:label => 'Play')
       remove_button = Gtk::Button.new(:label => 'X')
 


### PR DESCRIPTION
This fixes showing "Wrayth" instead of "Stormfront" on the non-tabbed interface, as well as adds "custom" to the entry if custom_launch for it