### PR TITLE
[all][games.rb] bugfix: Wrayth <settings> bad XML

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -212,7 +212,6 @@ module Lich
                   @@cli_scripts = true
                   Lich.log("info: logged in as #{XMLData.game}:#{XMLData.name}")
                 end
-
                 unless $_SERVERSTRING_ =~ /^<settings /
                   begin
                     # Check for valid XML prior to sending to client, corrects double and single nested quotes


### PR DESCRIPTION
Move the ignore for Wrayth `<settings>` being sent to before trying to REXML parse since it's not anything Lich5 needs and is not true XML and can cause issues parsing