### PR TITLE
fix(all): gameobj.rb - add type? method for explicit type check

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -45,6 +45,11 @@ module Lich
         end
       end
 
+      def type?(type_to_check)
+        # handle nil types
+        return self.type.to_s.split(',').any?(type_to_check)
+      end
+
       def sellable
         GameObj.load_data if @@sellable_data.empty?
         list = @@sellable_data.keys.find_all { |t| (@name =~ @@sellable_data[t][:name] or @noun =~ @@sellable_data[t][:noun]) and (@@sellable_data[t][:exclude].nil? or @name !~ @@sellable_data[t][:exclude]) }


### PR DESCRIPTION
Quick syntactic sugar to do a cleaner explicit type checks instead of a regex on a potentially multi-type blob all the time.

```ruby
You remove a praying white ora figurine from in your cloak.
>;e echo GameObj.right_hand
--- Lich: exec1 active.
[exec1: figurine]
--- Lich: exec1 has exited.

>;e echo GameObj.right_hand.type
--- Lich: exec1 active.
[exec1: magic,uncommon]
--- Lich: exec1 has exited.

>;e echo GameObj.right_hand.type?('magic')
--- Lich: exec1 active.
[exec1: true]
--- Lich: exec1 has exited.

>;e echo GameObj.right_hand.type?('magi')
--- Lich: exec1 active.
[exec1: false]
--- Lich: exec1 has exited.

>;e echo GameObj.right_hand.type?('uncommon')
--- Lich: exec1 active.
[exec1: true]
--- Lich: exec1 has exited.

>;e echo GameObj.right_hand.type?('unc')
--- Lich: exec1 active.
[exec1: false]
--- Lich: exec1 has exited.

>;e echo GameObj.right_hand.type?(/unc/)
--- Lich: exec1 active.
[exec1: true]
--- Lich: exec1 has exited.
```

and handling a nil case
```ruby
>;e echo GameObj.pcs.first.type.nil?
--- Lich: exec1 active.
[exec1: true]
--- Lich: exec1 has exited.

>;e echo GameObj.pcs.first.type?('poop')
--- Lich: exec1 active.
[exec1: false]
--- Lich: exec1 has exited.
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `type?` method to `GameObj` in `gameobj.rb` for explicit type checks, improving readability and handling `nil` types.
> 
>   - **Behavior**:
>     - Adds `type?` method to `GameObj` class in `gameobj.rb` for explicit type checks.
>     - `type?` checks if a given type exists in the object's type list, handling `nil` by converting to an empty string.
>   - **Usage**:
>     - Allows checking types using strings or regex, e.g., `type?('magic')` or `type?(/unc/)`.
>     - Improves readability and reduces regex usage for type checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for d5135d333b8a605f1b1c170324e0d00b3aba75c2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->