### PR TITLE
fix(all): messaging.rb xml_encode mono method msg

### DIFF
--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -133,6 +133,8 @@ module Lich
       return msg_format("cmd", link_text, cmd_link: link_action, encode: encode)
     end
 
+    # defaulting encoding here to false instead of true like other methods due to backwards compatibility that it never encoded before
+    # whereas all the other methods were already encoding and therefor should default to allow for them.
     def self.mono(msg, encode: false)
       return raise StandardError.new 'Lich::Messaging.mono only works with String parameters!' unless msg.is_a?(String)
       msg = xml_encode(msg) if encode


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `encode` parameter to several methods in `messaging.rb` for optional XML encoding, and remove changelog comments.
> 
>   - **Behavior**:
>     - Add `encode` parameter to `monsterbold`, `stream_window`, `msg_format`, `msg`, `make_cmd_link`, and `mono` methods in `messaging.rb`.
>     - `encode` defaults to `true` for all methods except `mono`, which defaults to `false`.
>     - XML encoding is applied conditionally based on the `encode` parameter.
>   - **Misc**:
>     - Remove changelog and metadata comments from the top of `messaging.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 281507b3683bae8a3965c6d48d1f478fd3e3717f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->