### PR TITLE
fix(gs): weapon.rb assault break if no targets

### DIFF
--- a/lib/gemstone/psms/weapon.rb
+++ b/lib/gemstone/psms/weapon.rb
@@ -334,7 +334,7 @@ module Lich
             end
             break if usage_result.eql?(false)
             break if usage_result =~ technique[:assault_rx]
-            break if usage_result =~ /^#{name} what\?$/i,
+            break if usage_result =~ /^#{name} what\?$/i
             break if usage_result =~ in_cooldown_regex
             break if Time.now() > break_out
             sleep 0.25


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `Weapon.use` in `weapon.rb` to handle no target case and improve loop clarity with individual `break` statements.
> 
>   - **Behavior**:
>     - In `Weapon.use` in `weapon.rb`, refactor loop to handle no target case by breaking on `^#{name} what\?$` regex.
>     - Replace `elsif` conditions with individual `break` statements for clarity.
>     - Handles cases where `usage_result` is `false`, matches `technique[:assault_rx]`, matches `in_cooldown_regex`, or exceeds `break_out` time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for af2b7b40cf88f6be03dfb052a946371f1f102773. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->