### PR TITLE
[dr][drparser.rb] bugfix: non-lich auth Account module

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -318,7 +318,7 @@ module Lich
             end
           when Pattern::PlayedSubscription
             if Account.subscription.nil?
-              Account.subscription = Regexp.last_match[:subscription].upcase
+              Account.subscription = Regexp.last_match[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').upcase
             end
           else
             :noop


### PR DESCRIPTION
Allows for population of Account.name and Account.subscription into Account module if they're nil due to not using Lich to authenticate