### PR TITLE
feat(gs): add creature module, including Hinterwilds creatures

### DIFF
--- a/lib/common/game-loader.rb
+++ b/lib/common/game-loader.rb
@@ -38,6 +38,7 @@ module Lich
         require File.join(LIB_DIR, 'gemstone', 'gift.rb')
         require File.join(LIB_DIR, 'gemstone', 'readylist.rb')
         require File.join(LIB_DIR, 'gemstone', 'stowlist.rb')
+        require File.join(LIB_DIR, 'gemstone', 'creature.rb')
         ActiveSpell.watch!
         self.common_after
       end

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -746,6 +746,7 @@ module Lich
               if @active_tags.include?('a')
                 if @bold
                   GameObj.new_npc(@obj_exist, @obj_noun, text_string)
+                  Creature.register_creature(text_string, @obj_exist)
                 else
                   GameObj.new_loot(@obj_exist, @obj_noun, text_string)
                 end

--- a/lib/gemstone/creature.rb
+++ b/lib/gemstone/creature.rb
@@ -1,0 +1,594 @@
+require 'singleton'
+require 'ostruct'
+module Lich
+  module Gemstone
+    class Creature
+      module Template
+        BOON_ADJECTIVES = %w[
+          adroit afflicted apt barbed belligerent blurry canny combative dazzling deft diseased drab
+          dreary ethereal flashy flexile flickering flinty frenzied ghastly ghostly gleaming glittering
+          glorious glowing grotesque hardy illustrious indistinct keen lanky luminous lustrous muculent
+          nebulous oozing pestilent radiant raging ready resolute robust rune-covered shadowy shifting
+          shimmering shining sickly green sinous slimy sparkling spindly spiny stalwart steadfast stout
+          tattoed tenebrous tough twinkling unflinching unyielding wavering wispy
+        ]
+
+        @template_cache ||= {}
+        @missing_templates ||= Set.new
+
+        def self.fix_template_name(template_name)
+          name = template_name.dup.downcase
+          BOON_ADJECTIVES.each { |adj| name.sub!(/^#{Regexp.escape(adj)}\s+/i, '') }
+          name.strip.gsub(/\s+/, '_')
+        end
+
+        def self.load(template_name)
+          key = fix_template_name(template_name)
+
+          return nil if @missing_templates.include?(key)
+          return @template_cache[key] if @template_cache.key?(key)
+
+          base_dir = File.join(File.dirname(__FILE__), 'creatures')
+          paths = [
+            File.join(base_dir, "#{key}.rb"),
+            File.join(base_dir, "#{template_name.strip.downcase.gsub(/\s+/, '_')}.rb")
+          ]
+
+          path = paths.find { |p| File.exist?(p) }
+
+          unless path
+            puts "--- error: Template file not found for: #{template_name}"
+            @missing_templates << key
+            return nil
+          end
+
+          @template_cache[key] = eval(File.read(path))
+        rescue => e
+          puts "--- error loading template #{template_name}: #{e.message}"
+          @missing_templates << key
+          nil
+        end
+      end
+
+      class SpecialAbility
+        attr_accessor :name, :note
+
+        def initialize(data)
+          @name = data[:name]
+          @note = data[:note]
+        end
+      end
+
+      class Treasure
+        def initialize(data = {})
+          @data = {
+            coins: false,
+            gems: false,
+            boxes: false,
+            skin: nil,
+            magic_items: nil,
+            other: nil,
+            blunt_required: false
+          }.merge(data)
+        end
+
+        def has_coins? = !!@data[:coins]
+        def has_gems? = !!@data[:gems]
+        def has_boxes? = !!@data[:boxes]
+        def has_skin? = !!@data[:skin]
+        def blunt_required? = !!@data[:blunt_required]
+
+        def to_h = @data
+      end
+
+      class Messaging
+        attr_accessor :description, :arrival, :flee, :death,
+                      :spell_prep, :frenzy, :sympathy, :bite,
+                      :claw, :attack, :enrage, :mstrike
+
+        PLACEHOLDER_MAP = {
+          Pronoun: %w[He Her His It She],
+          pronoun: %w[he her his it she],
+          direction: %w[north south east west up down northeast northwest southeast southwest],
+          weapon: %w[RAW:.+?]
+        }
+
+        def initialize(data)
+          data.each do |key, value|
+            instance_variable_set("@#{key}", normalize(value))
+          end
+        end
+
+        def normalize(value)
+          if value.is_a?(Array)
+            value.map { |v| normalize(v) }
+          elsif value.is_a?(String) && value.match?(/\{[a-zA-Z_]+\}/)
+            phs = value.scan(/\{([a-zA-Z_]+)\}/).flatten.map(&:to_sym)
+            placeholders = phs.map { |ph| [ph, PLACEHOLDER_MAP[ph] || []] }.to_h
+            PlaceholderTemplate.new(value, placeholders)
+          else
+            value
+          end
+        end
+
+        def display(field, subs = {})
+          msg = send(field)
+          if msg.is_a?(Array)
+            msg.map { |m| m.is_a?(PlaceholderTemplate) ? m.to_display(subs) : m }.join("\n")
+          elsif msg.is_a?(PlaceholderTemplate)
+            msg.to_display(subs)
+          else
+            msg
+          end
+        end
+
+        def match(field, str)
+          msg = send(field)
+          if msg.is_a?(PlaceholderTemplate)
+            msg.match(str)
+          else
+            msg == str ? {} : nil
+          end
+        end
+      end
+
+      class DefenseAttributes
+        attr_accessor :asg, :melee, :ranged, :bolt, :udf,
+                      :bar_td, :cle_td, :emp_td, :pal_td,
+                      :ran_td, :sor_td, :wiz_td, :mje_td, :mne_td,
+                      :mjs_td, :mns_td, :mnm_td, :immunities,
+                      :defensive_spells, :defensive_abilities, :special_defenses
+
+        def initialize(data)
+          @asg = data[:asg]
+          @melee = parse_td(data[:melee])
+          @ranged = parse_td(data[:ranged])
+          @bolt = parse_td(data[:bolt])
+          @udf = parse_td(data[:udf])
+
+          %i[bar_td cle_td emp_td pal_td ran_td sor_td wiz_td mje_td mne_td mjs_td mns_td mnm_td].each do |key|
+            instance_variable_set("@#{key}", parse_td(data[key]))
+          end
+
+          @immunities = data[:immunities] || []
+          @defensive_spells = data[:defensive_spells] || []
+          @defensive_abilities = data[:defensive_abilities] || []
+          @special_defenses = data[:special_defenses] || []
+        end
+
+        private
+
+        def parse_td(val)
+          return nil if val.nil?
+          return val if val.is_a?(Range)
+          return eval(val) if val.is_a?(String) && val.match?(/\A\d+\.\.\d+\z/)
+          val
+        end
+      end
+
+      class PlaceholderTemplate
+        # Initialize with a template string and a placeholder map.
+        # Example:
+        #   template = "A stunted halfling bloodspeaker utters ... around {pronoun} gnarled hands."
+        #   placeholders = { pronoun: %w[her his their] }
+        def initialize(template, placeholders = {})
+          @template = template
+          @placeholders = placeholders
+        end
+
+        # Returns the raw template string
+        def template
+          @template
+        end
+
+        # Returns the placeholder map (symbol keys, array of options)
+        def placeholders
+          @placeholders
+        end
+
+        # Substitute placeholders for display (e.g., pick user’s preference)
+        # Example: to_display(pronoun: "her")
+        def to_display(subs = {})
+          line = @template.dup
+          @placeholders.each do |key, options|
+            value = subs[key] || options.sample || ""
+            line.gsub!("{#{key}}", value.to_s)
+          end
+          line
+        end
+
+        # Compile a regex for matching
+        # Optionally pass a restricted set for each placeholder (default is all options)
+        def to_regex(literals = {})
+          if @template.is_a?(Array)
+            regexes = @template.map { |t| self.class.new(t, @placeholders).to_regex(literals) }
+            Regexp.union(*regexes)
+          else
+            pattern = Regexp.escape(@template)
+            @placeholders.each do |key, options|
+              if options == [:wildcard] || options.first&.start_with?('RAW:')
+                # Insert as raw regex, NOT escaped!
+                raw = options.first.start_with?('RAW:') ? options.first[4..-1] : options.first
+                pattern.gsub!(/\\\{#{key}\\\}/, raw)
+              else
+                # Use named capture group!
+                regex_group = "(?<#{key}>#{(literals[key] || options).map { |opt| Regexp.escape(opt) }.join('|')})"
+                pattern.gsub!(/\\\{#{key}\\\}/, regex_group)
+              end
+            end
+            Regexp.new("#{pattern}")
+          end
+        end
+
+        # Match a given string against this template’s regex
+        # Returns the matched groups as a hash if match, or nil
+        def match(str, literals = {})
+          regex = to_regex(literals)
+          m = regex.match(str)
+          return nil unless m
+          m.names.any? ? m.named_captures.transform_keys(&:to_sym) : m.captures
+        end
+      end
+
+      class Registry
+        include Singleton
+
+        def initialize
+          @creatures_by_id = {}
+          @creatures_by_name = {}
+        end
+
+        # Resets the registry data, clearing all creatures.
+        #
+        # @example
+        #   Registry.instance.reset_data
+        def reset_data
+          @creatures_by_id.clear
+          @creatures_by_name.clear
+        end
+
+        def add(creature)
+          @creatures_by_id[creature.id.to_i] ||= creature if creature.id
+          @creatures_by_name[creature.name.downcase] ||= creature if creature.name
+        end
+
+        # Retrieves all creatures in the registry.
+        #
+        # @return [Array<Creature>] An array of all registered creatures.
+        # @example
+        #   all_creatures = registry.instance.all_creatures
+        def all_creatures
+          @creatures_by_name.values
+        end
+
+        # Finds a creature by its ID.
+        #
+        # @param id [Integer] The ID of the creature to find.
+        # @return [Creature, nil] The found creature instance or nil if not found.
+        # @example
+        #   creature = registry.instance.find_by_id(53262363)
+        def find_by_id(id)
+          @creatures_by_id[id.to_i]
+        end
+
+        def find_by_name(name)
+          @creatures_by_name[name.downcase]
+        end
+
+        # Imports all creatures into the registry.
+        #
+        # @example
+        #   registry.instance.import_all
+        def import_all
+          Creature.all.each { |c| add(c) if c }
+        end
+      end
+
+      attr_accessor :name, :url, :picture, :level, :family, :type,
+                    :undead, :otherclass, :areas, :bcs, :hitpoints,
+                    :speed, :height, :size, :attack_attributes, :status,
+                    :defense_attributes, :treasure, :messaging, :injuries,
+                    :special_other, :abilities, :alchemy, :id, :update_log
+
+      BODY_PARTS = %w[abdomen back chest head leftArm leftEye leftFoot leftHand leftLeg neck nerves rightArm rightEye rightFoot rightHand rightLeg]
+
+      def initialize(data, id: nil)
+        @name = data[:name]
+        @url = data[:url]
+        @picture = data[:picture]
+        @level = data[:level].to_i
+        @family = data[:family]
+        @type = data[:type]
+        @undead = data[:undead]
+        @otherclass = data[:otherclass] || []
+        @areas = data[:areas] || []
+        @bcs = data[:bcs]
+        @hitpoints = data[:hitpoints].to_i
+        @speed = data[:speed]
+        @height = data[:height].to_i
+        @size = data[:size]
+        @id = id.to_i if id
+        @update_log = []
+        @status = []
+        @injuries = Hash.new(0)
+
+        atk = data[:attack_attributes] || {}
+        @attack_attributes = OpenStruct.new(
+          physical_attacks: atk[:physical_attacks] || [],
+          bolt_spells: atk[:bolt_spells] || [],
+          warding_spells: normalize_spells(atk[:warding_spells]),
+          offensive_spells: normalize_spells(atk[:offensive_spells]),
+          maneuvers: atk[:maneuvers] || [],
+          special_abilities: (atk[:special_abilities] || []).map { |s| SpecialAbility.new(s) }
+        )
+
+        @defense_attributes = DefenseAttributes.new(data[:defense_attributes] || {})
+        @treasure = Treasure.new(data[:treasure])
+        @messaging = Messaging.new(data[:messaging] || {})
+        @special_other = data[:special_other]
+        @abilities = data[:abilities] || []
+        @alchemy = data[:alchemy] || []
+      end
+
+      def self.create(creature_name, creature_id)
+        data = Template.load(creature_name)
+        return nil unless data
+        data[:name] = creature_name
+        new(data, id: creature_id)
+      end
+
+      # Registers a creature by adding it to the registry.
+      #
+      # @param name [String] The name of the creature.
+      # @param id [Integer] The ID of the creature.
+      # @return [Creature] The registered creature instance.
+      # @example
+      #   creature = Creature.register_creature("Kobold", 35623463)
+      def self.register_creature(name, id)
+        creature = create(name, id)
+        Registry.instance.add(creature) if creature
+        creature
+      end
+
+      # Retrieves all creatures from the filesystem.
+      #
+      # @return [Array<Creature>] An array of all creature instances.
+      # @example
+      #   creatures = Creature.all
+      def self.all
+        Dir[File.join(File.dirname(__FILE__), 'creatures', '*.rb')].map do |path|
+          name = File.basename(path, '.rb').tr('_', ' ')
+          create(name, nil)
+        end
+      end
+
+      def self.find_by_name(name)
+        create(name, nil)
+      rescue
+        nil
+      end
+
+      def to_h
+        instance_variables.each_with_object({}) do |var, hash|
+          hash[var.to_s.delete('@').to_sym] = instance_variable_get(var)
+        end
+      end
+
+      # Updates a specific field of the creature.
+      #
+      # @param key [Symbol] The attribute to update.
+      # @param value [Object] The new value for the attribute.
+      # @raise [RuntimeError] If there is no setter for the given key.
+      # @example
+      #   creature.update_field(:level, 5)
+      def update_field(key, value)
+        if respond_to?(key)
+          current = send(key)
+          current.is_a?(Array) ? current << value : send("#{key}=", value)
+        elsif respond_to?("#{key}=")
+          send("#{key}=", value)
+        else
+          raise "No setter for #{key}"
+        end
+        log_update({ key => value })
+      end
+
+      # Adds a status to the creature.
+      #
+      # @param status [String] The status to add.
+      # @example
+      #   creature.add_status("poisoned")
+      def add_status(status)
+        @status << status unless @status.include?(status)
+        log_update({ status: "added #{status}" })
+      end
+
+      # Removes a status from the creature.
+      #
+      # @param status [String] The status to remove.
+      # @example
+      #   creature.remove_status("poisoned")
+      def remove_status(status)
+        if @status.delete(status)
+          log_update({ status: "removed #{status}" })
+        else
+          log_update({ status: "status #{status} not found for removal" })
+        end
+      end
+
+      # Appends an injury to a specific body part.
+      #
+      # @param body_part [String] The body part to append the injury to.
+      # @param delta [Integer] The amount of injury to append.
+      # @raise [ArgumentError] If the body part is invalid.
+      # @example
+      #   creature.append_injury("leftArm", 5)
+      #   creature.append_injury(:leftArm, 5)
+      def append_injury(body_part, delta)
+        unless BODY_PARTS.include?(body_part.to_s)
+          raise ArgumentError, "Invalid body part in append_injury: #{body_part}."
+        end
+        @injuries[body_part.to_sym] += delta # should this be + or += ?
+        log_update({ injuries: { body_part => delta } })
+      end
+
+      # Checks if the creature is injured at a specific location.
+      #
+      # @param location [String] The body part to check for injury.
+      # @param threshold [Integer] The injury threshold to check against.
+      # @return [Boolean] True if injured, false otherwise.
+      # @example
+      #   is_injured = creature.injured?("leftArm", 1)
+      def injured?(location, threshold = 1)
+        @injuries[location.to_sym] >= threshold
+      end
+
+      # Retrieves all injured locations above a certain threshold.
+      #
+      # @param threshold [Integer] The injury threshold to check against.
+      # @return [Array<Symbol>] An array of injured body parts.
+      # @example
+      #   injured_parts = creature.injured_locations(2)
+      def injured_locations(threshold = 1)
+        @injuries.select { |_, value| value >= threshold }.keys
+      end
+
+      def current_data
+        to_h.reject { |k, _| k == :update_log }
+      end
+
+      def log_update(new_data)
+        @update_log << { time: Time.now.to_i, data: new_data }
+      end
+
+      def [](key)
+        current_data[key]
+      end
+
+      def []=(key, value)
+        update_field(key, value)
+      end
+
+      # Retrieves a creature by its ID or name.
+      #
+      # @param creature_id_or_name [Integer, String] The ID or name of the creature.
+      # @return [Creature, nil] The found creature instance or nil if not found.
+      # @example
+      #   creature = Creature[5323466] # by ID
+      #   creature = Creature["immense gold-bristled hinterboar"] # by name
+      def self.[](creature_id_or_name)
+        if creature_id_or_name.is_a?(Integer)
+          Registry.instance.find_by_id(creature_id_or_name)
+        else
+          Registry.instance.find_by_name(creature_id_or_name)
+        end
+      end
+
+      private
+
+      def normalize_spells(spells)
+        (spells || []).map do |s|
+          {
+            name: s[:name].to_s.strip,
+            cs: parse_td(s[:cs])
+          }
+        end
+      end
+
+      def parse_td(val)
+        return nil if val.nil?
+        return val if val.is_a?(Range)
+        return eval(val) if val.is_a?(String) && val.match?(/\\A\\d+\\.\\.\\d+\\z/)
+        val
+      end
+    end
+  end
+end
+
+# Lich::Gemstone::Creature
+#
+# Gemstone IV Bestiary Creature Data System
+#
+# This module provides a flexible, extensible framework for managing creature definitions, behaviors,
+# and messaging for Lich scripting in Gemstone IV. It supports structured creature data,
+# advanced templating for combat/emote messages (with regex-ready placeholders and randomization),
+# and a singleton-backed registry for efficient lookup.
+#
+# Features:
+# ----------
+# - Creature templates loaded from external files (with boon adjective normalization).
+# - Central registry for creatures (lookup by name or instance ID).
+# - Fully structured data: levels, stats, messaging, special abilities, loot, etc.
+# - Advanced placeholder templating for creature messages—supporting named capture regex and randomization.
+# - Robust methods for both display and pattern-matching of creature-generated text.
+#
+# Core Classes:
+# -------------
+# - Lich::Gemstone::Creature::Template
+#     Loads and caches creature templates (see `/creatures/*.rb`).
+#
+# - Lich::Gemstone::Creature::Registry
+#     Singleton registry for creature lookup by name and instance ID.
+#
+# - Lich::Gemstone::Creature
+#     The main data structure for each creature.
+#
+# - Lich::Gemstone::Creature::Messaging
+#     Manages all creature-related messages (arrival, flee, spell_prep, etc), with support for
+#     placeholder substitution, array-of-lines randomization, and regex pattern building.
+#
+# - Lich::Gemstone::Creature::PlaceholderTemplate
+#     A utility for representing templated lines with placeholders (e.g., "{pronoun}", "{direction}"),
+#     supporting `.to_display` for text substitution and `.to_regex` for pattern-matching.
+#
+#
+# Quick Usage:
+# -------------
+# Register or look up a creature:
+#   creature = Lich::Gemstone::Creature.register_creature("Kobold", 12345)
+#   creature = Lich::Gemstone::Creature[12345]              # by ID
+#   creature = Lich::Gemstone::Creature["immense gold-bristled hinterboar"] # by name
+#
+# Access data:
+#   puts creature.level
+#   puts creature.treasure.has_gems?
+#   puts creature.defense_attributes.asg
+#
+# Access and display templated messages:
+#   msg = creature.messaging.flee
+#   puts msg.to_display(direction: "north")          # Fill placeholders, or auto-random if not given
+#
+# Get a matching regex for a message:
+#   regex = creature.messaging.flee.to_regex
+#   if (match = regex.match("The panther flees north."))
+#     puts match[:direction]                         # => "north"
+#   end
+#
+# If the message is an array, .to_display samples all and joins with line breaks; .to_regex unions all patterns.
+#
+#
+# Adding New Creatures:
+# ---------------------
+# - Place a new template Ruby file in `/creatures/`, named like "kobold.rb" (lowercase, underscores, boon adjectives stripped).
+# - The file must return a Hash in the expected format (see other templates for examples).
+#
+# Placeholders for templating:
+# ----------------------------
+# - Placeholders in curly braces (e.g., "{pronoun}", "{direction}", "{weapon}") are automatically detected and substituted.
+# - To use a raw regex for a placeholder (e.g., any weapon name), set its options to ["RAW:.+?"] in PLACEHOLDER_MAP.
+#
+# Example Placeholder Map:
+#   PLACEHOLDER_MAP = {
+#     pronoun: %w[he her his it she],
+#     direction: %w[north south east west ...],
+#     weapon: %w[RAW:.+?]
+#   }
+#
+# Special Notes:
+# --------------
+# - Named capture groups are used in generated regex for easy extraction of placeholder values.
+# - If the same placeholder appears multiple times in a string, only the last is available as a named group.
+# - The system supports arrays of message lines (for randomization and flexible matching).
+# - All registry, lookup, and normalization is case-insensitive.
+#
+# See code for further details or extension points.

--- a/lib/gemstone/creatures/_creature_template.rb
+++ b/lib/gemstone/creatures/_creature_template.rb
@@ -1,0 +1,137 @@
+{
+  # ---------- Identity ----------
+  schema_version: 3,            # bumped due to structural changes
+  name: "",                     # display name
+  noun: "",                     # in-game noun (optional; leave "" if same as name)
+  url: "",
+  picture: "",
+
+  level: nil,                   # Integer
+  family: "",                   # e.g., "canine", "gigas"
+  type: "",                     # e.g., "biped", "quadruped", "avian", "ooze"
+  undead: false,                # corporeality is separate:
+  non_corporeal: false,         # true => incorporeal; false => corporeal
+  boss: false,                  # special encounter flag (optional)
+  otherclass: [],               # any extra tags you keep (optional)
+  bcs: nil,                     # true/false/nil if unknown
+
+  # ---------- Physical ----------
+  max_hp: nil,                  # base / typical max HP
+  speed: nil,                   # free-form or numeric if you standardize
+  height: nil,                  # Integer (feet) if known
+  size: "",                     # "small" | "medium" | "large" | "huge" | ...
+
+  # ---------- Habitat / Locations ----------
+  # Multiple areas, each with its own room list
+  areas: [
+    # { name: "Hinterwilds", rooms: [/* room ids */] }
+  ],
+
+  # ---------- Offense / Capabilities ----------
+  attack_attributes: {
+    physical_attacks: [
+      # { name: "bite", as: 527, damage_type: "puncture" }
+    ],
+    bolt_spells: [
+      # { name: "Minor Cold (1709)", cs: 410, damage_type: "cold" }
+    ],
+    warding_spells: [
+      # { name: "Frenzy (216)", cs: (438..450), effect: "anger" }
+    ],
+    offensive_spells: [
+      # { name: "Major Elemental Wave (435)" }
+    ],
+    maneuvers: [
+      # { name: "shield bash" }
+    ],
+    special_abilities: [
+      # light list of capability names (optional)
+      # { name: "frenzy" }, { name: "mstrike" }
+    ],
+    special_notes: []
+  },
+
+  # ---------- Defense ----------
+  defense_attributes: {
+    asg: nil,                   # "10N" or Integer if you standardize
+    immunities: [],             # ["crit_kill", "knockdown", ...]
+    melee: nil,                 # DS (Integer or Range)
+    ranged: nil,                # DS vs ranged
+    bolt: nil,                  # DS vs bolt
+    udf: nil,                   # UDF (for UAC)
+    bar_td: nil, cle_td: nil, emp_td: nil, pal_td: nil, ran_td: nil,
+    sor_td: nil, wiz_td: nil, mje_td: nil, mne_td: nil, mjs_td: nil,
+    mns_td: nil, mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    special_defenses: []
+  },
+
+  # ---------- Player-facing Ability Declarations (for Bestiary) ----------
+  # Informational only. Runtime applies effects from code via these ids.
+  abilities: [
+    # {
+    #   id: :frenzy,
+    #   name: "Frenzy",
+    #   type: :buff,                 # :buff | :debuff | :aura | :proc
+    #   target: :self,               # :self | :opponent | :area
+    #   typical_duration_s: 30,
+    #   effects: { as: +100 },       # human-facing summary
+    #   dispellable: true,
+    #   notes: "Often preceded by scream/eye-glow; reapply refreshes."
+    # }
+  ],
+
+  # ---------- Crafting / Misc ----------
+  alchemy: [],
+  abilities_misc: [],            # keep if you want to separate non-combat traits
+
+  # ---------- Treasure ----------
+  treasure: {
+    coins: nil,                  # true/false/nil
+    magic_items: nil,            # true/false/nil
+    gems: nil,                   # true/false/nil
+    boxes: nil,                  # true/false/nil
+    # prefer object form so we can carry flags
+    # { name: "inky black valravn plume", blunt_required: false }
+    skin: nil,
+    other: nil                   # string or [strings]
+  },
+
+  # ---------- Messaging ----------
+  # All fields are arrays (even singletons) for uniform consumption.
+  messaging: {
+    # Flavor (not used for parsing unless you choose to)
+    description: [],
+    arrival: [],
+    flee: [],
+    death: [],
+    decay: [],
+    search: [],
+    spell_prep: [],
+
+    # Optional informational block for human tips (NOT triggers)
+    info: {
+      general: [],               # free-form notes someone wrote about the creature
+      class_tips: {              # optional per-profession
+        cleric: [], paladin: [], ranger: [], bard: [], wizard: [],
+        empath: [], rogue: [], warrior: [], sorcerer: []
+      },
+      miscellany: []             # any extra flavor lines you want to keep
+    },
+
+    # Parsing cues. Keys here are the event ids your runtime understands.
+    # Values are arrays of message variants/patterns to match.
+    triggers: {
+      # frenzy: [
+      #   "A savage fork-tongued wendigo's eyes blaze a murderous crimson!"
+      # ],
+      # pack_bolster: [
+      #   "Bolstered by nearby members of its pack, a niveous giant warg ..."
+      # ],
+      # shield_bash: [
+      #   "A brawny gigas shield-maiden ... attempts a shield bash!"
+      # ]
+    }
+  }
+}

--- a/lib/gemstone/creatures/behemothic_gorefrost_golem.rb
+++ b/lib/gemstone/creatures/behemothic_gorefrost_golem.rb
@@ -1,0 +1,141 @@
+{
+  name: "Behemothic gorefrost golem",
+  url: "https://gswiki.play.net/Behemothic_gorefrost_golem",
+  picture: "",
+  level: 104,
+  family: "golem",
+  type: "biped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: 1000,
+  speed: "",
+  height: 40,
+  size: "huge",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "closed fist",
+        as: (480..500)
+      },
+      {
+        name: "pound",
+        as: 445
+      },
+      {
+        name: "stomp",
+        as: (495..505)
+      }
+    ],
+    bolt_spells: [
+      {
+        name: "minor cold (1709)",
+        as: 410
+      }
+    ],
+    warding_spells: [
+      {
+        name: "cold snap (512)",
+        cs: 444
+      }
+    ],
+    offensive_spells: [
+      {
+        name: "major elemental wave (435)"
+      }
+    ],
+    maneuvers: [
+      {
+        name: "haymaker"
+      },
+      {
+        name: "headbutt"
+      },
+      {
+        name: "heat leaching"
+      },
+      {
+        name: "colossal fist"
+      },
+    ],
+    special_abilities: [
+      {
+        name: "topple",
+        type: "falls on you and ruins your day"
+      }
+    ],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "20N",
+    immunities: [],
+    melee: 339,
+    ranged: 317,
+    bolt: 325,
+    udf: 765,
+    bar_td: 428,
+    cle_td: nil,
+    emp_td: 426,
+    pal_td: nil,
+    ran_td: 395,
+    sor_td: 454,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: 457,
+    mjs_td: nil,
+    mns_td: 428,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    special_defenses: []
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: true,
+    magic_items: "",
+    gems: true,
+    boxes: true,
+    skin: "None",
+    other: "gigas artifact",
+    blunt_required: false
+  },
+  messaging: {
+    description: "The golem stands taller than a two-story building, a crude and blocky humanoid shape of ice that glows with an unsavory sanguine aura.  Clouds of frozen blood and bits of viscera are trapped in its frosty depths.  All are lifeless and still save for a single preserved organ at the golem's core: a humanoid heart.  The heart is shrouded in a swirl of slushy red fluid and, impossibly, it pulses with a sluggish, uneven beat, giving off coruscations of sanguine light.",
+    arrival: [
+      "The ground shudders as a behemothic gorefrost golem stomps in.",
+      "The frozen earth underfoot shifts precipitously as an arm of blood-flecked ice erupts upward, followed by the towering form of a behemothic gorefrost golem.  The golem straightens its massive bulk with a sound like shattering glass."
+    ],
+    flee: [
+      "A behemothic gorefrost golem stomps {direction}, shedding bits of broken ice and detritus.",
+      "The ground shudders as a behemothic gorefrost golem stomps {direction}.",
+    ],
+    spell_prep: "A behemothic gorefrost golem glows with shimmering incarnadine light that suffuses its monstrous form with power.",
+    death: "A rush of silent thunder explodes outward from the golem as the power animating it disperses.",
+    decay: "Cracks spread over the surface of a behemothic gorefrost golem.  With a ringing sound like struck crystal, the golem shatters into shards of inert ice.",
+    search: [
+      "A behemothic gorefrost golem hesitates for a moment, as if uncertain.",
+      "Corruscating light flares where a behemothic gorefrost golem's eyes ought to be as it searches the shadows."
+    ],
+    heat_leaching: "Hungering cold tears at your flesh, viciously leaching the heat from your body!",
+    colossal_fist: "A behemothic gorefrost golem raises a colossal fist of enchanted ice overhead and brings it crashing down.  A line of jagged ice streaks along the ground, racing toward you!",
+    topple: "Despite desperate windmilling to catch its balance, a behemothic gorefrost golem topples toward you!  You leap to the side and avoid being flattened as the golem topples over with a thunderous crash!",
+    major_elemental_wave: "Intense light begins to bleed from within a behemothic gorefrost golem, shimmering blue and unsavory scarlet warring with one another for brilliance.  A wave of blinding elemental energy pulses from the golem, so cold that moisture in the air crystallizes into stinging frost.",
+    closed_fist: "A behemothic gorefrost golem swings a colossal fist of ice at you!",
+    stomp: "Raising a prodigious foot, a behemothic gorefrost golem tries to stomp on you!",
+    pound: "A behemothic gorefrost golem rears back slowly and swings a mighty arm of blood-flecked ice down at you!",
+    twin_hammerfists: "A behemothic gorefrost golem raises its hands high, laces them together and brings them crashing down towards you!",
+    haymaker: "A behemothic gorefrost golem clenches its right fist and brings its arm back for a roundhouse punch aimed at you!",
+    headbutt: "A behemothic gorefrost golem charges towards you and attempts a headbutt!",
+    minor_cold: "A behemothic gorefrost golem hurls a chunk of ice at you!",
+    cold_snap: "A behemothic gorefrost golem thrusts a blocky fist toward you!",
+
+    wizards: "* Golems are great targets for [[Mana Leech (516)]] as they have a lower TD.\n* Open with [[Hand of Tonis (505)]] and prioritize keeping the golems prone. Follow up by bolting.",
+    general_advice: "* Like many other creatures of this type, these golems' high amount of health and immunity to being killed by lethal crits is offset by low DS. This makes flurries of unaimed attacks such as assault techniques or [[mstrike]]s backed up by [[Two Weapon Combat]], assault techniques or mstrikes using [[Brawling|unarmed combat]], or repeated attacks backed up by [[Celerity (506)]] relatively effective.\n* These golems take additional damage from [[Fire critical table|fire]], though the exact mechanics of how aren't known at the time of this writing.\n* Weapon techniques and [[combat maneuvers]] that knock golems prone and inflict Staggered, like [[Twin Hammerfists]], [[Sweep]], or [[Tackle]], can often stall out golems since their combat rounds are fairly slow and they don't have high [[Standard_maneuver_roll|SMR]] defense.",
+
+  }
+}

--- a/lib/gemstone/creatures/bloody_halfling_cannibal.rb
+++ b/lib/gemstone/creatures/bloody_halfling_cannibal.rb
@@ -1,0 +1,130 @@
+{
+  name: "bloody halfling cannibal",
+  url: "https://gswiki.play.net/Bloody_halfling_cannibal",
+  picture: "",
+  level: 101,
+  family: "humanoid",
+  type: "biped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: 300,
+  speed: "",
+  height: 3,
+  size: "small",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "bite",
+        as: 474
+      },
+      {
+        name: "grimy little fists",
+        as: (464..544)
+      },
+      {
+        name: "hurtle",
+        as: (327..564)
+      },
+      {
+        name: "wiry arms",
+        as: (464..544)
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [
+      {
+        name: "cannibalize"
+      }
+    ],
+    special_abilities: [
+      {
+        name: "hunger",
+        note: "+80 AS"
+      },
+    ],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "12",
+    immunities: [],
+    melee: (379..383),
+    ranged: (353..366),
+    bolt: (353..366),
+    udf: (586..805),
+    bar_td: (364..379),
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: (335..350),
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: 428,
+    mjs_td: nil,
+    mns_td: 381,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [
+      {
+        name: "unstun",
+        note: "able to break stuns"
+      },
+      {
+        name: "vanish",
+        note: "able to evade an attack by hiding in the shadows"
+      }
+    ],
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: true,
+    magic_items: "",
+    gems: true,
+    boxes: true,
+    skin: false,
+    other: "gigas artifact",
+    blunt_required: false
+  },
+  messaging: {
+    description: "A skim of dark, congealing blood slicks the features of the raw-boned halfling.  {pronoun} eyes are black as burnt coals and feverish with single-minded hunger, a hunger that has burnt away every last shred of fat from {pronoun} body and left behind only knotted sinew.  The cannibal's teeth are sharpened to jagged points, and from between them darts a tiny pink tongue that is constantly tasting the air.  {pronoun} wears tattered, weather-eaten remains of furs and homespun fabric.  They, too, are soaked red with blood.",
+    arrival: [
+      "Accompanied by the fetid stench of old meat, a bloody halfling cannibal races into the area with a froth of bloody saliva on {pronoun} lips.",
+      "You hear soft footfalls."
+    ],
+    flee: [
+      "Licking {pronoun} lips ravenously, a bloody halfling cannibal creeps {direction}.",
+      "You hear soft footfalls."
+    ],
+    death: "A monstrous, too-wide smile spreads across the cannibal's face as {prooun} collapses to the ground, dead.",
+    decay: "A bloody halfling cannibal's body rots away, leaving only a small stain on the ground.",
+    search: [
+      "A bloody halfling cannibal sniffs at the air, {pronoun} eyes glinting as {pronoun} searches the shadows.",
+      "a bloody halfling cannibal's eyes dart around, suspicion warring with hunger in {pronoun} beady eyes."
+    ],
+    hide: "A bloody halfling cannibal darts into the shadows.",
+    vanish: "As you move to attack a bloody halfling cannibal, the cannibal shrinks away from you, baring sharpened teeth as {pronoun} darts into the shadows!",
+    hunger: "A bloody halfling cannibal's eyes grow bloodshot with ravening hunger!",
+    unstun: "A bloody halfling cannibal gurgles out an animalistic shriek of rage, {pronoun} eyes filling with bloody blackness as {pronoun} surges back into action!",
+    cannibalize: "A bloody halfling cannibal falls into a lopsided crouch.  The muscles of {pronoun} hindquarters tense as {pronoun} springs toward you, sharpened teeth gnashing.",
+    wiry_arms: [
+      "A bloody halfling cannibal throws her wiry arms around you, fueled by panicked hunger!",
+      "With an ululating shriek, a bloody halfling cannibal leaps from the shadows and throws {pronoun} wiry arms around you, fueled by panicked hunger!"
+    ],
+    hurtle: [
+      "A bloody halfling cannibal hurtles at you, swinging wildly with a twisted obsidian dagger!",
+      "With an ululating shriek, a bloody halfling cannibal leaps from the shadows and hurtles at you, swinging wildly with a twisted obsidian dagger!"
+    ],
+    bite: "A bloody halfling cannibal bares {pronoun} sharpened teeth as {pronoun} tries to bite into you!",
+    grimy_little_fists: "A bloody halfling cannibal hammers blindly at you with grimy little fists!",
+    general_advice: "* Despite being the lowest level creature in the [[Hinterwilds]], cannibals can't be underestimated or ignored, especially if the Boreal Forest has started filling up. Cannibals' namesake biting maneuver can be lethal if its [[standard maneuver roll]] gets a significant bonus from other creatures in the area stunning or otherwise disabling a character. Cannibals also take advantage of stealth, which means they can get stance pushdown from [[ambush]] mechanics in situations where you might never have seen them coming. As such, even in cases where relatively low-mana-cost AoE spells like [[Censure (316)]], [[Elemental Wave (410)]], or [[Grasp of the Grave (709)]] might seem unnecessary for the number of visible creatures, sometimes they can still be helpful in revealing the invisible threat of cannibals.",
+
+  }
+}

--- a/lib/gemstone/creatures/brawny_gigas_shield-maiden.rb
+++ b/lib/gemstone/creatures/brawny_gigas_shield-maiden.rb
@@ -1,0 +1,145 @@
+{
+  name: "brawny gigas shield-maiden",
+  url: "https://gswiki.play.net/Brawny_gigas_shield-maiden",
+  picture: "",
+  level: 106,
+  family: "gigas",
+  type: "biped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 30,
+  size: "huge",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "shield strike",
+        as: (525..566)
+      },
+      {
+        name: "spear",
+        as: (525..566)
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [
+      {
+        name: "aura of the arkati (1614)",
+        cs: (440..482)
+      },
+      {
+        name: "judgment (1630)",
+        cs: (443..482)
+      }
+    ],
+    offensive_spells: [],
+    maneuvers: [
+      {
+        name: "shield bash",
+      },
+      {
+        name: "shield push"
+      },
+      {
+        name: "shield trample"
+      }
+    ],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "17",
+    immunities: [],
+    melee: (463..695),
+    ranged: (383..548),
+    bolt: nil,
+    udf: nil,
+    bar_td: (377..380),
+    cle_td: nil,
+    emp_td: 411,
+    pal_td: nil,
+    ran_td: (311..341),
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: 462,
+    mjs_td: nil,
+    mns_td: (396..408),
+    mnm_td: nil,
+    defensive_spells: [
+      {
+        name: "divine shield (1609)"
+      },
+      {
+        name: "dauntless (1606)"
+      }
+    ],
+    defensive_abilities: [
+      {
+        name: "damage resistance",
+        note: "able to gain resistance to damage type attacked with"
+      }
+    ],
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: true,
+    magic_items: "",
+    gems: true,
+    boxes: true,
+    skin: false,
+    other: "gigas fragment",
+    blunt_required: false
+  },
+  messaging: {
+    description: "Voluptuous and sturdy of build, the gigas shield-maiden has the musculature of a seasoned fighter and the cool gaze of a practiced tactician.  Towering at nearly thirty feet in height, the shield-maiden moves with a dangerous grace.  The armor {pronoun} wears is not ornate, but it shines like hammered gold and barely makes a sound as {pronoun} moves.",
+    arrival: [
+      "A brawny gigas shield-maiden marches in with the grace of a seasoned warrior.",
+      "A brawny gigas shield-maiden marches into the area, grim purpose written across {pronoun} face.",
+      "A brawny gigas shield-maiden rides a heavily armored battle mastodon in, swaying with every heavy footfall."
+    ],
+    flee: [
+      "Warily scanning the area for threats, a brawny gigas shield-maiden marches {direction}.",
+      "Keeping {pronoun} head held high in spite of {pronoun} wounds, a brawny gigas shield-maiden struggles {direction}.",
+      "A brawny gigas shield-maiden just went into a thatched timber smithy.", # need to deal with portals
+      "A brawny gigas shield-maiden rides a heavily armored battle mastodon {direction}, the mastodon limping with every great step."
+    ],
+    spell_prep: "A brawny gigas shield-maiden raises a fist to the heavens as {pronoun} eyes begin to glow like molten gold.",
+    death: "A plaintive look passes across a brawny gigas shield-maiden's eyes like a fleeting shadow as {pronoun} goes still in death.",
+    decay: "Rot consumes a brawny gigas shield-maiden's body, leaving little behind.",
+    damage_resistance: "In response to the vibrations, a brawny gigas shield-maiden's skin seems to discolor and harden, lending the shield-maiden unnatural durability!",
+    shield_bash: "A brawny gigas shield-maiden lunges forward at you with {pronoun} golden targe and attempts a shield bash!",
+    shield_push: "A brawny gigas shield-maiden raises {pronoun} golden targe and attempts to push you away!",
+    shield_strike: "A brawny gigas shield-maiden launches a quick bash with {pronoun} golden targe at you!",
+    shield_trample: "A brawny gigas shield-maiden raises her golden targe and charges headlong towards you!",
+    spear: "In a display of martial precision, a brawny gigas shield-maiden thrusts with a gold-tipped heavy spear at you!",
+
+    general_advice: "* Shield-maidens are [[square]] creatures, so players of [[semi]]s and [[pure]]s can take advantage of their low [[TD]] by casting [[CS]]-based offensive spells.\n* Shield-maidens have a pretty high rate of blocking physical attacks with their shields when unhindered, so setup abilities like [[Sunder Shield]], [[Aura of the Arkati (1614)]], anything that inflicts [[Blinded]], anything that knocks prone, and so forth are recommended for primarily physical combatants. Alternatively, [[Brawling|unarmed combat]] can't be blocked.",
+    bards: "* [[Vibration Chant (1002)]] works twice and will often leave them helpless or dead.",
+    wizards: "* Shield-maidens can be targeted with [[Mana Leech (516)]].",
+
+  }
+}
+
+=begin
+# mount
+A brawny gigas shield-maiden gets a running start and then acrobatically leaps up onto the back of a heavily armored battle mastodon, mounting it!
+
+# reveal
+A brawny gigas shield-maiden glowers disdainfully as she sweeps the surroundings with her gaze.
+A brawny gigas shield-maiden points forcefully into the shadows, revealing you in your hiding place!
+
+# damage resistance
+In response to the vibrations, a brawny gigas shield-maiden's skin seems to discolor and harden, lending the shield-maiden unnatural durability!
+A brawny gigas shield-maiden is unharmed by the impact!
+A brawny gigas shield-maiden is unharmed by the impact!
+A brawny gigas shield-maiden is unharmed by the impact!
+
+=end

--- a/lib/gemstone/creatures/colossal_boreal_undansormr.rb
+++ b/lib/gemstone/creatures/colossal_boreal_undansormr.rb
@@ -1,0 +1,71 @@
+{
+  name: "Colossal boreal undansormr",
+  url: "https://gswiki.play.net/Colossal_boreal_undansormr",
+  picture: "",
+  level: 111,
+  family: "Worm",
+  type: "Worm",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: "",
+  size: "",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "",
+        as: "AS"
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: nil,
+    immunities: [],
+    melee: nil,
+    ranged: nil,
+    bolt: nil,
+    udf: nil,
+    bar_td: "460",
+    cle_td: nil,
+    emp_td: "488..519",
+    pal_td: nil,
+    ran_td: nil,
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: "557..572",
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: "?",
+    skin: "?",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    general_advice: "* Undansormrs have great amounts of health, pretty high [[DS]], exceptional [[TD]], decent [[Standard maneuver roll|maneuver]] defense by virtue of their high level if nothing else, immunity to being knocked prone, and no limbs to get rid of to make them less effective. However, [[Brawling|unarmed combat]] can kill undansormrs reasonably effectively with focused mstrikes, [[Fury]], or stray tiered-up shots to the head (one of the only body parts this worm-like creature does have). Even a [[pure]] (with trained Brawling and [[Combat Maneuvers]]) can make unarmed combat work against them with minor setup of stunning the undansormr first to increase MM and more than overcome the UAF vs. UDF gap."
+  }
+}

