### PR TITLE
[all][global_defs.rb] bugfix: regexp escape hmr command

### DIFF
--- a/lib/common/hmr.rb
+++ b/lib/common/hmr.rb
@@ -18,15 +18,20 @@ module Lich
 
       def self.reload(pattern)
         self.clear_cache
-        self.loaded.grep(pattern).each { |file|
-          begin
-            load(file)
-            self.msg "<b>[lich.hmr] reloaded %s</b>" % file
-          rescue => exception
-            self.msg exception
-            self.msg exception.backtrace.join("\n")
-          end
-        }
+        loaded_paths = self.loaded.grep(pattern)
+        unless loaded_paths.empty?
+          loaded_paths.each { |file|
+            begin
+              load(file)
+              self.msg "<b>[lich.hmr] reloaded %s</b>" % file
+            rescue => exception
+              self.msg exception
+              self.msg exception.backtrace.join("\n")
+            end
+          }
+        else
+          self.msg "<b>[lich.hmr] nothing matching regex pattern: %s</b>" % pattern.source
+        end
       end
     end
   end

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2392,7 +2392,7 @@ def do_client(client_string)
       respond "   #{$clean_lich_char}set <variable> [on|off]   set a global toggle variable on or off"
       respond "   #{$clean_lich_char}lich5-update --<command>  Lich5 ecosystem management "
       respond "                              see #{$clean_lich_char}lich5-update --help"
-      respond "   #{$clean_lich_char}hmr <path/to/file>        Hot module reload a Ruby or Lich5 file without relogging"
+      respond "   #{$clean_lich_char}hmr <regex filepath>      Hot module reload a Ruby or Lich5 file without relogging, uses Regular Expression matching"
       if XMLData.game =~ /^GS/
         respond
         respond "   #{$clean_lich_char}infomon sync              sends all the various commands to resync character data for infomon (fixskill)"

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2269,7 +2269,7 @@ def do_client(client_string)
       nil
     elsif cmd =~ /^hmr\s+(?<pattern>.*)/i
       require "lib/common/hmr"
-      HMR.reload %r{#{Regexp.last_match[:pattern]}}
+      HMR.reload %r{#{Regexp.escape(Regexp.last_match[:pattern])}}
     elsif XMLData.game =~ /^GS/ && cmd =~ /^infomon sync/i
       ExecScript.start("Infomon.sync", { :quiet => true })
     elsif XMLData.game =~ /^GS/ && cmd =~ /^infomon (?:reset|redo)!?/i
@@ -2392,6 +2392,7 @@ def do_client(client_string)
       respond "   #{$clean_lich_char}set <variable> [on|off]   set a global toggle variable on or off"
       respond "   #{$clean_lich_char}lich5-update --<command>  Lich5 ecosystem management "
       respond "                              see #{$clean_lich_char}lich5-update --help"
+      respond "   #{$clean_lich_char}hmr <path/to/file>        Hot module reload a Ruby or Lich5 file without relogging"
       if XMLData.game =~ /^GS/
         respond
         respond "   #{$clean_lich_char}infomon sync              sends all the various commands to resync character data for infomon (fixskill)"


### PR DESCRIPTION
Prevent OS unicode errors due to un-escaped regexp characters