### PR TITLE
fix(all): limitedarray.rb max_size increase

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -587,6 +587,7 @@ module Lich
         end
         @quiet = (args[:quiet] ? true : false)
         @downstream_buffer = LimitedArray.new
+        @downstream_buffer.max_size = 400
         @want_downstream = true
         @want_downstream_xml = false
         @want_script_output = false
@@ -986,6 +987,7 @@ module Lich
           @quiet = false
         end
         @downstream_buffer = LimitedArray.new
+        @downstream_buffer.max_size = 400
         @want_downstream = true
         @want_downstream_xml = false
         @upstream_buffer = LimitedArray.new


### PR DESCRIPTION
Increasing `@max_size` due to buffer usage utilizing LimitedArray and some game responses having more than 200 lines response (looking at you GS4 locksmith pool worker!)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase `@downstream_buffer.max_size` to 400 in `ExecScript` class to handle larger game responses in `lib/common/script.rb`.
> 
>   - **Behavior**:
>     - Increase `@downstream_buffer.max_size` to 400 in `ExecScript` class in `lib/common/script.rb` to handle larger game responses.
>   - **Context**:
>     - Addresses issues with buffer overflow due to responses exceeding 200 lines, particularly in GS4 locksmith pool worker scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 868e133b126e926f2f877062b20e03215dacd1c6. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->