### PR TITLE
fix(dr): change keys for DR_SKILLS_DATA[:guild_skill_aliases] to be strings instead of symbols

### DIFF
--- a/lib/dragonrealms/drinfomon/drvariables.rb
+++ b/lib/dragonrealms/drinfomon/drvariables.rb
@@ -137,17 +137,17 @@ module Lich
         ]
       },
       "guild_skill_aliases": {
-        "Cleric"        => { "Primary Magic" => "Holy Magic" },
-        "Necromancer"   => { "Primary Magic" => "Arcane Magic" },
-        "Warrior Mage"  => { "Primary Magic" => "Elemental Magic" },
-        "Thief"         => { "Primary Magic" => "Inner Magic" },
-        "Barbarian"     => { "Primary Magic" => "Inner Fire" },
-        "Ranger"        => { "Primary Magic" => "Life Magic" },
-        "Bard"          => { "Primary Magic" => "Elemental Magic" },
-        "Paladin"       => { "Primary Magic" => "Holy Magic" },
-        "Empath"        => { "Primary Magic" => "Life Magic" },
-        "Trader"        => { "Primary Magic" => "Lunar Magic" },
-        "Moon Mage"     => { "Primary Magic" => "Lunar Magic" }
+        "Cleric"       => { "Primary Magic" => "Holy Magic" },
+        "Necromancer"  => { "Primary Magic" => "Arcane Magic" },
+        "Warrior Mage" => { "Primary Magic" => "Elemental Magic" },
+        "Thief"        => { "Primary Magic" => "Inner Magic" },
+        "Barbarian"    => { "Primary Magic" => "Inner Fire" },
+        "Ranger"       => { "Primary Magic" => "Life Magic" },
+        "Bard"         => { "Primary Magic" => "Elemental Magic" },
+        "Paladin"      => { "Primary Magic" => "Holy Magic" },
+        "Empath"       => { "Primary Magic" => "Life Magic" },
+        "Trader"       => { "Primary Magic" => "Lunar Magic" },
+        "Moon Mage"    => { "Primary Magic" => "Lunar Magic" }
       }
     }
 


### PR DESCRIPTION
Fixes issues in method `lookup_alias` of module 'DRSkill' for converting Primary Magic to guild specific PM skill name.  This method expects the guild and skill names to be strings, not symbols.  

Possible regression when switching from YAML stored data to ruby.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `lookup_alias` method by changing `guild_skill_aliases` keys to strings in `drvariables.rb`.
> 
>   - **Behavior**:
>     - Changes keys in `guild_skill_aliases` from symbols to strings in `drvariables.rb`.
>     - Fixes `lookup_alias` method in `DRSkill` module to correctly convert Primary Magic to guild-specific skill names.
>   - **Regression**:
>     - Addresses potential regression from YAML to Ruby data storage conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 1c184e5c8761b929e93a65d59918f8f29282c800. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->