### PR TITLE
fix(all): gameobj.rb deeper lookup

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -90,12 +90,17 @@ module Lich
       end
 
       def GameObj.[](val)
-        if val.is_a?(Integer)
-          val = val.to_s
-          respond "--- Lich: error: GameObj[] passed with integer #{val} via caller: #{caller[0]}"
+        unless val.is_a?(String) || val.is_a?(Regexp)
+          respond "--- Lich: error: GameObj[] passed with #{val.class} #{val} via caller: #{caller[0]}"
           respond "--- Lich: error: GameObj[] supports String or Regexp only"
-          Lich.log "--- Lich: error: GameObj[] passed with integer #{val} via caller: #{caller[0]}\n\t"
+          Lich.log "--- Lich: error: GameObj[] passed with #{val.class} #{val} via caller: #{caller[0]}\n\t"
           Lich.log "--- Lich: error: GameObj[] supports String or Regexp only\n\t"
+          if val.is_a?(Integer)
+            respond "--- Lich: error: GameObj[] converted Integer #{val} to String to continue"
+            val = val.to_s
+          else
+            return
+          end
         end
         if val.is_a?(String)
           if val =~ /^\-?[0-9]+$/ # ID lookup


### PR DESCRIPTION
Previously if you had an item inside of a container, it would get assigned to the contents of a container, but those contents would not be searched when doing a direct `GameObj["#####"]` lookup as it would return nil.
```
>;e echo GameObj.containers.values.flatten.find { |t| t.name =~ /crook/ }.inspect 
--- Lich: exec1 active.
[exec1: #<Lich::Common::GameObj:0x000077cebb54f158 @id="47362909", @noun="crook", @name="gnarled rowan crook", @before_name="a", @after_name="wound with knotted yarn">]
--- Lich: exec1 has exited.
```
```
;e echo GameObj["47362909"].inspect
--- Lich: exec1 active.
[exec1: ]
--- Lich: exec1 has exited.
```
With this change, it now responds correctly as:
```
>;e echo GameObj["47475888"].inspect
--- Lich: exec1 active.
[exec1: #<Lich::Common::GameObj:0x000077cebb54f158 @id="47362909", @noun="crook", @name="gnarled rowan crook", @before_name="a", @after_name="wound with knotted yarn">]
--- Lich: exec1 has exited.
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `GameObj.[]` in `gameobj.rb` for deeper container lookups and improves error handling for invalid input types.
> 
>   - **Behavior**:
>     - Enhances `GameObj.[]` in `gameobj.rb` to perform deeper lookups for items within containers using ID.
>     - Adds error handling for non-String/Regexp inputs, converting Integers to Strings or logging errors.
>   - **Misc**:
>     - Updates `GameObj.merge_data` to use `is_a?` instead of `class ==` for type checking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 64ea2f3d89c93e2d116758de890560bbb118a014. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->