### PR TITLE
[gs][infomon/parser.rb] bugfix: non-lich auth Account module

### DIFF
--- a/lib/gemstone/infomon/parser.rb
+++ b/lib/gemstone/infomon/parser.rb
@@ -401,7 +401,7 @@ module Lich
             when Pattern::AccountSubscription
               if Account.subscription
                 match = Regexp.last_match
-                Account.subscription = match[:subscription].gsub('Standard', 'Basic').upcase
+                Account.subscription = match[:subscription].gsub('Standard', 'Normal').gsub('F2P', 'Free').upcase
                 :ok
               else
                 :noop


### PR DESCRIPTION
Allows for population of AccountName and Subscription into `Account` module if they're nil due to not using Lich to authenticate