### PR TITLE
fix(gs): Bounty heirloom return msg'ing update

### DIFF
--- a/lib/gemstone/bounty/parser.rb
+++ b/lib/gemstone/bounty/parser.rb
@@ -28,7 +28,7 @@ module Lich
           :rescue_assignment   => /#{HMM_REGEX}It appears that a local resident urgently needs our help in some matter/,
           :skin_assignment     => /#{HMM_REGEX}The local furrier (?<npc_name>.+) has an order to fill and wants our help/,
           :taskmaster          => /^You have succeeded in your task and can return to the Adventurer's Guild/,
-          :heirloom_found      => /^You have located (?:an?|some) (?<item>.+) and should bring it back to #{GUARD_REGEX}\.$/,
+          :heirloom_found      => /^You have located (?:an?|some) (?<item>.+) and should bring (?:it back|your find) to #{GUARD_REGEX}\.$/,
           :guard               => /^You succeeded in your task and should report back to #{GUARD_REGEX}\.$/,
           :dangerous_spawned   => /^You have been tasked to hunt down and kill a particularly dangerous (?<creature>[^.]+) that has established a territory #{LOCATION_REGEX}\.  You have provoked (?:his|her|its) attention and now you must(?: return to where you left (?:him|her|it) and)? kill (?:him|her|it)!$/,
           :rescue_spawned      => /^You have made contact with the child you are to rescue and you must get (?:him|her) back alive to #{GUARD_REGEX}\.$/,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update regex in `parser.rb` to handle additional phrasing for `:heirloom_found` task descriptions.
> 
>   - **Behavior**:
>     - Update regex for `:heirloom_found` in `TASK_MATCHERS` in `parser.rb` to match both "bring it back" and "bring your find" phrasing.
>   - **Misc**:
>     - No other changes or additions in the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 0417f581ba79c5eb0b2d64b46b6d75279f9bb380. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->