### PR TITLE
fix(all): messaging.rb fix XML encoding for wizard and avalon

### DIFF
--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -34,7 +34,11 @@ Entries added here should always be accessible from Lich::Messaging.feature name
 module Lich
   module Messaging
     def self.xml_encode(msg)
-      msg.encode(:xml => :text)
+      if $frontend =~ /^(wizard|avalon)$/i
+        sf_to_wiz(msg.encode(:xml => :text))
+      else
+        msg.encode(:xml => :text)
+      end
     end
 
     def self.monsterbold(msg)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes XML encoding in `xml_encode` for 'wizard' and 'avalon' frontends in `messaging.rb`.
> 
>   - **Behavior**:
>     - Fixes XML encoding in `xml_encode` for 'wizard' and 'avalon' frontends by using `sf_to_wiz()`.
>     - Retains existing XML encoding for other frontends.
>   - **Functions**:
>     - Modifies `xml_encode` in `messaging.rb` to conditionally apply `sf_to_wiz()` based on frontend.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 0c57eb8ad49b95121cd54420660b393d035a8f1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->