### PR TITLE
fix(gs): weapon PSM affordable check against Glorious Momentum

### DIFF
--- a/lib/gemstone/psms/weapon.rb
+++ b/lib/gemstone/psms/weapon.rb
@@ -233,6 +233,7 @@ module Lich
       #   Weapon.affordable?("Weapon_blessing") => true # if enough skill and stamina
       #   Weapon.affordable?("Weapon_blessing", forcert_count: 1) => false  # if not enough skill or stamina
       def Weapon.affordable?(name, forcert_count: 0)
+        return true if @@weapon_techniques.fetch(PSMS.find_name(name, "Weapon")[:long_name])[:type] == :area_of_effect && Effects::Buffs.active?("Glorious Momentum")
         return PSMS.assess(name, 'Weapon', true, forcert_count: forcert_count)
       end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `Weapon.affordable?`, return `true` for `:area_of_effect` techniques if `Glorious Momentum` buff is active.
> 
>   - **Behavior**:
>     - In `Weapon.affordable?`, return `true` if technique type is `:area_of_effect` and `Glorious Momentum` buff is active.
>   - **Misc**:
>     - No changes to other methods or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for a4d850e8d1317740ad8196bc77e91d66492d9150. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->