### PR TITLE
fix(gs): change namespace accessors to Ruby 2.6 compatible

### DIFF
--- a/lib/gemstone/society.rb
+++ b/lib/gemstone/society.rb
@@ -166,7 +166,15 @@ require_relative 'societies/order_of_voln.rb'
 
 # This module provides a simple namespace for accessing society classes.
 module Lich::Gemstone::Societies
-  def self.voln = OrderOfVoln
-  def self.col = CouncilOfLight
-  def self.sunfist = GuardiansOfSunfist
+  def self.voln
+    OrderOfVoln
+  end
+
+  def self.col
+    CouncilOfLight
+  end
+
+  def self.sunfist
+    GuardiansOfSunfist
+  end
 end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change method definitions in `Lich::Gemstone::Societies` to multi-line syntax for Ruby 2.6 compatibility.
> 
>   - **Syntax Change**:
>     - In `Lich::Gemstone::Societies`, change method definitions `voln`, `col`, and `sunfist` from single-line to multi-line syntax for Ruby 2.6 compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for e4c81375aeea494e4543791bcce921f160cb6bc3. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->