### PR TITLE
fix(gs): warcry.rb yowlp :buff to string instead of regexp

### DIFF
--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -18,7 +18,7 @@ module Lich
         },
         "yowlp"  => {
           :regex => /You throw back your shoulders and let out a resounding yowlp!/i,
-          :buff  => /Yertie's Yowlp/,
+          :buff  => "Yertie's Yowlp",
         },
         "growl"  => {
           :regex => /Your face contorts as you unleash a guttural, deep-throated growl at .+!/i,


### PR DESCRIPTION
yowlp buff value was saved as a regexp in error instead of as a string, correcting to string to fix