--- a/lib/gemstone/creatures/eyeless_black_valravn.rb
+++ b/lib/gemstone/creatures/eyeless_black_valravn.rb
@@ -1,0 +1,94 @@
+{
+  name: "Eyeless black valravn",
+  url: "https://gswiki.play.net/Eyeless_black_valravn",
+  picture: "",
+  level: 112,
+  family: "Bird",
+  type: "Avian",
+  undead: "",
+  otherclass: [
+    "Corporeal undead"
+  ],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 5,
+  size: "medium",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "",
+        as: ""
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "1",
+    immunities: [],
+    melee: nil,
+    ranged: nil,
+    bolt: nil,
+    udf: nil,
+    bar_td: nil,
+    cle_td: nil,
+    emp_td: "493",
+    pal_td: nil,
+    ran_td: "457",
+    sor_td: "527",
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: true,
+    boxes: "?",
+    skin: "inky black valravn plume",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    description: "Wings of stygian darkness enshroud the huge black bird.  When not in motion, there is an ominous and unnatural stillness to the valravn that marks it as otherworldly.  Where eyes should be, there are strange hollows that occasionally flicker with scintillating golden light.",
+    general_advice: "* Broadly speaking, valravns are a \"glass cannon\" type of creature. Their \"glass\" is durable in the sense of high [[DS]] and [[TD]], but when attacks get past those thresholds--or attacks that bypass them, like [[Standard maneuver roll|SMR]]-based attacks or [[Brawling|unarmed combat]]--they're likely to hit these unarmored creatures hard and they have a fairly small amount of health.\n* Valravns are primarily magical creatures and are fairly vulnerable to maneuver-based spells and attacks like [[Earthen Fury (917)]], [[Hamstring]], [[Spike Thorn (616)]], [[Twin Hammerfists]], and more. This is offset somewhat by their high level, however.",
+    voln: "* [[Symbol of Diminishment]] can make valravns far more manageable. However, their high level imposes a penalty against the [[standard success resolution system]] that [[Order of Voln|Voln]] symbols use, so it might take multiple tries. High [[Influence]] can counteract level disadvantage somewhat.",
+    clerics: "* Valravns have high TD, but [[Prayer of Holding (301)]] only needs a 101 endroll to set up for one or two strong casts of [[Condemn (309)]] afterward.",
+    paladins: "* High [[Spiritual Lore, Religion|Religion]] lore is doubly helpful against valravns, as [[Zealot (1617)]] can push paladins' [[attack strength|AS]] over the top and [[Divine Incarnation (1650)]] Smite, given enough lore to reliably hit twice, frequently destroys valravns while divine energy lasts.\n* Either [[Aura of the Arkati (1614)]] or [[Repentance (1615)]] as the infused spell in a paladin's [[Holy Weapon (1625)|bonded weapon]] works well, since in either case they only need a 101 endroll to accomplish their main goals of, respectively, a debuff or forcing a valravn to kneel.",
+    rangers: "* [[Moonbeam (611)]] is a near universal solution in the [[Hinterwilds]] and valravns are no exception.",
+    arrival_messaging: "An eyeless black valravn soars in on wings darker than night.",
+    unstun_messaging: "An eyeless black valravn ruffles its feathers in a single, precise shake as it recovers its wits.",
+    death_messaging: "An eyeless black valravn tumbles to the ground, landing in an awful tangle of talons and feathers.",
+    search_messaging: "Shadows coil around the broken form of an eyeless black valravn, collapsing into a lightless sphere that erupts soundlessly, bathing the area in momentary darkness.",
+    combat_messaging: "An eyeless black valravn swoops down, extending its talons in a display of blatant threat.\nAn eyeless black valravn turns to look at you, the empty pits where its eyes should be swelling into lightless pools that hungrily drink the surrounding light.\nCS: +500 - TD: +410 + CvA: -4 + d100: +19 == +105\nWarding failed!"
+  }
+}
+
+=begin
+
+An eyeless black valravn turns to look at you, the empty pits where its eyes should be swelling into lightless pools that hungrily drink the surrounding light.
+Mana cascades across your x'aganjira ataniki, causing the fabric to shiver against your skin as it draws the scattered power into it and transforms it into mana.  [You gain 2 mana!]
+  CS: +505 - TD: +441 + CvA: +5 + d98: +2 - -5 == +76
+  Warded off!
+  You shut your eyes, resisting the force of the valravn's gaze.
+
+
+=end

