### PR TITLE
fix(all): log.rb force msg to String for regexp comparison

### DIFF
--- a/lib/common/log.rb
+++ b/lib/common/log.rb
@@ -64,7 +64,7 @@ module Lich
 
       def self.out(msg, label: :debug)
         return unless Script.current.vars.include?("--debug") || Log.on?
-        return if msg !~ Log.filter
+        return if msg.to_s !~ Log.filter
         if msg.is_a?(Exception)
           ## pretty-print exception
           _write _view(msg.message, label)


### PR DESCRIPTION
Handles `Log.out(msg)` when the message itself is an exception comparing against the current `Log.filter` via regexp.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `lib/common/log.rb`, `Log.out(msg)` now converts `msg` to a string before regex comparison with `Log.filter`, handling exceptions and non-string objects.
> 
>   - **Behavior**:
>     - In `lib/common/log.rb`, `Log.out(msg)` now converts `msg` to a string with `msg.to_s` before comparing with `Log.filter`.
>     - Handles cases where `msg` is an exception or non-string object, preventing potential errors during regex comparison.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for f20245328145da621717a5e4872905d5743ebc3a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->