### PR TITLE
build(all): installer.yml use windows-2022

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   installer:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         ruby: ['3.4.4']


### PR DESCRIPTION
InnoSetup removed from 2025 image. Forcing use of 2022 for now until manual process can be setup to install and configure InnoSetup for use on 2025.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `installer.yml` to use `windows-2022` due to InnoSetup removal from the 2025 image.
> 
>   - **Workflow Change**:
>     - Updates `installer.yml` to use `windows-2022` instead of `windows-latest` due to InnoSetup removal from the 2025 image.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 35cb8b9981a8795f6d1f00bfce715ff1e3f8eacb. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->