### PR TITLE
fix(dr): xmlparser.rb - Clear out spells properly

### DIFF
--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -106,6 +106,7 @@ module Lich
         @society_task = String.new
 
         @dr_active_spells = Hash.new
+        @dr_active_spells_clear = false
         @dr_active_spells_tmp = Hash.new
         @dr_active_spell_tracking = false
         @dr_active_spells_stellar_percentage = 0


### PR DESCRIPTION
The old method didn't clear our spells when they were the last spell to be released. Now it does. Also consolidated the `prompt` tag section into one.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes spell clearing logic in `xmlparser.rb` and consolidates `prompt` tag handling for better readability.
> 
>   - **Behavior**:
>     - Fixes spell clearing logic in `tag_start()` in `xmlparser.rb` to ensure spells are cleared when they are the last to be released.
>     - Consolidates `prompt` tag handling logic in `tag_start()` for better readability.
>   - **Misc**:
>     - Removes redundant code related to spell clearing in `tag_start()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for fff1a8ab6d8b81bbed2fe55929be3f038a8505d8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->