### PR TITLE
feat(gs): gameobj.rb allow for custom gameobj data

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -386,13 +386,13 @@ module Lich
             @@sellable_data = nil
             echo "error: GameObj.load_data: #{$!}"
             respond $!.backtrace[0..1]
-            false
+            return false
           end
         else
           @@type_data = nil
           @@sellable_data = nil
           echo "error: GameObj.load_data: file does not exist: #{filename}"
-          false
+          return false
         end
         filename = File.join(DATA_DIR, 'gameobj-custom', 'gameobj-data.xml')
         if (File.exist?(filename))
@@ -410,19 +410,19 @@ module Lich
               doc.elements.each('data/sellable') { |e|
                 if (sellable = e.attributes['name'])
                   @@sellable_data[sellable] ||= Hash.new
-                  @@sellable_data[sellable][:name]	  = GameObj.merge_data(@@type_data[type][:name], Regexp.new(e.elements['name'].text)) unless e.elements['name'].text.nil? or e.elements['name'].text.empty?
-                  @@sellable_data[sellable][:noun]	  = GameObj.merge_data(@@type_data[type][:noun], Regexp.new(e.elements['noun'].text)) unless e.elements['noun'].text.nil? or e.elements['noun'].text.empty?
-                  @@sellable_data[sellable][:exclude] = GameObj.merge_data(@@type_data[type][:exclude], Regexp.new(e.elements['exclude'].text)) unless e.elements['exclude'].text.nil? or e.elements['exclude'].text.empty?
+                  @@sellable_data[sellable][:name]	  = GameObj.merge_data(@@sellable_data[sellable][:name], Regexp.new(e.elements['name'].text)) unless e.elements['name'].text.nil? or e.elements['name'].text.empty?
+                  @@sellable_data[sellable][:noun]	  = GameObj.merge_data(@@sellable_data[sellable][:noun], Regexp.new(e.elements['noun'].text)) unless e.elements['noun'].text.nil? or e.elements['noun'].text.empty?
+                  @@sellable_data[sellable][:exclude] = GameObj.merge_data(@@sellable_data[sellable][:exclude], Regexp.new(e.elements['exclude'].text)) unless e.elements['exclude'].text.nil? or e.elements['exclude'].text.empty?
                 end
               }
             }
           rescue
             echo "error: Custom GameObj.load_data: #{$!}"
             respond $!.backtrace[0..1]
-            false
+            return false
           end
         end
-        true
+        return true
       end
 
       def GameObj.type_data


### PR DESCRIPTION
Allows for a custom `gameobj-data.xml` loaded from `Lich5\data\gameobj-custom` folder
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for loading and merging custom game object data from `Lich5\data\gameobj-custom` in `gameobj.rb`.
> 
>   - **Custom Data Loading**:
>     - `GameObj.load_data` now loads custom `gameobj-data.xml` from `Lich5\data\gameobj-custom` if it exists.
>     - Merges custom data with existing data using `GameObj.merge_data`.
>   - **New Method**:
>     - `GameObj.merge_data` added to merge existing and new data, specifically handling `Regexp` objects.
>   - **Error Handling**:
>     - Improved error handling for missing files and exceptions during data loading in `GameObj.load_data`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for b914dac3f3a2e30d200067a8acc3b169c937f45e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->