### PR TITLE
fix(dr): exp mods output is not enclosed in preset xml tags anymore

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -74,8 +74,8 @@ module Lich
           end
         else
           if @parsing_exp_mods_output
-            # https://regex101.com/r/keSBYF/1
-            match = /(?<sign>\+|\-)+(?<value>\d+) \b(?<skill>[\w\s]+)\b/.match(server_string)
+            # https://regex101.com/r/5ZE8lq/1
+            match = /^(?<sign>[+-])(?<value>\d+)\s+(?<skill>[\w\s]+)$/.match(server_string)
             if match
               skill = match[:skill]
               sign = match[:sign]

--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -77,7 +77,7 @@ module Lich
             # https://regex101.com/r/5ZE8lq/1
             match = /^(?<sign>[+-])(?<value>\d+)\s+(?<skill>[\w\s]+)$/.match(server_string)
             if match
-              skill = match[:skill]
+              skill = match[:skill].strip
               sign = match[:sign]
               value = match[:value].to_i
               value = (value * -1) if sign == '-'


### PR DESCRIPTION
### Issue

When the `exp mods` command is ran, any skill modifiers are NOT being applied to the `DRSkill` class. In effect, the `skill-recorder` script does not detect the correct amount a skill has been modified if beyond the base 10%. This impacts a character's ability to use athletics-based travel routes sooner rather than later.

### Cause

In `drparser.rb`, the `check_exp_mods` function is expecting the modified skills to be enclosed in XML tags like `<preset id="speech">` or `<preset id="thought">` but, at least as of April 2025, that is no longer the case.

### Changes

- Update the parsing logic to not expect the skill modifier output to be wrapped in XML tags per line
- Apply regex tweak per ellipsis code review

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `check_exp_mods` in `drparser.rb` to parse skill modifiers without XML tags, updating regex for direct line matching.
> 
>   - **Behavior**:
>     - Fixes `check_exp_mods` in `drparser.rb` to correctly parse skill modifiers without XML tags.
>     - Updates regex to match lines with skill modifiers directly, handling both positive and negative values.
>   - **Misc**:
>     - Removes redundant XML tag checks in `check_exp_mods`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 73ddb5064f1087cc7ab883857cbc6270c2677105. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->