### PR TITLE
fix(gs): bounty location regex needs to match "under"

### DIFF
--- a/lib/gemstone/bounty/parser.rb
+++ b/lib/gemstone/bounty/parser.rb
@@ -3,7 +3,7 @@ module Lich
     class Bounty
       class Parser
         HMM_REGEX = /(?:Hmm, I've got a task here from .*?(?<town>[A-Z].*?)\..*?)?/
-        LOCATION_REGEX = /(?:on|in|near) (?:the\s+)?(?<area>[^.]+?)(?:\s+(?:near|between) (?<town>[^.]+))?/
+        LOCATION_REGEX = /(?:on|in|near) (?:the\s+)?(?<area>[^.]+?)(?:\s+(?:near|between|under) (?<town>[^.]+))?/
         GUARD_REGEX = Regexp.union(
           /one of the guardsmen just inside the (?<town>Ta'Illistim) City Gate/,
           /one of the guardsmen just inside the Sapphire Gate/,


### PR DESCRIPTION
You have been tasked to suppress carrion worm activity in the subterranean tunnels under Icemule Trace.  You need to kill 27 of them to complete your task.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `LOCATION_REGEX` in `parser.rb` to include 'under' for location parsing in bounty tasks.
> 
>   - **Regex Update**:
>     - Modify `LOCATION_REGEX` in `parser.rb` to include 'under' as a valid location descriptor.
>     - Affects parsing of locations in bounty tasks, allowing for 'under' a town.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 5f061d4500c841865c32e9378cab6c71e2888fa8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->