--- a/lib/gemstone/creatures/grim_gigas_skald.rb
+++ b/lib/gemstone/creatures/grim_gigas_skald.rb
@@ -1,0 +1,123 @@
+{
+  name: "Grim gigas skald",
+  url: "https://gswiki.play.net/Grim_gigas_skald",
+  picture: "",
+  level: 105,
+  family: "Gigas",
+  type: "Biped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 28,
+  size: "huge",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "",
+        as: ""
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [
+      {
+        name: "Stunning Shout (1008)",
+        cs: (494..499)
+      }
+    ],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "6",
+    immunities: [],
+    melee: (504..690),
+    ranged: (510..554),
+    bolt: nil,
+    udf: nil,
+    bar_td: (430..443),
+    cle_td: nil,
+    emp_td: (449..461),
+    pal_td: nil,
+    ran_td: (381..396),
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: (445..461),
+    mnm_td: nil,
+    defensive_spells: [
+      {
+        name: "Warding Sphere (310)"
+      },
+      {
+        name: "Lesser Shroud (120)"
+      },
+      {
+        name: "Resist Elements (602)"
+      }
+    ],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: "?",
+    skin: "?",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    description: "A grim gigas skald is not especially tall for one of {pronoun} kind, but still stands just under two stories tall.  {Pronoun} has a raw-boned face and a grim gaze.  The robes he wears are of dusky golden boarskin and appear ceremonial, having been stitched with hundreds of beads made from semiprecious gems.  A grim gigas skald wears a tremendous drinking horn at {pronoun} belt.",
+    arrival: [
+      "Preceded by a mournful dirge, a grim gigas skald stalks in, his song accompanied by the clacking of the crude jeweled beads adorning the ceremonial garb that he wears.",
+      "A grim gigas skald meanders in, dourly taking in the surroundings."
+    ],
+    death: "A grim gigas skald raises a hand as if to grasp for support as she collapses, life going out of her form.",
+    decay: "A grim gigas skald's corpse succumbs to rot, collapsing in upon itself until naught but dust remains.",
+
+    general_advice: "* Options like [[Hamstring]] or [[Brawling|unarmed combat]] essentially get around [[DS]], which is useful since skalds have pretty high DS even when forced into offensive stance and their unconventional lyre weapon can't be removed by typical tactics like [[Disarm Weapon]] or [[Vibration Chant (1002)]].\n* [[Standard_maneuver_roll|SMR]]-based offense like [[Condemn (309)]], [[Earthen Fury (917)]], and [[Spike Thorn (616)]] works well against skalds.",
+    clerics: "* Since the strength of each damaging round of Condemn is based only on the initial roll, it can often be worthwhile to cast Condemn again before the first cast has finished if that first cast had a low enough endroll. This is especially true if the first cast isn't doing enough damage to keep them stunned, which is crucial since skalds' SMR attack can be lethal and their TD is sufficiently high that [[Soul Ward (319)]] isn't always reliable defense.",
+    rangers: "* Spike Thorn is an excellent option, but if the ranger is relatively untrained to make use of it because he has few ranks of [[Ranger Base]] and/or [[Spiritual Lore, Summoning|Summoning]] lore, or simply if mana needs to be conserved, then [[Animal Companion (630)|animal companions]] can also do significant damage to or even kill skalds affected by [[Wild Entropy (603)]] or [[Moonbeam (611)]].",
+
+    combat_messaging: "A grim gigas skald artfully plays her hoarbeam lyre, sending a ripple of shimmering air toward you!\nAS: +447 vs DS: +450 with AvD: +41 + d100 roll: +78 = +116\n... and hits for 10 points of damage!\nChest hit causes you to spin around like a halfling after a fresh tart."
+  }
+}
+
+=begin
+
+A grim gigas skald raises her sonorous voice into a resounding cry that crashes like mad thunder through the area!
+[SMR result: -6 (Open d100: -12, Bonus: 12)]
+You manage to throw yourself free from the auditory assault!
+
+Perfect harmonics collude to intensify a grim gigas skald's mastery of music!  A grim gigas skald artfully plays her ruic lyre, sending a ripple of shimmering air toward you!
+  AS: +512 vs DS: +624 with AvD: +52 + d80 roll: +27 = -33
+   A clean miss.
+
+A grim gigas skald artfully plays her ruic lyre, sending a ripple of shimmering air toward you!
+  AS: +412 vs DS: +594 with AvD: +52 + d79 roll: +56 = -74
+   A clean miss.
+
+A grim gigas skald artfully plays her ruic lyre, sending a ripple of shimmering air toward you!
+You move at the last moment to evade the bolt!
+
+
+A grim gigas skald flails on the ground, making the ground shudder, before managing to fight her way into a standing position.
+
+One leg dragging behind her, a grim gigas skald staggers northwest.
+
+
+=end

