### PR TITLE
fix(all): lich.rb class variable not initialized

### DIFF
--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -15,6 +15,7 @@ module Lich
   @@track_autosort_state = nil # boolean
   @@track_dark_mode      = nil # boolean
   @@track_layout_state   = nil # boolean
+  @@debug_messaging      = nil # boolean
 
   def self.db_mutex
     @@db_mutex


### PR DESCRIPTION
`@@debug_messaging` class variable is not initialized so errors on use in `Lich.debug_messaging`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Initialize `@@debug_messaging` class variable in `lich.rb` to prevent errors when accessed.
> 
>   - **Initialization**:
>     - Initialize `@@debug_messaging` class variable to `nil` in `lich.rb` to prevent errors when accessed via `Lich.debug_messaging`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 58ffc89853a77d404ba0c7de7165a97f24ddda71. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->