### PR TITLE
fix(gs): group.rb anchor additional regex checks

### DIFF
--- a/lib/gemstone/group.rb
+++ b/lib/gemstone/group.rb
@@ -177,14 +177,14 @@ module Lich
           NOOP    = %r{^But <a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> is already a member of your group!$}
           # <a exist="-10488845" noun="Etanamir">Etanamir</a> designates you as the new leader of the group.
           HAS_LEADER = %r{<a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> designates you as the new leader of the group\.$}
-          SWAP_LEADER = %r{<a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> designates <a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> as the new leader of the group.}
+          SWAP_LEADER = %r{<a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> designates <a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> as the new leader of the group.$}
 
           # You designate <a exist="-10778599" noun="Ondreian">Ondreian</a> as the new leader of the group.
           GAVE_LEADER_AWAY = %r{You designate <a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> as the new leader of the group\.$}
           # You disband your group.
           DISBAND = %r{^You disband your group}
           # <a exist="-10488845" noun="Etanamir">Etanamir</a> adds you to <a exist="-10488845" noun="Etanamir">his</a> group.
-          ADDED_TO_NEW_GROUP = %r{<a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> adds you to <a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> group.}
+          ADDED_TO_NEW_GROUP = %r{<a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> adds you to <a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a> group.$}
           # You join <a exist="-10488845" noun="Etanamir">Etanamir</a>.
           JOINED_NEW_GROUP = %r{You join <a exist="(?<id>[\d-]+)" noun="(?<noun>[A-Za-z]+)">(?<name>\w+?)</a>\.$}
           # <a exist="-10488845" noun="Etanamir">Etanamir</a> adds <a exist="-10974229" noun="Szan">Szan</a> to <a exist="-10488845" noun="Etanamir">his</a> group.
@@ -211,10 +211,10 @@ module Lich
           ##
           ## active messages
           ##
-          NO_GROUP = /You are not currently in a group/
+          NO_GROUP = /^You are not currently in a group/
           # Previous GROUP output below, left in-case something missing/needed to resolve after change
           # MEMBER   = /<a exist="(?<id>.*?)" noun="(?<name>.*?)">(?:.*?)<\/a> is (?<type>(?:the leader|also a member) of your group|following you)\./
-          MEMBER   = /You are (?:leading|grouped with) (.*)/
+          MEMBER   = /^You are (?:leading|grouped with) (.*)/
           STATUS   = /^Your group status is currently (?<status>open|closed)\./
 
           GROUP_EMPTIED    = %[<indicator id='IconJOINED' visible='n'/>]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance regex patterns in `lib/gemstone/group.rb` by adding line anchors for precise group message matching.
> 
>   - **Regex Enhancements**:
>     - Add end-of-line anchors `$` to `SWAP_LEADER` and `ADDED_TO_NEW_GROUP` regex patterns in `lib/gemstone/group.rb` to ensure full line matching.
>     - Add start-of-line anchors `^` to `NO_GROUP` and `MEMBER` regex patterns for precise matching.
>   - **Behavior**:
>     - Ensures regex patterns match entire lines, reducing false positives in group message parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 2557ed3fc190eda7959933b73d281a40bc277316. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->