--- a/lib/gemstone/creatures/heavily_armored_battle_mastodon.rb
+++ b/lib/gemstone/creatures/heavily_armored_battle_mastodon.rb
@@ -1,0 +1,102 @@
+{
+  name: "heavily armored battle mastodon",
+  url: "https://gswiki.play.net/Heavily_armored_battle_mastodon",
+  picture: "",
+  level: 102,
+  family: "elephantid",
+  type: "quadruped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 30,
+  size: "huge",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "trunk slam",
+        as: 532
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "1",
+    immunities: [],
+    melee: (425..746),
+    ranged: (447..509),
+    bolt: nil,
+    udf: nil,
+    bar_td: (408..415),
+    cle_td: nil,
+    emp_td: 427,
+    pal_td: nil,
+    ran_td: (293..305),
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: 480,
+    mjs_td: nil,
+    mns_td: (377..392),
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: false,
+    magic_items: "",
+    gems: false,
+    boxes: false,
+    skin: "a woolly mastodon trunk",
+    other: false,
+    blunt_required: false
+  },
+  messaging: {
+    description: "Heavy plates of copper barding shield the flanks of the immense mastodon, a woolly beast covered in dark, matted hair. The mastodon's eyes are dark, round, and surprisingly expressive.  To either side of its long, prehensile trunk are curved tusks that taper to deadly points.  The yellowed bones have been delicately etched with carved runes.",
+    arrival: [
+      "A heavily armored battle mastodon stomps in, trunk swinging between its huge forelegs.",
+      "A heavily armored battle mastodon just came through a rune-carved white granite arch.",
+    ],
+    flee: [
+      "A heavily armored battle mastodon just went through a rune-carved white granite arch.",
+      "A heavily armored battle mastodon stomps {direction}, trunk swinging between its huge forelegs."
+    ],
+    death: "As a heavily armored battle mastodon collapses, it lets out a shrill trumpet of despair.  Its trunk flails futilely before slamming to the ground, still.",
+    search: [
+      "A heavily armored battle mastodon quests about with its trunk, eyes narrowing.",
+      "A heavily armored battle mastodon looks about in alarm as its trunk tests the air."
+    ],
+
+    combat_messaging: "A heavily armored battle mastodon raises its trunk and rears back onto its immense hind legs, blaring out a note of sheer fury!\n[SSR result: 34 (Open d100: 8)]\nYou keep your wits amidst the mastodon's angry trumpeting!\n[SSR result: 138 (Open d100: 87)]\nThe mastodon's angry trumpeting startles XXX!\nA heavily armored battle mastodon slams a gigantic foot down, sending tremors rippling outward from the point of impact!"
+  }
+}
+
+=begin
+
+
+A heavily armored battle mastodon tries to spear you with its enormous tusks!
+  AS: +529 vs DS: +868 with AvD: +37 + d100 roll: +98 = -204
+   A clean miss.
+
+A heavily armored battle mastodon raises its trunk and slams it down toward you!
+  AS: +529 vs DS: +838 with AvD: +38 + d100 roll: +38 = -233
+   A clean miss.
+
+   A heavily armored battle mastodon rears back and tries to stomp you with a great foot!
+You flail on the ground but manage to barely dodge the attack!
+
+
+
+=end

