### PR TITLE
fix(dr): common-items.rb wear/remove messaging additions

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -119,6 +119,7 @@ module Lich
         /^You work your way into/,
         /^You are already wearing/,
         /^Gritting your teeth, you grip/,
+        /^You expertly sling the/,
         /put it on/, # weird clerical collar thing, trying to make it a bit generic
         /slide effortlessly onto your/,
         /^You carefully arrange/,
@@ -187,7 +188,8 @@ module Lich
         /slide themselves off of your/,
         /you manage to loosen/,
         /you unlace/,
-        /^You slam the heels/
+        /^You slam the heels/,
+        /^With masterful grace, you ready/
       ]
 
       REMOVE_ITEM_FAILURE_PATTERNS = [


### PR DESCRIPTION
Added support messaging for forester's longbow with a vibrant patch of clover around the grip:

>rem longb
With masterful grace, you ready the forester's longbow and call out, "Lirisa guide my strike, let no evil remain in sight!"
>wear longb
You expertly sling the forester's longbow over your shoulder, taking care to not dislodge the clover growths.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added support for forester's longbow with clover grip in `common-items.rb`, including new success patterns for wearing and removing the item.
> 
>   - **Behavior**:
>     - Added support for forester's longbow with clover grip in `common-items.rb`.
>     - New success pattern `/^You expertly sling the/` for wearing items.
>     - New success pattern `/^With masterful grace, you ready/` for removing items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 852a5a03d40a947846f32e937c6085553af3b13c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->