### PR TITLE
chore(all): fix prepare-prerelease.yaml for white noise

### DIFF
--- a/.github/workflows/prepare-prerelease.yaml
+++ b/.github/workflows/prepare-prerelease.yaml
@@ -36,6 +36,26 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
+      # Ensure the prerelease target branch exists; create it from base if missing
+      - name: Ensure target prerelease branch exists (create from base if missing)
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET="${{ inputs.target_branch }}"
+          BASE="origin/${{ inputs.base_branch }}"
+
+          # Make sure we have the latest refs for both base and target
+          git fetch --prune --tags --force origin "${{ inputs.base_branch }}"
+          if git ls-remote --exit-code --heads origin "$TARGET" >/dev/null 2>&1; then
+            echo "Remote branch $TARGET exists; checking out local tracking branch"
+            git fetch origin "$TARGET":"$TARGET"
+            git checkout "$TARGET"
+          else
+            echo "Creating $TARGET from base $BASE"
+            git checkout -b "$TARGET" "$BASE"
+            git push -u origin "$TARGET"
+          fi
+
       - name: Fetch tags
         run: git fetch --tags --force
 
@@ -97,6 +117,6 @@ jobs:
         with:
           config-file: release-please-config.prerelease.json
           manifest-file: .release-please-manifest.json
-          target-branch: pre/beta            # or ${{ github.ref_name }}
+          target-branch: ${{ inputs.target_branch }} # allow input, but default is pre/beta
           skip-github-pull-request: false    # you want the PR
           skip-github-release: true          # <-- prevent create-a-release here


### PR DESCRIPTION
Two causes for the white noise in our first run is drift from our conversion and potential variance in CRLF versus LF.  This patch corrects for both by declaring only drawing from `main` as the base branch, and sets EOL to `lf` only.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes 'white noise' in `prepare-prerelease.yaml` by setting base branch to `main` and configuring LF EOL.
> 
>   - **Workflow Configuration**:
>     - Adds `base_branch` input to `prepare-prerelease.yaml`, defaulting to `main`.
>     - Configures Git to use LF for EOL in `prepare-prerelease.yaml`.
>   - **Branch Management**:
>     - Ensures target prerelease branch exists; creates from base if missing in `prepare-prerelease.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 2e01ea448618846aeacd0b18ff735a6551546676. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->