### PR TITLE
fix(gs): stowlist.rb wait for RT when issuing check

### DIFF
--- a/lib/gemstone/stowlist.rb
+++ b/lib/gemstone/stowlist.rb
@@ -63,6 +63,7 @@ module Lich
           else
             start_pattern = /You have the following containers set as stow targets:/
           end
+          waitrt?
           Lich::Util.issue_command("stow list", start_pattern, silent: silent, quiet: quiet)
           @checked = true
         end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `waitrt?` call in `StowList#check` to wait for roundtime before issuing `stow list` command in `stowlist.rb`.
> 
>   - **Behavior**:
>     - Adds `waitrt?` call in `check` method of `StowList` class in `stowlist.rb` to wait for roundtime before issuing `stow list` command.
>   - **Misc**:
>     - No changes to other methods or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for e8e232f899d37e57fb9785fa2ba94c753ae764b4. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->