### PR TITLE
fix(dr): common-items.rb Fix for changed inventory command output

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -503,7 +503,7 @@ module Lich
       #########################################
 
       def search?(item)
-        /Your .* is in/ =~ DRC.bput("inv search #{item}", /^You can't seem to find anything/, /Your .* is in/)
+        /(?:An?|Some) .+ is (?:in|being)/ =~ DRC.bput("inv search #{item}", /^You can't seem to find anything/, /(?:An?|Some) .+ is (?:in|being)/)
       end
 
       # Taps items to check if you're wearing it.


### PR DESCRIPTION
As per title.

It now also allows for returning without hanging on worn items that match our search.