### PR TITLE
fix(dr): games.rb - ignore UIDs for Frostbite mapping

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -442,7 +442,11 @@ module Lich
             process_room_information(alt_string)
 
             # Handle frontend-specific modifications
-            if $frontend =~ /genie|frostbite/i && alt_string =~ /^<streamWindow id='room' title='Room' subtitle=" - \[.*\] \((?:\d+|\*\*)\)"/
+            if $frontend =~ /genie/i && alt_string =~ /^<streamWindow id='room' title='Room' subtitle=" - \[.*\] \((?:\d+|\*\*)\)"/
+              alt_string.sub!(/] \((?:\d+|\*\*)\)/) { "]" }
+            end
+
+            if $frontend =~ /frostbite/i && alt_string =~ /^<streamWindow id='main' title='Story' subtitle=" - \[.*\] \((?:\d+|\*\*)\)"/
               alt_string.sub!(/] \((?:\d+|\*\*)\)/) { "]" }
             end
 


### PR DESCRIPTION
Requires usage of `--frostbite` flag on Lich startup for `$frontend` to be set appropriately.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `process_downstream_hooks` in `games.rb` to include 'frostbite' in frontend check, affecting room subtitle processing.
> 
>   - **Behavior**:
>     - Update `process_downstream_hooks` in `games.rb` to include 'frostbite' in frontend check for room subtitle processing.
>     - Affects room subtitle handling for 'frostbite' frontend, removing UID display in subtitles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7541d5464cb6d0865df4469de92f880cdce1b9e9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->