### PR TITLE
[all][xmlparser.rb] fix: Gameobj objs clearing on new nav room

### DIFF
--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -245,6 +245,10 @@ module Lich
 
           if name == 'nav'
             Lich::Claim.lock if defined?(Lich::Claim)
+            GameObj.clear_loot
+            GameObj.clear_npcs
+            GameObj.clear_pcs
+            GameObj.clear_room_desc
             @check_obvious_hiding = true
             unless XMLData.game =~ /^DR/
               @previous_nav_rm = @room_id
@@ -252,7 +256,6 @@ module Lich
             end
             @arrival_pcs = []
             $nav_seen = true
-            Map.last_seen_objects = nil if Map.method_defined?(:last_seen_objects); # DR Only
           end
 
           if name == 'compass'

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -284,10 +284,6 @@ module Lich
                   stripped_server = strip_xml($_SERVERSTRING_, type: 'main')
                   stripped_server.split("\r\n").each { |line|
                     @@buffer.update(line) if TESTING
-                    if defined?(Map) and Map.method_defined?(:last_seen_objects) and !Map.last_seen_objects and line =~ /(You also see .*)$/
-                      Map.last_seen_objects = $1 # DR only: copy loot line to Map.last_seen_objects
-                    end
-
                     Script.new_downstream(line) if !line.empty?
                   }
                 end
@@ -909,10 +905,6 @@ module Lich
                   stripped_server = strip_xml($_SERVERSTRING_, type: 'main')
                   stripped_server.split("\r\n").each { |line|
                     @@buffer.update(line) if TESTING
-                    if defined?(Map) and Map.method_defined?(:last_seen_objects) and !Map.last_seen_objects and line =~ /(You also see .*)$/
-                      Map.last_seen_objects = $1 # DR only: copy loot line to Map.last_seen_objects
-                    end
-
                     Script.new_downstream(line) if !line.empty?
                   }
                 end


### PR DESCRIPTION
clear loot, npcs, pcs, room_desc GameObjs on new `<nav>` room movement. Prevents race condition of these not getting cleared upon entry to new room due to large xmlparsing.

Also removes no longer used `Map.last_seen_objects` from code as deprecated and removed from DR's `map_dr.rb` file.