### PR TITLE
chore(all): Tailor RSpec to ignore config / CI changes

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Classify changed files (preflight)
         id: preflight
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v6.1.0
         with:
           script: |
             const owner = context.repo.owner;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a preflight step to RSpec CI workflow to skip tests for changes affecting only ignored files, optimizing CI resource usage.
> 
>   - **Behavior**:
>     - Adds a preflight step in `.github/workflows/rspec_tests.yaml` to determine if RSpec tests should run based on changed files.
>     - Skips Ruby setup and RSpec tests if only ignored files are changed, running a noop step instead.
>     - Ensures tests run if any non-ignored files are changed or if file list determination fails.
>   - **Preflight Logic**:
>     - Uses `actions/github-script` to classify changed files against an ignore list.
>     - Ignore list includes paths like `.github/workflows/**`, `.gitignore`, `README.adoc`, etc.
>     - Always runs tests for changes in `spec/**`, `Gemfile`, and `Gemfile.lock`.
>   - **Operational Effects**:
>     - Docs/meta-only PRs complete quickly with a skip message.
>     - Full RSpec job runs for test or dependency changes.
>     - Workflow triggers remain unchanged, maintaining required checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for df60f673276ee4caae450c0eac84b9c64c2f979b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->