### PR TITLE
fix(all): games.rb show CUSTOM in script cmd echos if custom script

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -242,7 +242,7 @@ module Lich
           if Script.current&.file_name
             script_name = "#{Pathname.new(Script.current&.file_name).expand_path.dirname.basename.to_s == 'custom' ? 'custom/' : ''}#{Script.current&.name}"
           else
-            script_name = '(unknown script)'
+            script_name = Script.current&.name || '(unknown script)'
           end
           $_CLIENTBUFFER_.push "[#{script_name}]#{$SEND_CHARACTER}#{$cmd_prefix}#{str}\r\n"
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> In `lib/games.rb`, the `puts` method now prepends 'custom/' to script names in command echos if the script is in a 'custom' directory.
> 
>   - **Behavior**:
>     - In `lib/games.rb`, the `puts` method now prepends 'custom/' to the script name if the script is in a 'custom' directory.
>     - This change affects command echo outputs, providing more context for custom scripts.
>   - **Misc**:
>     - No other files or functionalities are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7e4ef48346f45f90824093dc240830a74b1dc352. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->