### PR TITLE
fix(gs): infomon parsing for CHE membership

### DIFF
--- a/lib/gemstone/infomon/parser.rb
+++ b/lib/gemstone/infomon/parser.rb
@@ -111,8 +111,8 @@ module Lich
             case state
             when Goals, Profile
               unless @state.eql?(Ready)
-                respond "--- Lich: error: Infomon::Parser::State is in invalid state(#{@state} - caller: #{caller[0]}"
-                Lich.log "error: Infomon::Parser::State is in invalid state(#{@state} - caller: #{caller[0]}"
+                Lich.log "error: Infomon::Parser::State is in invalid state(#{@state}) - caller: #{caller[0]}"
+                fail "--- Lich: error: Infomon::Parser::State is in invalid state(#{@state}) - caller: #{caller[0]}"
               end
             end
             @state = state


### PR DESCRIPTION
Update infomon parsing to match on PROFILE house membership for only self profile. Also allow for RESIGN output to match and update status as well.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update infomon parser to handle self-profile CHE membership and resignation parsing with new regex patterns and state management.
> 
>   - **Behavior**:
>     - Update `ProfileHouseCHE` regex to match house membership only for self-profile.
>     - Add `ResignCHE` regex to handle resignation output and update status.
>   - **State Management**:
>     - Introduce `Profile` state in `State` module to manage parsing state transitions.
>     - Use `State.set()` and `State.get()` in `parse()` to handle state transitions for profile and goals.
>   - **Patterns**:
>     - Add `ProfileStart` and `ProfileName` patterns to identify self-profile parsing.
>     - Update `All` regex union to include new patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for b96c0842a6d47495a313b42e7a638970c5f3fa04. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->