--- a/lib/gemstone/creatures/immense_gold-bristled_hinterboar.rb
+++ b/lib/gemstone/creatures/immense_gold-bristled_hinterboar.rb
@@ -1,0 +1,110 @@
+{
+  name: "immense gold-bristled hinterboar",
+  url: "https://gswiki.play.net/Immense_gold-bristled_hinterboar",
+  picture: "",
+  level: 102,
+  family: "suine",
+  type: "quadruped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: 600,
+  speed: "",
+  height: 25,
+  size: "huge",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "stomp",
+        as: (515..529)
+      },
+      {
+        name: "impale",
+        as: (509..523)
+      },
+      {
+        name: "charge (attack)",
+        as: (529)
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [
+      {
+        name: "boarrush"
+      },
+      {
+        name: "feint"
+      }
+    ],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "1",
+    immunities: [],
+    melee: (546),
+    ranged: nil,
+    bolt: (451..460),
+    udf: (582..584),
+    bar_td: (402..409),
+    cle_td: nil,
+    emp_td: (404),
+    pal_td: nil,
+    ran_td: (360),
+    sor_td: (431),
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: (454..467),
+    mjs_td: (405),
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: []
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: nil,
+    magic_items: nil,
+    gems: nil,
+    boxes: nil,
+    skin: "golden hinterboar mane",
+    other: nil,
+    blunt_required: false
+  },
+  messaging: {
+    description: "Squinty eyes the color of molten copper dart here and there as if the immense boar is always on the alert for predators, but given its tremendous mass, it likely has little cause for worry.  The hinterboar's pelt is a glittering, metallic golden in hue, but is shot through with a hypnotic pattern of duskier bristles.  The line of raised bristles down the center of the beast's spine seems to radiate faint luminescence, warm and honey-hued.",
+    arrival: [
+      "Heavy hoofbeats herald the arrival of an immense gold-bristled hinterboar.",
+      "An immense gold-bristled hinterboar trots in with its tusks lifted skyward.  Its great hooves shake the ground with every step."
+    ],
+    flee: "An immense gold-bristled hinterboar charges {direction}, shaking the ground with each hoofbeat.",
+    death: "With a final discordant squeal, an immense gold-bristled hinterboar's great head sinks to the ground as its form goes still.",
+    decay: "An immense gold-bristled hinterboar's form succumbs to decay, collapsing into ruined meat and patchy bristles.",
+    search: [
+      "An immense gold-bristled hinterboar puts its snout to the ground and snuffles for unseen prey.",
+      "An immense gold-bristled hinterboar snuffles at the ground, trying to ferret out hidden threats."
+    ],
+    charge: "Lowering its head, an immense gold-bristled hinterboar barrels into a merciless charge at you!",
+    boarrush: "An immense gold-bristled hinterboar scrapes the ground with one forehoof before lowering its huge head.  It barrels into a mighty charge, hooves pounding across the ground as it races toward you.",
+    impale: "Murder in its eyes, an immense gold-bristled hinterboar tries to gore you with its tusks!",
+    feint: "An immense gold-bristled hinterboar feints low.",
+    stomp: "Rearing up on its hind legs, an immense gold-bristled hinterboar stomps at you with its huge hooves!"
+  }
+}
+
+=begin
+description, arrival, flee, death, decay, search, spell_prep, creature specific
+
+  An immense gold-bristled hinterboar puts its snout to the ground and snuffles for unseen prey.
+  An immense gold-bristled hinterboar snuffles at the ground, trying to ferret out hidden threats.
+
+  An immense gold-bristled hinterboar charges west, shaking the ground with each hoofbeat.
+
+=end

--- a/lib/gemstone/creatures/niveous_giant_warg.rb
+++ b/lib/gemstone/creatures/niveous_giant_warg.rb
@@ -1,0 +1,154 @@
+{
+  name: "niveous giant warg",
+  url: "https://gswiki.play.net/Niveous_giant_warg",
+  picture: "",
+  level: 104,
+  family: "canine",
+  type: "quadruped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 15,
+  size: "large",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "bite",
+        as: 527
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "1",
+    immunities: [],
+    melee: (432..701),
+    ranged: (389..491),
+    bolt: nil,
+    udf: nil,
+    bar_td: 410,
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: (339..360),
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: (403..433),
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: "?",
+    skin: "Y",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    description: "Larger than a draft horse, the warg is the apotheosis of predatory instinct and lupine form.  With a heavy coat the color of freshly driven snow and a thick mane agleam with frost crystals in glittering blues and glacial greens, the warg is as beautiful as it is murderous.  The beast's eyes are cold aquamarine and faintly lambent, shining with ferocious intellect.",
+    arrival: [
+      "With a plaintive howl, a niveous giant warg bounds in, hackles raised and sickle-sized fangs bared.",
+      "A niveous giant warg pads in, deadly quiet despite its great size.",
+      "A niveous giant warg just came through a rune-carved white granite arch."
+    ],
+    flee: "A niveous giant warg lopes {direction}, muscle bunching under its fur.",
+    search: [
+      "A niveous giant warg sniffs after unseen prey.",
+      "A niveous giant warg sniffs around, its hackles rising in agitation."
+    ],
+
+    general_advice: "* By design, wargs grow significantly and synergistically more dangerous as more of them come into the same room since the presence of others from their pack bolsters one another's attacks. As such, even though an individual warg might not be threatening, treating them as high priority targets is often a safer option than most other creatures in their areas.",
+    war_cries: "As A niveous giant warg moves agressively towards you, XXX moves away a bit.\nA niveous giant warg sits back on its haunches and unleashes a long, high-pitched howl that sends a shiver of primal terror down your spine.\n[SSR result: 111 (Open d100: 16)]\nXXX looks terrified and drops her guard!\n[SSR result: 260 (Open d100: 180)]\nXXX looks terrified and drops his guard!\n[SSR result: 214 (Open d100: 149)]\nRoundtime: 10 sec."
+  }
+}
+
+=begin
+# hamstring
+With a quick lunge, a niveous giant warg tries to hamstring you with its !
+[SMR result: 92 (Open d100: 83, Bonus: 1)]
+A niveous giant warg's swing goes wide!
+
+# howl? warcry
+A niveous giant warg sits back on its haunches and unleashes a long, high-pitched howl that sends a shiver of primal terror down your spine.
+[SSR result: 144 (Open d100: 80)]
+Roundtime: 6 sec.
+Your heart quavers in your chest and you find yourself unable to focus on defending yourself!
+
+# tackle?
+A niveous giant warg hurls itself at you!
+[SMR result: 86 (Open d100: 64, Bonus: 1)]
+A niveous giant warg fails to bring you down, but manages to scramble to its feet!
+
+# coup?
+A niveous giant warg moves agressively towards you to finish you off, but you still have enough wits about you to thwart its attempt.
+A niveous giant warg sits back on its haunches and unleashes a long, high-pitched howl that sends a shiver of primal terror down your spine.
+[SSR result: 122 (Open d100: 58)]
+Roundtime: 3 sec.
+You fall further into the clutches of primal terror, insensate with the sound of the warg's cries!
+
+
+# bite (attack)
+A niveous giant warg lunges at you, maw slathering as it tries to take a ferocious bite!
+  AS: +524 vs DS: +768 with AvD: +39 + d100 roll: +88 = -121
+   A clean miss.
+
+A niveous giant warg lunges at you, maw slathering as it tries to take a ferocious bite!
+  AS: +480 vs DS: +663 with AvD: +39 + d100 roll: +61 = -83
+   A clean miss.
+
+#  slash (attack)
+A niveous giant warg bounds forward and slashes at you with a foreclaw!
+  AS: +520 vs DS: +804 with AvD: +41 + d100 roll: +26 = -217
+   A clean miss.
+
+A niveous giant warg bounds forward and slashes at you with a foreclaw!
+  AS: +480 vs DS: +663 with AvD: +41 + d100 roll: +35 = -107
+   A clean miss.
+
+
+Emboldened by the addition of more pack members, a niveous giant warg bares its teeth in a hungry snarl!
+A niveous giant warg lunges at you, maw slathering as it tries to take a ferocious bite!
+  AS: +541 vs DS: +734 with AvD: +39 + d100 roll: +49 = -105
+   A clean miss.
+
+Emboldened by the addition of more pack members, a niveous giant warg bares its teeth in a hungry snarl!
+A niveous giant warg bounds forward and slashes at you with a foreclaw!
+  AS: +545 vs DS: +629 with AvD: +41 + d100 roll: +41 = -2
+   A clean miss.
+
+Bolstered by nearby members of its pack, a niveous giant warg grows bolder and more fierce!
+A niveous giant warg bounds forward and slashes at you with a foreclaw!
+  AS: +570 vs DS: +679 with AvD: +41 + d100 roll: +90 = +22
+   A clean miss.
+
+Emboldened by the addition of more pack members, a niveous giant warg bares its teeth in a hungry snarl!
+A niveous giant warg lunges at you, maw slathering as it tries to take a ferocious bite!
+  AS: +570 vs DS: +574 with AvD: +39 + d100 roll: +30 = +65
+   A clean miss.
+
+# Side by side?  +speed? +as?
+Bolstered by nearby members of its pack, a niveous giant warg grows bolder and more fierce!
+Emboldened by the addition of more pack members, a niveous giant warg bares its teeth in a hungry snarl!
+
+=end

