### PR TITLE
fix(dr): add bput match for system updates preventing actions

### DIFF
--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -45,7 +45,7 @@ module Lich
           log += [response]
 
           case response
-          when /For some strange reason you are unable to do that\.  The world somehow seems frozen in place/
+          when /^For some strange reason you are unable to do that\.  The world somehow seems frozen in place/
             # Zadraes — 13:32 It's a "You're in an area actively being updated" message
             pause 1
             put message


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds handling in `bput` function for system update message indicating the world is frozen, pausing and retrying the command.
> 
>   - **Behavior**:
>     - In `bput` function in `common.rb`, added handling for system update message: "For some strange reason you are unable to do that. The world somehow seems frozen in place".
>     - On receiving this message, the function pauses for 1 second, retries the command, and resets the timer.
>   - **Misc**:
>     - Comment added to explain the new case handling in `bput`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 5e8f900a88719ec0f2e05d9c85ee0204a2b224d5. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->