### PR TITLE
fix(dr): drparser.rb update for PlayedSubscription

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -341,10 +341,11 @@ module Lich
               Account.name = Regexp.last_match[:account].upcase
             end
           when Pattern::PlayedSubscription
+            matches = Regexp.last_match
             if Account.subscription.nil?
-              Account.subscription = Regexp.last_match[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').gsub('Platinum', 'Premium').upcase
+              Account.subscription = matches[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').gsub('Platinum', 'Premium').upcase
             end
-            UserVars.account_type = Regexp.last_match[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').upcase
+            UserVars.account_type = matches[:subscription].gsub('Basic', 'Normal').gsub('F2P', 'Free').upcase
             if Account.subscription == 'PREMIUM' || XMLData.game == 'DRX' || XMLData.game == 'DRF'
               UserVars.premium = true
             else


### PR DESCRIPTION
Fixes issue with reuse of Regexp.last_match after gsub use
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `Regexp.last_match` reuse issue in `parse()` in `drparser.rb` by storing match data in a variable before `gsub` operations.
> 
>   - **Behavior**:
>     - Fixes issue with `Regexp.last_match` reuse after `gsub` in `parse()` in `drparser.rb`.
>     - Stores `Regexp.last_match` in `matches` variable before `gsub` operations for `Pattern::PlayedSubscription`.
>   - **Misc**:
>     - No changes to other parts of the code or additional files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for d00e312456dbacab16a14fc723e05ded42fe81bd. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->