--- a/lib/gemstone/creatures/quivering_sanguine_ooze.rb
+++ b/lib/gemstone/creatures/quivering_sanguine_ooze.rb
@@ -1,0 +1,71 @@
+{
+  name: "Quivering sanguine ooze",
+  url: "https://gswiki.play.net/Quivering_sanguine_ooze",
+  picture: "",
+  level: 107,
+  family: "Ooze",
+  type: "Globoid",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: "",
+  size: "",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "",
+        as: ""
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: nil,
+    immunities: [],
+    melee: nil,
+    ranged: nil,
+    bolt: nil,
+    udf: nil,
+    bar_td: nil,
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: nil,
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: true,
+    skin: "?",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    general_advice: "* Oozes are essentially noncorporeal, uncrittable, unstunnable damage sponges that often divide themselves into oozelings upon getting hit, where each oozeling has a fraction of the original ooze's health but otherwise has similar combat abilities and stats on all fronts. If left unchecked long enough, the oozelings' health will grow. Since oozes reduce their own health by splitting and since they split when they're attacked, using even weak AoE attacks can clear rooms more quickly than using powerful single-target attacks. [[Clash]], [[Cyclone]], [[Divine Incarnation (1650)]] Onslaught, [[Divine Wrath (335)]], [[Judgment (1630)]], [[Nature's Fury (635)]], [[Pulverize]], [[Song of Sonic Disruption (1030)]], [[Volley]] (with a [[short bow]] or [[hand crossbow]] only to keep [[roundtime|RT]] manageable), [[Whirling Blade]], and [[Whirlwind]] are all good. In particular, Divine Wrath, Song of Sonic Disruption, and Volley stand out due to respectively multiple rounds of damage, low [[mana]] cost (upon renewal), and low [[stamina]] cost mixed with multiple rounds of damage. All three of those options can lead to rooms going from one ooze to ten in no time, then down to zero also in no time, as oozes divide constantly.\n* If absorbed by an ooze, an adventurer can attack its organ until it spits them out.\n** Military pick worked, dagger & spear did not.\n* Culling bounties for oozes go quickly since oozelings count."
+  }
+}

--- a/lib/gemstone/creatures/roiling_crimson_angargeist.rb
+++ b/lib/gemstone/creatures/roiling_crimson_angargeist.rb
@@ -1,0 +1,74 @@
+{
+  name: "Roiling crimson angargeist",
+  url: "https://gswiki.play.net/Roiling_crimson_angargeist",
+  picture: "",
+  level: 110,
+  family: "",
+  type: "",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 13,
+  size: "large",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "",
+        as: ""
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: nil,
+    immunities: [],
+    melee: nil,
+    ranged: nil,
+    bolt: "510",
+    udf: nil,
+    bar_td: nil,
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: "441",
+    sor_td: "504",
+    wiz_td: nil,
+    mje_td: "541",
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: "?",
+    skin: "?",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    description: "Swirling ectoplasm, crimson and black and lit from within by crackles of sickly yellow energy, takes on a rough humanoid shape, but the angargeist is clearly nothing alive.  Where a face ought to be is a molten ruin, lopsided eyes of unholy flame sparking in its ill-made sockets.  Immaterial and dripping essence, the arms and legs are uneven, both ending in straining talons.  The angargeist's form bubbles and simmers in places like fury lent form.",
+    fade: "Angargeist fade similar to [[Banshee]] and reappear randomly.",
+    vortex_smr: "The shadows bubble and seethe as a roiling crimson angargeist rematerializes, swirling together into a vortex of vile energies!\nCrackling torrents of spectral energy erupt from the angargeist as it reforms, warping the air as they ripple outward!",
+    sympathy: "Quivering with rage, a roiling crimson angargeist sends dripping tendrils of rust-colored ectoplasm toward you!\nThe dull golden nimbus surrounding you flares into life as it glows brightly for a moment.\nCS: +489 - TD: +353 + CvA: -27 + d100: +20 - +5 == +124\nWarding failed!\nRage, boiling and hot, bubbles up within your chest as you feel overwhelmed with sympathy for the angargeist!"
+  }
+}

--- a/lib/gemstone/creatures/savage_fork-tongued_wendigo.rb
+++ b/lib/gemstone/creatures/savage_fork-tongued_wendigo.rb
@@ -1,0 +1,180 @@
+{
+  name: "savage fork-tongued wendigo",
+  url: "https://gswiki.play.net/Savage_fork-tongued_wendigo",
+  picture: "",
+  level: 105,
+  family: "humanoid",
+  type: "biped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: 600,
+  speed: "",
+  height: 8,
+  size: "large",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "attack",
+        as: (530..630)
+      },
+      {
+        name: "bite (attack)",
+        as: (505..605)
+      },
+      {
+        name: "claw (attack)",
+        as: (515..615)
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [
+      {
+        name: "frenzy (216)",
+        cs: (438..450)
+      },
+      {
+        name: "sympathy (1120)",
+        cs: (438..450)
+      }
+    ],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [
+      {
+        name: "enrage", # wiki calls this Attack Strength boost
+        note: "+100 AS"
+      },
+      {
+        name: "mstrike",
+        note: "x5"
+      }
+    ]
+  },
+  defense_attributes: {
+    asg: "10N",
+    immunities: [],
+    melee: (428),
+    ranged: (404),
+    bolt: (404),
+    udf: (656),
+    bar_td: (432..434),
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: (398..403),
+    sor_td: (471..483),
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: (489..495),
+    mjs_td: nil,
+    mns_td: (444),
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    special_defenses: []
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: true,
+    magic_items: nil,
+    gems: true,
+    boxes: true,
+    skin: nil,
+    other: nil,
+    blunt_required: false
+  },
+  messaging: {
+    description: "The wendigo looks to have once been humanoid.  Magics have contorted and stretched its form into an atrocity of exposed bone and raw tissues that stands several heads taller than a giantman.  Sprouting antlers of bloodstained bone breach up from the sparse flesh of the wendigo's skull.  Its eyes are misty pools of light that cast the rest of the wendigo's face in haunted shadow.  The abomination's maw is forced open by multifarious rows of shark-like teeth, but its tongue is forked like that of a snake.",
+    arrival: [
+      "A savage fork-tongued wendigo steps in, eyes like luminous pools searching the surroundings.",
+      "A savage fork-tongued wendigo steps in, luminous eyes hungrily eyeing the surroundings despite its grievous wounds.",
+      "Eyes like twin pools of ghostly light materialize through the falling snow, illuminating the abominable shape of a savage fork-tongued wendigo.  The creature races forward with unnatural speed, mouth opening unnaturally wide as it bares rows of shark-like teeth."
+    ],
+    flee: [
+      "Heedless of its grievous wounds, a savage fork-tongued wendigo stalks {direction}.",
+      "A savage fork-tongued wendigo gets down on all fours and sprints {direction} at unnatural speed.",
+      "A savage fork-tongued wendigo's luminous eyes flare with unnatural light as it turns and stalks {direction}."
+    ],
+    death: "Rage flickers in the wendigo's eyes as it collapses, bloody maw still working hungrily until the last hint of life goes out of its form.",
+    decay: "Rot sets into a savage fork-tongued wendigo's body with unnatural speed, skin sloughing away to reveal greying muscle and rampant suppuration.  In moments, all that remain are yellowing bones and stinking effluvia.",
+    search: [
+      "A savage fork-tongued wendigo tilts its head, eyeing the shadows with a hideous smile upon its face.",
+      "a savage fork-tongued wendigo's eyes dart around, suspicion warring with hunger in its beady eyes."
+    ],
+    spell_prep: "A savage fork-tongued wendigo rasps out a dissonant, sing-song phrase.",
+
+    frenzy: "A savage fork-tongued wendigo crooks an oddly elongated finger at you!",
+    sympathy: "A savage fork-tongued wendigo points skyward with a single gristly talon!",
+    bite: "A savage fork-tongued wendigo's jaw unhinges as it tries to ravage you with its shark-like teeth!",
+    claw: [
+      "Lashing out unpredictably, a savage fork-tongued wendigo slices at you with an elongated talon!",
+      "A savage fork-tongued wendigo flails with its clawed fists at you!"
+    ],
+    attack: "With inhuman swiftness and precision, a savage fork-tongued wendigo swings its {weapon} at you!",
+    enrage: "A savage fork-tongued wendigo's eyes blaze a murderous crimson!",
+    mstrike: "In an awe-inspiring display of combat mastery, a savage fork-tongued wendigo engages you in a furious dance macabre, spiraling into a blur of strikes and ripostes!",
+  }
+}
+
+=begin
+
+
+# make you mad spell  Frenzy?
+  A savage fork-tongued wendigo rasps out a dissonant, sing-song phrase.
+  >
+  A savage fork-tongued wendigo crooks an oddly elongated finger at you!
+    CS: +450 - TD: +441 + CvA: +4 + d100: +88 == +101
+    Warding failed!
+  Anger beyond all reason boils up within you!
+
+
+# some aoe spell... Sympathy?
+  A savage fork-tongued wendigo points skyward with a single gristly talon!
+  A savage fork-tongued wendigo closes its eyes in deep concentration...
+
+  An echo of foreign thought brushes your mind.
+    CS: +450 - TD: +478 + CvA: +4 + d100: +20 == -4
+    Warded off!
+  You blink a few times.
+
+    CS: +450 - TD: +403 + CvA: +25 + d100: +26 == +98
+    Warded off!
+  A niveous giant warg blinks a few times.
+
+  A savage fork-tongued wendigo opens its eyes, looking less focused.
+
+
+
+# cyclone?  frigid cyclone in room
+  The air grows even colder as an intensely localized cyclone forms overhead, assailing the area with an onslaught of snow and icy wind.
+
+  Shrill wind gusts from the cyclone, howling through the area in a stinging onslaught.
+  [SMR result: 179 (Open d100: 193, Penalty: 7)]
+  Cold air strikes you with the force of a great fist, knocking you to the ground!
+    ... 10 points of damage!
+    You just got the cold shoulder!
+  Roundtime: 7 sec.
+
+  A frigid cyclone fluctuates before dissipating with a last gust of frigid wind.
+
+
+
+# Jump up and flee
+  A savage fork-tongued wendigo jerks up from the ground in a single boneless motion.
+  Heedless of its grievous wounds, a savage fork-tongued wendigo stalks northwest.
+
+  A savage fork-tongued wendigo points skyward with a single gristly talon!
+  A savage fork-tongued wendigo gets an intense expression.
+
+  A savage fork-tongued wendigo tilts its head slowly to an unnatural angle.  Its forked tongue protrudes from split lips, tasting the air ravenously.
+
+
+  A savage fork-tongued wendigo tilts its head, eyeing the shadows with a hideous smile upon its face.
+  A savage fork-tongued wendigo extends an elongated finger, pointing toward you in your hiding place!
+=end

