### PR TITLE
fix(dr): add 'You scoop' match pattern to common-items

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -65,6 +65,7 @@ module Lich
         /^You pick/,
         /^You pluck/,
         /^You slip/,
+        /^You scoop/,
         /^You deftly remove/,
         /^You are already holding/,
         /^You fade in for a moment as you/,


### PR DESCRIPTION
### Background

The vanity-pet script tried to pick up my pet but didn't recognize the game string and though I didn't pick it up.

### Changes

- Add match for `^You scoop`

### Context

```
[vanity-pet]>get snaggletoothed boar

You scoop the snaggletoothed boar up.

[vanity-pet: *** No match was found after 15 seconds, dumping info]

[vanity-pet: message: You scoop the snaggletoothed boar up.]

[vanity-pet: checked against [/you draw (?!\w+'s wounds)/i, /^You get/, /^You pick/, /^You pluck/, /^You slip/, /^You deftly remove/, /^You are already holding/, /^You fade in for a moment as you/, /^You carefully lift/, /^You carefully remove .* from the bundle/, /^A magical force keeps you from grasping/, /^You need a free hand/, /^You can't pick that up with your hand that damaged/, /^Your (left|right) hand is too injured/, /^You just can't/, /^You stop as you realize the .* is not yours/, /^You can't reach that from here/, /^You don't seem to be able to move/, /^You should untie/, /^You can't do that/, /^Get what/, /^I could not/, /^What were you/, /already in your inventory/, /needs to be tended to be removed/, /push you over the item limit/, /rapidly decays away/, /cracks and rots away/, /^You should stop practicing your Athletics skill before you do that/]]

[vanity-pet: for command get snaggletoothed boar ]

Could not pick up pet, where did it go?

--- Lich: vanity-pet has exited.
```