### PR TITLE
fix(gs): Bounty parser for SG npcs matching

### DIFF
--- a/lib/gemstone/bounty/parser.rb
+++ b/lib/gemstone/bounty/parser.rb
@@ -140,7 +140,7 @@ module Lich
             "Kraken's Fall"
           elsif description =~ /the tavernkeeper at Rawknuckle's Common House\.$/
             "Cold River"
-          elsif description =~ /Captain|Reiya|Ataum/ || description =~ /gem dealer in has received/
+          elsif description =~ /\b(?:Captain|Reiya|Ataum|Galeb)\b/ || description =~ /gem dealer in has received/
             # the latter is a temporary workaround because of an actual typo in the messaging
             # that should be removed if it is ever actually fixed
             'Contempt'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Updates regex in `determine_town` method to include `Ataum` and `Galeb` for correct town identification in bounty tasks.
> 
>   - **Behavior**:
>     - Updates regex in `determine_town` method in `parser.rb` to include `Ataum` and `Galeb` for matching NPCs related to 'Contempt'.
>     - This change helps in correctly identifying the town for certain bounty tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for de030898279a219af601e23459d9097536fcb57b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->