### PR TITLE
fix(dr): Tighten checks on releasing invisibility for thieves

### DIFF
--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -478,7 +478,7 @@ module Lich
 
         # handle khri silence as it's not part of base-spells data, and method of ending it differs from spells
         bput('khri stop silence', 'You attempt to relax') if DRSpells.active_spells.keys.include?('Khri Silence')
-        bput('khri stop vanish', /^You would need to start Vanish/, /^Your control over the limited subversion of reality falters/) if DRStats.guild == "Thief"
+        bput('khri stop vanish', /^You would need to start Vanish/, /^Your control over the limited subversion of reality falters/, /^You are not trained in the Vanish meditation/) if (DRStats.guild == "Thief" && invisible?)
       end
 
       def check_encumbrance(refresh = true)


### PR DESCRIPTION
Adds match for the case where the Thief doesn't know Khri Vanish, and only tries to stop Vanish if the Thief is actually invisible.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `release_invisibility` in `common.rb` to only stop `Khri Vanish` if the Thief is invisible and knows the meditation.
> 
>   - **Behavior**:
>     - In `release_invisibility` in `common.rb`, added check to only stop `Khri Vanish` if the Thief is invisible and knows the meditation.
>     - Prevents unnecessary `khri stop vanish` command when Thief is not invisible or lacks the meditation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 21609126fdc3dd6d9f9dd4225fbe3ab7003c858d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->