### PR TITLE
fix(dr): drparser.rb to set ShowRoomID to on if turned off

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -364,6 +364,7 @@ module Lich
           when Pattern::RoomIDOff
             put("flag showroomid on")
             respond("Lich requires ShowRoomID to be ON for mapping to work, please do not turn this off.")
+            respond("If you wish to hide the Real ID#, you can toggle it off by doing ;display flaguid")
           else
             :noop
           end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds detection and automatic re-enabling of ShowRoomID in `drparser.rb` to ensure mapping functionality works.
> 
>   - **Behavior**:
>     - Adds `Pattern::RoomIDOff` to detect when room IDs are turned off in `drparser.rb`.
>     - Automatically executes `put("flag showroomid on")` and sends a response to keep ShowRoomID on for mapping.
>   - **Patterns**:
>     - New regex pattern `RoomIDOff` added to `Pattern` module in `drparser.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 2934c2e4832c270ef70b1c3f886f4d7ef95bd387. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->