### PR TITLE
fix(dr): drdefs.rb npc parsing

### DIFF
--- a/lib/dragonrealms/drinfomon/drdefs.rb
+++ b/lib/dragonrealms/drinfomon/drdefs.rb
@@ -100,18 +100,18 @@ module Lich
 
     def add_ordinals_to_duplicates(npc_list)
       flat_npcs = []
-      
+
       npc_list.uniq.each do |npc|
         # Count how many times this NPC appears
         count = npc_list.count(npc)
-        
+
         # Create entries with ordinals for duplicates
         count.times do |index|
           name = index.zero? ? npc : "#{$ORDINALS[index]} #{npc}"
           flat_npcs << name
         end
       end
-      
+
       flat_npcs
     end
 


### PR DESCRIPTION
Rooms containing multiple NPCs with different names were not being parsed correctly. The first appearing NPC name is duplicated for the entire list. For example:
```xml
<resource picture="0"/><style id="roomName" />[Crossing Forging Society, Tool Store] (44010)
<style id=""/><preset id='roomDesc'>Masters and journeyman of the forging craft find a home in this room purchasing tools and ingredients.  Loud thumps and groaning accompany the loading and unloading of goods from storage.</preset>  You also see <pushBold/>Forging Society Mistress Yalda<popBold/>, <pushBold/>a master consultant<popBold/>, a steel crate, a large sign, a sturdy low counter with a small placard on it and <pushBold/>a clerk<popBold/>.
Obvious exits: <d>north</d>, <d>south</d>, <d>west</d>.
>;e echo DRRoom.npcs
--- Lich: exec1 active.
[exec1: ["Yalda", "Yalda", "Yalda"]]
```
3 Yaldas instead of `["Yalda", "consultant", "clerk"]`. 
jackal_ encountered a similar unresolved issue in March 2025: https://discord.com/channels/745675889622384681/745676101392793651/1353365550910410803

The edit fixes the problem while still assigning ordinals correctly. But the changed line is pretty dense, so I'm grateful for any additional eyes on it. I've been using this edit on multiple characters for a few weeks and haven't noticed any unexpected issues. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes NPC parsing in `drdefs.rb` to correctly handle multiple NPCs with different names by modifying `clean_npc_string`.
> 
>   - **Behavior**:
>     - Fixes NPC parsing in `clean_npc_string` in `drdefs.rb` to correctly handle multiple NPCs with different names.
>     - Previously, the first NPC name was duplicated for all NPCs in the list.
>   - **Code**:
>     - Modifies line in `clean_npc_string` to ensure unique NPC names are maintained and ordinals are correctly assigned.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 46ded9f49e415ab5f9d012c0467bf441ccfb3ce8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->