### PR TITLE
chore(all): Update release-please-config.json to anchor v5.12.7

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
+  "bootstrap-sha": "d1a7dcec986eb9b5de6fae21c7bed557747b8432",
+  "last-release-sha": "d1a7dcec986eb9b5de6fae21c7bed557747b8432",
+  "commit-search-depth": 200,
+  "release-search-depth": 50,
   "packages": {
     ".": {
       "release-type": "ruby",


### PR DESCRIPTION
Avoids needless clutter by defining starting point for release please.  After run, the two lines `bootstrap-sha` and `last-release-sha` should be removed to prevent performance hits.