### PR TITLE
fix(dr): common-arcana.rb Regalia fix for changed game output.

### DIFF
--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -497,20 +497,11 @@ module Lich
       def parse_regalia # generates an array of currently-worn regalia armor nouns
         return unless DRStats.trader?
 
-        DRC.bput('inv armor', 'Use INVENTORY HELP for more options')
-        snapshot = reget(40)
-        if snapshot.grep(/All of your armor|You aren't wearing anything like that/).any? && snapshot.grep(/Use INVENTORY HELP/).any?
-          snapshot
-            .map(&:strip)
-            .reverse
-            .take_while { |item| !['All of your armor:', "You aren't wearing anything like that."].include?(item) }
-            .drop_while { |item| item != '[Use INVENTORY HELP for more options.]' }
-            .drop(1)
-            .select { |item| item.include?('rough-cut crystal') || item.include?('faceted crystal') || item.include?('resplendent crystal') }
-            .map { |item| DRC.get_noun(item) }
-        else
-          parse_regalia
-        end
+        snapshot = Lich::Util.issue_command("inv combat", /All of your worn combat|You aren't wearing anything like that/, /Use INVENTORY HELP for more options/, usexml: false, include_end: false)
+                             .map(&:strip)
+        snapshot = snapshot - ["All of your worn combat equipment:", "You aren't wearing anything like that."]
+        snapshot.select { |item| item.include?('rough-cut crystal') || item.include?('faceted crystal') || item.include?('resplendent crystal') }
+                .map { |item| DRC.get_noun(item) }
       end
 
       def shatter_regalia?(worn_regalia = nil) # takes an array of armor nouns to remove or gets its own from parse_regalia

--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -499,8 +499,7 @@ module Lich
 
         snapshot = Lich::Util.issue_command("inv combat", /All of your worn combat|You aren't wearing anything like that/, /Use INVENTORY HELP for more options/, usexml: false, include_end: false)
                              .map(&:strip)
-        snapshot = snapshot - ["All of your worn combat equipment:", "You aren't wearing anything like that."]
-        snapshot.select { |item| item.include?('rough-cut crystal') || item.include?('faceted crystal') || item.include?('resplendent crystal') }
+        (snapshot - ["All of your worn combat equipment:", "You aren't wearing anything like that."]).select { |item| item.include?('rough-cut crystal') || item.include?('faceted crystal') || item.include?('resplendent crystal') }
                 .map { |item| DRC.get_noun(item) }
       end
 

--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -500,7 +500,7 @@ module Lich
         snapshot = Lich::Util.issue_command("inv combat", /All of your worn combat|You aren't wearing anything like that/, /Use INVENTORY HELP for more options/, usexml: false, include_end: false)
                              .map(&:strip)
         (snapshot - ["All of your worn combat equipment:", "You aren't wearing anything like that."]).select { |item| item.include?('rough-cut crystal') || item.include?('faceted crystal') || item.include?('resplendent crystal') }
-                .map { |item| DRC.get_noun(item) }
+                                                                                                     .map { |item| DRC.get_noun(item) }
       end
 
       def shatter_regalia?(worn_regalia = nil) # takes an array of armor nouns to remove or gets its own from parse_regalia


### PR DESCRIPTION
Updated parse_regalia to use issue_command and accommodate new game output.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `parse_regalia` in `common-arcana.rb` to use `Lich::Util.issue_command` for new game output format, simplifying logic.
> 
>   - **Behavior**:
>     - Update `parse_regalia` in `common-arcana.rb` to use `Lich::Util.issue_command` instead of `DRC.bput` and `reget`.
>     - Adjust logic to accommodate new game output format, removing unnecessary checks and directly filtering relevant items.
>   - **Misc**:
>     - Simplifies logic by removing redundant checks for 'All of your armor' and 'You aren't wearing anything like that'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for ff93450fe2e8e6c7cdbb288c67f6f07f4928a4df. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->