### PR TITLE
feat(gs): PSMS updates, including CMan.use

### DIFF
--- a/lib/gemstone/psms.rb
+++ b/lib/gemstone/psms.rb
@@ -36,6 +36,19 @@ module Lich
           Infomon.get("#{type.downcase}.#{seek_psm[:short_name]}")
         end
       end
+
+      # Common failure messages potentially used across all PSMs.
+      FAILURES_REGEXES = Regexp.union(
+        /^Roundtime: [0-9]+ sec\.$/,
+        /^And give yourself away!  Never!$/,
+        /^You are unable to do that right now\.$/,
+        /^You don't seem to be able to move to do that\.$/,
+        /^Provoking a GameMaster is not such a good idea\.$/,
+        /^You do not currently have a target\.$/,
+        /^Your mind clouds with confusion and you glance around uncertainly\.$/,
+        /^But your hands are full\!$/,
+        /^You are still stunned\.$/
+      )
     end
   end
 end

--- a/lib/gemstone/psms/armor.rb
+++ b/lib/gemstone/psms/armor.rb
@@ -54,15 +54,21 @@ module Lich
           :usage => "stealth",
         },
         "crush_protection"    => {
-          :regex => /You adjusts? \w+(?:'s)? [\w\s]+ with your plate armor fittings, rearranging and reinforcing the armor to better protect against (?:punctur|crush|slash)ing damage\.|You must specify an armor slot\.|You don't seem to have the necessary armor fittings in hand\./i,
+          :regex => Regexp.union(/You adjusts? \w+(?:'s)? [\w\s]+ with your plate armor fittings, rearranging and reinforcing the armor to better protect against (?:punctur|crush|slash)ing damage\./i,
+                                 /You must specify an armor slot\./,
+                                 /|You don't seem to have the necessary armor fittings in hand\./),
           :usage => "crush",
         },
         "puncture_protection" => {
-          :regex => /You adjusts? \w+(?:'s)? [\w\s]+ with your plate armor fittings, rearranging and reinforcing the armor to better protect against (?:punctur|crush|slash)ing damage\.|You must specify an armor slot\.|You don't seem to have the necessary armor fittings in hand\./i,
+          :regex => Regexp.union(/You adjusts? \w+(?:'s)? [\w\s]+ with your plate armor fittings, rearranging and reinforcing the armor to better protect against (?:punctur|crush|slash)ing damage\./i,
+                                 /You must specify an armor slot\./,
+                                 /You don't seem to have the necessary armor fittings in hand\./),
           :usage => "puncture",
         },
         "slash_protection"    => {
-          :regex => /You adjusts? \w+(?:'s)? [\w\s]+ with your plate armor fittings, rearranging and reinforcing the armor to better protect against (?:punctur|crush|slash)ing damage\.|You must specify an armor slot\.|You don't seem to have the necessary armor fittings in hand\./i,
+          :regex => Regexp.union(/You adjusts? \w+(?:'s)? [\w\s]+ with your plate armor fittings, rearranging and reinforcing the armor to better protect against (?:punctur|crush|slash)ing damage\./i,
+                                 /You must specify an armor slot\./,
+                                 /You don't seem to have the necessary armor fittings in hand\./),
           :usage => "slash",
         },
       }
@@ -83,22 +89,22 @@ module Lich
         Armor.known?(name) and Armor.affordable?(name) and !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
       end
 
-      def Armor.use(name, target = "")
+      def Armor.use(name, target = "", results_of_interest: nil)
         return unless Armor.available?(name)
         usage = @@armor_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:usage]
         return if usage.nil?
 
         results_regex = Regexp.union(
+          PSMS::FAILURES_REGEXES,
           @@armor_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex],
           /^#{name} what\?$/i,
-          /^Roundtime: [0-9]+ sec\.$/,
-          /^And give yourself away!  Never!$/,
-          /^You are unable to do that right now\.$/,
-          /^You don't seem to be able to move to do that\.$/,
-          /^Provoking a GameMaster is not such a good idea\.$/,
-          /^You do not currently have a target\.$/,
-          /^\w+ (?:is|are) not wearing any armor that you can work with\.$/,
+          /^\w+ [a-z]+ not wearing any armor that you can work with\.$/
         )
+
+        if results_of_interest.is_a?(Regexp)
+          results_regex = Regexp.union(results_regex, results_of_interest)
+        end
+
         usage_cmd = "armor #{usage}"
         if target.class == GameObj
           usage_cmd += " ##{target.id}"
@@ -115,6 +121,10 @@ module Lich
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
         usage_result
+      end
+
+      def Armor.regexp(name)
+        @@armor_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex]
       end
 
       Armor.armor_lookups.each { |armor|

--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -9,7 +9,7 @@ module Lich
          { long_name: 'berserk',                 short_name: 'berserk',          cost: 20 },
          { long_name: 'block_specialization',    short_name: 'blockspec',        cost:  0 },
          { long_name: 'bull_rush',               short_name: 'bullrush',         cost: 14 },
-         { long_name: 'burst_of_swiftness',      short_name: 'burst',            cost: 30 },
+         { long_name: 'burst_of_swiftness',      short_name: 'burst',            cost: Lich::Util.normalize_lookup('Cooldowns', 'burst_of_swiftness') ? 60 : 30 },
          { long_name: 'cheapshots',              short_name: 'cheapshots',       cost:  7 },
          { long_name: 'combat_focus',            short_name: 'focus',            cost:  0 },
          { long_name: 'combat_mobility',         short_name: 'mobility',         cost:  0 },
@@ -25,7 +25,7 @@ module Lich
          { long_name: 'divert',                  short_name: 'divert',           cost:  7 },
          { long_name: 'duck_and_weave',          short_name: 'duckandweave',     cost: 20 },
          { long_name: 'dust_shroud',             short_name: 'shroud',           cost: 10 },
-         { long_name: 'evade_specialization',    short_name: 'evadespec',        cost: 0 },
+         { long_name: 'evade_specialization',    short_name: 'evadespec',        cost:  0 },
          { long_name: 'eviscerate',              short_name: 'eviscerate',       cost: 14 },
          { long_name: 'executioners_stance',     short_name: 'executioner',      cost: 20 },
          { long_name: 'exsanguinate',            short_name: 'exsanguinate',     cost: 15 },
@@ -36,7 +36,7 @@ module Lich
          { long_name: 'garrote',                 short_name: 'garrote',          cost: 10 },
          { long_name: 'grappel_specialization',  short_name: 'grapplespec',      cost:  0 },
          { long_name: 'griffins_voice',          short_name: 'griffin',          cost: 20 },
-         { long_name: 'groin_kick',              short_name: 'gkick',            cost:	7 },
+         { long_name: 'groin_kick',              short_name: 'gkick',            cost:  7 },
          { long_name: 'hamstring',               short_name: 'hamstring',        cost:  9 },
          { long_name: 'haymaker',                short_name: 'haymaker',         cost:  9 },
          { long_name: 'headbutt',                short_name: 'headbutt',         cost:  9 },
@@ -71,7 +71,7 @@ module Lich
          { long_name: 'subdue',                  short_name: 'subdue',           cost:  9 },
          { long_name: 'sucker_punch',            short_name: 'spunch',           cost:  7 },
          { long_name: 'sunder_shield',           short_name: 'sunder',           cost:  7 },
-         { long_name: 'surge_of_strength',       short_name: 'surge',            cost: 30 },
+         { long_name: 'surge_of_strength',       short_name: 'surge',            cost: Lich::Util.normalize_lookup('Cooldowns', 'surge_of_strength') ? 60 : 30 },
          { long_name: 'sweep',                   short_name: 'sweep',            cost:  7 },
          { long_name: 'swiftkick',               short_name: 'swiftkick',        cost:  7 },
          { long_name: 'tackle',                  short_name: 'tackle',           cost:  7 },
@@ -86,6 +86,570 @@ module Lich
          { long_name: 'whirling_dervish',        short_name: 'dervish',          cost: 20 }]
       end
 
+      @@combat_mans = {
+        "acrobats_leap"          => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Acrobat\'s Leap combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "bearhug"                => {
+          :cost  => 10,
+          :type  => "concentration",
+          :regex => Regexp.union(/You charge towards .+ and attempt to grasp .+ in a ferocious bearhug!/,
+                                 /.+ manages to fend off your grasp\!/),
+          :usage => "bearhug"
+        },
+        "berserk"                => {
+          :cost  => 20,
+          :type  => "attack",
+          :regex => /Everything around you turns red as you work yourself into a berserker's rage\!/,
+          :usage => "berserk"
+        },
+        "block_specialization"   => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Block Specialization combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "bull_rush"              => {
+          :cost  => 14,
+          :type  => "area of effect",
+          :regex => /You dip your shoulder and rush towards an .+!/,
+          :usage => "bullrush"
+        },
+        "burst_of_swiftness"     => {
+          :cost               => Lich::Util.normalize_lookup('Cooldowns', 'Surge of Strength') ? 60 : 30,
+          :type               => "buff",
+          :regex              => Regexp.union(/You prepare yourself to move swiftly at a moment\'s notice\./,
+                                              /You prepare yourself to move swiftly at a moment\'s notice, overcoming the fatigue from your previous exertion\./),
+          :usage              => "burst",
+          :ignorable_cooldown => true
+        },
+        "cheapshots"             => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => /You should activate Footstomp, Nosetweak, Templeshot, Kneebash, Eyepoke, Throatchop or Swiftkick instead\./,
+          :usage => nil
+        },
+        "combat_focus"           => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Combat Focus combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "combat_mobility"        => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Combat Mobility maneuver works automatically when you are attacked\./,
+          :usage => nil
+        },
+        "combat_movement"        => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Combat Movement combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "combat_toughness"       => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Combat Toughness combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "coup_de_grace"          => {
+          :cost  => 20,
+          :type  => "attack",
+          :regex => Regexp.union(/You lunge towards .+, intending to finish [a-z]+ off\!/, # Standard
+                                 /You move towards .+ to finish [a-z]+ off, but [a-z]+ isn\'t injured enough to be susceptible to a Coup de Grace\./, # Standard
+                                 /You advance upon .+ with grim finality\./, # RW2025
+                                 /As .+ shows signs of weakness, you seize the opportunity to launch a mortal blow\!/, # RW2025
+                                 /Seeing your chance, you lunge toward .+ with its death your only goal\!/, # RW2025
+                                 /As .+ falters, you surge forward with murderous intent\!/), # RW2025
+          :usage => "coupdegrace"
+        },
+        "crowd_press"            => {
+          :cost  => 9,
+          :type  => "setup",
+          :regex => /You approach .+\./,
+          :usage => "cpress"
+        },
+        "cunning_defense"        => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Cunning Defense combat maneuver is always active once you have learned it./,
+          :usage => nil
+        },
+        "cutthroat"              => {
+          :cost  => 14,
+          :type  => "setup",
+          :regex => Regexp.union(/You spring from hiding and attempt to slit .+ throat with your .+\!/,
+                                 /For this to work, you\'ll need to take your target by surprise\.  Try hiding first\./,
+                                 /You need to be holding a weapon in your right hand in order to use cutthroat\./,
+                                 /The .+ is too cumbersome to use with cutthroat./),
+          :usage => "cutthroat"
+        },
+        "dirtkick"               => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => /After a quick assessment of your surroundings\, you haul back with one foot and let it fly\!/, # there is probably a climate/terrain combo where there's not dirt to kick, but was unable to test/find one.
+          :usage => "dirtkick"
+        },
+        "disarm_weapon"          => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/You swing your .+ at .+\!/,
+                                 /Choosing your opening, you attempt to disarm .+ with your empty hand!/,
+                                 /You haven\'t learned how to disarm without a weapon\!/),
+          :usage => "disarm"
+        },
+        "dislodge"               => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/.+ does not currently have any suitable weapons lodged in .+\./,
+                                 /You rush toward .+ with an open hand, attempting to dislodge .+ from .+\!/),
+          :usage => "dislodge"
+        },
+        "divert"                 => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/You throw your voice behind .+ and .+ attention is diverted by the noise\!/,
+                                 /Maybe you should try to divert .+ in a different fashion\./,
+                                 /You can\'t find a valid direction in which to push the .+\./,
+                                 /Silently, you inhale and prepare your diversion\./),
+          :usage => "divert"
+        },
+        "duck_and_weave"         => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You balance your posture and narrow your eyes, preparing to misdirect your foes\' attacks\./,
+                                 /You check that your posture remains well-balanced and continue to focus on the misdirection of your foes\' attacks\./),
+          :usage => "duckandweave"
+        },
+        "dust_shroud"            => {
+          :cost  => 10,
+          :type  => "buff",
+          :regex => /You quickly begin kicking up as much dirt as you can\!/, # there is probably a climate/terrain combo where there's not dirt to kick, but was unable to test/find one.
+          :usage => "shroud"
+        },
+        "evade_specialization"   => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Evade Specialization combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "eviscerate"             => {
+          :cost  => 14,
+          :type  => "area of effect",
+          :regex => Regexp.union(/The .+ abdomen is out of reach\!/,
+                                 /You uncoil from the shadows, your .+ poised to eviscerate .+\!/,
+                                 /You can\'t use eviscerate with empty hands\!/),
+          :usage => "eviscerate"
+        },
+        "executioners_stance"    => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You assume the Executioner\'s Stance, altering your grip and posture to minimize the loss of momentum when striking down a foe\./,
+                                 /You re\-settle into the Executioner\'s Stance, re\-altering your grip and posture to minimize the loss of momentum when striking down a foe\./),
+          :usage => "executioner"
+        },
+        "exsanguinate"           => {
+          :cost  => 15,
+          :type  => "attack",
+          :regex => /You lunge at .+, your .+ a blur of .+ in your eagerness to spill [a-z]+ blood\!/,
+          :usage => "exsanguinate"
+        },
+        "eyepoke"                => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/The .+ (?:right|left) eye is out of reach\!/,
+                                 /You jab a finger at the eye of .+\!/),
+          :usage => "eyepoke"
+        },
+        "feint"                  => {
+          :cost  => 9,
+          :type  => "setup",
+          :regex => /You feint .+\./,
+          :usage => "feint"
+        },
+        "flurry_of_blows"        => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You assume a stance suitable to unleash a flurry of blows\./,
+                                 /You re\-settle into a stance suitable to unleash a flurry of blows\./),
+          :usage => "flurry"
+        },
+        "footstomp"              => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => /You raise your heel high, attempting to footstomp .+\!/,
+          :usage => "footstomp"
+        },
+        "garrote"                => {
+          :cost  => 10,
+          :type  => "concentration",
+          :regex => /You fling your .+ around .+ neck and snap it taut\.  Success\!/, # #TODO: Need Failure Message
+          :usage => nil # "garrote" # Set to nil as the messaging is missing to test properly
+        },
+        "grappel_specialization" => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Grapple Specialization combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "griffins_voice"         => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You assume the Griffin\'s Voice stance, altering your breathing patterns to maximize the efficiency of your warcries\./,
+                                 /You re-settle into the Griffin\'s Voice stance, re-altering your breathing patterns to maximize the efficiency of your warcries\./),
+          :usage => "griffin"
+        },
+        "groin_kick"             => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/You attempt to deliver a kick to .+ groin!/, # Standard
+                                 /Leaning close to .+, you quickly raise your knee in an attempt to make debilitating contact with [a-z]+ groin\!/, # RW2025
+                                 /Scuffing your foot upon the ground, you pivot at the hip, targeting your foot at .+ groin\!/, # RW2025
+                                 /Performing a shuffling skip, you viciously kick out at .+ groin with malicious intent\!/, # RW2025
+                                 /You aim a vicious kick square at .+ nether regions\!/), # RW2025
+          :usage => "gkick"
+        },
+        "hamstring"              => {
+          :cost  => 9,
+          :type  => "setup",
+          :regex => Regexp.union(/You lunge forward and try to hamstring .+ with your .+!/,
+                                 /The .+ is too unwieldy for that\./,
+                                 /You need to be holding a weapon capable of slashing to do that\./),
+          :usage => "hamstring"
+        },
+        "haymaker"               => {
+          :cost  => 9,
+          :type  => "setup",
+          :regex => Regexp.union(/You clench your right fist and bring your arm back for a roundhouse punch aimed at .+!/,
+                                 /You can\'t use haymaker with .+!/),
+          :usage => "haymaker"
+        },
+        "headbutt"               => {
+          :cost  => 9,
+          :type  => "setup",
+          :regex => Regexp.union(/You charge towards .+ and attempt to headbutt .+!/, # Standard
+                                 /Coiling your trapezius muscles, you feel your neck tense before springing into action and slamming your head down toward .+\!/, # RW2025
+                                 /Shrugging almost casually, you quickly snap your head foward in an attempt to headbutt .+\!/, # RW2025
+                                 /Rising on your tip toes, you cock back your head and slam it down towards .+\!/, # RW2025
+                                 /Bellowing like an angry bull, you lower your head and charge straight at .+\!/), # RW2025
+          :usage => "headbutt"
+        },
+        "inner_harmony"          => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You center your mind, body and soul and enter a state of inner harmony\./,
+                                 /You continue in your state of inner harmony\./),
+          :usage => "iharmony"
+        },
+        "internal_power"         => {
+          :cost  => 20,
+          :type  => "buff",
+          :regex => /You concentrate on restoring your internal well\-being\./,
+          :usage => "ipower"
+        },
+        "ki_focus"               => {
+          :cost  => 20,
+          :type  => "buff",
+          :regex => Regexp.union(/You summon your inner ki and focus it to enhance your next attack\./,
+                                 /You have already summoned your inner ki and are ready for a devastating attack\./),
+          :usage => "kifocus"
+        },
+        "kick_specialization"    => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Kick Specialization combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "kneebash"               => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/You reverse your weapon and swing the blunt end down at the knee of .+\!/,
+                                 /You clench your fist tightly and snap it down at the knee of .+\!/,
+                                 /You do not know how to kneebash barehanded yet\!/),
+          :usage => "kneebash"
+        },
+        "leap_attack"            => {
+          :cost  => 15,
+          :type  => "attack",
+          :regex => Regexp.union(/.+ isn\'t flying\.  Maybe you should just attack it\?/,
+                                 /You sprint toward .+ and leap into the air\!/,
+                                 /.+ is flying, but low enough for you to attack it\./),
+          :usage => "leapattack"
+        },
+        "mighty_blow"            => {
+          :cost  => 15,
+          :type  => "attack",
+          :regex => Regexp.union(/You need to be holding a weapon in your right hand to use this maneuver\./,
+                                 /Tightening your grip on your .+, you strike out at .+ with all of your might!/),
+          :usage => "mblow"
+        },
+        "mug"                    => {
+          :cost  => 15,
+          :type  => "attack",
+          :regex => /You boldly accost .+, your attack masking your larcenous intent!/,
+          :usage => "mug"
+        },
+        "nosetweak"              => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/The .+ head is out of reach\!/,
+                                 /You reach out and grab at .+ nose!/),
+          :usage => "nosetweak"
+        },
+        "parry_specialization"   => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Parry Specialization combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "precision"              => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /Usage\: CMAN PRECIS \<damage type\>/,
+          :usage => nil
+        },
+        "predators_eye"          => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You begin to survey your surroundings with a Predator\'s Eye\./,
+                                 /You continue to survey your surroundings with a Predator\'s Eye\./),
+          :usage => "predator"
+        },
+        "punch_specialization"   => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Punch Specialization combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "retreat"                => {
+          :cost  => 30,
+          :type  => "buff",
+          :regex => /You withdraw, disengaging from .+\./,
+          :usage => "retreat"
+        },
+        "rolling_krynch_stance"  => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You assume the Rolling Krynch Stance\./,
+                                 /You re\-settle into the Rolling Krynch Stance\./),
+          :usage => "krynch"
+        },
+        "shield_bash"            => {
+          :cost  => 9,
+          :type  => "setup",
+          :regex => /You lunge forward at .* with your .* and attempt a shield bash\!/,
+          :usage => "sbash"
+        },
+        "side_by_side"           => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /Side by Side is automatically active whenever you are grouped with other characters\./,
+          :usage => nil
+        },
+        "slippery_mind"          => {
+          :cost  => 0,
+          :type  => "martial stance",
+          :regex => /You focus inward and prepare to blank your mind at a moment\'s notice\./, # reapply message not missing, just the same
+          :usage => "slipperymind"
+        },
+        "spell_cleave"           => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => /You might have more success with anti-magical equipment\./, # #TODO: Need Success Message
+          :usage => nil # "scleave" # Set to nil as the messaging is missing to test properly
+        },
+        "spell_parry"            => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Spell Parry combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "spell_thieve"           => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => /You might have more success with anti-magical equipment\./, # #TODO: Need Success Message
+          :usage => nil # "sthieve" # Set to nil as the messaging is missing to test properly
+        },
+        "spike_focus"            => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Armor Spike Focus combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "spin_attack"            => {
+          :cost  => 0,
+          :type  => "attack",
+          :regex => Regexp.union(/You let out a shrill yell and leap, spinning through the air and into the fracas\!/, # Standard
+                                 /You spin on your toes, deliberate in your motion as you lunge at .+\!/, # RW2025
+                                 /Giving voice to manic laughter, you whirl toward .+ with vicious glee\!/, # RW2025
+                                 /Snapping around, you pivot on one foot and spin toward .+\!/, # RW2025
+                                 /Silent and intent, you pivot on the ball of one foot and whirl toward .+\!/), # RW2025
+          :usage => "sattack"
+        },
+        "staggering_blow"        => {
+          :cost  => 15,
+          :type  => "attack",
+          :regex => Regexp.union(/Winding back with your .+, you launch yourself at .+ with staggering might!/,
+                                 /You need to be holding an appropriate weapon before attempting this maneuver\./),
+          :usage => "sblow"
+        },
+        "stance_perfection"      => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /You are currently using .+ of your combat skill to defend yourself\./,
+          :usage => nil
+        },
+        "stance_of_the_mongoose" => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You assume the Stance of the Mongoose, ready to retaliate instantly against your foes\./,
+                                 /You re\-settle into the Stance of the Mongoose, ready to retaliate instantly against your foes\./),
+          :usage => "mongoose"
+        },
+        "striking_asp"           => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You assume the Striking Asp Stance, ready to find the right position for a quick strike\./,
+                                 /You re\-settle Striking Asp Stance, ready to find the right position for a quick strike\./),
+          :usage => "asp"
+        },
+        "stun_maneuvers"         => {
+          :cost  => 10,
+          :type  => "buff",
+          :regex => Regexp.union(/Usage: CMAN STUNMAN \[option\]/,
+                                 /You're not stunned\./,
+                                 /You try to command your muscles and you can almost feel them react\!/,
+                                 /You shakily command your muscles to ready a shield\./,
+                                 /You shakily command your muscles to ready a suitable weapon\./,
+                                 /You successfully command your resistant muscles to remove .+ from in your .+\./,
+                                 /You stumble about in a daze, trying to regain your balance\./,
+                                 /You struggle valiantly against the effects of the stun as you attempt to stand up\./,
+                                 /You successfully command your resistant muscles to pick up .+\./,
+                                 /You attempt to blend with the surroundings, and feel confident that no one has noticed your doing so\./, # There may be a non-standard failure message for this.
+                                 /You are now in a .+ stance\./,
+                                 /You stumble about in a daze, trying to regain your balance\./),
+          :usage => "stunman"
+        },
+        "subdue"                 => {
+          :cost  => 9,
+          :type  => "setup",
+          :regex => Regex.union(/You haven\'t learned how to subdue without a weapon\!/,
+                                /You spring from hiding and aim a blow at .+ head\!/,
+                                /The .+ head is out of reach\!/,
+                                /For this to work, you\'ll need to take your target by surprise\.  Try hiding first\./),
+          :usage => "subdue"
+        },
+        "sucker_punch"           => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/The .+ back is out of reach\!/,
+                                 /You punch .+ in the lower back\!/,
+                                 /You deliver a quick punch to .+ lower back\!/,
+                                 /You deliver a solid punch to .+ lower back with your hand\!/),
+          :usage => "spunch"
+        },
+        "sunder_shield"          => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/You can\'t use sunder shield with empty hands!/,
+                                 /You drive your .+ directly at .+ in an attempt to split it asunder!/),
+          :usage => "sunder"
+        },
+        "surge_of_strength"      => {
+          :cost               => Lich::Util.normalize_lookup('Cooldowns', 'Surge of Strength') ? 60 : 30,
+          :type               => "buff",
+          :regex              => /You focus deep within yourself, searching for untapped sources of strength\./,
+          :usage              => "surge",
+          :ignorable_cooldown => true
+        },
+        "sweep"                  => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/You crouch and sweep a leg at .+\!/,
+                                 /You cannot sweep .+\./),
+          :usage => "sweep"
+        },
+        "swiftkick"              => {
+          :cost               => 7,
+          :type               => "setup",
+          :regex              => /You spin around behind .+, attempting a swiftkick\!/,
+          :usage              => "swiftkick",
+          :ignorable_cooldown => true
+        },
+        "tackle"                 => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => /You hurl yourself at .+!/,
+          :usage => "tackle"
+        },
+        "tainted_bond"           => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Tainted Bond combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "templeshot"             => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/The .+ head is out of reach\!/,
+                                 /You reverse your .+ and swing the blunt end at the head of .+\!/,
+                                 /You clench your fist tightly and snap it towards the head of .+\!/,
+                                 /You do not know how to templeshot barehanded yet\!/),
+          :usage => "templeshot"
+        },
+        "throatchop"             => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/The .+ neck is out of reach\!/,
+                                 /You swing your rigid hand at the throat of .+\!/,
+                                 /You chop at .+ throat with your .+\!/,
+                                 /You do not know how to throatchop barehanded yet\!/),
+          :usage => "throatchop"
+        },
+        "trip"                   => {
+          :cost  => 7,
+          :type  => "setup",
+          :regex => Regexp.union(/You can\'t reach far enough to trip anything with .+\./,
+                                 /With a fluid whirl, you plant .+ firmly into the ground near .+ and jerk the weapon sharply sideways\./),
+          :usage => "trip"
+        },
+        "true_strike"            => {
+          :cost  => 15,
+          :type  => "attack",
+          :regex => /Determined, you resolve that your next attack will strike true\./,
+          :usage => "truestrike"
+        },
+        "unarmed_specialist"     => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /The Unarmed Specialist combat maneuver is always active once you have learned it\./,
+          :usage => nil
+        },
+        "vault_kick"             => {
+          :cost  => 30,
+          :type  => "setup",
+          :regex => /You can't use vault kick with .+!/,
+          :usage => "vaultkick"
+        },
+        "weapon_specialization"  => {
+          :cost  => 0,
+          :type  => "passive",
+          :regex => /You are currently specialized in .+ with .+ in Weapon Specialization\./,
+          :usage => nil
+        },
+        "whirling_dervish"       => {
+          :cost  => 20,
+          :type  => "martial stance",
+          :regex => Regexp.union(/You assume the Whirling Dervish stance, ready to switch targets at a moment\'s notice\./,
+                                 /You re-settle into the Whirling Dervish stance, ready to switch targets at a moment\'s notice\./),
+          :usage => "dervish"
+        }
+      }
+
       def CMan.[](name)
         return PSMS.assess(name, 'CMan')
       end