--- a/lib/gemstone/creatures/shining_winged_disir.rb
+++ b/lib/gemstone/creatures/shining_winged_disir.rb
@@ -1,0 +1,110 @@
+{
+  name: "Shining winged disir",
+  url: "https://gswiki.play.net/Shining_winged_disir",
+  picture: "",
+  level: 114,
+  family: "",
+  type: "",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 9,
+  size: "medium",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "Lance",
+        as: ""
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [
+      {
+        name: "Censure",
+        cs: ""
+      }
+    ],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: nil,
+    immunities: [],
+    melee: nil,
+    ranged: nil,
+    bolt: nil,
+    udf: nil,
+    bar_td: nil,
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: nil,
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: "?",
+    skin: "?",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    description: "Clad from head to toe in armor of shining gold, the disir takes the form of a powerfully built woman with ageless features and eyes like pools of sunlit sky.  On her head, nestled atop curls of shimmering hair, is a winged helm whose visor dips low over her face, lending a grim cast to her features.  The disir's skin is faintly luminous, with hints of rainbowed color pulsing beneath it.",
+
+    bards: "* [[Vibration Chant (1002)]] can eliminate their \"[[spear]]s\" (which hit like [[lance]]s). Disirs then switch to a magical, non-physical shield which can't be blown up, but many will find that preferable to letting them swing lances with 650 AS.",
+    clerics: "* Disirs behave somewhat unpredictably under the effects of [[Prayer of Holding (301)]], as sometimes it'll keep them bound while other times they'll shake it off immediately and counterattack in a single combat round. The fact that it even sometimes holds them makes it viable as a setup leading into [[Condemn (309)]], though, as it just means binding them repeatedly until it sticks.",
+    paladins: "* Disirs move fairly quickly in combat, so, in this case, casting [[Aura of the Arkati (1614)]] the hard way and then attacking with a beseeched [[Repentance (1615)]] is far more reliable than the other way around. Opening with Repentance might allow the disir to get up by the time the paladin's out of cast RT and on to her physical attack, but opening with the Aura of the Arkati debuff will leave that lasting long enough to carry through to the followup.",
+    rangers: "* [[Moonbeam (611)]] is a near universal solution in the [[Hinterwilds]] and disirs are no exception. However, they can occasionally get out of even that, so tread carefully. A followup [[Spike Thorn (616)]] against a bound disir will often miss the kill even with heavy training in [[Ranger Base]] and [[Spiritual Lore, Summoning|Summoning lore]], which is more than most Hinterwilds creatures can say, but repeated casts will still win the day.",
+    retreat: "",
+    divine_intervention: "The winged disir is stunned!",
+    flaming_aura: "The flaming aura surrounding a shining winged disir lashes out at you, but you manage to dodge the licking flames!\n[SMR result: 83 (Open d100: 28, Bonus: 8)]",
+    call_wind: "A shining winged disir throws her shining wings wide, buffeting the area with a cruel gale!\nA gust of wind tugs at your sleeves.  Suddenly, a fierce wind rips through the area, scattering everything in its path and making it difficult to remain standing.",
+    battle_standard_divine_bulwark_effect: "A shining winged disir raises her a gleaming golden aegis and braces for an assault as a luminous barrier momentarily enshrouds her form.\nYou take aim and swing a gleaming rune-scribed maul at a shining winged disir!",
+    shield_throw: "A shining winged disir settles into a firm stance and flings her golden aegis at you![SMR result: 185 (Open d100: 155, Penalty: 12)]\nThe aegis races through the air and strikes you in the left arm!\n... 4 points of damage!\nLight blow to your left arm.",
+    unknown_ability: "A shining winged disir focuses her luminous gaze upon you!\nA shining winged disir silently mouths an incantation that does not seem to be in any language you know."
+  }
+}
+
+=begin
+
+# +100 DS pre-resolution flare
+A shining winged disir raises her a gleaming golden aegis and braces for an assault as a luminous barrier momentarily enshrouds her form.
+
+You swing a sleek gleaming steel baselard at a shining winged disir!
+  AS: +707 vs DS: +587 with AvD: +19 + d100 roll: +21 = +160
+   ... and hit for 8 points of damage!
+   Blow glances off the winged disir's shoulder.
+Soot brown specks of leaf mold trail in the wake of a shining winged disir's movements, distorted by a murky haze.
+Vital energy infuses you, hastening your arcane reflexes!
+A shining winged disir raises her a gleaming golden aegis and braces for an assault as a luminous barrier momentarily enshrouds her form.
+You swing a sleek gleaming steel baselard at a shining winged disir!
+  AS: +678 vs DS: +687 with AvD: +19 + d100 roll: +80 = +90
+   A clean miss.
+Roundtime: 4 sec.
+Roundtime changed to 1 second.
+
+Many-colored radiance builds in the air nearby, coalescing into the powerful form of a towering woman with shining wings.  The disir steps forth from the light as it ebbs away.
+
+=end

--- a/lib/gemstone/creatures/squamous_reptilian_mutant.rb
+++ b/lib/gemstone/creatures/squamous_reptilian_mutant.rb
@@ -1,0 +1,82 @@
+{
+  name: "Squamous reptilian mutant",
+  url: "https://gswiki.play.net/Squamous_reptilian_mutant",
+  picture: "",
+  level: 109,
+  family: "Reptilian",
+  type: "",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: "",
+  size: "",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "Cudgel",
+        as: "598"
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [
+      {
+        name: "Bind",
+        cs: "475"
+      }
+    ],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: nil,
+    immunities: [],
+    melee: nil,
+    ranged: nil,
+    bolt: nil,
+    udf: nil,
+    bar_td: nil,
+    cle_td: nil,
+    emp_td: "496",
+    pal_td: nil,
+    ran_td: nil,
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: "?",
+    skin: "?",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    general_advice: "* As primarily casting creatures, mutants are fairly vulnerable to [[Standard_maneuver_roll|SMR]]-based spells and attacks like [[Condemn (309)]], [[Earthen Fury (917)]], [[Hamstring]], [[Spike Thorn (616)]], [[Twin Hammerfists]], and so on. This is offset somewhat by their high level, though.\n* Mutants have exceptionally high CS--over 520--that leaves their [[Thought Lash (1210)]], [[Bind (214)]], and [[Vertigo (1219)]] spells nearly guaranteed to hit against every profession and leave characters stunned or disabled. Keep them from casting by any means including [[Sweep]], [[Feint]], [[Corrupt Essence (703)]], [[Moonbeam (611)]], Condemn, Earthen Fury, or other options that keep them stalled out, unable to cast, or repeatedly stunned.\n* Mutants have [[Brace (1214)]], which can disarm against many forms of physical attacks. However, many combat maneuvers and SMR-based weapon techniques bypass this, as do ranged attacks and [[Brawling|unarmed combat]]. Brace can also be removed via dispelling magic such as [[Spirit Dispel (119)]], [[Spiritual Abolition (230)]], [[Elemental Dispel (417)]], [[Mental Dispel (1218)]], and [[Song of Unravelling (1013)]] or other similar effects like [[Spell Cleave]].",
+    voln: "* [[Symbol of Transcendence]] can sometimes salvage a bad situation, either preemptively or used with its emergency cooldown. High CS aside, mutants are still mostly casting disablers or attacking with one of the weaker weapon bases, the [[cudgel]], so it's possible to survive even ten rounds of stun with enough luck.\n* [[Symbol of Restoration]] can be used while [[Immobilized]] by Bind.",
+    bards: "* [[Vibration Chant (1002)]] can destroy their weapons and has at least a chance to kill outright.\n* Be ready to shout [[Troubadour's Rally (1040)]] at a moment's notice to get away safely after being hit by any of a mutant's dangerous spells.",
+    clerics: "* The INFUSE SPIRIT option of [[Soul Ward (319)]] can sometimes delay mutants long enough to keep a cleric alive through lengthy stun.",
+    empaths: "* The REGENERATE option of [[Regeneration (1150)]] can sometimes keep an empath healed and padded to survive lengthy stun a limited number of times per day, depending on [[Mental Lore, Transformation|Transformation]] lore.",
+    paladins: "* [[Divine Incarnation (1650)]] Smite with enough [[Spiritual Lore, Religion|Religion]] lore to reliably hit twice will usually do substantial damage to mutants, if not outright kill them, while divine energy lasts.\n* Be ready to beseech [[Divine Intervention (1635)]] at a moment's notice to get away safely after being hit by any of a mutant's dangerous spells.",
+    rangers: "* With enough [[Ranger Base]] ranks, Moonbeam is a nearly universal solution in the Hinterwilds and mutants are no exception."
+  }
+}

--- a/lib/gemstone/creatures/stunted_halfling_bloodspeaker.rb
+++ b/lib/gemstone/creatures/stunted_halfling_bloodspeaker.rb
@@ -1,0 +1,157 @@
+{
+  name: "stunted halfling bloodspeaker",
+  url: "https://gswiki.play.net/Stunted_halfling_bloodspeaker",
+  picture: "",
+  level: 103,
+  family: "humanoid",
+  type: "biped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: 367,
+  speed: "",
+  height: 3,
+  size: "small",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "attack",
+        as: (420..550)
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [
+      {
+        name: "blood burst (701)",
+        cs: (455..473)
+      },
+      {
+        name: "bone shatter (1106)",
+        cs: (439..454)
+      },
+      {
+        name: "corrupt essence (703)",
+        cs: (455..473)
+      },
+      {
+        name: "limb disruption (708)",
+        cs: (455..473)
+      },
+      {
+        name: "wither (1115)",
+        cs: (439..454)
+      }
+    ],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "2",
+    immunities: [],
+    melee: (467..502),
+    ranged: (521..530),
+    bolt: (451..541),
+    udf: (542..568),
+    bar_td: 470,
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: (400..412),
+    sor_td: 482,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: 537,
+    mjs_td: nil,
+    mns_td: (450..461),
+    mnm_td: nil,
+    defensive_spells: [
+      {
+        name: "prayer (313)"
+      },
+      {
+        name: "foresight (1204)"
+      },
+      {
+        name: "mindward (1208)"
+      }
+    ],
+    defensive_abilities: [
+      {
+        name: "health regen",
+        note: "similar to trolls blood or regeneration?"
+      },
+      {
+        name: "unstun",
+        note: "able to break stuns"
+      }
+    ],
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: true,
+    magic_items: nil,
+    gems: true,
+    boxes: true,
+    skin: false,
+    other: ["herbs", "gigas fragments"],
+    requires_blunt: false
+  },
+  messaging: {
+    description: "Small even for a halfling, the bloodspeaker is twisted of limb and stunted of form.  Bulging eyes the color of dried blood peer out from a face like molten wax.  The ritualistic burn scars marring {pronoun} flesh look painful beyond the most grotesque of imaginings.  The bloodspeaker wears heavy robes of red velvet that do little to conceal the broken-puppet jangle of {pronoun} misshapen body beneath them.  {pronoun} tongue is bisected and lolls forth from a mouth that looks like a wet gash in {pronoun} obscene face.",
+    arrival: "A stunted halfling bloodspeaker hurries in, ebon eyes darting about in paranoia.",
+    flee: "Ebon eyes darting about in paranoia, a stunted halfling bloodspeaker hurries {direction}.",
+    spell_prep: "A stunted halfling bloodspeaker utters a garbled, sibilant phrase as globules of crimson light spin around {pronoun} gnarled hands.",
+    death: "A stunted halfling bloodspeaker's eyes bulge as {pronoun} stares toward the heavens, mouthing a gurgling prayer as {pronoun} succumbs to death.",
+    decay: "A stunted halfling bloodspeaker's body collapses in upon itself as if everything solid within has turned to liquid, the sanguine remains oozing out of the remaining folds of skin.",
+    search: [
+      "A stunted halfling bloodspeaker licks her lips as she looks around, as if certain that she has missed something.",
+      "a stunted halfling bloodspeaker's sniffs the air, bulging eyes darting about wildly"
+    ],
+
+    unstun: "Rivulets of swirling incarnadine energy envelop a stunted halfling bloodspeaker's scarred flesh, allowing {pronoun} to move freely once more.",
+    stand: "A stunted halfling bloodspeaker struggles, grunting and cursing as {pronoun} rises to {pronoun} feet.",
+    health_regen: [
+      "A stunted halfling bloodspeaker raises {pronoun} malformed fingers overhead, contorting them into jarring patterns as globules of carmine radiance pirouette through the air around {pronoun}. The spinning beads of radiance gather into a dripping sanguine orb that hovers in the air nearby, pulsing with otherworldly light.",
+      "Eldritch radiance from a swirling sanguine orb bathes a stunted halfling bloodspeaker, causing {pronoun} wounds to sluggishly tug themselves closed in the sanguine light."
+    ],
+    attack: "With incongruous alacrity, a stunted halfling bloodspeaker swings {weapon} at you!",
+    bone_shatter: "A stunted halfling bloodspeaker concentrates intently on you, and a pulse of pearlescent energy ripples toward you!",
+    wither: "The force of a stunted halfling bloodspeaker's power warps the air as it surges toward you!",
+
+    general_advice: "* Warding casters will have more success against this creature with a high [[TD]] if they cast dispelling magic upon it first.\n* [[Standard_maneuver_roll|SMR]]-based attacks like [[Condemn (309)]], [[Earthen Fury (917)]], and [[Spike Thorn (616)]] frequently tear through bloodspeakers. [[Animal Companion (630)|Animal companions]] can also do significant damage.\n* [[Silenced|Silencing]] tactics like [[Cutthroat]] and [[Sucker Punch]], or the similar [[Corrupt Essence (703)]], will halt their threatening [[Wither (1115)]] spell. ([[Silence (210)]] itself is unlikely to hit barring an unusual build heavily focused on [[Major Spiritual]] ranks.)",
+  }
+}
+
+=begin
+description, arrival, flee, death, decay, search, spell_prep, creature specific
+# blood burst
+A stunted halfling bloodspeaker points a blunt, swollen finger at you!
+  CS: +455 - TD: +410 + CvA: +5 + d94: +91 - -5 == +146
+  Warding failed!
+Blood sprays from your neck in a crimson arc!
+   ... 10 points of damage!
+Attenuated droplets of Nisugi's blood are drawn into the sanguine lattice encircling a stunted halfling bloodspeaker.
+
+# limb disruption
+A stunted halfling bloodspeaker points a blunt, swollen finger at you!
+  CS: +473 - TD: +410 + CvA: +5 + d91: +48 - -5 == +121
+  Warding failed!
+Your left leg twists painfully but does not break.
+You are stunned 1 round!
+
+# corrupt essence
+A stunted halfling bloodspeaker points a blunt, swollen finger at you!
+  CS: +473 - TD: +393 + CvA: +5 + d80: +16 - -5 == +106
+  Warding failed!
+You feel weakened as a blood red haze forms around you.
+
+The veins of a stunted halfling bloodspeaker's blood shield shrivel and dry, darkening brown and flaking away into windblown dust.
+
+=end

