### PR TITLE
fix(gs): cman.rb regex updates

### DIFF
--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -336,7 +336,7 @@ module Lich
           :type  => "setup",
           :regex => Regexp.union(/You charge towards .+ and attempt to headbutt .+!/, # Standard
                                  /Coiling your trapezius muscles, you feel your neck tense before springing into action and slamming your head down toward .+\!/, # RW2025
-                                 /Shrugging almost casually, you quickly snap your head foward in an attempt to headbutt .+\!/, # RW2025
+                                 /Shrugging almost casually, you quickly snap your head for?ward in an attempt to headbutt .+\!/, # RW2025
                                  /Rising on your tip toes, you cock back your head and slam it down towards .+\!/, # RW2025
                                  /Bellowing like an angry bull, you lower your head and charge straight at .+\!/), # RW2025
           :usage => "headbutt"


### PR DESCRIPTION
Addresses #858 

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updated regex patterns and usage for `garrote`, `spell_cleave`, and `spell_thieve` in `cman.rb` to handle more cases and improve accuracy.
> 
>   - **Regex Updates**:
>     - Updated `garrote` regex to handle success, hand requirement, and dodge cases.
>     - Updated `spell_cleave` regex to handle success, failure, and mental drain cases.
>     - Updated `spell_thieve` regex to handle success, failure, and hand requirement cases.
>   - **Usage Updates**:
>     - Set `usage` for `garrote`, `spell_cleave`, and `spell_thieve` to their respective short names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 6c4644646cbf724a5ed71cbe61850c5150e9f177. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->