### PR TITLE
fix(all): update.rb word boundary for abbreviations

### DIFF
--- a/lib/update.rb
+++ b/lib/update.rb
@@ -14,21 +14,21 @@ module Lich
 
       def self.request(type = '--announce')
         case type
-        when /^--announce\b|^-a\b/
+        when /^(?:--announce|-a)\b/
           self.announce
         when /^--(?:beta|test)(?: --(?:(script|library|data))=(.+))?\b/
           self.prep_betatest($1.dup, $2.dup)
-        when /^--help\b|^-h\b/
+        when /^(?:--help|-h)\b/
           self.help # Ok, that's just wrong.
-        when /^--update\b|^-u\b/
+        when /^(?:--update|-u)\b/
           self.download_update
         when /^--refresh\b/
           respond; respond "This command has been removed."
-        when /^--revert\b|^-r\b/
+        when /^(?:--revert|-r)\b/
           self.revert
         when /^--(?:(script|library|data))=(.+)\b/
           self.update_file($1.dup, $2.dup)
-        when /^--snapshot\b|^-s\b/ # this one needs to be after --script
+        when /^(?:--snapshot|-s)\b/ # this one needs to be after --script
           self.snapshot
         else
           respond; respond "Command '#{type}' unknown, illegitimate and ignored.  Exiting . . ."; respond


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update regex patterns in `lib/update.rb` to ensure command-line options are matched as whole words.
> 
>   - **Behavior**:
>     - Update regex patterns in `request` method in `lib/update.rb` to use word boundaries for command-line options.
>     - Ensures options like `--announce`, `--beta`, `--help`, `--update`, `--refresh`, `--revert`, `--script`, `--library`, `--data`, and `--snapshot` are matched as whole words.
>   - **Misc**:
>     - Minor adjustments to regex patterns to prevent partial matches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 06f2c6aefed7a2577d0b60e06f69363657132783. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->