### PR TITLE
fix(gs): Bounty parser.rb fix for HW & KF guard return

### DIFF
--- a/lib/gemstone/bounty/parser.rb
+++ b/lib/gemstone/bounty/parser.rb
@@ -111,9 +111,9 @@ module Lich
         end
 
         def determine_town(captured_town)
-          if description =~ /^You succeeded in your task and should report back to the sentry just outside town\.$/
+          if description =~ /the sentry just outside town\.$/
             "Kraken's Fall"
-          elsif description =~ /^You succeeded in your task and should report back to the tavernkeeper at Rawknuckle's Common House\.$/
+          elsif description =~ /the tavernkeeper at Rawknuckle's Common House\.$/
             "Cold River"
           else
             captured_town


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix `determine_town` in `parser.rb` to recognize "Cold River" from specific description text.
> 
>   - **Behavior**:
>     - Update `determine_town` in `parser.rb` to recognize "Cold River" when description includes "the tavernkeeper at Rawknuckle's Common House."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 4bee3078cb4aff26450cad99994437adf66e1835. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->