### PR TITLE
chore(dr): common-moonmage - refactor of peer_telescope

### DIFF
--- a/lib/dragonrealms/commons/common-moonmage.rb
+++ b/lib/dragonrealms/commons/common-moonmage.rb
@@ -68,14 +68,15 @@ module Lich
       end
 
       def peer_telescope
-        DRC.bput('peer my telescope',
-                 'The pain is too much',
-                 'You see nothing regarding the future',
-                 "You believe you've learned all that you can about",
-                 get_data('constellations').observe_finished_messages,
-                 'open it',
-                 'Your vision is too fuzzy',
-                 'Roundtime')
+        telescope_regex_patterns = Regexp.union(
+          /The pain is too much/,
+          /You see nothing regarding the future/,
+          /You believe you've learned all that you can about/,
+          Regexp.union(get_data('constellations').observe_finished_messages),
+          /open it/,
+          /Your vision is too fuzzy/,
+        )
+        Lich::Util.issue_command("peer my telescope", telescope_regex_patterns, /Roundtime: /, usexml: false)
       end
 
       def center_telescope(target)


### PR DESCRIPTION
refactor script to output multi-line array of results

Part 1 of 5 of a suite of astrology changes
- Part 1: #783 common-moonmage - update to peer_telescope for multi-line parsing of observation results
- Part 2: https://github.com/elanthia-online/dr-scripts/pull/7127 base - addition of settings support for astrology and walkingastro changes
- Part 3: https://github.com/elanthia-online/dr-scripts/pull/7125 astrology - refactor to account for peer_telescope change and addition of option to force vision predictions
- Part 4: https://github.com/elanthia-online/dr-scripts/pull/7124 walkingastro - extensive quality of life changes to default behaviour and new optional features
- Part 5: https://github.com/elanthia-online/dr-scripts/pull/7126 combat-trainer - refactor to account for peer_telescope change, no change to function