### PR TITLE
[dr][drroom] Fix missing DRRoom.title and description

### DIFF
--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -704,6 +704,8 @@ module Lich
 
           if @current_style == 'roomName'
             @room_name = text_string.match(/(?<roomname>\[.*?\])/)[:roomname]
+            # Additionally setting room_title for backwards compatibility.
+            @room_title = @room_name
           end
 
           if @active_tags.include?('inv')

--- a/lib/dragonrealms/drinfomon/drroom.rb
+++ b/lib/dragonrealms/drinfomon/drroom.rb
@@ -37,19 +37,11 @@ module Lich
       end
 
       def self.title
-        @@title
-      end
-
-      def self.title=(val)
-        @@title = val
+        XMLData.room_title
       end
 
       def self.description
-        @@description
-      end
-
-      def self.description=(val)
-        @@description = val
+        XMLData.room_description
       end
 
       def self.group_members


### PR DESCRIPTION
These got dropped in the move from drinfomon.lic to core lich.