### PR TITLE
[gs][bounty/parser.rb] bugfix: proper town detection for Hinterwilds

### DIFF
--- a/lib/gemstone/bounty/parser.rb
+++ b/lib/gemstone/bounty/parser.rb
@@ -113,6 +113,8 @@ module Lich
         def determine_town(captured_town)
           if description =~ /^You succeeded in your task and should report back to the sentry just outside town\.$/
             "Kraken's Fall"
+          elsif captured_town == "Cold River"
+            "Hinterwilds"
           else
             captured_town
           end


### PR DESCRIPTION
Unfortunately some Hinterwilds bounties show the town as Cold River. Update town to register as Hinterwilds