### PR TITLE
fix(gs): correct clean_key method for critranks

### DIFF
--- a/lib/gemstone/critranks.rb
+++ b/lib/gemstone/critranks.rb
@@ -56,9 +56,9 @@ module Lich
 
       def self.clean_key(key)
         return key.to_i if key.is_a?(Integer) || key =~ (/^\d+$/)
-        return key.upcase if key.is_a?(Symbol)
+        return key.downcase if key.is_a?(Symbol)
 
-        key.strip.upcase.gsub(' ', '_')
+        key.strip.downcase.gsub(/[ -]/, '_')
       end
 
       def self.validate(key, valid)


### PR DESCRIPTION
Moving to standard GS downcase in method.  To be used with PRs 801 - 820.