### PR TITLE
fix(all): script.rb show custom at script exit as well

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -667,7 +667,7 @@ module Lich
                 @at_exit_procs.each { |p| report_errors { p.call } }
                 @die_with = @at_exit_procs = @downstream_buffer = @upstream_buffer = @match_stack_labels = @match_stack_strings = nil
                 @@running.delete(self)
-                respond("--- Lich: #{@name} has exited.") unless @quiet
+                respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.") unless @quiet
                 GC.start
               rescue
                 respond "--- Lich: error: #{$!}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance script exit message in `script.rb` to include 'custom/' prefix for custom scripts.
> 
>   - **Behavior**:
>     - In `kill` method of `Script` class in `script.rb`, exit message now includes 'custom/' prefix if the script is custom.
>   - **Misc**:
>     - Minor change to the exit message format for better clarity on script type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 592d0e08c366efff8246865286ec8938ab26c96f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->