### PR TITLE
fix(gs): activespell.rb prevent removal of RF Penalty

### DIFF
--- a/lib/gemstone/infomon/activespell.rb
+++ b/lib/gemstone/infomon/activespell.rb
@@ -125,7 +125,7 @@ module Lich
 
           existing_spell_names = []
           active_spells = Spell.active
-          ignore_spells = ["Berserk", "Council Task", "Council Punishment", "Briar Betrayer"]
+          ignore_spells = ["Berserk", "Council Task", "Council Punishment", "Briar Betrayer", "Rapid Fire Penalty"]
           active_spells.each { |s| existing_spell_names << s.name }
           inactive_spells = existing_spell_names - ignore_spells - spell_update_names
           inactive_spells.reject! do |s|


### PR DESCRIPTION
Due to the 515 Rapid Fire penalty not being tracked by SPELL ACTIVE, prevent the effect-list.xml capture/monitor if it from being cleared from Effects module.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents 'Rapid Fire Penalty' from being removed in `update_spell_durations` by adding it to the ignore list in `activespell.rb`.
> 
>   - **Behavior**:
>     - Prevents removal of 'Rapid Fire Penalty' from active spells in `update_spell_durations` in `activespell.rb` by adding it to `ignore_spells` list.
>   - **Misc**:
>     - No changes to other functionalities or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 1b48064a1bd009ab39a9e441fa3d22a9e8f02cec. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->