### PR TITLE
chore(dr): common-arcana - predicate to return backfire status and spell regex patterns update

### DIFF
--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -293,7 +293,6 @@ module Lich
         Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
         Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
         Flags.add('spell-backfired', /^Your spell .*backfires/)
-        @@backfired_status = false
 
         case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
         when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/
@@ -324,7 +323,7 @@ module Lich
           DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
         end
 
-        @@backfired_status = true if Flags['spell-backfired']
+        @@backfired_status = Flags['spell-backfired']
 
         !Flags['spell-fail']
       end

--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -289,7 +289,7 @@ module Lich
 
         Flags.add('unknown-command', "Please rephrase that command")
         Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that", "You do not know how to manipulate that pathway.", "You cannot BARRAGE with that spell.")
-        Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', /^Your spell .*backfires/, 'Something is interfering with the spell', 'There is nothing else to face', 'You strain, but are too mentally fatigued', 'The spell pattern resists the influx of unfocused mana', 'Your target pattern dissipates because')
+        Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', "You don't have a spell prepared!", /^Your spell .*backfires/, 'Something is interfering with the spell', 'There is nothing else to face', 'You strain, but are too mentally fatigued', 'The spell pattern resists the influx of unfocused mana', 'Your target pattern dissipates because')
         Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
         Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
         Flags.add('spell-backfired', /^Your spell .*backfires/)

--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -280,15 +280,21 @@ module Lich
         return true
       end
 
+      def backfired?
+        return @@backfired_status || false
+      end
+
       def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])
         before.each { |action| DRC.bput(action['message'], action['matches']) }
 
         Flags.add('unknown-command', "Please rephrase that command")
         Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that", "You do not know how to manipulate that pathway.", "You cannot BARRAGE with that spell.")
-        Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell', 'There is nothing else to face', 'You strain, but are too mentally fatigued')
+        Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', /^Your spell .*backfires/, 'Something is interfering with the spell', 'There is nothing else to face', 'You strain, but are too mentally fatigued', 'The spell pattern resists the influx of unfocused mana', 'Your target pattern dissipates because')
         Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
         Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
-
+        Flags.add('spell-backfired', /^Your spell .*backfires/)
+        @@backfired_status = false
+        
         case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
         when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/
           DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
@@ -317,6 +323,8 @@ module Lich
         elsif Flags['spell-fail']
           DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
         end
+
+        @@backfired_status = true if Flags['spell-backfired']
 
         !Flags['spell-fail']
       end

--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -294,7 +294,7 @@ module Lich
         Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
         Flags.add('spell-backfired', /^Your spell .*backfires/)
         @@backfired_status = false
-        
+
         case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
         when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/
           DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")


### PR DESCRIPTION
backfired? provides a boolean status on whether the last spell cast using DRCA.cast? backfired.
  - increase selectivity for auto_mana to pick out a backfire vs the (super-)set of all spell failures which shouldn't be penalised.
 
Updated spell failure patterns to include sorcery backlash, more specific regex for backfire, and missing target (dead before spell finished prepping)