### PR TITLE
fix(gs): infomon parser.rb for profile full name matching

### DIFF
--- a/lib/gemstone/infomon/parser.rb
+++ b/lib/gemstone/infomon/parser.rb
@@ -443,7 +443,7 @@ module Lich
               :ok
             when Pattern::ProfileName
               match = Regexp.last_match
-              if State.get.eql?(State::Profile) && match[:name].split(' ').last != Char.name
+              if State.get.eql?(State::Profile) && !match[:name].split(' ').include?(Char.name)
                 State.set(State::Ready)
                 :ok
               else


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes profile full name matching in `parse()` in `parser.rb` by checking if `Char.name` is included in the profile name.
> 
>   - **Behavior**:
>     - Fixes profile full name matching in `parse()` in `parser.rb` by checking if `Char.name` is included in `match[:name]` instead of comparing the last name part.
>   - **State Management**:
>     - Sets state to `Ready` if `Char.name` is not included in the profile name during profile parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 89c35a6c4fa4622484818bd8379b82a3e090cb7e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->