@@ -98,8 +662,49 @@ module Lich
         return PSMS.assess(name, 'CMan', true)
       end
 
-      def CMan.available?(name)
-        CMan.known?(name) and CMan.affordable?(name) and !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
+      def CMan.available?(name, ignore_cooldown: false)
+        return false unless CMan.known?(name)
+        return false unless CMan.affordable?(name)
+        return false if Lich::Util.normalize_lookup('Cooldowns', name) unless ignore_cooldown && @@combat_mans.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:ignorable_cooldown] # check that the request to ignore_cooldown is on something that can have the cooldown ignored as well
+        return false if Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
+        return true
+      end
+
+      def CMan.use(name, target = "", ignore_cooldown: false, results_of_interest: nil)
+        return unless CMan.available?(name, ignore_cooldown: ignore_cooldown)
+        usage = @@combat_mans.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:usage]
+        return if usage.nil?
+
+        results_regex = Regexp.union(
+          PSMS::FAILURES_REGEXES,
+          @@combat_mans.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex],
+          /^#{name} what\?$/i
+        )
+
+        if results_of_interest.is_a?(Regexp)
+          results_regex = Regexp.union(results_regex, results_of_interest)
+        end
+
+        usage_cmd = "cman #{usage}"
+        if target.class == GameObj
+          usage_cmd += " ##{target.id}"
+        elsif target.class == Integer
+          usage_cmd += " ##{target}"
+        elsif target != ""
+          usage_cmd += " #{target}"
+        end
+        waitrt?
+        waitcastrt?
+        usage_result = dothistimeout usage_cmd, 5, results_regex
+        if usage_result == "You don't seem to be able to move to do that."
+          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+          usage_result = dothistimeout usage_cmd, 5, results_regex
+        end
+        usage_result
+      end
+
+      def CMan.regexp(name)
+        @@combat_mans.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex]
       end
 
       CMan.cman_lookups.each { |cman|

--- a/lib/gemstone/psms/feat.rb
+++ b/lib/gemstone/psms/feat.rb
@@ -39,164 +39,173 @@ module Lich
       end
 
       @@feats = {
-        "absorbmagic"     => {
+        "absorb_magic"              => {
           :cost  => 0,
-          :regex => /You open yourself to the ravenous void at the core of your being, allowing it to surface\.  Muted veins of metallic grey ripple just beneath your skin\.|You strain, but the void within remains stubbornly out of reach\.  You need more time\./,
+          :regex => Regexp.union(/You open yourself to the ravenous void at the core of your being, allowing it to surface\.  Muted veins of metallic grey ripple just beneath your skin\./,
+                                 /You strain, but the void within remains stubbornly out of reach\.  You need more time\./),
           :usage => "absorbmagic"
         },
-        "chainarmor"      => {
+        "chain_armor_proficiency"   => {
           :cost  => 0,
           :regex => /Chain Armor Proficiency is passive and cannot be activated\./,
           :usage => nil
         },
-        "combatmastery"   => {
+        "combat_mastery"            => {
           :cost  => 0,
           :regex => /Combat Mastery is passive and cannot be activated\./,
           :usage => nil
         },
-        "escapeartist"    => {
+        "covert_art_escape_artist"  => {
           :cost  => 15, # cost is actually 0 if "recent evasion" is present
-          :regex => /You roll your shoulders and subtly test the flexion of your joints, staying limber for ready escapes\.|You were unable to find any targets that meet Covert Art\: Escape Artist\'s reaction requirements./,
+          :regex => Regex.union(/You roll your shoulders and subtly test the flexion of your joints, staying limber for ready escapes\./,
+                                /You were unable to find any targets that meet Covert Art\: Escape Artist\'s reaction requirements./),
           :usage => "escapeartist"
         },
-        "keeneye"         => {
+        "covert_art_keen_eye"       => {
           :cost  => 0,
           :regex => /Covert Art\: Keen Eye is always active as long as you stay up to date on training\./,
           :usage => nil
         },
-        "poisoncraft"     => {
+        "covert_art_poisoncraft"    => {
           :cost  => 0,
           :regex => /USAGE\: FEAT POISONCRAFT \{options\} \[args\]/, #  USAGE: FEAT POISONCRAFT {options} [args]
           :usage => nil # usage set to NIL as not currently supported due to complexity
         },
-        "sidestep"        => {
+        "covert_art_sidestep"       => {
           :cost  => 10,
           :regex => /You tread lightly and keep your head on a swivel, prepared to sidestep any loose salvos that might stray your way\./,
           :usage => "sidestep"
         },
-        "swiftrecovery"   => {
+        "covert_art_swift_recovery" => {
           :cost  => 0,
           :regex => /Covert Art\: Swift Recovery is always active as long as you stay up to date on training\./,
           :usage => nil
         },
-        "throwpoison"     => {
+        "covert_art_throw_poison"   => {
           :cost  => 15,
-          :regex => /What did the (.+) ever do to you\?|You pop the cork on (.+) and, with a nimble flick of the wrist, fling a portion of its contents in a wide arc\!|Covert Art\: Throw Poison what\?/,
+          :regex => Regexp.union(/What did the .+ ever do to you\?/,
+                                 /You pop the cork on .+ and, with a nimble flick of the wrist, fling a portion of its contents in a wide arc\!/,
+                                 /Covert Art\: Throw Poison what\?/),
           :usage => "throwpoison"
         },
-        "covert"          => {
+        "covert_arts"               => {
           :cost  => 0,
           :regex => /USAGE\: FEAT COVERT \{options\} \[args\]/, #  USAGE: FEAT COVERT {options} [args]
           :usage => nil # usage not supported at this time, complicated and used to train others in the skills
         },
-        "criticalcounter" => {
+        "critical_counter"          => {
           :cost  => 0,
           :regex => /Critical Counter is passive and cannot be activated\./,
           :usage => nil
         },
-        "dispelmagic"     => {
+        "dispel_magic"              => {
           :cost  => 30,
-          :regex => /You reach for the emptiness within, but there are no spells afflicting you to dispel\.|You reach for the emptiness within\.  A single, hollow note reverberates through your core, resonating outward and scouring away the energies that cling to you\./,
+          :regex => Regexp.union(/You reach for the emptiness within, but there are no spells afflicting you to dispel\./,
+                                 /You reach for the emptiness within\.  A single, hollow note reverberates through your core, resonating outward and scouring away the energies that cling to you\./),
           :usage => "dispelmagic"
         },
-        "dragonscaleskin" => {
+        "dragonscale_skin"          => {
           :cost  => 0,
           :regex => /The Dragonscale Skin\s{1,2}feat is always active once you have learned it\./, # Note: Game has a typo with two spaces after the name of the feat, modified regex to match 1 or 2 spaces so this doesn't break if the typo gets fixed.
           :usage => nil
         },
-        "guard"           => {
+        "guard"                     => {
           :cost  => 0,
-          :regex => /Guard what\?|You move over to (.+) and prepare to guard (him|her|it) from attack\.|You stop guarding (.+), move over to (.+), and prepare to guard (him|her|it) from attack\.You stop protecting (.+), move over to (.+), and prepare to guard (him|her|it) from attack\.|You stop protecting (.+) and prepare to guard (him|her|it) instead\.|You are already guarding (.+)\./,
-          # "any variation of "feat guard" or bad target:  Protect what\?"
-          # "Guard <target>": You move over to (.+) and prepare to guard (him|her|it) from attack\.
-          # "Guard <target2>" while already guarding <target1>:  You stop guarding (.+), move over to (.+), and prepare to guard (him|her|it) from attack\.
-          # "Guard <target2>" while protecting <target1>:  You stop protecting (.+), move over to (.+), and prepare to guard (him|her|it) from attack\.
-          # "Guard <target>" while protecting <target>:  You stop protecting (.+) and prepare to guard (him|her|it) instead\.
-          # "Guard <target>" while already doing so:  You are already guarding (.+)\.
+          :regex => Regexp.union(/Guard what\?/, # "any variation of "feat guard" or bad target
+                                 /You move over to .+ and prepare to guard [a-z]+ from attack\./, # "Guard <target>"
+                                 /You stop guarding .+, move over to .+, and prepare to guard [a-z]+ from attack\./, # "Guard <target2>" while already guarding <target1>
+                                 /You stop protecting .+, move over to .+, and prepare to guard [a-z]+ from attack\./, # "Guard <target2>" while protecting <target1>
+                                 /You stop protecting .+ and prepare to guard [a-z]+ instead\./, # "Guard <target>" while protecting <target>
+                                 /You are already guarding .+\./), # "Guard <target>" while already doing so
           :usage => "guard"
         },
-        "kroderinesoul"   => {
+        "kroderine_soul"            => {
           :cost  => 0,
           :regex => /Kroderine Soul is passive and always active as long as you do not learn any spells\.  You have access to two new abilities\:/,
           :usage => nil
         },
-        "lightarmor"      => {
+        "light_armor_proficiency"   => {
           :cost  => 0,
           :regex => /Light Armor Proficiency is passive and cannot be activated\./,
           :usage => nil
         },
-        "martialarts"     => {
+        "martial_arts_mastery"      => {
           :cost  => 0,
           :regex => /Martial Arts Mastery is passive and cannot be activated\./,
           :usage => nil
         },
-        "martialmastery"  => {
+        "martial_mastery"           => {
           :cost  => 0,
           :regex => /Martial Mastery is passive and cannot be activated\./,
           :usage => nil
         },
-        "mentalacuity"    => {
+        "mental_acuity"             => {
           :cost  => 0,
           :regex => /The Mental Acuity\s{1,2}feat is always active once you have learned it\./, # Note: Game has a typo with two spaces after the name of the feat, modified regex to match 1 or 2 spaces so this doesn't break if the typo gets fixed.
           :usage => nil
         },
-        "mysticstrike"    => {
+        "mystic_strike"             => {
           :cost  => 10,
           :regex => /You prepare yourself to deliver a Mystic Strike with your next attack\./,
           :usage => "mysticstrike"
         },
-        "tattoo"          => {
+        "mystic_tattoo"             => {
           :cost  => 0,
           :regex => /Usage\:/,
           :usage => nil # usage not supported at this time, complicated and used for a service
         },
-        "perfectself"     => {
+        "perfect_self"              => {
           :cost  => 0,
           :regex => /The Perfect Self feat is always active once you have learned it\.  It provides a constant enhancive bonus to all your stats\./,
           :usage => nil
         },
-        "platearmor"      => {
+        "plate_armor_proficiency"   => {
           :cost  => 0,
           :regex => /Plate Armor Proficiency is passive and cannot be activated\./,
           :usage => nil
         },
-        "protect"         => {
+        "protect"                   => {
           :cost  => 0,
-          :regex => /Protect what\?|You move over to (.+) and prepare to protect (him|her|it) from attack\.|while already protecting <target1>: You stop protecting (.+), move over to (.+), and prepare to protect (him|her|it) from attack\.|You stop guarding (.+), move over to (.+), and prepare to protect (him|her|it) from attack\.|You stop guarding (.+) and prepare to protect (him|her|it) instead\.|You are already protecting (.+)\./,
-          #  any variation of "feat protect" or bad target:  Protect what\?
-          #  "protect <target>": You move over to (.+) and prepare to protect (him|her|it) from attack\.
-          #  "protect <target2>" while already protecting <target1>: You stop protecting (.+), move over to (.+), and prepare to protect (him|her|it) from attack\.
-          #  "protect <target2>" while guarding <target1>:  You stop guarding (.+), move over to (.+), and prepare to protect (him|her|it) from attack\.
-          #  "protect <target>" while already guarding <target>:  You stop guarding (.+) and prepare to protect (him|her|it) instead\.
-          #  "protect <target>" while already protecting <target>: You are already protecting (.+)\.
+          :regex => Regexp.union(/Protect what\?/, #  any variation of "feat protect" or bad target:
+                                 /You move over to .+ and prepare to protect [a-z]+ from attack\./, #  "protect <target>"
+                                 /You stop protecting .+, move over to .+, and prepare to protect [a-z]+ from attack\./, #  "protect <target2>" while already protecting <target1>
+                                 /You stop guarding .+, move over to .+, and prepare to protect [a-z]+ from attack\./, #  "protect <target2>" while guarding <target1>
+                                 /You stop guarding .+ and prepare to protect [a-z]+ instead\./, #  "protect <target>" while already guarding <target>
+                                 /You are already protecting .+\./), #  "protect <target>" while already protecting <target>
           :usage => "protect"
         },
-        "scalearmor"      => {
+        "scale_armor_proficiency"   => {
           :cost  => 0,
           :regex => /Scale Armor Proficiency is passive and cannot be activated\./,
           :usage => nil
         },
-        "shadowdance"     => {
+        "shadow_dance"              => {
           :cost  => 30,
           :regex => /You focus your mind and body on the shadows\./,
           :usage => nil
         },
-        "silentstrike"    => {
+        "silent_strike"             => {
           :cost  => 20,
-          :regex => /Silent Strike can not be used with fire as the attack type\.|You quickly leap from hiding to attack\!/,
+          :regex => Regexp.union(/Silent Strike can not be used with fire as the attack type\./,
+                                 /You quickly leap from hiding to attack\!/),
           :usage => "silentstrike"
         },
-        "vanish"          => {
+        "vanish"                    => {
           :cost  => 30,
           :regex => /With subtlety and speed, you aim to clandestinely vanish into the shadows\./,
           :usage => "vanish"
         },
-        "weaponbonding"   => {
+        "weapon_bonding"            => {
           :cost  => 0,
           :regex => /USAGE\:/,
           :usage => nil # not currently supported due to complexity
         },
-        "wps"             => {
+        "weighting"                 => {
+          :cost  => 0,
+          :regex => /USAGE\: FEAT WPS \{options\} \[args\]/, # USAGE: FEAT WPS {options} [args]
+          :usage => nil # not currently supported due to complexity
+        },
+        "padding"                   => {
           :cost  => 0,
           :regex => /USAGE\: FEAT WPS \{options\} \[args\]/, # USAGE: FEAT WPS {options} [args]
           :usage => nil # not currently supported due to complexity
@@ -219,21 +228,21 @@ module Lich
         Feat.known?(name) and Feat.affordable?(name) and !Lich::Util.normalize_lookup('Cooldowns', name) and !Lich::Util.normalize_lookup('Debuffs', 'Overexerted')
       end
 
-      def Feat.use(name, target = "")
+      def Feat.use(name, target = "", results_of_interest: nil)
         return unless Feat.available?(name)
         usage = @@feats.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:usage]
         return if usage.nil?
 
         results_regex = Regexp.union(
+          PSMS::FAILURES_REGEXES,
           @@feats.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex],
-          /^#{name} what\?$/i,
-          /^Roundtime: [0-9]+ sec\.$/,
-          /^And give yourself away!  Never!$/,
-          /^You are unable to do that right now\.$/,
-          /^You don't seem to be able to move to do that\.$/,
-          /^Provoking a GameMaster is not such a good idea\.$/,
-          /^You do not currently have a target\.$/,
+          /^#{name} what\?$/i
         )
+
+        if results_of_interest.is_a?(Regexp)
+          results_regex = Regexp.union(results_regex, results_of_interest)
+        end
+
         usage_cmd = (['guard', 'protect'].include?(usage) ? "#{usage}" : "feat #{usage}")
         if target.class == GameObj
           usage_cmd += " ##{target.id}"
@@ -250,6 +259,10 @@ module Lich
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
         usage_result
+      end
+
+      def Feat.regexp(name)
+        @@feats.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex]
       end
 
       Feat.feat_lookups.each { |feat|

--- a/lib/gemstone/psms/shield.rb
+++ b/lib/gemstone/psms/shield.rb
@@ -45,162 +45,166 @@ module Lich
       @@shield_techniques = {
         "adamantine_bulwark"    => {
           :cost  => 0,
-          :regex => /Adamantine Bulwark does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Adamantine Bulwark does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "block_the_elements"    => {
           :cost  => 0,
-          :regex => /Block the Elements does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Block the Elements does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "deflect_magic"         => {
           :cost  => 0,
-          :regex => /Deflect Magic does not need to be activated once you have learned it.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization./i,
+          :regex => /Deflect Magic does not need to be activated once you have learned it\.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization\./,
           :usage => nil,
         },
         "deflect_missiles"      => {
           :cost  => 0,
-          :regex => /Deflect Missiles does not need to be activated once you have learned it.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization./i,
+          :regex => /Deflect Missiles does not need to be activated once you have learned it\.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization\./,
           :usage => nil,
         },
         "deflect_the_elements"  => {
           :cost  => 0,
-          :regex => /Deflect the Elements does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Deflect the Elements does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "disarming_presence"    => {
           :cost  => 20,
-          :regex => /You assume the Disarming Presence Stance, adjusting your footing and grip to allow for the proper pivot and thrust technique to disarm attacking foes.|You re-settle into the Disarming Presence Stance, re-ensuring your footing and grip are properly positioned./i,
+          :regex => Regexp.union(/You assume the Disarming Presence Stance, adjusting your footing and grip to allow for the proper pivot and thrust technique to disarm attacking foes\./,
+                                 /You re\-settle into the Disarming Presence Stance, re-ensuring your footing and grip are properly positioned\./),
           :usage => "dpresence",
         },
         "guard_mastery"         => {
           :cost  => 0,
-          :regex => /Guard Mastery does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Guard Mastery does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "large_shield_focus"    => {
           :cost  => 0,
-          :regex => /Large Shield Focus does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Large Shield Focus does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "medium_shield_focus"   => {
           :cost  => 0,
-          :regex => /Medium Shield Focus does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Medium Shield Focus does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "phalanx"               => {
           :cost  => 0,
-          :regex => /Phalanx does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Phalanx does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "prop_up"               => {
           :cost  => 0,
-          :regex => /Prop Up does not need to be activated once you have learned it.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization./i,
+          :regex => /Prop Up does not need to be activated once you have learned it\.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization\./,
           :usage => nil,
         },
         "protective_wall"       => {
           :cost  => 0,
-          :regex => /Protective Wall does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Protective Wall does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "shield_bash"           => {
           :cost  => 9,
-          :regex => /Shield Bash what?|You lunge forward at (.*) with your (.*) and attempt a shield bash\!/i,
+          :regex => /You lunge forward at .+ with your .+ and attempt a shield bash\!/,
           :usage => "bash",
         },
         "shield_charge"         => {
           :cost  => 14,
-          :regex => /You charge forward at (.*) with your (.*) and attempt a shield charge!/i,
+          :regex => /You charge forward at .+ with your .+ and attempt a shield charge\!/,
           :usage => "charge",
         },
         "shield_forward"        => {
           :cost  => 0,
-          :regex => /Shield Forward does not need to be activated once you have learned it.  It will automatically activate upon the use of a shield attack./i,
+          :regex => /Shield Forward does not need to be activated once you have learned it\.  It will automatically activate upon the use of a shield attack\./,
           :usage => "forward",
         },
         "shield_mind"           => {
           :cost  => 10,
-          :regex => /You must be wielding an ensorcelled or anti-magical shield to be able to properly shield your mind and soul.|/i,
+          :regex => /You must be wielding an ensorcelled or anti-magical shield to be able to properly shield your mind and soul\./,
           :usage => "mind",
         },
         "shield_pin"            => {
           :cost  => 15,
-          :regex => /You attempt to expose a vulnerability with a diversionary shield bash on (.*)\!/i,
+          :regex => /You attempt to expose a vulnerability with a diversionary shield bash on .+\!/,
           :usage => "pin",
         },
         "shield_push"           => {
           :cost  => 7,
-          :regex => /You raise your (.*) before you and attempt to push (.*) away!/i,
+          :regex => /You raise your .+ before you and attempt to push .+ away\!/,
           :usage => "push",
         },
         "shield_riposte"        => {
           :cost  => 20,
-          :regex => /You assume the Shield Riposte Stance, preparing yourself to lash out at a moment's notice.|You re\-settle into the Shield Riposte Stance, preparing yourself to lash out at a moment's notice./i,
+          :regex => Regexp.union(/You assume the Shield Riposte Stance, preparing yourself to lash out at a moment's notice\./,
+                                 /You re\-settle into the Shield Riposte Stance, preparing yourself to lash out at a moment's notice\./),
           :usage => "riposte",
         },
         "shield_spike_mastery"  => {
           :cost  => 0,
-          :regex => /Shield Spike Mastery does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Shield Spike Mastery does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "shield_strike"         => {
           :cost  => 15,
-          :regex => /You launch a quick bash with your (.*) at (.*)\!/i,
+          :regex => /You launch a quick bash with your .+ at .+\!/,
           :usage => "strike",
         },
         "shield_strike_mastery" => {
           :cost  => 0,
-          :regex => /Shield Strike Mastery does not need to be activated once you have learned it.  It will automatically apply to all relevant focused multi-attacks, provided that you maintain the prerequisite ranks of Shield Bash./i,
+          :regex => /Shield Strike Mastery does not need to be activated once you have learned it\.  It will automatically apply to all relevant focused multi\-attacks, provided that you maintain the prerequisite ranks of Shield Bash\./,
           :usage => nil,
         },
         "shield_swiftness"      => {
           :cost  => 0,
-          :regex => /Shield Swiftness does not need to be activated once you have learned it.  It will automatically apply to all relevant attacks, provided that you are wielding a small or medium shield and have at least 3 ranks of the relevant Shield Focus specialization./i,
+          :regex => /Shield Swiftness does not need to be activated once you have learned it\.  It will automatically apply to all relevant attacks, provided that you are wielding a small or medium shield and have at least 3 ranks of the relevant Shield Focus specialization\./,
           :usage => nil,
         },
         "shield_throw"          => {
           :cost  => 20,
-          :regex => /You snap your arm forward, hurling your (.*) at (.*) with all your might\!/i,
+          :regex => /You snap your arm forward, hurling your .+ at .+ with all your might\!/,
           :usage => "throw",
         },
         "shield_trample"        => {
           :cost  => 14,
-          :regex => /You raise your (.*) before you and charge headlong towards (.*)\!/i,
+          :regex => /You raise your .+ before you and charge headlong towards .+\!/,
           :usage => "trample",
         },
         "shielded_brawler"      => {
           :cost  => 0,
-          :regex => /Shielded Brawler does not need to be activated once you have learned it.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization./i,
+          :regex => /Shielded Brawler does not need to be activated once you have learned it\.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization\./,
           :usage => nil,
         },
         "small_shield_focus"    => {
           :cost  => 0,
-          :regex => /Small Shield Focus does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Small Shield Focus does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./,
           :usage => nil,
         },
         "spell_block"           => {
           :cost  => 0,
-          :regex => /Spell Block does not need to be activated once you have learned it.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization./i,
+          :regex => /Spell Block does not need to be activated once you have learned it\.  It will automatically apply to all relevant attacks, provided that you are wielding a shield and possess 3 ranks of the relevant Shield Focus specialization\./,
           :usage => nil,
         },
         "steady_shield"         => {
           :cost  => 0,
-          :regex => /Steady Shield does not need to be activated once you have learned it.  It will automatically apply to all relevant attacks against you, provided that you maintain the prerequisite ranks of Stun Maneuvers./i,
+          :regex => /Steady Shield does not need to be activated once you have learned it\.  It will automatically apply to all relevant attacks against you, provided that you maintain the prerequisite ranks of Stun Maneuvers\./,
           :usage => nil,
         },
         "steely_resolve"        => {
           :cost  => 30,
-          :regex => /You focus your mind in a steely resolve to block all attacks against you.|You are still mentally fatigued from your last invocation of your Steely Resolve./i,
+          :regex => Regexp.union(/You focus your mind in a steely resolve to block all attacks against you\./,
+                                 /You are still mentally fatigued from your last invocation of your Steely Resolve\./),
           :usage => "resolve",
         },
         "tortoise_stance"       => {
           :cost  => 20,
-          :regex => /You assume the Stance of the Tortoise, holding back some of your offensive power in order to maximize your defense.|You re\-settle into the Stance of the Tortoise, holding back your offensive power in order to maximize your defense./i,
+          :regex => Regexp.union(/You assume the Stance of the Tortoise, holding back some of your offensive power in order to maximize your defense\./,
+                                 /You re\-settle into the Stance of the Tortoise, holding back your offensive power in order to maximize your defense\./),
           :usage => "tortoise",
         },
         "tower_shield_focus"    => {
           :cost  => 0,
-          :regex => /Tower Shield Focus does not need to be activated.  If you are wielding the appropriate type of shield, it will always be active./i,
+          :regex => /Tower Shield Focus does not need to be activated\.  If you are wielding the appropriate type of shield, it will always be active\./i,
           :usage => nil,
         },
       }
@@ -221,21 +225,21 @@ module Lich
       end
 
       # unmodified from 5.6.2
-      def Shield.use(name, target = "")
+      def Shield.use(name, target = "", results_of_interest: nil)
         return unless Shield.available?(name)
         usage = @@shield_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:usage]
         return if usage.nil?
 
         results_regex = Regexp.union(
+          PSMS::FAILURES_REGEXES,
           @@shield_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex],
-          /^#{name} what\?$/i,
-          /^Roundtime: [0-9]+ sec\.$/,
-          /^And give yourself away!  Never!$/,
-          /^You are unable to do that right now\.$/,
-          /^You don't seem to be able to move to do that\.$/,
-          /^Provoking a GameMaster is not such a good idea\.$/,
-          /^You do not currently have a target\.$/,
+          /^#{name} what\?$/i
         )
+
+        if results_of_interest.is_a?(Regexp)
+          results_regex = Regexp.union(results_regex, results_of_interest)
+        end
+
         usage_cmd = "shield #{usage}"
         if target.class == GameObj
           usage_cmd += " ##{target.id}"
@@ -252,6 +256,10 @@ module Lich
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
         usage_result
+      end
+
+      def Shield.regexp(name)
+        @@shield_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex]
       end
 
       Shield.shield_lookups.each { |shield|

--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -14,24 +14,24 @@ module Lich
 
       @@warcries = {
         "bellow" => {
-          :regex => /You glare at .+ and let out a nerve-shattering bellow! /i,
+          :regex => /You glare at .+ and let out a nerve-shattering bellow!/,
         },
         "yowlp"  => {
-          :regex => /You throw back your shoulders and let out a resounding yowlp!/i,
+          :regex => /You throw back your shoulders and let out a resounding yowlp!/,
           :buff  => "Yertie's Yowlp",
         },
         "growl"  => {
-          :regex => /Your face contorts as you unleash a guttural, deep-throated growl at .+!/i,
+          :regex => /Your face contorts as you unleash a guttural, deep-throated growl at .+!/,
         },
         "shout"  => {
-          :regex => /You let loose an echoing shout!/i,
+          :regex => /You let loose an echoing shout!/,
           :buff  => 'Empowered (+20)',
         },
         "cry"    => {
-          :regex => /You stare down .+ and let out an eerie, modulating cry!/i,
+          :regex => /You stare down .+ and let out an eerie, modulating cry!/,
         },
         "holler" => {
-          :regex => /You throw back your head and let out a thundering holler!/i,
+          :regex => /You throw back your head and let out a thundering holler!/,
           :buff  => 'Enh. Health (+20)',
         },
       }
@@ -58,21 +58,21 @@ module Lich
         Lich::Util.normalize_lookup('Buffs', buff)
       end
 
-      def Warcry.use(name, target = "")
+      def Warcry.use(name, target = "", results_of_interest: nil)
         return unless Warcry.available?(name)
         return if Warcry.buffActive?(name)
         name = PSMS.name_normal(name)
 
         results_regex = Regexp.union(
-          @@warcries.fetch(name)[:regex],
-          /^#{name} what\?$/i,
-          /^Roundtime: [0-9]+ sec\.$/,
-          /^And give yourself away!  Never!$/,
-          /^You are unable to do that right now\.$/,
-          /^You don't seem to be able to move to do that\.$/,
-          /^Provoking a GameMaster is not such a good idea\.$/,
-          /^You do not currently have a target\.$/,
+          PSMS::FAILURES_REGEXES,
+          @@warcries.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex],
+          /^#{name} what\?$/i
         )
+
+        if results_of_interest.is_a?(Regexp)
+          results_regex = Regexp.union(results_regex, results_of_interest)
+        end
+
         usage_cmd = "warcry #{name}"
         if target.class == GameObj
           usage_cmd += " ##{target.id}"
@@ -89,6 +89,10 @@ module Lich
           usage_result = dothistimeout(usage_cmd, 5, results_regex)
         end
         usage_result
+      end
+
+      def Warcry.regexp(name)
+        @@warcries.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex]
       end
 
       Warcry.warcry_lookups.each { |warcry|

--- a/lib/gemstone/psms/weapon.rb
+++ b/lib/gemstone/psms/weapon.rb
@@ -35,32 +35,32 @@ module Lich
 
       @@weapon_techniques = {
         "barrage"          => {
-          :regex      => /Drawing several arrows from your (?:.+), you grip them loosely between your fingers in preparation for a rapid barrage\./,
+          :regex      => /Drawing several (?:arrows|bolts) from your .+, you grip them loosely between your fingers in preparation for a rapid barrage\./,
           :assault_rx => /Your satisfying display of dexterity bolsters you and inspires those around you\!/,
           :buff       => "Enh. Dexterity (+10)",
         },
         "charge"           => {
-          :regex => /You rush forward at (?:.+) with your (?:.+) and attempt a charge\!/,
+          :regex => /You rush forward at .+ with your .+ and attempt a charge\!/,
         },
         "clash"            => {
           :regex => /Steeling yourself for a brawl, you plunge into the fray\!/,
         },
         "clobber"          => {
-          :regex => /You redirect the momentum of your parry, hauling your (?:.+) around to clobber (?:.+)\!/,
+          :regex => /You redirect the momentum of your parry, hauling your .+ around to clobber .+\!/,
         },
         "cripple"          => {
-          :regex => /You reverse your grip on your (?:.+) and dart toward (?:.+) at an angle\!/,
+          :regex => /You reverse your grip on your .+ and dart toward .+ at an angle\!/,
         },
         "cyclone"          => {
-          :regex => /You weave your (?:.+) in an under arm spin, swiftly picking up speed until it becomes a blurred cyclone of (?:.+)\!/,
+          :regex => /You weave your .+ in an under arm spin, swiftly picking up speed until it becomes a blurred cyclone of .+\!/,
         },
         "dizzying_swing"   => {
-          :regex => /You heft your (?:.+) and, looping it once to build momentum, lash out in a strike at (?:.+) head\!/,
+          :regex => /You heft your .+ and, looping it once to build momentum, lash out in a strike at .+ head\!/,
           :usage => "dizzyingswing",
         },
         "flurry"           => {
-          :regex      => /You rotate your wrist, your (?:.+) executing a casual spin to establish your flow as you advance upon (?:.+)\!/,
-          :assault_rx => /The mesmerizing sway of body and blade glides to its inevitable end with one final twirl of your (.+)\./,
+          :regex      => /You rotate your wrist, your .+ executing a casual spin to establish your flow as you advance upon .+\!/,
+          :assault_rx => /The mesmerizing sway of body and blade glides to its inevitable end with one final twirl of your .+\./,
           :buff       => "Slashing Strikes",
         },
         "fury"             => {
@@ -69,54 +69,54 @@ module Lich
           :buff       => "Enh. Constitution (+10)",
         },
         "guardant_thrusts" => {
-          :regex => /Retaining a defensive profile, you raise your (?:.+) in a hanging guard and prepare to unleash a barrage of guardant thrusts upon (?:.+)\!/,
+          :regex => /Retaining a defensive profile, you raise your .+ in a hanging guard and prepare to unleash a barrage of guardant thrusts upon .+\!/,
           :usage => "gthrusts",
         },
         "overpower"        => {
-          :regex => /On the heels of (?:.+) parry, you erupt into motion, determined to overpower (?:.+) defenses\!/,
+          :regex => /On the heels of .+ parry, you erupt into motion, determined to overpower .+ defenses\!/,
         },
         "pin_down"         => {
-          :regex => /You take quick assessment and raise your (?:.+), several arrows nocked to your string in parallel\./,
+          :regex => /You take quick assessment and raise your .+, several (?:arrows|bolts) nocked to your string in parallel\./,
           :usage => "pindown",
         },
         "pulverize"        => {
-          :regex => /You wheel your (?:.+) overhead before slamming it around in a wide arc to pulverize your foes\!/,
+          :regex => /You wheel your .+ overhead before slamming it around in a wide arc to pulverize your foes\!/,
         },
         "pummel"           => {
-          :regex      => /You take a menacing step toward (?:.+), sweeping your (?:.+) out low to your side in your advance\./,
-          :assault_rx => /With a final snap of your wrist, you sweep your (.+) back to the ready, your assault complete\./,
+          :regex      => /You take a menacing step toward .+, sweeping your .+ out low to your side in your advance\./,
+          :assault_rx => /With a final snap of your wrist, you sweep your .+ back to the ready, your assault complete\./,
           :buff       => "Concussive Blows",
         },
         "radial_sweep"     => {
-          :regex => /Crouching low, you sweep your (?:.+) in a broad arc\!/,
+          :regex => /Crouching low, you sweep your .+ in a broad arc\!/,
           :usage => "radialsweep",
         },
         "reactive_shot"    => {
-          :regex => /You fire off a quick shot at the (?:.+), then make a hasty retreat\!/,
+          :regex => /You fire off a quick shot at the .+, then make a hasty retreat\!/,
           :usage => "reactiveshot",
         },
         "reverse_strike"   => {
-          :regex => /Spotting an opening in (?:.+) defenses, you quickly reverse the direction of your (?:.+) and strike from a different angle\!/,
+          :regex => /Spotting an opening in .+ defenses, you quickly reverse the direction of your .+ and strike from a different angle\!/,
           :usage => "reversestrike",
         },
         "riposte"          => {
-          :regex => /Before (?:.+) can recover, you smoothly segue from parry to riposte\!/,
+          :regex => /Before .+ can recover, you smoothly segue from parry to riposte\!/,
         },
         "spin_kick"        => {
           :regex => /Stepping with deliberation, you wheel into a leaping spin\!/,
           :usage => "spinkick",
         },
         "thrash"           => {
-          :regex => /You rush (?:.+), raising your (?:.+) high to deliver a sound thrashing\!/,
+          :regex => /You rush .+, raising your .+ high to deliver a sound thrashing\!/,
         },
         "twin_hammerfists" => {
-          :regex => /You raise your hands high, lace them together and bring them crashing down towards the (?:.+)\!/,
+          :regex => /You raise your hands high, lace them together and bring them crashing down towards the .+\!/,
         },
         "volley"           => {
-          :regex => /Raising your (?:.+) high, you loose arrow after arrow as fast as you can, filling the sky with a volley of deadly projectiles\!/,
+          :regex => /Raising your .+ high, you loose (?:arrow|bolt) after (?:arrow|bolt) as fast as you can, filling the sky with a volley of deadly projectiles\!/,
         },
         "whirling_blade"   => {
-          :regex => /With a broad flourish, you sweep your (?:.+) into a whirling display of keen-edged menace\!/,
+          :regex => /With a broad flourish, you sweep your .+ into a whirling display of keen-edged menace\!/,
           :usage => "wblade",
         },
         "whirlwind"        => {
@@ -146,25 +146,25 @@ module Lich
         Effects::Buffs.active?(@@weapon_techniques.fetch(name)[:buff])
       end
 
-      def Weapon.use(name, target = "")
+      def Weapon.use(name, target = "", results_of_interest: nil)
         return unless Weapon.available?(name)
         name = PSMS.name_normal(name)
         technique = @@weapon_techniques.fetch(name)
         usage = technique.key?(:usage) ? technique[:usage] : name
 
-        in_cooldown_regex = /^#{name} is still in cooldown/
+        in_cooldown_regex = /^#{name} is still in cooldown\./
+
         results_regex = Regexp.union(
-          technique[:regex],
+          PSMS::FAILURES_REGEXES,
+          @@weapon_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex],
           /^#{name} what\?$/i,
-          /You were unable to find any targets that meet #{name}'s reaction requirements/,
-          /^Roundtime: [0-9]+ sec\.$/,
-          /^And give yourself away!  Never!$/,
-          /^You are unable to do that right now\.$/,
-          /^You don't seem to be able to move to do that\.$/,
-          /^Provoking a GameMaster is not such a good idea\.$/,
-          /^You do not currently have a target\.$/,
           in_cooldown_regex
         )
+
+        if results_of_interest.is_a?(Regexp)
+          results_regex = Regexp.union(results_regex, results_of_interest)
+        end
+
         usage_cmd = "weapon #{usage}"
         if target.class == GameObj
           usage_cmd += " ##{target.id}"
@@ -201,6 +201,10 @@ module Lich
           end
         end
         usage_result
+      end
+
+      def Weapon.regexp(name)
+        @@weapon_techniques.fetch(name.to_s.gsub(/[\s\-]/, '_').gsub("'", "").downcase)[:regex]
       end
 
       Weapon.weapon_lookups.each { |weapon|

--- a/spec/infomon_spec.rb
+++ b/spec/infomon_spec.rb
@@ -37,29 +37,6 @@ end
 
 LIB_DIR = File.join(File.expand_path("..", File.dirname(__FILE__)), 'lib')
 
-require "common/sharedbuffer"
-require "common/buffer"
-require "games"
-require "gemstone/infomon"
-require "attributes/stats"
-require "attributes/resources"
-require "gemstone/infomon/currency"
-require "gemstone/infomon/status"
-require "gemstone/experience"
-require "gemstone/psms"
-require "gemstone/psms/ascension"
-
-module Lich
-  module Gemstone
-    module Infomon
-      # cheat definition of `respond` to prevent having to load global_defs with dependenciesw
-      def self.respond(msg)
-        pp msg
-      end
-    end
-  end
-end
-
 module XMLData
   @dialogs = {}
   def self.game
@@ -126,7 +103,7 @@ module Effects
   Cooldowns = Registry.new("Cooldowns")
 end
 
-module Games
+module Lich
   module Gemstone
     class Spellsong
       @@renewed ||= Time.at(Time.now.to_i - 1200)
@@ -142,21 +119,49 @@ module Games
 end
 
 # fake GameObj to allow for passing.
-class GameObj
-  @@npcs = Array.new
-  def initialize(id, noun, name, before = nil, after = nil)
-    @id = id
-    @noun = noun
-    @name = name
-    @before_name = before
-    @after_name = after
-  end
+module Lich
+  module Common
+    class GameObj
+      @@npcs = Array.new
+      def initialize(id, noun, name, before = nil, after = nil)
+        @id = id
+        @noun = noun
+        @name = name
+        @before_name = before
+        @after_name = after
+      end
 
-  def GameObj.npcs
-    if @@npcs.empty?
-      nil
-    else
-      @@npcs.dup
+      def GameObj.npcs
+        if @@npcs.empty?
+          nil
+        else
+          @@npcs.dup
+        end
+      end
+    end
+  end
+end
+
+require "common/sharedbuffer"
+require "common/buffer"
+require "games"
+require "gemstone/infomon"
+require "attributes/stats"
+require "attributes/resources"
+require "gemstone/infomon/currency"
+require "gemstone/infomon/status"
+require "gemstone/experience"
+require "util/util"
+require "gemstone/psms"
+require "gemstone/psms/ascension"
+
+module Lich
+  module Gemstone
+    module Infomon
+      # cheat definition of `respond` to prevent having to load global_defs with dependenciesw
+      def self.respond(msg)
+        pp msg
+      end
     end
   end
 end

--- a/spec/psms_spec.rb
+++ b/spec/psms_spec.rb
@@ -37,9 +37,9 @@ end
 
 LIB_DIR = File.join(File.expand_path("..", File.dirname(__FILE__)), 'lib')
 
+require 'util/util'
 require 'gemstone/psms'
 require 'gemstone/infomon'
-require 'util/util'
 
 module Char
   def self.name


### PR DESCRIPTION
Implemented CMan.use
Refactored common regexes for failures to PSMS::FAILURES_REGEXES 
Added .regexp(name) for all PSMS
Added optional results_of_interest to .use methods for all PSMS 
Corrected @@feats table to use long name instead of short name 
Added support for custom CMANs and added RW2025 customs.

includes spec test changes by mrhoribu

Replaces #857 