### PR TITLE
fix(all): global_defs.rb bug in fput

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -1530,8 +1530,8 @@ def fput(message, *waitingfor)
   put(message)
 
   while (string = get)
-    if string =~ /(?:\.\.\.wait |Wait )[0-9]+/
-      hold_up = string.slice(/[0-9]+/).to_i
+    if string =~ /(?:\.\.\.wait |Wait )(?<wait_time>[0-9]+)/
+      hold_up = Regexp.last_match[:wait_time].to_i
       sleep(hold_up) unless hold_up.nil?
       clear
       put(message)


### PR DESCRIPTION
Fix issue where multiple lines come thru with a wait message. Causing incorrect match on time to sleep.

Example when EXP output is accidentally merged with wait output:
```
Level: 100...wait 1 seconds.
```
This is a real example and caused the script utilizing fput to sleep for 100 seconds.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes incorrect wait time parsing in `fput` function in `global_defs.rb` by using named capture groups to accurately extract wait times.
> 
>   - **Bug Fix**:
>     - Fixes incorrect wait time parsing in `fput` function in `global_defs.rb`.
>     - Uses named capture group `(?<wait_time>[0-9]+)` to accurately extract wait times from strings like `"...wait 1 seconds."`.
>     - Prevents excessive sleep durations caused by mixed EXP and wait output lines.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 48847bd95de88cc9eda4afea1c42cadccd6233ba. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->