### PR TITLE
fix(all): games.rb catch additional error for nested single/double qu…

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -386,7 +386,7 @@ module Lich
           rescue => e
             case e.to_s
             # Missing attribute equal: <s> - in dynamic dialogs with a single apostrophe for possessive 'Tsetem's Items'
-            when /nested single quotes|nested double quotes|Missing attribute equal: <\w+>/
+            when /nested single quotes|nested double quotes|Missing attribute equal: <[^>]+>|Invalid attribute name: <[^>]+>/
               original_server_string = server_string.dup
               server_string = XMLCleaner.clean_nested_quotes(server_string)
               if original_server_string != server_string


### PR DESCRIPTION
…otes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance XML error handling in `games.rb` by adding support for 'Invalid attribute name' errors in `process_xml_data`.
> 
>   - **Error Handling**:
>     - In `process_xml_data` in `games.rb`, added handling for `Invalid attribute name: <[^>]+>` error in XML parsing.
>     - This is added to the existing rescue block that handles nested quotes and missing attribute errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 8d50941183c12cd383264785cae634bb9915928c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->