### PR TITLE
fix(gs): gameobj.rb for Sailor's Grief ghostly/boss/guild tentacles

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -329,7 +329,7 @@ module Lich
           if (npc = @@npcs.find { |n| n.id == id })
             next if (npc.status =~ /dead|gone/i)
             next if (npc.name =~ /^animated\b/i && npc.name !~ /^animated slush/i)
-            next if (npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i && npc.name !~ /amaranthine kraken tentacle/i)
+            next if (npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i && npc.name !~ /(?:amaranthine|ghostly|grizzled|ancient) kraken tentacle/i)
             a.push(npc)
           end
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `GameObj.targets` in `gameobj.rb` to include more kraken tentacle types in the exclusion list for NPC targets.
> 
>   - **Behavior**:
>     - Update regex in `GameObj.targets` to include `ghostly`, `grizzled`, and `ancient` kraken tentacles in the exclusion list for NPC targets.
>     - Ensures these specific tentacle types are not mistakenly filtered out as targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7ad6335321ed95be9d17609a64b4e01993873967. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->