### PR TITLE
revert: "chore(all): change class to is_a? checks"

### DIFF
--- a/lib/common/buffer.rb
+++ b/lib/common/buffer.rb
@@ -124,7 +124,7 @@ module Lich
       end
 
       def Buffer.streams=(val)
-        if (!val.is_a?(Integer)) or ((val & 63) == 0)
+        if (val.class != Integer) or ((val & 63) == 0)
           respond "--- Lich: error: invalid streams value\n\t#{$!.caller[0..2].join("\n\t")}"
           return nil
         end

--- a/lib/common/downstreamhook.rb
+++ b/lib/common/downstreamhook.rb
@@ -8,7 +8,7 @@ module Lich
       @@downstream_hook_sources ||= Hash.new
 
       def DownstreamHook.add(name, action)
-        unless action.is_a?(Proc)
+        unless action.class == Proc
           echo "DownstreamHook: not a Proc (#{action})"
           return false
         end

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -90,7 +90,7 @@ module Lich
       end
 
       def GameObj.[](val)
-        if val.is_a?(String)
+        if val.class == String
           if val =~ /^\-?[0-9]+$/
             @@inv.find { |o| o.id == val } || @@loot.find { |o| o.id == val } || @@npcs.find { |o| o.id == val } || @@pcs.find { |o| o.id == val } || [@@right_hand, @@left_hand].find { |o| o.id == val } || @@room_desc.find { |o| o.id == val }
           elsif val.split(' ').length == 1
@@ -98,7 +98,7 @@ module Lich
           else
             @@inv.find { |o| o.name == val } || @@loot.find { |o| o.name == val } || @@npcs.find { |o| o.name == val } || @@pcs.find { |o| o.name == val } || [@@right_hand, @@left_hand].find { |o| o.name == val } || @@room_desc.find { |o| o.name == val } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || [@@right_hand, @@left_hand].find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val.strip)}$/i } || @@inv.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@loot.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@npcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@pcs.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || [@@right_hand, @@left_hand].find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i } || @@room_desc.find { |o| o.name =~ /\b#{Regexp.escape(val).sub(' ', ' .*')}$/i }
           end
-        elsif val.is_a?(Regexp)
+        elsif val.class == Regexp
           @@inv.find { |o| o.name =~ val } || @@loot.find { |o| o.name =~ val } || @@npcs.find { |o| o.name =~ val } || @@pcs.find { |o| o.name =~ val } || [@@right_hand, @@left_hand].find { |o| o.name =~ val } || @@room_desc.find { |o| o.name =~ val }
         end
       end
@@ -351,7 +351,7 @@ module Lich
       end
 
       def GameObj.merge_data(data, newData)
-        return newData unless data.is_a?(Regexp)
+        return newData unless data.class == Regexp
         return Regexp.union(data, newData)
       end
 

--- a/lib/common/map/map_dr.rb
+++ b/lib/common/map/map_dr.rb
@@ -48,7 +48,7 @@ module Lich
 
       def Map.[](val)
         Map.load unless @@loaded
-        if (val.is_a?(Integer)) or val =~ /^[0-9]+$/
+        if (val.class == Integer) or val =~ /^[0-9]+$/
           @@list[val.to_i]
         elsif val =~ /^u(-?\d+)$/i
           uid_request = $1.dup.to_i
@@ -360,7 +360,7 @@ module Lich
                       end
                     }
                     room['timeto'].keys.each { |k|
-                      if (room['timeto'][k].is_a?(String)) and (room['timeto'][k][0..2] == ';e ')
+                      if (room['timeto'][k].class == String) and (room['timeto'][k][0..2] == ';e ')
                         room['timeto'][k] = StringProc.new(room['timeto'][k][3..-1])
                       end
                     }
@@ -579,7 +579,7 @@ module Lich
           :check_location => @check_location,
           :unique_loot    => @unique_loot,
           :uid            => @uid,
-        }).delete_if { |_a, b| b.nil? or (b.is_a?(Array) and b.empty?) };
+        }).delete_if { |_a, b| b.nil? or (b.class == Array and b.empty?) };
         JSON.pretty_generate(mapjson);
       end
 
