### PR TITLE
fix(dr): common-items: add and fix match strings

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -27,7 +27,7 @@ module Lich
         /^Perhaps you should be holding that first/,
         /^You're kidding, right/,
         /^You can't do that/,
-        /^No littering/,
+        /No littering/, # A guard steps over to you and says, "No littering in the bank."
         /^Where do you want to put that/,
         /^You really shouldn't be loitering/,
         /^You don't seem to be able to move/,
@@ -76,6 +76,7 @@ module Lich
       GET_ITEM_FAILURE_PATTERNS = [
         /^A magical force keeps you from grasping/,
         /^You'll need both hands free/,
+        /^You need both hands free/,
         /^You need a free hand/,
         /^You can't pick that up with your hand that damaged/,
         /^Your (left|right) hand is too injured/,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves pattern matching in `common-items.rb` by updating and adding specific match strings for item handling scenarios.
> 
>   - **Pattern Matching**:
>     - Updated `DROP_TRASH_FAILURE_PATTERNS` to remove the `^` from `/No littering/` to match more cases.
>     - Added `/^You need both hands free/` to `GET_ITEM_FAILURE_PATTERNS` to handle cases where both hands are required.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 03529d030501bded477fadd649f8ac92fdd9b820. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->