### PR TITLE
fix(all): lich.rb deprecated FE message

### DIFF
--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -90,7 +90,7 @@ module Lich
     msg = "Deprecated call to #{old_object} used in #{script_location}. Please change to #{new_object} instead!"
     return if limit_log && @@deprecated_log.include?(msg)
     Lich.log(msg) if debug_log
-    _respond Lich::Messaging.monsterbold(msg) if fe_log
+    Lich::Messaging.msg("bold", msg) if fe_log
     @@deprecated_log.push(msg) unless @@deprecated_log.include?(msg)
   end
 


### PR DESCRIPTION
Fix `Lich.deprecated` to utilize `Lich::Messaging.msg` instead of `Lich::Messaging.monsterbold`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `Lich::Messaging.monsterbold` with `Lich::Messaging.msg` in `Lich.deprecated` for handling deprecated messages.
> 
>   - **Behavior**:
>     - In `Lich.deprecated`, replace `Lich::Messaging.monsterbold` with `Lich::Messaging.msg("bold", msg)` to handle deprecated messages.
>   - **Misc**:
>     - No other changes or files affected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for a65fdf4a7060fd252b89fdd0e90d72b106e98453. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->