@@ -648,14 +648,14 @@ module Lich
               room.room_objects.to_a.each { |loot| file.write "      <room_objects>#{loot.gsub(/(<|>|"|'|&)/) { escape[$1] }}</room_objects>\n" }
               file.write "      <image name=\"#{room.image.gsub(/(<|>|"|'|&)/) { escape[$1] }}\" coords=\"#{room.image_coords.join(',')}\" />\n" if room.image and room.image_coords
               room.wayto.keys.each { |target|
-                if room.timeto[target].is_a?(Proc)
+                if room.timeto[target].class == Proc
                   cost = " cost=\"#{room.timeto[target]._dump.gsub(/(<|>|"|'|&)/) { escape[$1] }}\""
                 elsif room.timeto[target]
                   cost = " cost=\"#{room.timeto[target]}\""
                 else
                   cost = ''
                 end
-                if room.wayto[target].is_a?(Proc)
+                if room.wayto[target].class == Proc
                   file.write "      <exit target=\"#{target}\" type=\"Proc\"#{cost}>#{room.wayto[target]._dump.gsub(/(<|>|"|'|&)/) { escape[$1] }}</exit>\n"
                 else
                   file.write "      <exit target=\"#{target}\" type=\"#{room.wayto[target].class}\"#{cost}>#{room.wayto[target].gsub(/(<|>|"|'|&)/) { escape[$1] }}</exit>\n"
@@ -675,14 +675,14 @@ module Lich
 
       def Map.estimate_time(array)
         Map.load unless @@loaded
-        unless array.is_a?(Array)
+        unless array.class == Array
           raise Exception.exception("MapError"), "Map.estimate_time was given something not an array!"
         end
         time = 0.to_f
         until array.length < 2
           room = array.shift
           if (t = Map[room].timeto[array.first.to_s])
-            if t.is_a?(Proc)
+            if t.class == Proc
               time += t.call.to_f
             else
               time += t.to_f
@@ -695,7 +695,7 @@ module Lich
       end
 
       def Map.dijkstra(source, destination = nil)
-        if source.is_a?(Map)
+        if source.class == Map
           source.dijkstra(destination)
         elsif (room = Map[source])
           room.dijkstra(destination)
@@ -731,7 +731,7 @@ module Lich
               @@list[v].wayto.keys.each { |adj_room|
                 adj_room_i = adj_room.to_i
                 unless visited[adj_room_i]
-                  if @@list[v].timeto[adj_room].is_a?(Proc)
+                  if @@list[v].timeto[adj_room].class == Proc
                     nd = @@list[v].timeto[adj_room].call
                   else
                     nd = @@list[v].timeto[adj_room]
@@ -747,7 +747,7 @@ module Lich
                 end
               }
             end
-          elsif destination.is_a?(Integer)
+          elsif destination.class == Integer
             until pq.size == 0
               v = pq.shift
               break if v == destination
@@ -755,7 +755,7 @@ module Lich
               @@list[v].wayto.keys.each { |adj_room|
                 adj_room_i = adj_room.to_i
                 unless visited[adj_room_i]
-                  if @@list[v].timeto[adj_room].is_a?(Proc)
+                  if @@list[v].timeto[adj_room].class == Proc
                     nd = @@list[v].timeto[adj_room].call
                   else
                     nd = @@list[v].timeto[adj_room]
@@ -771,7 +771,7 @@ module Lich
                 end
               }
             end
-          elsif destination.is_a?(Array)
+          elsif destination.class == Array
             dest_list = destination.collect { |dest| dest.to_i }
             until pq.size == 0
               v = pq.shift
@@ -780,7 +780,7 @@ module Lich
               @@list[v].wayto.keys.each { |adj_room|
                 adj_room_i = adj_room.to_i
                 unless visited[adj_room_i]
-                  if @@list[v].timeto[adj_room].is_a?(Proc)
+                  if @@list[v].timeto[adj_room].class == Proc
                     nd = @@list[v].timeto[adj_room].call
                   else
                     nd = @@list[v].timeto[adj_room]
@@ -806,7 +806,7 @@ module Lich
       end
 
       def Map.findpath(source, destination)
-        if source.is_a?(Map)
+        if source.class == Map
           source.path_to(destination)
         elsif (room = Map[source])
           room.path_to(destination)

--- a/lib/common/map/map_gs.rb
+++ b/lib/common/map/map_gs.rb
@@ -56,7 +56,7 @@ module Lich
 
       def Map.[](val)
         Map.load unless @@loaded
-        if (val.is_a?(Integer) or val =~ /^[0-9]+$/)
+        if (val.class == Integer or val =~ /^[0-9]+$/)
           return @@list[val.to_i]
         elsif val =~ /^u(-?\d+)$/i
           uid_request = $1.dup.to_i
@@ -491,7 +491,7 @@ module Lich
                       end
                     }
                     room['timeto'].keys.each { |k|
-                      if (room['timeto'][k].is_a?(String)) and (room['timeto'][k][0..2] == ';e ')
+                      if (room['timeto'][k].class == String) and (room['timeto'][k][0..2] == ';e ')
                         room['timeto'][k] = StringProc.new(room['timeto'][k][3..-1])
                       end
                     }
@@ -713,7 +713,7 @@ module Lich
           :check_location => @check_location,
           :unique_loot    => @unique_loot,
           :uid            => @uid,
-        }).delete_if { |_a, b| b.nil? or (b.is_a?(Array) and b.empty?) };
+        }).delete_if { |_a, b| b.nil? or (b.class == Array and b.empty?) };
         # can't remove empty wayto and timeto, fails test on repository server side
         JSON.pretty_generate(mapjson);
       end
