### PR TITLE
fix(gs): allow spell.rb casting to take a force_stance parameter

### DIFF
--- a/lib/common/spell.rb
+++ b/lib/common/spell.rb
@@ -764,7 +764,7 @@ module Lich
         else
           arg_options = "cast"
         end
-        cast(target, results_of_interest, arg_options, force_stance: nil)
+        cast(target, results_of_interest, arg_options, force_stance: force_stance)
       end
 
       def force_channel(target = nil, arg_options = nil, results_of_interest = nil, force_stance: nil)
@@ -773,7 +773,7 @@ module Lich
         else
           arg_options = "channel"
         end
-        cast(target, results_of_interest, arg_options, force_stance: nil)
+        cast(target, results_of_interest, arg_options, force_stance: force_stance)
       end
 
       def force_evoke(target = nil, arg_options = nil, results_of_interest = nil, force_stance: nil)
@@ -782,7 +782,7 @@ module Lich
         else
           arg_options = "evoke"
         end
-        cast(target, results_of_interest, arg_options, force_stance: nil)
+        cast(target, results_of_interest, arg_options, force_stance: force_stance)
       end
 
       def force_incant(arg_options = nil, results_of_interest = nil, force_stance: nil)
@@ -791,7 +791,7 @@ module Lich
         else
           arg_options = "incant"
         end
-        cast(nil, results_of_interest, arg_options, force_stance: nil)
+        cast(nil, results_of_interest, arg_options, force_stance: force_stance)
       end
 
       def _bonus


### PR DESCRIPTION
This allows for overriding whatever the current `effect-list.xml` stance value is for a single cast, so you can do things like `Spell[118].force_incant(force_stance: false)` to prevent it from stance dancing for you.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `force_stance` parameter to spell casting methods in `spell.rb` for stance control during casting.
> 
>   - **Behavior**:
>     - Adds `force_stance` parameter to `cast()`, `force_cast()`, `force_channel()`, `force_evoke()`, and `force_incant()` in `spell.rb`.
>     - Allows overriding `effect-list.xml` stance value for a single cast.
>     - Example usage: `Spell[118].force_incant(force_stance: false)` to prevent stance dancing.
>   - **Logic**:
>     - Modifies stance change logic in `cast()` to consider `force_stance` parameter.
>     - Adjusts stance to offensive if `force_stance` is true or not explicitly false.
>     - Reverts stance post-cast if `force_stance` is true or not explicitly false.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for fe7b6d7ea7927394f9d506199413cbc0387e4305. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->