### PR TITLE
fix(all): settings.rb unwrap data from objects before Marshal

### DIFF
--- a/lib/common/settings.rb
+++ b/lib/common/settings.rb
@@ -9,6 +9,11 @@ module Lich
     require_relative 'settings/path_navigator'
 
     module Settings
+      class CircularReferenceError < StandardError
+        def initialize(msg = "Circular Reference Detected")
+          super(msg)
+        end
+      end
       # Initialize database adapter and path navigator
       @db_adapter = DatabaseAdapter.new(DATA_DIR, :script_auto_settings)
       @path_navigator = PathNavigator.new(@db_adapter)
@@ -23,7 +28,7 @@ module Lich
       # safeguarding against circular references.
       def self.unwrap_proxies(data, visited = Set.new)
         # Check if we have already visited this object_id to detect cycles
-        raise StandardError.new("settings.rb - Circular Reference Detected") if visited.include?(data.object_id)
+        raise CircularReferenceError.new() if visited.include?(data.object_id)
 
         # Add current object_id to visited set if it's a container type
         visited.add(data.object_id) if data.is_a?(Hash) || data.is_a?(Array) || data.is_a?(SettingsProxy)


### PR DESCRIPTION
Summary of the changes for settings.rb

Introduced unwrap_proxies Helper: 
A new private class method, unwrap_proxies, has been added to the Lich::Common::Settings module. This method recursively traverses any given data structure (Hash, Array, etc.) and replaces any SettingsProxy instance it finds with the actual data the proxy holds (its target).

Modified save_to_database: 
Before saving the settings data, the save_to_database method now calls unwrap_proxies to ensure that the data passed to Marshal.dump is completely free of proxy objects.

Modified set_script_settings: 
When assigning a value using Settings[:key] = value, the value is now automatically unwrapped using unwrap_proxies before being stored. This prevents proxy objects from being directly inserted into the settings structure in the first place.

Modified Destructive Methods (method_missing): 
When methods that modify the data (like push, delete, etc.) are called via the proxy, any arguments that are themselves SettingsProxy objects are now unwrapped before the method is executed on the underlying data.

Modified include?: 
The item being checked for inclusion is unwrapped first.

Modified to_h/to_hash: 
These methods now return the unwrapped data structure.

These changes ensure that only standard Ruby Hashes, Arrays, and scalar values are serialized, resolving the issue with Marshal.dump including the proxy class name and preventing related type errors during data retrieval or conversion.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `lib/common/settings.rb` by unwrapping `SettingsProxy` instances before processing to prevent serialization issues and ensure data integrity.
> 
>   - **Behavior**:
>     - Added `unwrap_proxies` method to `Settings` to recursively replace `SettingsProxy` instances with their targets, preventing circular references.
>     - Modified `save_to_database` to use `unwrap_proxies` before `Marshal.dump` to ensure no proxy objects are serialized.
>     - Updated `set_script_settings` to unwrap values before storing them, preventing proxies from entering the settings structure.
>     - Adjusted `method_missing` to unwrap arguments that are `SettingsProxy` instances before executing destructive methods.
>     - Changed `include?` to unwrap the item being checked for inclusion.
>     - Updated `to_h` and `to_hash` to return unwrapped data structures.
>   - **Error Handling**:
>     - Introduced `CircularReferenceError` to handle circular references during unwrapping.
>   - **Misc**:
>     - Minor adjustments to comments and method calls for clarity and consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 46c1564304f3babbe05482d82a880c59f9d2904b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->