### PR TITLE
feat(dr): support meta:trashcan tag for DRCI.dispose_trash

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -441,19 +441,19 @@ module Lich
 
         # Check for meta:trashcan tag on the room to identify a specific trashcan to use.
         if Room.current.tags.find { |t| t =~ /meta:trashcan:(.*)/ }
-          trashcan = Regexp.last_match(1)
+          metatag_trashcan = Regexp.last_match(1)
 
           # Gelapod needs special handling since you feed it, and it disappears in winter
-          trash_command = nil
-          if trashcan == 'gelapod'
-            trash_command = "feed my #{item} to gelapod" if DRRoom.room_objs.include?('gelapod')
+          metatag_trash_command = nil
+          if metatag_trashcan == 'gelapod'
+            metatag_trash_command = "feed my #{item} to gelapod" if DRRoom.room_objs.include?('gelapod')
           else
-            trash_command = "put my #{item} in #{trashcan}"
+            metatag_trash_command = "put my #{item} in #{metatag_trashcan}"
           end
 
           # gelapod is not here - probably winter move on to next attempt to get rid of
-          unless trash_command.nil?
-            case DRC.bput(trash_command, DROP_TRASH_SUCCESS_PATTERNS, DROP_TRASH_FAILURE_PATTERNS, DROP_TRASH_RETRY_PATTERNS, /^Perhaps you should be holding that first/)
+          unless metatag_trash_command.nil?
+            case DRC.bput(metatag_trash_command, DROP_TRASH_SUCCESS_PATTERNS, DROP_TRASH_FAILURE_PATTERNS, DROP_TRASH_RETRY_PATTERNS, /^Perhaps you should be holding that first/)
             when *DROP_TRASH_SUCCESS_PATTERNS
               return true
             when *DROP_TRASH_FAILURE_PATTERNS

--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -467,7 +467,7 @@ module Lich
             end
           end
         end
-        
+
         trashcans = DRRoom.room_objs
                           .reject { |obj| obj =~ /azure \w+ tree/ }
                           .map { |long_name| DRC.get_noun(long_name) }


### PR DESCRIPTION
+ Minor code refactor to align case statement logic
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `meta:trashcan` tag in `dispose_trash` and refactors case logic in `common-items.rb`.
> 
>   - **Behavior**:
>     - Adds support for `meta:trashcan` tag in `dispose_trash` to identify specific trashcans.
>     - Handles 'gelapod' trashcan with special command `feed my item to gelapod`.
>   - **Refactor**:
>     - Reorders case patterns in `dispose_trash` for better logic flow.
>     - Adds NOOP comments for failure patterns in `dispose_trash`.
>   - **Misc**:
>     - Minor code refactor for clarity in `common-items.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 263337daf5d8e87eb22ac8db46064bd4ddbdddc8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->