### PR TITLE
fix(all): record PID at fe launch

### DIFF
--- a/lib/main/argv_options.rb
+++ b/lib/main/argv_options.rb
@@ -251,6 +251,7 @@ if (arg = ARGV.find { |a| (a == '-g') or (a == '--game') })
   else
     $frontend = 'unknown'
   end
+  $frontend_pid = Process.ppid unless @argv_options[:detachable_client] && !$frontend_pid.nil
 elsif ARGV.include?('--gemstone')
   if ARGV.include?('--platinum')
     $platinum = true
@@ -364,4 +365,5 @@ else
   @game_host, @game_port = nil, nil
   Lich.log "info: no force-mode info given"
 end
+
 # rubocop:enable Lint/UselessAssignment

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -311,7 +311,9 @@ reconnect_if_wanted = proc {
           Dir.chdir(custom_launch_dir)
         end
 
-        spawn launcher_cmd
+        frontend_pid = spawn(launcher_cmd)
+        Process.detach(wrayth_pid)
+        $frontend_pid = frontend_pid
       rescue
         Lich.log "error: #{$!.to_s.sub(game_key.to_s, '[scrubbed key]')}\n\t#{$!.backtrace.join("\n\t")}"
         Lich.msgbox(:message => "error: #{$!.to_s.sub(game_key.to_s, '[scrubbed key]')}", :icon => :error)

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -755,6 +755,13 @@ reconnect_if_wanted = proc {
               }
             end
             while (client_string = $_DETACHABLE_CLIENT_.gets)
+              # --------------------------------------------------------------
+              # Profanity / FrostBite handshake:  SET_FRONTEND_PID <pid>
+              if client_string =~ /^SET_FRONTEND_PID\s+(\d+)\s*$/
+                $frontend_pid = $1.to_i
+                next # swallow the control line; don't pass it to do_client
+              end
+              # --------------------------------------------------------------
               client_string = "#{$cmd_prefix}#{client_string}" # if $frontend =~ /^(?:wizard|avalon)$/
               begin
                 $_IDLETIMESTAMP_ = Time.now

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -13,6 +13,12 @@ if RUBY_PLATFORM =~ /mingw|mswin/ && !defined?(Win32Enum)
   end
 end
 
+def windows_parent_pid(wmi, p)
+  rows  = wmi.ExecQuery("SELECT ParentProcessId FROM Win32_Process WHERE ProcessId=#{p}")
+  row   = rows.each.first rescue nil
+  row ? row.ParentProcessId.to_i : 0
+end
+
 module FrontendPID
   extend self
 
@@ -37,8 +43,7 @@ module FrontendPID
         return p if found
 
         # climb to parent
-        parent = nil
-        wmi.ExecQuery("SELECT ParentProcessId FROM Win32_Process WHERE ProcessId=#{p}").each { |row| parent = row.ParentProcessId.to_i; break }
+        parent = windows_parent_pid(wmi, p)
         break if parent.nil? || parent.zero? || parent == p
         p = parent
       end

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -312,7 +312,7 @@ reconnect_if_wanted = proc {
         end
 
         frontend_pid = spawn(launcher_cmd)
-        Process.detach(wrayth_pid)
+        Process.detach(frontend_pid)
         $frontend_pid = frontend_pid
       rescue
         Lich.log "error: #{$!.to_s.sub(game_key.to_s, '[scrubbed key]')}\n\t#{$!.backtrace.join("\n\t")}"


### PR DESCRIPTION
Records pid to $frontend_pid at fe launch to be used in refocusing window.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Records frontend process ID at launch in `main.rb` for potential refocusing operations.
> 
>   - **Behavior**:
>     - Records frontend process ID (`$frontend_pid`) at launch in `main.rb`.
>     - Uses `spawn` to launch frontend and `Process.detach` to allow independent execution.
>   - **Error Handling**:
>     - Logs errors with scrubbed game keys if frontend launch fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for e105fa6c63235b05d00cfd25fdabd3fa4d319f7c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->