### PR TITLE
fix(gs): readylist.rb wait for RT when issuing check

### DIFF
--- a/lib/gemstone/readylist.rb
+++ b/lib/gemstone/readylist.rb
@@ -57,6 +57,7 @@ module Lich
           else
             start_pattern = /Your current settings are:/
           end
+          waitrt?
           Lich::Util.issue_command("ready list", start_pattern, silent: silent, quiet: quiet)
           @checked = true
         end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `waitrt?` call in `check` method of `ReadyList` to ensure readiness before issuing command.
> 
>   - **Behavior**:
>     - Adds `waitrt?` call in `check` method of `ReadyList` class in `readylist.rb` to ensure readiness before issuing "ready list" command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 8b62695c4d6dd5d9fa367fe55dfdd2099dfb83bc. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->