### PR TITLE
fix(all): Util.issue_command allow single line captures

### DIFF
--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -75,7 +75,7 @@ module Lich
     #
     # @param command [String] The command to send.
     # @param start_pattern [Regexp] Pattern marking the start of output capture.
-    # @param end_pattern [Regexp] Pattern marking the end of output capture. Defaults to /<prompt/.
+    # @param end_pattern [Regexp, Symbol] Pattern marking the end of output capture. Defaults to /<prompt/. Use :ignore for single-line capture.
     # @param include_end [Boolean] Whether to include the end line in the result. Defaults to true.
     # @param timeout [Integer] Timeout in seconds for the command. Defaults to 5.
     # @param silent [Boolean, nil] Whether to silence script output. Defaults to nil (no change).


### PR DESCRIPTION
Allows for single line `issue_command` calls with the `end_pattern` of `:ignore`. Also expand module's documentation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `issue_command` in `util.rb` to support single-line captures with `:ignore` and updates documentation.
> 
>   - **Behavior**:
>     - `issue_command` in `util.rb` now supports `:ignore` as `end_pattern` for single-line captures.
>   - **Documentation**:
>     - Expanded and clarified documentation for `normalize_lookup`, `normalize_name`, `anon_hook`, `issue_command`, `silver_count`, and `install_gem_requirements` in `util.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 47a200e5cea768bf0c7547572a25640105583e81. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->