### PR TITLE
fix(all): games.rb fix multiple single and double quote in XML

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -246,7 +246,7 @@ module Lich
                       # <link id='2' value='Ever wondered about the time you've spent in Elanthia?  Check the PLAYED verb!' cmd='played' echo='played' />
                       # From GS
                       # <d cmd='forage Imaera's Lace'>Imaera's Lace</d>, <d cmd='forage stalk burdock'>stalk of burdock</d>
-                      while (matches = $_SERVERSTRING_.scan(/'([^=>]*'[^=>]*)'/))
+                      if (matches = $_SERVERSTRING_.scan(/'([^=>]*'[^=>]*)'/))
                         Lich.log "Invalid nested single quotes XML tags detected: #{$_SERVERSTRING_.inspect}"
                         matches.flatten.each do |match|
                           $_SERVERSTRING_.gsub!(match, match.gsub(/'/, '&apos;'))
@@ -256,7 +256,7 @@ module Lich
                       end
                       # Fixes invalid XML with nested double quotes in it such as:
                       # <subtitle=" - [Avlea's Bows, "The Straight and Arrow"]">
-                      while (matches = $_SERVERSTRING_.scan(/"([^=]*"[^=]*)"/))
+                      if (matches = $_SERVERSTRING_.scan(/"([^=]*"[^=]*)"/))
                         Lich.log "Invalid nested double quotes XML tags detected: #{$_SERVERSTRING_.inspect}"
                         matches.flatten.each do |match|
                           $_SERVERSTRING_.gsub!(match, match.gsub(/"/, '&quot;'))
@@ -877,7 +877,7 @@ module Lich
                       # <link id='2' value='Ever wondered about the time you've spent in Elanthia?  Check the PLAYED verb!' cmd='played' echo='played' />
                       # From GS
                       # <d cmd='forage Imaera's Lace'>Imaera's Lace</d>, <d cmd='forage stalk burdock'>stalk of burdock</d>
-                      while (matches = $_SERVERSTRING_.scan(/'([^=>]*'[^=>]*)'/))
+                      if (matches = $_SERVERSTRING_.scan(/'([^=>]*'[^=>]*)'/))
                         Lich.log "Invalid nested single quotes XML tags detected: #{$_SERVERSTRING_.inspect}"
                         matches.flatten.each do |match|
                           $_SERVERSTRING_.gsub!(match, match.gsub(/'/, '&apos;'))
@@ -887,7 +887,7 @@ module Lich
                       end
                       # Fixes invalid XML with nested double quotes in it such as:
                       # <subtitle=" - [Avlea's Bows, "The Straight and Arrow"]">
-                      while (matches = $_SERVERSTRING_.scan(/"([^=]*"[^=]*)"/))
+                      if (matches = $_SERVERSTRING_.scan(/"([^=]*"[^=]*)"/))
                         Lich.log "Invalid nested double quotes XML tags detected: #{$_SERVERSTRING_.inspect}"
                         matches.flatten.each do |match|
                           $_SERVERSTRING_.gsub!(match, match.gsub(/"/, '&quot;'))


### PR DESCRIPTION
Current fix for nested single/double quotes only works for one match, not multiple. Changing from `.match` to `.scan` and fixing all found instances in XML string.