### PR TITLE
fix(gs): infomon state reset on status prompt

### DIFF
--- a/lib/gemstone/infomon/xmlparser.rb
+++ b/lib/gemstone/infomon/xmlparser.rb
@@ -95,8 +95,10 @@ module Lich
           ReadyItemClear = /^Cleared your default (?<type>shield|(?:secondary |ranged )?weapon|ammo2? bundle|(?:secondary )?sheath)\.\r?\n?$/
           ReadyItemSet = /^Setting (?:an?|some) <a exist="(?<id>[^"]+)" noun="(?<noun>[^"]+)">(?<name>[^<]+)<\/a>(?<after> [^<]+)? to be your default (?<type>shield|(?:secondary |ranged )?weapon|ammo2? bundle|(?:secondary )?sheath)\.\r?\n?$/
 
+          StatusPrompt = /<prompt time="[0-9]+">/
+
           All = Regexp.union(NpcDeathMessage, Group_Short, Also_Here_Arrival, StowListOutputStart, StowListContainer, StowSetContainer1, StowSetContainer2,
-                             ReadyListOutputStart, ReadyListNormal, ReadyListAmmo2, ReadyListSheathsSet, ReadyListFinished, ReadyItemClear, ReadyItemSet)
+                             ReadyListOutputStart, ReadyListNormal, ReadyListAmmo2, ReadyListSheathsSet, ReadyListFinished, ReadyItemClear, ReadyItemSet, StatusPrompt)
         end
 
         def self.parse(line)
@@ -149,6 +151,9 @@ module Lich
             when Pattern::ReadyItemClear
               match = Regexp.last_match
               ReadyList.__send__("#{Lich::Util.normalize_name(match[:type].downcase)}=", nil)
+              :ok
+            when Pattern::StatusPrompt
+              Infomon::Parser::State.set(Infomon::Parser::State::Ready) unless Infomon::Parser::State.get.eql?(Infomon::Parser::State::Ready)
               :ok
             else
               :noop


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `StatusPrompt` handling in `xmlparser.rb` to reset state to `Ready` on status prompt match.
> 
>   - **Behavior**:
>     - Adds `StatusPrompt` regex to match `<prompt time="[0-9]+">` in `xmlparser.rb`.
>     - Updates `Pattern::All` to include `StatusPrompt`.
>     - In `parse(line)`, sets state to `Ready` on `StatusPrompt` match if not already `Ready`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 122a19bd5bf66c346d27b086442a515c455e2451. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->