### PR TITLE
fix(all): Updated update.rb for single trunk and release please

### DIFF
--- a/lib/update.rb
+++ b/lib/update.rb
@@ -279,8 +279,18 @@ module Lich
         end
       end
 
-      def self.version_key(tag)
-        Gem::Version.new(tag.to_s.sub(/^v/, '').gsub('-beta.', '.beta.'))
+      def self.version_key(tag_or_name)
+        s = tag_or_name.to_s
+        # strip leading 'v'
+        s = s.sub(/^v/, '')
+        # if this looks like a branch or path (e.g., "pre/beta/5.15.0" or "pre/beta-5.15.0"),
+        # extract the first version-looking substring to avoid prefix text interfering
+        if s =~ /(\d+\.\d+(?:\.\d+)?(?:-[0-9A-Za-z\.]+)?)/ # captures 1.2 or 1.2.3 and optional suffix like -beta.
+          s = Regexp.last_match(1)
+        end
+        # normalize beta prerelease so beta.10 > beta.9
+        s = s.gsub('-beta.', '.beta.').gsub(/-beta(?!\.)/, '.beta')
+        Gem::Version.new(s)
       end
 
       def self.major_minor_from(str)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `update.rb` with improved beta/stable ref resolution, GitHub API caching, and error handling.
> 
>   - **Behavior**:
>     - Updates `prep_betatest` and `prep_update` to resolve beta and stable refs using `resolve_channel_ref`.
>     - Adds in-memory cache for GitHub API responses with TTL of 60 seconds.
>     - Improves error handling for network issues in `fetch_github_json`.
>   - **Functions**:
>     - Adds `resolve_channel_ref`, `fetch_github_json`, `latest_stable_tag`, `latest_prerelease_tag_greater_than`, `latest_prefixed_branch_greater_than`, `version_key`, and `major_minor_from` for version and branch resolution.
>     - Modifies `update_file` to map `staging` and `master` to `production`.
>   - **Constants**:
>     - Defines `STABLE_REF`, `BETA_BRANCH_PREFIX`, and `ASSET_TARBALL_NAME` for channel and asset management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 960e7afdead8dab82ef3a6f2b95136f6d5951c21. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->