### PR TITLE
fix(dr): add `moon_visible?(moon)` convenience method to common-moonmage

### DIFF
--- a/lib/dragonrealms/commons/common-moonmage.rb
+++ b/lib/dragonrealms/commons/common-moonmage.rb
@@ -348,7 +348,7 @@ module Lich
       #  above the horizon and won't set for at least another ~4 minutes.
       def bright_celestial_object?
         check_moonwatch
-        (UserVars.sun['day'] && UserVars.sun['timer'] >= 4) || visible_moons.include?('xibar') || visible_moons.include?('yavash')
+        (UserVars.sun['day'] && UserVars.sun['timer'] >= 4) || moon_visible?('xibar') || moon_visible?('yavash')
       end
 
       # returns true if at least one moon (katamba, yavash, xibar) or the sun are
@@ -362,6 +362,11 @@ module Lich
       # is above the horizon and won't set for at least another ~4 minutes.
       def moons_visible?
         !visible_moons.empty?
+      end
+
+      # Returns true if the moon is above the horizon and won't set for at least another ~4 minutes.
+      def moon_visible?(moon_name)
+        visible_moons.include?(moon_name)
       end
 
       # Returns list of moon names (e.g. katamba, yavash, xibar)


### PR DESCRIPTION
Previously, to check if a moon was visible then you had to call `DRCMM.visible_moons.include?(moon_name)`.

This PR adds a convenience method `DRCMM.moon_visible?(moon_name)` that is a bit less verbose and more descriptive of what the code is trying to do.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `moon_visible?` method to `common-moonmage.rb` for checking moon visibility, improving code readability.
> 
>   - **Behavior**:
>     - Adds `moon_visible?(moon_name)` method to `common-moonmage.rb` to check if a moon is visible.
>     - Replaces `visible_moons.include?('xibar')` and `visible_moons.include?('yavash')` with `moon_visible?('xibar')` and `moon_visible?('yavash')` in `bright_celestial_object?`.
>   - **Misc**:
>     - Improves code readability by providing a more descriptive method for checking moon visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 27bfbe03904f9d96ed8b5290aec48ef516ec97c7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->