### PR TITLE
map rb to lich common namespace

### DIFF
--- a/lib/common/game-loader.rb
+++ b/lib/common/game-loader.rb
@@ -12,7 +12,7 @@ module Lich
       def self.gemstone
         self.common_before
         require File.join(LIB_DIR, 'gemstone', 'sk.rb')
-        require File.join(LIB_DIR, 'gemstone', 'map_gs.rb')
+        require File.join(LIB_DIR, 'common', 'map', 'map_gs.rb')
         require File.join(LIB_DIR, 'gemstone', 'effects.rb')
         require File.join(LIB_DIR, 'gemstone', 'bounty.rb')
         require File.join(LIB_DIR, 'gemstone', 'claim.rb')
@@ -37,7 +37,7 @@ module Lich
 
       def self.dragon_realms
         self.common_before
-        require File.join(LIB_DIR, 'dragonrealms', 'map_dr.rb')
+        require File.join(LIB_DIR, 'common', 'map', 'map_dr.rb')
         require File.join(LIB_DIR, 'attributes', 'char.rb')
         require File.join(LIB_DIR, 'dragonrealms', 'drinfomon.rb')
         require File.join(LIB_DIR, 'dragonrealms', 'commons.rb')

--- a/lib/common/map/map_dr.rb
+++ b/lib/common/map/map_dr.rb
@@ -1,5 +1,5 @@
 module Lich
-  module DragonRealms
+  module Common
     class Map
       @@loaded                   = false
       @@load_mutex               = Mutex.new

--- a/lib/common/map/map_gs.rb
+++ b/lib/common/map/map_gs.rb
@@ -1,5 +1,5 @@
 module Lich
-  module Gemstone
+  module Common
     class Map
       @@loaded                   = false
       @@load_mutex               = Mutex.new


### PR DESCRIPTION
Moving `class Map` to `Lich::Common` namespace.