### PR TITLE
fix(gs): Various CMan cost corrections

### DIFF
--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -571,7 +571,7 @@ module Lich
         "surge_of_strength"      => {
           :short_name          => "surge",
           :type                => :buff,
-          :cost                => Lich::Util.normalize_lookup('Cooldowns', 'surge_of_strength') ? 60 : 30,
+          :cost                => { stamina: Lich::Util.normalize_lookup('Cooldowns', 'surge_of_strength') ? 60 : 30 },
           :regex               => /You focus deep within yourself, searching for untapped sources of strength\./,
           :usage               => "surge",
           "ignorable_cooldown" => true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects the `cost` attribute for the `swiftkick` maneuver in `cman.rb` to `{ stamina: 7 }`.
> 
>   - **Behavior**:
>     - Corrects the `cost` attribute for the `swiftkick` maneuver in `cman.rb` from `7` to `{ stamina: 7 }`.
>   - **Misc**:
>     - No other changes or additions were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 82203ca24a9c2472946f10cda966c51950c0db65. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->