### PR TITLE
fix(gs): add .compact to input of Disk.find_by_name

### DIFF
--- a/lib/gemstone/group.rb
+++ b/lib/gemstone/group.rb
@@ -45,7 +45,7 @@ module Lich
 
       def self.disks
         return [Disk.find_by_name(Char.name)].compact if Group.leader? && members.empty?
-        member_disks = members.map(&:noun).map { |noun| Disk.find_by_name(noun) }.compact
+        member_disks = members.map(&:noun).compact.map { |noun| Disk.find_by_name(noun) }.compact
         member_disks.push(Disk.find_by_name(Char.name)) if Disk.find_by_name(Char.name)
         return member_disks
       end


### PR DESCRIPTION
add .compact to input of Disk.find_by_name to prevent nil values being input

Could possibly happen from losing a group member but group not updating before the find_by_name check