--- a/lib/gemstone/creatures/tattooed_gigas_berserker.rb
+++ b/lib/gemstone/creatures/tattooed_gigas_berserker.rb
@@ -1,0 +1,167 @@
+{
+  name: "tattooed gigas berserker",
+  url: "https://gswiki.play.net/Tattooed_gigas_berserker",
+  picture: "",
+  level: 103,
+  family: "gigas",
+  type: "biped",
+  undead: "",
+  otherclass: [],
+  areas: [
+    "hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 30,
+  size: "huge",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "hatchet",
+        as: 531
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "10",
+    immunities: [],
+    melee: (462..659),
+    ranged: (423..550),
+    bolt: nil,
+    udf: nil,
+    bar_td: 401,
+    cle_td: nil,
+    emp_td: 418,
+    pal_td: nil,
+    ran_td: (333..348),
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: 462,
+    mjs_td: nil,
+    mns_td: (406..418),
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: true,
+    skin: false,
+    other: "gigas fragments",
+    blunt_required: false
+  },
+  messaging: {
+    description: "A tattooed gigas berserker is a hulking brute of a gigas, standing more than four times the height of a man and with the immense muscle mass to match.  His vast biceps are ringed with intricate tattoos in auroral colors: glacial blues and flashfire greens that are bright enough to have been stolen from cut jewels.  The rest of him is unlovely, from his matted beard to the look of murder in his bulging eyes.",
+    arrival: [
+      "A tattooed gigas berserker barrels in, bellowing a mad battlecry that shakes the ground with its intensity!",
+      "A tattooed gigas berserker charges in, madness twisting his features.",
+    ],
+    death: "A tattooed gigas berserker's fists tense with impotent rage as she surrenders to death.",
+    decay: "Creeping decay races across a tattooed gigas berserker's prone form, swiftly consuming the body despite its colossal size.",
+    search: [
+      "A tattooed gigas berserker raises his great head, bulging eyes searching the shadows.",
+      "A tattooed gigas berserker's brow knits sneers as his eyes fruitlessly search the shadows."
+    ],
+
+    general_advice: "* Berserkers are [[square]] creatures in fairly light armor, so players of [[semi]]s and [[pure]]s can take advantage of low [[TD]] and [[CvA]] by casting [[CS]]-based offensive spells.",
+    bards: "* By destroying berserkers' weapons, [[Vibration Chant (1002)]] stops many of the most threatening things they can do and sometimes kills them outright.",
+    wizards: "* Berserkers can be targeted with [[Mana Leech (516)]].",
+
+    combat_messaging: "[SMR result: 93 (Open d100: 7)]\nStooping down from his vast height, a tattooed gigas berserker reaches toward you with a gigantic fist!  You scurry out of the way of the huge fingers, heart pounding in your chest!"
+  }
+}
+
+=begin
+
+A tattooed gigas berserker glares at you and lets out a nerve-shattering bellow!
+[SSR result: 101 (Open d100: 53)]
+You maintain your resolve, ignoring the unnerving cry!
+
+
+In a breathtaking display of agility and combat mastery, a tattooed gigas berserker whirls in a fury of unrelenting strikes and ripostes!
+Froth bubbling on his lips, a tattooed gigas berserker swings an immense fel-hafted handaxe at you in a murderous arc!
+You barely dodge the attack!
+The ethereal necrotic film covering a tattooed gigas berserker's fel-hafted handaxe shrivels away.
+
+In a breathtaking display of agility and combat mastery, a tattooed gigas berserker whirls in a fury of unrelenting strikes and ripostes!
+Froth bubbling on his lips, a tattooed gigas berserker swings an immense fel-hafted handaxe at you in a murderous arc!
+  AS: +516 vs DS: +896 with AvD: +30 + d100 roll: +97 = -253
+   A clean miss.
+
+In a display of martial precision, a brawny gigas shield-maiden thrusts with a gold-tipped heavy spear at you!
+A blackened mithril greathelm partially deflects the onslaught of the puncture attack.
+  AS: +566 vs DS: +403 with AvD: +28 + d100 roll: +48 = +239
+   ... and hits for 60 points of damage!
+   Pierced through neck, a fine shot!
+   You are stunned for 4 rounds!
+
+
+[SMR result: 118 (Open d100: 93, Bonus: 29)]
+Stooping down from his vast height, a tattooed gigas berserker reaches toward you with a gigantic fist!  Although you struggle to get away, his massive fingers snatch at you!
+   ... 5 points of damage!
+   Slight leg hold.
+
+In a breathtaking display of agility and combat mastery, a tattooed gigas berserker whirls in a fury of unrelenting strikes and ripostes!
+Froth bubbling on her lips, a tattooed gigas berserker swings an immense fel-hafted handaxe at you in a murderous arc!
+  AS: +517 vs DS: +838 with AvD: +30 + d100 roll: +47 = -244
+   A clean miss.
+
+
+A tattooed gigas berserker hangs back for a moment and concentrates intently on you, before unleashing an attack on the magical wards surrounding you!
+[SMR result: 96 (Open d100: 80)]
+A tattooed gigas berserker fails to connect solidly with any magical ward.
+
+In a breathtaking display of agility and combat mastery, a tattooed gigas berserker whirls in a fury of unrelenting strikes and ripostes!
+Froth bubbling on his lips, a tattooed gigas berserker swings an immense fel-hafted handaxe at you in a murderous arc!
+  AS: +527 vs DS: +753 with AvD: +30 + d100 roll: +21 = -175
+   A clean miss.
+
+P>
+[SMR result: 167 (Open d100: 143, Bonus: 21)]
+Stooping down from his vast height, a tattooed gigas berserker reaches toward you with a gigantic fist!  Massive fingers close around your midsection as the berserker tries to squeeze the life out of you!
+   ... 20 points of damage!
+   Hard shove to the midriff staggers you.
+   You are stunned for 3 rounds!
+The berserker lifts you into the air, trapping you in his huge fist!
+
+[SMR result: 167 (Open d100: 143, Bonus: 21)]
+Stooping down from his vast height, a tattooed gigas berserker reaches toward you with a gigantic fist!  Massive fingers close around your midsection as the berserker tries to squeeze the life out of you!
+   ... 20 points of damage!
+   Hard shove to the midriff staggers you.
+   You are stunned for 3 rounds!
+The berserker lifts you into the air, trapping you in his huge fist!
+
+[SMR result: 143 (Open d100: 16, Bonus: 113)]
+A tattooed gigas berserker grabs your hair and lifts you.  With a malevolent grin on his face, he winds up and hurls you into the air, sending you flying through a rune-carved white granite arch.
+[Ojandhaart, Approach - 29900] (u7503118)
+The dirt roadway proceeds beneath a monumental arch of white granite, the surface of which is roughly carved with an arcing spray of runes.  Beyond, smoke rises from the high roofs of buildings made from raw timber and rough-hewn stone.  All of the buildings are several times the height of a tall man.
+Obvious paths: west
+[claim.room] "claimed 7503118"
+You hit the ground hard at the end of your catastrophic descent!
+   ... 10 points of damage!
+   Light strike to your chest.
+
+In a breathtaking display of agility and combat mastery, a tattooed gigas berserker whirls in a fury of unrelenting strikes and ripostes!
+Froth bubbling on his lips, a tattooed gigas berserker swings an immense fel-hafted handaxe at you in a murderous arc!
+Rolling hurriedly, you dodge the attack!
+
+A tattooed gigas berserker gets a running start and then acrobatically leaps up onto the back of a heavily armored battle mastodon, mounting it!
+
+A tattooed gigas berserker rides a heavily armored battle mastodon southeast, the mastodon limping with every great step.
+
+=end

--- a/lib/gemstone/creatures/withered_shadowcloaked_draugr.rb
+++ b/lib/gemstone/creatures/withered_shadowcloaked_draugr.rb
@@ -1,0 +1,74 @@
+{
+  name: "Withered shadow-cloaked draugr",
+  url: "https://gswiki.play.net/Withered_shadow-cloaked_draugr",
+  picture: "",
+  level: 108,
+  family: "Gigas",
+  type: "Biped",
+  undead: "",
+  otherclass: [
+    "Corporeal undead"
+  ],
+  areas: [
+    "Hinterwilds"
+  ],
+  bcs: true,
+  hitpoints: "",
+  speed: "",
+  height: 30,
+  size: "huge",
+  attack_attributes: {
+    physical_attacks: [
+      {
+        name: "greatsword",
+        as: "592"
+      }
+    ],
+    bolt_spells: [],
+    warding_spells: [],
+    offensive_spells: [],
+    maneuvers: [],
+    special_abilities: [],
+    special_notes: []
+  },
+  defense_attributes: {
+    asg: "7",
+    immunities: [],
+    melee: nil,
+    ranged: nil,
+    bolt: nil,
+    udf: nil,
+    bar_td: nil,
+    cle_td: nil,
+    emp_td: nil,
+    pal_td: nil,
+    ran_td: nil,
+    sor_td: nil,
+    wiz_td: nil,
+    mje_td: nil,
+    mne_td: nil,
+    mjs_td: nil,
+    mns_td: nil,
+    mnm_td: nil,
+    defensive_spells: [],
+    defensive_abilities: [],
+    imm1: "",
+    sda1: ""
+  },
+  special_other: "",
+  abilities: [],
+  alchemy: [],
+  treasure: {
+    coins: "?",
+    magic_items: "",
+    gems: "?",
+    boxes: "?",
+    skin: "?",
+    other: "?",
+    blunt_required: false
+  },
+  messaging: {
+    description: "Utterly immense, the draugr's humanoid shape is comprised wholly of inky shadows that drip and pool at its intangible feet.  Cruel eyes of frigid light glare from a face of sharp lines and malevolent angles.  The shade's arms are lightless and devoid of all but the most rudimentary features, but are massively thick and traced with intricate lines of blazing blue radiance.",
+    general_advice: "* Taking out a draugr's greatsword and leaving them swinging a closed fist is as close to taking out the draugr as can be short of actually killing it, so [[Disarm Weapon]], [[Vibration Chant (1002)]], or even [[Limb Disruption (708)]] work great here. DoT spells like [[Condemn (309)]] and [[Earthen Fury (917)]] are liable to also sever an arm by sheer probability given enough rounds of going off.\n* In lieu of killing a draugr or getting rid of its weapon, another strong option is taking out its legs or inflicting [[Rooted]] since draugrs rely heavily on high [[attack strength|AS]] or maneuvers to be effective. [[Hamstring]] (despite [[Major Bleed]] not affecting [[undead]]), [[Cripple]], [[Pin Down]], and other options can do the trick.\n* In lieu of any of the above, draugrs are also [[square]] enemies in light armor, so low [[TD]] and low [[CvA]] leaves them pretty vulnerable to most [[CS]]-based attacks despite their high level."
+  }
+}


### PR DESCRIPTION
  The creature module provides both static creature data (from template files) and live instance tracking for active creatures in the game.

  Template Data (Static)

  Each creature has a template file with base stats that never change:

  # Load template data
  template = Creature.find_by_name("a tattooed gigas berserker")

  # Access static attributes
  template.level                          # => 109
  template.body_type                      # => "biped"
  template.family                         # => "gigas"
  template.undead?                        # => false
  template.attack_attributes.attack_strength  # => 449
  template.defense_attributes.dodge       # => 391
  template.defense_attributes.hitpoints   # => 450 (max HP)

  Instance Tracking (Live)

  When you encounter creatures in-game, they get registered with an ID and can track dynamic state:

  # Register a creature instance when seen in XML
  creature = Creature.register_creature("a tattooed gigas berserker", 1234567)

  # Or look up existing instance
  creature = Creature[1234567]

  Managing Instance State

  Status Effects

  # Add status effects
  creature.add_status("stunned")
  creature.add_status("prone")
  creature.add_status("webbed")

  # Remove status
  creature.remove_status("stunned")

  # Check current statuses
  creature.status  # => ["prone", "webbed"]

  Wounds/Injuries

  # Add wounds (body part, rank)
  creature.add_injury("leftLeg", 2)    # rank 2 leg wound
  creature.add_injury("head", 3)       # rank 3 head wound

  # Reduce wounds
  creature.remove_injury("leftLeg", 1)  # reduces leg wound by 1 rank

  # Check all wounds
  creature.injuries  # => {"leftLeg" => 1, "head" => 3}

  HP Tracking

  # Update current HP (instance data)
  creature.update_field(:hitpoints, 250)

  # Compare current vs max
  current_hp = creature.hitpoints                      # => 250 (current)
  max_hp = creature.defense_attributes.hitpoints       # => 450 (from template)
  percent = (current_hp.to_f / max_hp * 100).round    # => 56%

  Adding New Creature Templates

  1. Copy lib/gemstone/creatures/_creature_template.rb
  2. Rename to match the creature (e.g., frost_giant.rb)
  3. Fill in the static data from game observation
  4. The template automatically becomes available

  Integration Points

  - XMLParser: Automatically registers creatures when seen in game XML
  - GameObj: Provides .creature_data accessor for creature instances
  - Combat Module: Uses creature data for damage calculations and status tracking

  Registry Access

  # Get all registered instances
  Registry.instance.all_creatures

  # Find specific instance by ID
  Registry.instance.find_by_id(1234567)

  # Find by name (returns first match)
  Registry.instance.find_by_name("a tattooed gigas berserker")