### PR TITLE
chore(all): improve database_adapter.rb (settings) error handling

### DIFF
--- a/lib/common/settings/database_adapter.rb
+++ b/lib/common/settings/database_adapter.rb
@@ -28,20 +28,38 @@ module Lich
       end
 
       def save_settings(script_name, settings, scope = ":")
-        blob = Sequel::SQL::Blob.new(Marshal.dump(settings))
-
-        if @table.where(script: script_name, scope: scope).count > 0
-          @table
-            .where(script: script_name, scope: scope)
-            .insert_conflict(:replace)
-            .update(hash: blob)
-        else
-          @table.insert(
-            script: script_name,
-            scope: scope,
-            hash: blob
-          )
+        unless settings.is_a?(Hash)
+          Lich::Messaging.msg("error", "--- Error: Report this - settings must be a Hash, got #{settings.class} ---")
+          Lich.log("--- Error: settings must be a Hash, got #{settings.class} from call initiated by #{script_name} ---")
+          Lich.log(settings.inspect)
+          return false
         end
+
+        begin
+          blob = Sequel::SQL::Blob.new(Marshal.dump(settings))
+        rescue => e
+          Lich::Messaging.msg("error", "--- Error: failed to serialize settings ---")
+          Lich.log("--- Error: failed to serialize settings ---")
+          Lich_log(e.message)
+          return false
+        end
+
+        begin
+          @table
+            .insert_conflict(target: [:script, :scope], update: { hash: blob })
+            .insert(script: script_name, scope: scope, hash: blob)
+          return true
+        rescue Sequel::DatabaseError => db_err
+          Lich::Messaging.msg("error", "--- Database error while saving settings ---")
+          Lich.log("--- Database error while saving settings ---")
+          Lich.log(db_err.message)
+        rescue => e
+          Lich::Messaging.msg("error", "--- Unexpected error while saving settings ---")
+          Lich.log("--- Unexpected error while saving settings ---")
+          Lich.log(e.backtrace)
+        end
+
+        false
       end
     end
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved error handling and conflict resolution in `save_settings` method of `database_adapter.rb`.
> 
>   - **Error Handling**:
>     - In `save_settings` in `database_adapter.rb`, added check to ensure `settings` is a `Hash`, logging error if not.
>     - Added rescue block for serialization errors, logging specific error message and returning `false`.
>     - Improved database error handling with specific logging for `Sequel::DatabaseError` and other exceptions.
>   - **Database Operations**:
>     - Replaced `insert_conflict(:replace)` with `insert_conflict(target: [:script, :scope], update: { hash: blob })` to handle conflicts more explicitly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7284c4358ffdfb4722745cc821223384e5b1f3fd. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->