### PR TITLE
fix(gs): force PROFILE FULL to sync CHE info for infomon

### DIFF
--- a/lib/gemstone/infomon/cli.rb
+++ b/lib/gemstone/infomon/cli.rb
@@ -39,7 +39,8 @@ module Lich
         end
         respond 'Requested Infomon sync complete.'
         respond 'ATTENTION:  TEND TO YOUR SHROUD!' if shroud_detected
-        Infomon.set('infomon.last_sync', Time.now.to_i)
+        Infomon.set('infomon.last_sync_date', Time.now.to_i)
+        Infomon.set('infomon.last_sync_version', LICH_VERSION)
       end
 
       def self.redo!
@@ -70,7 +71,10 @@ module Lich
       def self.db_refresh_needed?
         # Change date below to the last date of infomon.db structure change to allow for a forced reset of data.
         # Change Lich version below to also force a refresh of DB as well due to new API/methods used by infomon (introduction of CHE and account subscription status for example).
-        Infomon.get("infomon.last_sync").nil? || Infomon.get("infomon.last_sync") < Time.new(2025, 6, 26, 20, 0, 0).to_i || Gem::Version.new("5.12.2") > Gem::Version.new(Lich.core_updated_with_lich_version)
+        return true if Infomon.get("infomon.last_sync_date").nil?
+        return true if Infomon.get("infomon.last_sync_date") < Time.new(2025, 6, 26, 20, 0, 0).to_i
+        return true if Gem::Version.new("5.12.2") > Gem::Version.new(Infomon.get("infomon.last_sync_version"))
+        return false
       end
     end
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance Infomon sync by adding 'profile full' command and updating sync tracking to include date and version in `cli.rb`.
> 
>   - **Behavior**:
>     - Added 'profile full' command to `sync` method in `cli.rb` to ensure complete synchronization.
>     - Updated sync tracking in `sync` method to store `infomon.last_sync_date` and `infomon.last_sync_version`.
>   - **Sync Logic**:
>     - `db_refresh_needed?` method in `cli.rb` now checks both `infomon.last_sync_date` and `infomon.last_sync_version` to determine if a refresh is needed.
>   - **Misc**:
>     - Renamed `infomon.last_sync` to `infomon.last_sync_date` in `cli.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7945daaa46e835ecfb8dee5790eb6c3f7dff81ff. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->