### PR TITLE
fix(dr): add missing match patterns

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -75,6 +75,7 @@ module Lich
 
       GET_ITEM_FAILURE_PATTERNS = [
         /^A magical force keeps you from grasping/,
+        /^You'll need both hands free/,
         /^You need a free hand/,
         /^You can't pick that up with your hand that damaged/,
         /^Your (left|right) hand is too injured/,
@@ -187,6 +188,7 @@ module Lich
       ]
 
       REMOVE_ITEM_FAILURE_PATTERNS = [
+        /^You'll need both hands free/,
         /^You need a free hand/,
         /^You aren't wearing/,
         /^You don't seem to be able to move/,


### PR DESCRIPTION
A couple more missing match strings
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing match patterns to `common-items.rb` for handling specific item tie and put away cases.
> 
>   - **Pattern Additions**:
>     - Added `/close the fan/` to `TIE_ITEM_FAILURE_PATTERNS` and `PUT_AWAY_ITEM_FAILURE_PATTERNS` in `common-items.rb` to handle specific failure cases.
>     - Added `/^You stuff/` to `PUT_AWAY_ITEM_SUCCESS_PATTERNS` in `common-items.rb` to handle additional success cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for db14fa373580a4243638e9d21641bfd6c8fe221a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->