### PR TITLE
fix(all): delegate .to_json properly in settings_proxy

### DIFF
--- a/lib/common/settings/settings_proxy.rb
+++ b/lib/common/settings/settings_proxy.rb
@@ -106,7 +106,12 @@ module Lich
 
       # added 20250620 for JSON.pretty_generate
       def to_json(*args)
-        @target.to_json(*args)
+        if @target.respond_to?(:to_json)
+          @settings_module._log(Settings::LOG_LEVEL_DEBUG, LOG_PREFIX, -> { "to_json: delegating with args" })
+          @target.to_json(*args)
+        else
+          raise NoMethodError, "undefined method :to_json for #{@target.inspect}:#{@target.class}"
+        end
       end
 
       # Other common conversions


### PR DESCRIPTION
Allows for JSON.pretty_generate (and other .to_json based methods) to operate with the settings_proxy / saved settings information.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `to_json` method to `SettingsProxy` in `settings_proxy.rb` to support JSON serialization methods like `JSON.pretty_generate`.
> 
>   - **Behavior**:
>     - Adds `to_json(*args)` method to `SettingsProxy` in `settings_proxy.rb`, delegating to `@target.to_json(*args)`.
>     - Enables `JSON.pretty_generate` and similar methods to work with `SettingsProxy` objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for a4e36658790902a50e9b50abe32a7c86cb807d56. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->