### PR TITLE
fix(dr): resolve race condition in DR crafting_magic_routine

### DIFF
--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -830,7 +830,9 @@ module Lich
         return if training_spells.empty?
         return if DRStats.mana <= settings.waggle_spells_mana_threshold
 
-        if !XMLData.prepared_spell.eql?('None') && checkcastrt == 0
+        if checkcastrt > 0
+          return
+        elsif !XMLData.prepared_spell.eql?('None') && checkcastrt == 0
           spell = XMLData.prepared_spell
           data = training_spells.find { |_skill, info| info['name'] == spell }.last
           crafting_cast_spell(data, settings)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes race condition in `crafting_magic_routine` by adding an early return if `checkcastrt` is greater than 0.
> 
>   - **Behavior**:
>     - Fixes race condition in `crafting_magic_routine` in `common-arcana.rb` by adding an early return if `checkcastrt` is greater than 0.
>     - Ensures function exits early to prevent further execution during cast roundtime.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7775e6d4c0b2021d93b857ff6b38691e19b4e0fc. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->