### PR TITLE
fix(all): messaging.rb debug not compared to falseclass

### DIFF
--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -125,7 +125,7 @@ module Lich
     end
 
     def self.msg(type = "info", msg = "", encode: true)
-      return if type == "debug" && (Lich.debug_messaging.nil? || Lich.debug_messaging == "false")
+      return if type == "debug" && (Lich.debug_messaging.nil? || Lich.debug_messaging == "false" || Lich.debug_messaging == false)
       _respond msg_format(type, msg, encode: encode)
     end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `msg()` in `lib/messaging.rb` to correctly handle `Lich.debug_messaging` when set to `false` (boolean), preventing debug messages from being processed.
> 
>   - **Behavior**:
>     - Fixes `msg()` in `lib/messaging.rb` to correctly handle `Lich.debug_messaging` when it is `false` (boolean), in addition to `nil` or "false" (string).
>     - Ensures debug messages are not processed if `Lich.debug_messaging` is not truthy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 2fee5f52ce3b485b2ebf5112c6dc384b0afc3d9e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->