### PR TITLE
fix(gs): Bounty task.rb fix for assigned? and Ruby 2.6

### DIFF
--- a/lib/gemstone/bounty/task.rb
+++ b/lib/gemstone/bounty/task.rb
@@ -118,7 +118,7 @@ module Lich
         end
 
         def assigned?
-          type.end_with?("assignment")
+          type.to_s.end_with?("assignment")
         end
 
         def ready?


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `assigned?` method in `task.rb` for Ruby 2.6 compatibility by converting `type` to string.
> 
>   - **Behavior**:
>     - Fixes `assigned?` method in `task.rb` to convert `type` to string before calling `end_with?`, ensuring compatibility with Ruby 2.6.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 4b055ecd1f737a20cb2402f22e476f654c30b486. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->