### PR TITLE
fix(dr): drparser.rb add $last_logoff tracking

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -331,7 +331,7 @@ module Lich
             month = Date::ABBR_MONTHNAMES.find_index(matches[:month])
             weekdays = [nil, 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
             dst_check = matches[:day].to_i - weekdays.find_index(matches[:weekday])
-            if month.between?(4,10) || (month == 3 && dst_check >= 7) || (month == 11 && dst_check < 0)
+            if month.between?(4, 10) || (month == 3 && dst_check >= 7) || (month == 11 && dst_check < 0)
               tz = '-0400'
             else
               tz = '-0500'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `$last_logoff` tracking in `drparser.rb` to store the last logoff time using regex and timezone handling.
> 
>   - **Behavior**:
>     - Adds `$last_logoff` tracking in `drparser.rb` to store the last logoff time.
>     - Uses regex `Pattern::LastLogoff` to match logoff time format.
>     - Updates `parse(line)` to extract and store logoff time in `$last_logoff`.
>   - **Time Zone Handling**:
>     - Determines timezone offset based on month and day of the week for DST adjustment.
>     - Uses `Time.new` to create a local time object with the correct timezone.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for dc08cbfcb52984dd58dc505f745b999fad2c6c1b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->