### PR TITLE
[gs][skills.rb] bugfix: proper name of Skill bonus lookup

### DIFF
--- a/lib/attributes/skills.rb
+++ b/lib/attributes/skills.rb
@@ -30,7 +30,7 @@ module Lich
           end
           bonus
         when String, Symbol
-          Infomon.get("skill.%s.bonus" % ranks)
+          Infomon.get("skill.%s_bonus" % ranks)
         else
           echo "You're trying to move the cheese!"
         end


### PR DESCRIPTION
Incorrectly used `Infomon.get("skill.%s.bonus" % ranks)` instead of how it's actually stored as `Infomon.get("skill.%s_bonus" % ranks)`