### PR TITLE
fix(dr): update message patterns in common-items

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -769,8 +769,9 @@ module Lich
       # TIE/UNTIE ITEM
       #########################################
 
-      def tie_item?(item, container)
-        case DRC.bput("tie my #{item} to my #{container}", TIE_ITEM_SUCCESS_PATTERNS, TIE_ITEM_FAILURE_PATTERNS)
+      def tie_item?(item, container = nil)
+        place = container ? "to my #{container}" : nil
+        case DRC.bput("tie my #{item} #{place}", TIE_ITEM_SUCCESS_PATTERNS, TIE_ITEM_FAILURE_PATTERNS)
         when *TIE_ITEM_SUCCESS_PATTERNS
           true
         else

--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -24,6 +24,7 @@ module Lich
         /^What were you referring to/,
         /^I could not find/,
         /^But you aren't holding that/,
+        /^Perhaps you should be holding that first/,
         /^You're kidding, right/,
         /^You can't do that/,
         /^No littering/,
@@ -72,6 +73,7 @@ module Lich
       ]
 
       GET_ITEM_FAILURE_PATTERNS = [
+        /^A magical force keeps you from grasping/,
         /^You need a free hand/,
         /^You can't pick that up with your hand that damaged/,
         /^Your (left|right) hand is too injured/,
@@ -80,6 +82,7 @@ module Lich
         /^You can't reach that from here/, # on a mount like a flying carpet
         /^You don't seem to be able to move/,
         /^You should untie/,
+        /^You can't do that/,
         /^Get what/,
         /^I could not/,
         /^What were you/,

--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -133,8 +133,7 @@ module Lich
 
       TIE_ITEM_SUCCESS_PATTERNS = [
         /^You .* tie/,
-        /^You attach/,
-        /^You untie/
+        /^You attach/
       ]
 
       TIE_ITEM_FAILURE_PATTERNS = [

--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -220,6 +220,7 @@ module Lich
 
       PUT_AWAY_ITEM_FAILURE_PATTERNS = [
         /^Stow what/,
+        /^I can't find your container for stowing things in/,
         /^Please rephrase that command/,
         /^What were you referring to/,
         /^I could not find what you were referring to/,
@@ -236,11 +237,14 @@ module Lich
         /^Containers can't be placed in/,
         /^The .* is not designed to carry anything/,
         /^You can't put that.*there/,
+        /^Weirdly, you can't manage .* to fit/,
+        /^\[Containers can't be placed in/,
         /even after stuffing it/,
         /is too .* to (fit|hold)/,
         /no matter how you arrange it/,
         /close the fan/,
         /to fit in the/,
+        /doesn't seem to want to leave you/, # trying to put a pet in a home within a container
         # You may get the next message if you've been cursed and unable to let go of items.
         # Find a Cleric to uncurse you.
         /Oddly, when you attempt to stash it away safely/,


### PR DESCRIPTION
### Changes

- consistent container logic with `tie_item?` and `untie_item?` methods
- add new messages for various success/failure patterns to get/drop/tie/etc
- remove an untie message from the tie item patterns
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update message patterns and logic for item interactions in `common-items.rb`, including new success/failure patterns and enhanced `tie_item?` method.
> 
>   - **Behavior**:
>     - Add new success/failure message patterns for `get`, `drop`, `tie`, and `put away` actions in `common-items.rb`.
>     - Remove an untie message from `TIE_ITEM_SUCCESS_PATTERNS`.
>   - **Logic**:
>     - Update `tie_item?` method to handle optional `container` parameter in `common-items.rb`.
>   - **Patterns**:
>     - Add `/^A magical force keeps you from grasping/` to `GET_ITEM_FAILURE_PATTERNS`.
>     - Add `/^Perhaps you should be holding that first/` to `DROP_TRASH_FAILURE_PATTERNS` and `PUT_AWAY_ITEM_FAILURE_PATTERNS`.
>     - Add `/^You can't do that/` to `GET_ITEM_FAILURE_PATTERNS`.
>     - Add `/^I can't find your container for stowing things in/` to `PUT_AWAY_ITEM_FAILURE_PATTERNS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 150de53af8fe24305e20d2bb4167fda5bade87b9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->