### PR TITLE
fix(gs): standardize warcry.rb to match other PSMS

### DIFF
--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -13,7 +13,7 @@ module Lich
     class Warcry
       # Internal table of all warcry abilities.
       #
-      # @return [Hash<String, Hash>] Mapping from short name to metadata, including:
+      # @return [Hash<String, Hash>] Mapping from long name to metadata, including:
       #   - `:long_name` [String]
       #   - `:short_name` [String]
       #   - `:cost` [Integer]


### PR DESCRIPTION
Adjust Warcry to use long_name as hash key instead of short_name to match all other PSM tables.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `@@warcries` hash key from `short_name` to `long_name` in `warcry.rb` to standardize with other PSM tables.
> 
>   - **Behavior**:
>     - Change hash key in `@@warcries` from `short_name` to `long_name` in `warcry.rb`.
>     - Update `warcry_lookups` to map `long_name` to `psm` instead of `short_name`.
>   - **Misc**:
>     - Adjust warcry names in `@@warcries` to use `long_name` as key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 8fb9b95176811279fb13816eaeb7101d8f0fb3db. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->