### PR TITLE
fix(dr): drparser.rb update for Platinum account status

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -341,9 +341,10 @@ module Lich
             end
           when Pattern::PlayedSubscription
             if Account.subscription.nil?
-              Account.subscription = Regexp.last_match[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').upcase
+              Account.subscription = Regexp.last_match[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').gsub('Platinum', 'Premium').upcase
             end
-            if Account.subscription == 'PREMIUM' || Account.subscription == 'PLATINUM' || XMLData.game == 'DRX' || XMLData.game == 'DRF'
+            UserVars.account_type = Regexp.last_match[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').upcase
+            if Account.subscription == 'PREMIUM' || XMLData.game == 'DRX' || XMLData.game == 'DRF'
               UserVars.premium = true
             else
               UserVars.premium = false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `drparser.rb` to recognize 'Platinum' account status and adjust premium account logic.
> 
>   - **Behavior**:
>     - Update `PlayedSubscription` regex in `drparser.rb` to include 'Platinum' as a valid account status.
>     - Modify `parse()` in `drparser.rb` to set `UserVars.premium` to true for 'PLATINUM' accounts.
>   - **Misc**:
>     - Adjust `parse()` logic to handle 'PLATINUM' and 'DRX' game type as premium.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 9f6fa88d076291efca36e52440f05f758487b929. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->