### PR TITLE
fix(gs): GameObj targets for new Sailor's Grief tentacle npc

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -329,7 +329,7 @@ module Lich
           if (npc = @@npcs.find { |n| n.id == id })
             next if (npc.status =~ /dead|gone/i)
             next if (npc.name =~ /^animated\b/i && npc.name !~ /^animated slush/i)
-            next if (npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i)
+            next if (npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i && npc.name !~ /amaranthine kraken tentacle/i)
             a.push(npc)
           end
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `GameObj.targets` to include 'amaranthine kraken tentacle' NPCs as valid targets in `gameobj.rb`.
> 
>   - **Behavior**:
>     - Update `GameObj.targets` in `gameobj.rb` to include NPCs with name 'amaranthine kraken tentacle' as valid targets.
>     - Previously, NPCs with nouns matching `/^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i` were excluded unless their name matched `/amaranthine kraken tentacle/i`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for b92fa009f84e31c08aa536073379ef5c4a253bfe. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->