### PR TITLE
fix(all): settings_proxy implement to_h for appropriate behaviors

### DIFF
--- a/lib/common/settings/settings_proxy.rb
+++ b/lib/common/settings/settings_proxy.rb
@@ -42,7 +42,7 @@ module Lich
           @target.send(method)
         else
           @settings_module._log(Settings::LOG_LEVEL_DEBUG, LOG_PREFIX, -> { "#{method}: not supported" })
-          
+
           if options[:strict]
             # For strict methods, raise NoMethodError
             raise NoMethodError.new("undefined method `#{method}' for #{@target.inspect}:#{@target.class}")
@@ -209,7 +209,10 @@ module Lich
         @settings_module._log(Settings::LOG_LEVEL_DEBUG, LOG_PREFIX, -> { "SET   target_after_set: #{@target.inspect}" })
         @settings_module._log(Settings::LOG_LEVEL_DEBUG, LOG_PREFIX, -> { "SET   calling save_proxy_changes on settings module" })
         @settings_module.save_proxy_changes(self)
+        # rubocop:disable Lint/Void
+        # This is Ruby expected behavior to return the value.
         value
+        # rubocop:enable Lint/Void
       end
 
       def method_missing(method, *args, &block)


### PR DESCRIPTION
### The Problem:
When you call GameSettings['custom targets'].sort_by { |key| key }.to_h, the following happens:

- GameSettings['custom targets'] returns a SettingsProxy wrapping a hash
- .sort_by { |key| key } returns an array of key-value pairs (not a hash)
- This array is wrapped in a new SettingsProxy
- .to_h is called on this array proxy

The original implementation of to_h in SettingsProxy only returned a value if the target was a Hash: 
- return nil unless @target.is_a?(Hash)
Since the target after sort_by is an Array (not a Hash), to_h was returning nil instead of converting the array of pairs back to a hash.  This is incorrect Ruby behavior.

This change updates both to_hash and to_h methods to delegate to the target's corresponding methods if they exist ensuring that when a call .to_h on a SettingsProxy wrapping an array of pairs (like the result of sort_by), it will correctly delegate to Array#to_h, which converts the array of pairs back to a hash.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `to_h` behavior in `SettingsProxy` by delegating to target's methods, ensuring correct array-to-hash conversion.
> 
>   - **Behavior**:
>     - Fixes `to_h` and `to_hash` in `SettingsProxy` to delegate to target's methods, ensuring correct conversion of arrays of pairs to hashes.
>     - Introduces `delegate_conversion` method to handle conversion method delegation with logging and error handling.
>   - **Methods**:
>     - Adds `delegate_conversion` to streamline conversion method delegation.
>     - Updates `to_h`, `to_hash`, `to_a`, `to_ary`, and other conversion methods to use `delegate_conversion`.
>   - **Logging**:
>     - Adds debug logging for method delegation and unsupported methods in `delegate_conversion`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 494dad975868f43ed3e2bf10af175b89ad01a07c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->