### PR TITLE
fix(gs): stash.rb stale sheaths recheck

### DIFF
--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -83,6 +83,14 @@ module Lich
       @checked_sheaths = true
     end
 
+    def self.missing_primary_sheath? # check entry against actual inventory to catch inventory updatees
+      @sheath.has_key?(:sheath) && !GameObj.inv.any? { |item| item.id == @sheath[:sheath].id }
+    end
+
+    def self.missing_secondary_sheath? # check entry against actual inventory to catch inventory updates
+      @sheath.has_key?(:secondary_sheath) && !GameObj.inv.any? { |item| item.id == @sheath[:secondary_sheath].id }
+    end
+
     def self.stash_hands(right: false, left: false, both: false)
       $fill_hands_actions ||= Array.new
       $fill_left_hand_actions ||= Array.new
@@ -93,10 +101,8 @@ module Lich
       left_hand = GameObj.left_hand
 
       # extending to use sheath / 2sheath wherever possible
-      if !@checked_sheaths ||
-         (@sheath.has_key?(:sheath) && !GameObj.inv.any? { |item| item.id == @sheath.fetch(:sheath).id }) ||
-         (@sheath.has_key?(:secondary_sheath) && !GameObj.inv.any? { |item| item.id == @sheath.fetch(:secondary_sheath).id })
-        Stash.sheath_bags
+      if !@checked_sheaths || missing_primary_sheath? || missing_secondary_sheath?
+        Stash.sheath_bags # @checked_sheaths is set true when this method executes
       end
       if @sheath.has_key?(:sheath)
         unless @sheath.has_key?(:secondary_sheath)


### PR DESCRIPTION
Addresses #504 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds checks for missing sheaths in `stash.rb` to ensure inventory is rechecked if sheaths are missing.
> 
>   - **Behavior**:
>     - Adds `missing_primary_sheath?` and `missing_secondary_sheath?` methods in `stash.rb` to check for sheath presence in inventory.
>     - Updates `stash_hands` method to call `sheath_bags` if sheaths are missing, ensuring inventory is rechecked.
>   - **Functions**:
>     - `missing_primary_sheath?` checks if primary sheath is missing from inventory.
>     - `missing_secondary_sheath?` checks if secondary sheath is missing from inventory.
>     - `stash_hands` now rechecks sheaths if any are missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7a64e54dfea6a4a97994a7f7319d2f1fadf887c0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->