### PR TITLE
chore: load HMR module by default

### DIFF
--- a/lib/common/game-loader.rb
+++ b/lib/common/game-loader.rb
@@ -46,6 +46,7 @@ module Lich
 
       def self.common_after
         ActiveSpell.watch!
+        require File.join(LIB_DIR, 'common', 'hmr.rb')
         # nil
       end
 

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2268,7 +2268,6 @@ def do_client(client_string)
       did_something = false
       nil
     elsif cmd =~ /^hmr\s+(?<pattern>.*)/i
-      require "lib/common/hmr"
       begin
         HMR.reload %r{#{Regexp.last_match[:pattern]}}
       rescue ArgumentError


### PR DESCRIPTION
removes `require` from global_defs when attempting to `;hmr` and allows usage of HMR module by default in other code usage without needing to require it as globally required via gameloader