### PR TITLE
fix(dr): Fix race condition when clearing and repopulating XMLData.dr_active_spells

### DIFF
--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -665,7 +665,6 @@ module Lich
           if @dr_active_spell_tracking
             spell = nil
             duration = nil
-            Lich.log "DR Active Spell tracking: #{text_string.inspect}"
             case text_string
             when /(?<spell>^[^\(]+)\((?<duration>\d+|Indefinite|OM|Fading)\s*(?:%|roisae?n)?\)/i
               # Spell with known duration remaining
@@ -699,7 +698,7 @@ module Lich
             when /(?<spell>^[^\(]+)\(.+\)/i
               # Spells with inexact duration verbiage, such as with
               # Barbarians without knowledge of Power Monger mastery
-              spell = Regexp.last_match[:spell].strip
+              spell = Regexp.last_match[:spell]
               duration = 1000
             when /.*orbiting sliver.*/i
               # Moon Mage slivers

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -279,9 +279,9 @@ module Lich
             end
           end
 
-         if (name == 'clearStream' && attributes['id'] == 'percWindow')
-           @dr_active_spells_clear = true
-         end
+          if (name == 'clearStream' && attributes['id'] == 'percWindow')
+            @dr_active_spells_clear = true
+          end
 
           if (name == 'pushStream' && attributes['id'] == 'percWindow')
             if @dr_active_spells_clear


### PR DESCRIPTION
As per title.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix race condition in `XMLParser` by using `@dr_active_spells_clear` flag to manage `dr_active_spells` clearing and repopulation.
> 
>   - **Behavior**:
>     - Fix race condition in `XMLParser` by introducing `@dr_active_spells_clear` flag to ensure `@dr_active_spells` is cleared before repopulation in `tag_start` and `tag_end`.
>     - Remove `strip` from spell name extraction in `text` method to prevent unintended whitespace removal.
>   - **Misc**:
>     - Minor logic adjustment in `tag_start` and `tag_end` for `dr_active_spell_tracking` and `dr_active_spells_slivers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 21e94efa4be0022c43382c5ffdb1c9ee452b7ae7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->