@@ -783,14 +783,14 @@ module Lich
               room.unique_loot.to_a.each { |loot| file.write "      <unique_loot>#{loot.gsub(/(<|>|"|'|&)/) { escape[$1] }}</unique_loot>\n" }
               file.write "      <image name=\"#{room.image.gsub(/(<|>|"|'|&)/) { escape[$1] }}\" coords=\"#{room.image_coords.join(',')}\" />\n" if room.image and room.image_coords
               room.wayto.keys.each { |target|
-                if room.timeto[target].is_a?(Proc)
+                if room.timeto[target].class == Proc
                   cost = " cost=\"#{room.timeto[target]._dump.gsub(/(<|>|"|'|&)/) { escape[$1] }}\""
                 elsif room.timeto[target]
                   cost = " cost=\"#{room.timeto[target]}\""
                 else
                   cost = ''
                 end
-                if room.wayto[target].is_a?(Proc)
+                if room.wayto[target].class == Proc
                   file.write "      <exit target=\"#{target}\" type=\"Proc\"#{cost}>#{room.wayto[target]._dump.gsub(/(<|>|"|'|&)/) { escape[$1] }}</exit>\n"
                 else
                   file.write "      <exit target=\"#{target}\" type=\"#{room.wayto[target].class}\"#{cost}>#{room.wayto[target].gsub(/(<|>|"|'|&)/) { escape[$1] }}</exit>\n"
@@ -810,14 +810,14 @@ module Lich
 
       def Map.estimate_time(array)
         Map.load unless @@loaded
-        unless array.is_a?(Array)
+        unless array.class == Array
           raise Exception.exception("MapError"), "Map.estimate_time was given something not an array!"
         end
         time = 0.to_f
         until array.length < 2
           room = array.shift
           if (t = Map[room].timeto[array.first.to_s])
-            if t.is_a?(Proc)
+            if t.class == Proc
               time += t.call.to_f
             else
               time += t.to_f
@@ -830,7 +830,7 @@ module Lich
       end
 
       def Map.dijkstra(source, destination = nil)
-        if source.is_a?(Map)
+        if source.class == Map
           return source.dijkstra(destination)
         elsif (room = Map[source])
           return room.dijkstra(destination)
@@ -866,7 +866,7 @@ module Lich
               @@list[v].wayto.keys.each { |adj_room|
                 adj_room_i = adj_room.to_i
                 unless visited[adj_room_i]
-                  if @@list[v].timeto[adj_room].is_a?(Proc)
+                  if @@list[v].timeto[adj_room].class == Proc
                     nd = @@list[v].timeto[adj_room].call
                   else
                     nd = @@list[v].timeto[adj_room]
@@ -882,7 +882,7 @@ module Lich
                 end
               }
             end
-          elsif destination.is_a?(Integer)
+          elsif destination.class == Integer
             until pq.size == 0
               v = pq.shift
               break if v == destination
@@ -890,7 +890,7 @@ module Lich
               @@list[v].wayto.keys.each { |adj_room|
                 adj_room_i = adj_room.to_i
                 unless visited[adj_room_i]
-                  if @@list[v].timeto[adj_room].is_a?(Proc)
+                  if @@list[v].timeto[adj_room].class == Proc
                     nd = @@list[v].timeto[adj_room].call
                   else
                     nd = @@list[v].timeto[adj_room]
@@ -906,7 +906,7 @@ module Lich
                 end
               }
             end
-          elsif destination.is_a?(Array)
+          elsif destination.class == Array
             dest_list = destination.collect { |dest| dest.to_i }
             until pq.size == 0
               v = pq.shift
@@ -915,7 +915,7 @@ module Lich
               @@list[v].wayto.keys.each { |adj_room|
                 adj_room_i = adj_room.to_i
                 unless visited[adj_room_i]
-                  if @@list[v].timeto[adj_room].is_a?(Proc)
+                  if @@list[v].timeto[adj_room].class == Proc
                     nd = @@list[v].timeto[adj_room].call
                   else
                     nd = @@list[v].timeto[adj_room]
@@ -941,7 +941,7 @@ module Lich
       end
 
       def Map.findpath(source, destination)
-        if source.is_a?(Map)
+        if source.class == Map
           source.path_to(destination)
         elsif (room = Map[source])
           room.path_to(destination)

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -1,6 +1,6 @@
 # Generated during infomon separation 230305
 # script bindings are convoluted, but don't change them without testing if:
-#    class methods such as Script.start and ExecScript.start become accessible without specifying the class name (which is just a symptom of a problem that will break scripts)
+#    class methods such as Script.start and ExecScript.start become accessible without specifying the class name (which is just a syptom of a problem that will break scripts)
 #    local variables become shared between scripts
 #    local variable 'file' is shared between scripts, even though other local variables aren't
 #    defined methods are instantly inaccessible
@@ -27,20 +27,20 @@ module Lich
         if args.empty?
           # fixme: error
           next nil
-        elsif args[0].is_a?(String)
+        elsif args[0].class == String
           script_name = args[0]
           if args[1]
-            if args[1].is_a?(String)
+            if args[1].class == String
               script_args = args[1]
               if args[2]
-                if args[2].is_a?(Hash)
+                if args[2].class == Hash
                   options = args[2]
                 else
                   # fixme: error
                   next nil
                 end
               end
-            elsif args[1].is_a?(Hash)
+            elsif args[1].class == Hash
               options = args[1]
               script_args = (options[:args] || String.new)
             else
@@ -50,7 +50,7 @@ module Lich
           else
             options = Hash.new
           end
-        elsif args[0].is_a?(Hash)
+        elsif args[0].class == Hash
           options = args[0]
           if options[:name]
             script_name = options[:name]
@@ -249,7 +249,7 @@ module Lich
           if script.name =~ /^lich$/i
             respond '--- error: Script.db cannot be used by a script named lich'
             nil
-          elsif script.is_a?(ExecScript)
+          elsif script.class == ExecScript
             respond '--- error: Script.db cannot be used by exec scripts'
             nil
           else
@@ -268,7 +268,7 @@ module Lich
           elsif script.name =~ /^entry$/i
             respond '--- error: Script.open_file cannot be used by a script named entry'
             nil
-          elsif script.is_a?(ExecScript)
+          elsif script.class == ExecScript
             respond '--- error: Script.open_file cannot be used by exec scripts'
             nil
           elsif ext.downcase == 'db3'
@@ -568,14 +568,14 @@ module Lich
       def initialize(args)
         @file_name = args[:file]
         @name = /.*[\/\\]+([^\.]+)\./.match(@file_name).captures.first
-        if args[:args].is_a?(String)
+        if args[:args].class == String
           if args[:args].empty?
             @vars = Array.new
           else
             @vars = [args[:args]]
             @vars.concat(args[:args].scan(/[^\s"]*(?<!\\)"(?:\\"|[^"])+(?<!\\)"[^\s]*|(?:\\"|[^"\s])+/).collect { |s| s.gsub(/(?<!\\)"/, '').gsub('\\"', '"') })
           end
-        elsif args[:args].is_a?(Array)
+        elsif args[:args].class == Array
           unless (args[:args].nil? || args[:args].empty?)
             @vars = [args[:args].join(" ")]
             @vars.concat args[:args]
@@ -1106,7 +1106,7 @@ module Lich
             line = "#{$1}matchwait"
           elsif line =~ /^([\s\t]*)if_([0-9])[\s\t]+(.*)/i
             indent, num, stuff = $1, $2, $3
-            line = "#{indent}if script.vars[#{num}]\n#{indent}\t#{fixline.call(stuff)}\n#{indent}end"
+            line = "#{indent}if script.vars[#{num}]\n#{indent}\t#{fixline.call($3)}\n#{indent}end"
           elsif line =~ /^([\s\t]*)shift\b/i
             line = "#{$1}script.vars.shift"
           else

--- a/lib/common/spell.rb
+++ b/lib/common/spell.rb
@@ -195,9 +195,9 @@ module Lich
 
       def Spell.[](val)
         Spell.load unless @@loaded
-        if val.is_a?(Spell)
+        if val.class == Spell
           val
-        elsif (val.is_a?(Integer)) or (val.is_a?(String) and val =~ /^[0-9]+$/)
+        elsif (val.class == Integer) or (val.class == String and val =~ /^[0-9]+$/)
           @@list.find { |spell| spell.num == val.to_i }
         else
           val = Regexp.escape(val)
@@ -640,9 +640,9 @@ module Lich
               cast_cmd = "incant #{@num}"
             elsif (target.nil? or target.to_s.empty?) and (@type =~ /attack/i) and not [410, 435, 525, 912, 909, 609].include?(@num)
               cast_cmd += ' target'
-            elsif target.is_a?(GameObj)
+            elsif target.class == GameObj
               cast_cmd += " ##{target.id}"
-            elsif target.is_a?(Integer)
+            elsif target.class == Integer
               cast_cmd += " ##{target}"
             elsif cast_cmd !~ /^incant/
               cast_cmd += " #{target}"
@@ -704,7 +704,7 @@ module Lich
                 put 'stance offensive'
                 # dothistimeout 'stance offensive', 5, /^You (?:are now in|move into) an? offensive stance|^You are unable to change your stance\.$/
               end
-              if results_of_interest.is_a?(Regexp)
+              if results_of_interest.class == Regexp
                 merged_results_regex = Regexp.union(@@results_regex, results_of_interest)
               else
                 merged_results_regex = @@results_regex
@@ -857,7 +857,7 @@ module Lich
         !@persist_on_death
       end
 
-      # for backwards compatibility
+      # for backwards compatiblity
       def duration;      self.time_per_formula;            end
       def cost;          self.mana_cost_formula    || '0'; end
       def manaCost;      self.mana_cost_formula    || '0'; end

--- a/lib/common/upstreamhook.rb
+++ b/lib/common/upstreamhook.rb
@@ -8,7 +8,7 @@ module Lich
       @@upstream_hook_sources ||= Hash.new
 
       def UpstreamHook.add(name, action)
-        unless action.is_a?(Proc)
+        unless action.class == Proc
           echo "UpstreamHook: not a Proc (#{action})"
           return false
         end

--- a/lib/common/watchfor.rb
+++ b/lib/common/watchfor.rb
@@ -1,4 +1,4 @@
-# Carve out class Watchfor
+# Carve out class WatchFor
 # 2024-06-13
 # has rubocop Lint issues (return nil) - overriding until it can be further researched
 
@@ -9,9 +9,9 @@ module Lich
       def initialize(line, theproc = nil, &block)
         return nil unless (script = Script.current)
 
-        if line.is_a?(String)
+        if line.class == String
           line = Regexp.new(Regexp.escape(line))
-        elsif !line.is_a?(Regexp)
+        elsif line.class != Regexp
           echo 'watchfor: no string or regexp given'
           return nil
         end

--- a/lib/dragonrealms/commons/common-travel.rb
+++ b/lib/dragonrealms/commons/common-travel.rb
@@ -165,7 +165,7 @@ module Lich
           end
           path = Map.findpath(room, Map[room_num])
           way = room.wayto[path.first.to_s]
-          if way.is_a?(Proc)
+          if way.class == Proc
             way.call
           else
             move way
@@ -208,7 +208,7 @@ module Lich
             timer = Time.now
             script_handle = start_script('go2', [room_num.to_s])
           end
-          # Something interfered with movement, stop script then restart
+          # Something interferred with movement, stop script then restart
           if (Time.now - timer) > 90
             kill_script(script_handle)
             pause 0.5 while Script.running.include?(script_handle)
@@ -221,7 +221,7 @@ module Lich
           if Script.running?('escort') || Script.running?('bescort') || (XMLData.room_description + XMLData.room_title) != prev_room || XMLData.room_description =~ /The terrain constantly changes as you travel along on your journey/
             timer = Time.now
           end
-          # Where did you come from, where did you go? Where did you come from, Cotten-Eyed Joe?
+          # Where did you come from, where did you go? Where did you come from, Cotten-Eye Joe?
           prev_room = XMLData.room_description + XMLData.room_title
           pause 0.5
         end
@@ -272,7 +272,7 @@ module Lich
         DRC.retreat(ignored_npcs)
       end
 
-      def find_empty_room(search_rooms, idle_room, predicate = nil, min_mana = 0, strict_mana = false, max_search_attempts = Float::INFINITY, prioritize_buddies = false)
+      def find_empty_room(search_rooms, idle_room, predicate = nil, min_mana = 0, strict_mana = false, max_search_attempts = Float::INFINITY, priotize_buddies = false)
         search_attempt = 0
         check_mana = min_mana > 0
         rooms_searched = 0
@@ -286,11 +286,11 @@ module Lich
 
             rooms_searched += 1
 
-            if prioritize_buddies && (rooms_searched <= search_rooms.size)
+            if priotize_buddies && (rooms_searched <= search_rooms.size)
               suitable_room = ((DRRoom.pcs & UserVars.friends).any? && (DRRoom.pcs & UserVars.hunting_nemesis).none?)
               if (rooms_searched == search_rooms.size && (DRRoom.pcs & UserVars.friends).empty? && (DRRoom.pcs & UserVars.hunting_nemesis).empty?)
                 echo("*** Reached last room in list, and found no buddies. Retrying for empty room. ***")
-                return find_empty_room(search_rooms, idle_room, predicate, min_mana, strict_mana, max_search_attempts, prioritize_buddies = false)
+                return find_empty_room(search_rooms, idle_room, predicate, min_mana, strict_mana, max_search_attempts, priotize_buddies = false)
               end
             else
               suitable_room = predicate ? predicate.call(search_attempt) : (DRRoom.pcs - DRRoom.group_members).empty?

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -608,7 +608,7 @@ module Lich
           room_exits = []
           Map.current.wayto.each do |key, value|
             # Don't include cardinals / up/down/out (usually just climb/go)
-            if value.is_a?(Proc)
+            if value.class == Proc
               if Map.current.timeto[key].is_a?(Numeric) || (Map.current.timeto[key].is_a?(StringProc) && Map.current.timeto[key].call.is_a?(Numeric))
                 room_exits << "<d cmd=';go2 #{key}'>#{Map[key].title.first.gsub(/\[|\]/, '')}#{Lich.display_lichid ? ('(' + Map[key].id.to_s + ')') : ''}</d>"
               end
@@ -622,7 +622,7 @@ module Lich
           Map.current.wayto.each do |_key, value|
             # Don't include cardinals / up/down/out (usually just climb/go)
             next if value.to_s =~ /^(?:o|d|u|n|ne|e|se|s|sw|w|nw|out|down|up|north|northeast|east|southeast|south|southwest|west|northwest)$/
-            if !value.is_a?(Proc)
+            if value.class != Proc
               room_exits << "<d cmd='#{value.dump[1..-2]}'>#{value.dump[1..-2]}</d>"
             end
           end
@@ -744,7 +744,7 @@ module Lich
           room_exits = []
           Map.current.wayto.each do |key, value|
             # Don't include cardinals / up/down/out (usually just climb/go)
-            if value.is_a?(Proc)
+            if value.class == Proc
               if Map.current.timeto[key].is_a?(Numeric) || (Map.current.timeto[key].is_a?(StringProc) && Map.current.timeto[key].call.is_a?(Numeric))
                 room_exits << "<d cmd=';go2 #{key}'>#{Map[key].title.first.gsub(/\[|\]/, '')}#{Lich.display_lichid ? ('(' + Map[key].id.to_s + ')') : ''}</d>"
               end
@@ -758,7 +758,7 @@ module Lich
           Map.current.wayto.each do |_key, value|
             # Don't include cardinals / up/down/out (usually just climb/go)
             next if value.to_s =~ /^(?:o|d|u|n|ne|e|se|s|sw|w|nw|out|down|up|north|northeast|east|southeast|south|southwest|west|northwest)$/
-            if !value.is_a?(Proc)
+            if value.class != Proc
               room_exits << "<d cmd='#{value.dump[1..-2]}'>#{value.dump[1..-2]}</d>"
             end
           end

--- a/lib/gemstone/psms/armor.rb
+++ b/lib/gemstone/psms/armor.rb
@@ -107,9 +107,9 @@ module Lich
         end
 
         usage_cmd = "armor #{usage}"
-        if target.is_a?(GameObj)
+        if target.class == GameObj
           usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
+        elsif target.class == Integer
           usage_cmd += " ##{target}"
         elsif target != ""
           usage_cmd += " #{target}"

--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -696,9 +696,9 @@ module Lich
         end
 
         usage_cmd = "cman #{usage}"
-        if target.is_a?(GameObj)
+        if target.class == GameObj
           usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
+        elsif target.class == Integer
           usage_cmd += " ##{target}"
         elsif target != ""
           usage_cmd += " #{target}"

--- a/lib/gemstone/psms/feat.rb
+++ b/lib/gemstone/psms/feat.rb
@@ -245,9 +245,9 @@ module Lich
         end
 
         usage_cmd = (['guard', 'protect'].include?(usage) ? "#{usage}" : "feat #{usage}")
-        if target.is_a?(GameObj)
+        if target.class == GameObj
           usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
+        elsif target.class == Integer
           usage_cmd += " ##{target}"
         elsif target != ""
           usage_cmd += " #{target}"

--- a/lib/gemstone/psms/shield.rb
+++ b/lib/gemstone/psms/shield.rb
@@ -242,9 +242,9 @@ module Lich
         end
 
         usage_cmd = "shield #{usage}"
-        if target.is_a?(GameObj)
+        if target.class == GameObj
           usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
+        elsif target.class == Integer
           usage_cmd += " ##{target}"
         elsif target != ""
           usage_cmd += " #{target}"

--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -75,9 +75,9 @@ module Lich
         end
 
         usage_cmd = "warcry #{name}"
-        if target.is_a?(GameObj)
+        if target.class == GameObj
           usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
+        elsif target.class == Integer
           usage_cmd += " ##{target}"
         elsif target != ""
           usage_cmd += " #{target}"

--- a/lib/gemstone/psms/weapon.rb
+++ b/lib/gemstone/psms/weapon.rb
@@ -167,9 +167,9 @@ module Lich
         end
 
         usage_cmd = "weapon #{usage}"
-        if target.is_a?(GameObj)
+        if target.class == GameObj
           usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
+        elsif target.class == Integer
           usage_cmd += " ##{target}"
         elsif target != ""
           usage_cmd += " #{target}"

--- a/lib/gemstone/sk.rb
+++ b/lib/gemstone/sk.rb
@@ -6,9 +6,9 @@ module Lich
       def self.sk_known
         if @sk_known.nil?
           val = DB_Store.read("#{XMLData.game}:#{XMLData.name}", "sk_known")
-          if val.nil? || (val.is_a?(Hash) && val.empty?)
+          if val.nil? || (val.class == Hash && val.empty?)
             old_settings = DB_Store.read("#{XMLData.game}:#{XMLData.name}", "vars")["sk/known"]
-            if old_settings.is_a?(Array)
+            if old_settings.class == Array
               val = old_settings
             else
               val = []

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -20,7 +20,7 @@ def start_scripts(*script_names)
 end
 
 def force_start_script(script_name, cli_vars = [], flags = {})
-  flags = Hash.new unless flags.is_a?(Hash)
+  flags = Hash.new unless flags.class == Hash
   flags[:force] = true
   start_script(script_name, cli_vars, flags)
 end
@@ -817,7 +817,7 @@ end
 def check_mind(string = nil)
   if string.nil?
     return XMLData.mind_text
-  elsif (string.is_a?(String)) and (string.to_i == 0)
+  elsif (string.class == String) and (string.to_i == 0)
     if string =~ /#{XMLData.mind_text}/i
       return true
     else
@@ -834,7 +834,7 @@ end
 def checkmind(string = nil)
   if string.nil?
     return XMLData.mind_text
-  elsif string.is_a?(String) and string.to_i == 0
+  elsif string.class == String and string.to_i == 0
     if string =~ /#{XMLData.mind_text}/i
       return true
     else
@@ -1002,7 +1002,7 @@ def checkstance(num = nil)
   Lich.deprecated('checkstance', 'Char.stance')
   if num.nil?
     XMLData.stance_text
-  elsif (num.is_a?(String)) and (num.to_i == 0)
+  elsif (num.class == String) and (num.to_i == 0)
     if num =~ /off/i
       XMLData.stance_value == 0
     elsif num =~ /adv/i
@@ -1019,7 +1019,7 @@ def checkstance(num = nil)
       echo "checkstance: invalid argument (#{num}).  Must be off/adv/for/neu/gua/def or 0-100"
       nil
     end
-  elsif (num.is_a?(Integer)) or (num =~ /^[0-9]+$/ and (num = num.to_i))
+  elsif (num.class == Integer) or (num =~ /^[0-9]+$/ and (num = num.to_i))
     XMLData.stance_value == num.to_i
   else
     echo "checkstance: invalid argument (#{num}).  Must be off/adv/for/neu/gua/def or 0-100"
@@ -1040,7 +1040,7 @@ def checkencumbrance(string = nil)
   Lich.deprecated('checkencumbrance', 'Char.encumbrance')
   if string.nil?
     XMLData.encumbrance_text
-  elsif (string.is_a?(Integer)) or (string =~ /^[0-9]+$/ and (string = string.to_i))
+  elsif (string.class == Integer) or (string =~ /^[0-9]+$/ and (string = string.to_i))
     string <= XMLData.encumbrance_value
   else
     # fixme
@@ -1235,7 +1235,7 @@ end
 def checkprep(spell = nil)
   if spell.nil?
     XMLData.prepared_spell
-  elsif !spell.is_a?(String)
+  elsif spell.class != String
     echo("Checkprep error, spell # not implemented!  You must use the spell name")
     false
   else
@@ -1331,11 +1331,11 @@ def pause(num = 1)
 end
 
 def cast(spell, target = nil, results_of_interest = nil)
-  if spell.is_a?(Spell)
+  if spell.class == Spell
     spell.cast(target, results_of_interest)
-  elsif ((spell.is_a?(Integer)) or (spell.to_s =~ /^[0-9]+$/)) and (find_spell = Spell[spell.to_i])
+  elsif ((spell.class == Integer) or (spell.to_s =~ /^[0-9]+$/)) and (find_spell = Spell[spell.to_i])
     find_spell.cast(target, results_of_interest)
-  elsif (spell.is_a?(String)) and (find_spell = Spell[spell])
+  elsif (spell.class == String) and (find_spell = Spell[spell])
     find_spell.cast(target, results_of_interest)
   else
     echo "cast: invalid spell (#{spell})"
@@ -1373,7 +1373,7 @@ end
 
 def matchtimeout(secs, *strings)
   unless (Script.current) then echo("An unknown script thread tried to fetch a game line from the queue, but Lich can't process the call without knowing which script is calling! Aborting..."); Thread.current.kill; return false end
-  unless (secs.is_a?(Float) || secs.is_a?(Integer))
+  unless (secs.class == Float || secs.class == Integer)
     echo('matchtimeout error! You appear to have given it a string, not a #! Syntax:  matchtimeout(30, "You stand up")')
     return false
   end
@@ -1448,14 +1448,14 @@ end
 
 def waitforre(regexp)
   unless (script = Script.current) then respond('--- waitforre: Unable to identify calling script.'); return false; end
-  unless regexp.is_a?(Regexp) then echo("Script error! You have given 'waitforre' something to wait for, but it isn't a Regular Expression! Use 'waitfor' if you want to wait for a string."); sleep 1; return nil end
+  unless regexp.class == Regexp then echo("Script error! You have given 'waitforre' something to wait for, but it isn't a Regular Expression! Use 'waitfor' if you want to wait for a string."); sleep 1; return nil end
   regobj = regexp.match(script.gets) until regobj
 end
 
 def waitfor(*strings)
   unless (script = Script.current) then respond('--- waitfor: Unable to identify calling script.'); return false; end
   strings.flatten!
-  if (script.is_a?(WizardScript)) and (strings.length == 1) and (strings.first.strip == '>')
+  if (script.class == WizardScript) and (strings.length == 1) and (strings.first.strip == '>')
     return script.gets
   end
 
@@ -1683,7 +1683,7 @@ end
 def respond(first = "", *messages)
   str = ''
   begin
-    if first.is_a?(Array)
+    if first.class == Array
       first.flatten.each { |ln| str += sprintf("%s\r\n", ln.to_s.chomp) }
     else
       str += sprintf("%s\r\n", first.to_s.chomp)
@@ -1724,7 +1724,7 @@ end
 def _respond(first = "", *messages)
   str = ''
   begin
-    if first.is_a?(Array)
+    if first.class == Array
       first.flatten.each { |ln| str += sprintf("%s\r\n", ln.to_s.chomp) }
     else
       str += sprintf("%s\r\n", first.to_s.chomp)

--- a/lib/init.rb
+++ b/lib/init.rb
@@ -108,7 +108,7 @@ elsif defined?(Wine)
 end
 ## The following should be deprecated with the direct-frontend-launch-method
 ## TODO: remove as part of chore/Remove unnecessary Win32 calls
-## Temporarily reinstated for DR
+## Temporarily reinstatated for DR
 
 if (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
   #
@@ -190,7 +190,7 @@ if (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
       else
         bInheritHandles = args[:bInheritHandles].to_i
       end
-      if args[:lpEnvironment].is_a?(Array)
+      if args[:lpEnvironment].class == Array
         # fixme
       end
       lpStartupInfo = [68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -324,17 +324,17 @@ if (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
     end
 
     def Win32.RegSetValueEx(args)
-      if [REG_EXPAND_SZ, REG_SZ, REG_LINK].include?(args[:dwType]) and (args[:lpData].is_a?(String))
+      if [REG_EXPAND_SZ, REG_SZ, REG_LINK].include?(args[:dwType]) and (args[:lpData].class == String)
         lpData = args[:lpData].dup
         lpData.concat("\x00")
         cbData = lpData.length
-      elsif (args[:dwType] == REG_MULTI_SZ) and (args[:lpData].is_a?(Array))
+      elsif (args[:dwType] == REG_MULTI_SZ) and (args[:lpData].class == Array)
         lpData = args[:lpData].join("\x00").concat("\x00\x00")
         cbData = lpData.length
-      elsif (args[:dwType] == REG_DWORD) and (args[:lpData].is_a?(Integer))
+      elsif (args[:dwType] == REG_DWORD) and (args[:lpData].class == Integer)
         lpData = [args[:lpData]].pack('L')
         cbData = 4
-      elsif (args[:dwType] == REG_QWORD) and (args[:lpData].is_a?(Integer))
+      elsif (args[:dwType] == REG_QWORD) and (args[:lpData].class == Integer)
         lpData = [args[:lpData]].pack('Q')
         cbData = 8
       elsif args[:dwType] == REG_BINARY
@@ -590,7 +590,7 @@ unless File.exist?(LICH_DIR)
   begin
     Dir.mkdir(LICH_DIR)
   rescue
-    message = "An error occurred while attempting to create directory #{LICH_DIR}\n\n"
+    message = "An error occured while attempting to create directory #{LICH_DIR}\n\n"
     if not File.exist?(LICH_DIR.sub(/[\\\/]$/, '').slice(/^.+[\\\/]/).chop)
       message.concat "This was likely because the parent directory (#{LICH_DIR.sub(/[\\\/]$/, '').slice(/^.+[\\\/]/).chop}) doesn't exist."
     elsif defined?(Win32) and (Win32.GetVersionEx[:dwMajorVersion] >= 6) and (dir !~ /^[A-z]\:\\(Users|Documents and Settings)/)
@@ -609,7 +609,7 @@ unless File.exist?(TEMP_DIR)
   begin
     Dir.mkdir(TEMP_DIR)
   rescue
-    message = "An error occurred while attempting to create directory #{TEMP_DIR}\n\n"
+    message = "An error occured while attempting to create directory #{TEMP_DIR}\n\n"
     if not File.exist?(TEMP_DIR.sub(/[\\\/]$/, '').slice(/^.+[\\\/]/).chop)
       message.concat "This was likely because the parent directory (#{TEMP_DIR.sub(/[\\\/]$/, '').slice(/^.+[\\\/]/).chop}) doesn't exist."
     elsif defined?(Win32) and (Win32.GetVersionEx[:dwMajorVersion] >= 6) and (dir !~ /^[A-z]\:\\(Users|Documents and Settings)/)
@@ -626,7 +626,7 @@ begin
   debug_filename = "#{TEMP_DIR}/debug-#{Time.now.strftime("%Y-%m-%d-%H-%M-%S-%L")}.log"
   $stderr = File.open(debug_filename, 'w')
 rescue
-  message = "An error occurred while attempting to create file #{debug_filename}\n\n"
+  message = "An error occured while attempting to create file #{debug_filename}\n\n"
   if defined?(Win32) and (TEMP_DIR !~ /^[A-z]\:\\(Users|Documents and Settings)/) and not Win32.isXP?
     message.concat "This was likely because Lich doesn't have permission to create files and folders here.  It is recommended to put Lich in your Documents folder."
   else
@@ -648,7 +648,7 @@ unless File.exist?(DATA_DIR)
     Dir.mkdir(DATA_DIR)
   rescue
     Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-    Lich.msgbox(:message => "An error occurred while attempting to create directory #{DATA_DIR}\n\n#{$!}", :icon => :error)
+    Lich.msgbox(:message => "An error occured while attempting to create directory #{DATA_DIR}\n\n#{$!}", :icon => :error)
     exit
   end
 end
@@ -657,7 +657,7 @@ unless File.exist?(SCRIPT_DIR)
     Dir.mkdir(SCRIPT_DIR)
   rescue
     Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-    Lich.msgbox(:message => "An error occurred while attempting to create directory #{SCRIPT_DIR}\n\n#{$!}", :icon => :error)
+    Lich.msgbox(:message => "An error occured while attempting to create directory #{SCRIPT_DIR}\n\n#{$!}", :icon => :error)
     exit
   end
 end
@@ -666,7 +666,7 @@ unless File.exist?("#{SCRIPT_DIR}/custom")
     Dir.mkdir("#{SCRIPT_DIR}/custom")
   rescue
     Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-    Lich.msgbox(:message => "An error occurred while attempting to create directory #{SCRIPT_DIR}/custom\n\n#{$!}", :icon => :error)
+    Lich.msgbox(:message => "An error occured while attempting to create directory #{SCRIPT_DIR}/custom\n\n#{$!}", :icon => :error)
     exit
   end
 end
@@ -675,7 +675,7 @@ unless File.exist?(MAP_DIR)
     Dir.mkdir(MAP_DIR)
   rescue
     Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-    Lich.msgbox(:message => "An error occurred while attempting to create directory #{MAP_DIR}\n\n#{$!}", :icon => :error)
+    Lich.msgbox(:message => "An error occured while attempting to create directory #{MAP_DIR}\n\n#{$!}", :icon => :error)
     exit
   end
 end
@@ -684,7 +684,7 @@ unless File.exist?(LOG_DIR)
     Dir.mkdir(LOG_DIR)
   rescue
     Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-    Lich.msgbox(:message => "An error occurred while attempting to create directory #{LOG_DIR}\n\n#{$!}", :icon => :error)
+    Lich.msgbox(:message => "An error occured while attempting to create directory #{LOG_DIR}\n\n#{$!}", :icon => :error)
     exit
   end
 end
@@ -693,7 +693,7 @@ unless File.exist?(BACKUP_DIR)
     Dir.mkdir(BACKUP_DIR)
   rescue
     Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-    Lich.msgbox(:message => "An error occurred while attempting to create directory #{BACKUP_DIR}\n\n#{$!}", :icon => :error)
+    Lich.msgbox(:message => "An error occured while attempting to create directory #{BACKUP_DIR}\n\n#{$!}", :icon => :error)
     exit
   end
 end

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -83,7 +83,7 @@ module Lich
       @checked_sheaths = true
     end
 
-    def self.missing_primary_sheath? # check entry against actual inventory to catch inventory updates
+    def self.missing_primary_sheath? # check entry against actual inventory to catch inventory updatees
       @sheath.has_key?(:sheath) && !GameObj.inv.any? { |item| item.id == @sheath[:sheath].id }
     end
 
@@ -117,11 +117,11 @@ module Lich
         sheath = second_sheath = nil
       end
       # weaponsack for both hands
-      if UserVars.weapon.is_a?(String) and UserVars.weaponsack.is_a?(String) and not UserVars.weapon.empty? and not UserVars.weaponsack.empty? and (right_hand.name =~ /#{Regexp.escape(UserVars.weapon.strip)}/i or right_hand.name =~ /#{Regexp.escape(UserVars.weapon).sub(' ', ' .*')}/i)
+      if UserVars.weapon.class == String and UserVars.weaponsack.class == String and not UserVars.weapon.empty? and not UserVars.weaponsack.empty? and (right_hand.name =~ /#{Regexp.escape(UserVars.weapon.strip)}/i or right_hand.name =~ /#{Regexp.escape(UserVars.weapon).sub(' ', ' .*')}/i)
         weaponsack = nil unless (weaponsack = find_container(UserVars.weaponsack, loud_fail: false)).is_a?(GameObj) # (Lich::Gemstone::GameObj)
       end
       # lootsack for both hands
-      if !UserVars.lootsack.is_a?(String) || UserVars.lootsack.empty?
+      if UserVars.lootsack.class != String || UserVars.lootsack.empty?
         lootsack = nil
       else
         lootsack = nil unless (lootsack = find_container(UserVars.lootsack, loud_fail: false)).is_a?(GameObj) # (Lich::Gemstone::GameObj)

--- a/spec/hmr_spec.rb
+++ b/spec/hmr_spec.rb
@@ -1,6 +1,6 @@
 def respond(first = "", *messages)
   str = ''
-  if first.is_a?(Array)
+  if first.class == Array
     first.flatten.each { |ln| str += sprintf("%s\r\n", ln.to_s.chomp) }
   else
     str += sprintf("%s\r\n", first.to_s.chomp)


### PR DESCRIPTION
Reverts elanthia-online/lich-5#876

Due to StringProc class not being a true "Proc" class, need to revert and start over with proper updating to check for a StringProc instead of Proc. 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts type checking from `is_a?` to `class` across multiple files, affecting type checks for various classes and fixing minor typos.
> 
>   - **Behavior**:
>     - Reverts type checking from `is_a?` to `class` in `buffer.rb`, `downstreamhook.rb`, `gameobj.rb`, and `map_dr.rb`.
>     - Affects type checks for `Integer`, `String`, `Regexp`, `Proc`, `Array`, `Hash`, `Map`, `GameObj`, and `ExecScript`.
>   - **Misc**:
>     - Fixes typos in comments and strings in `script.rb`, `common-travel.rb`, and `init.rb`.
>     - Corrects class name in `watchfor.rb` from `Watchfor` to `WatchFor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for d06ba20ccf7b1e7dd4c796eb84ff4eb08659f430. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->