### PR TITLE
fix(dr): Fix container reference in get_item_from_eddy_portal method

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -772,7 +772,7 @@ module Lich
       # http://forums.play.net/forums/DragonRealms/Discussions%20with%20DragonRealms%20Staff%20and%20Players/Game%20Master%20and%20Official%20Announcements/view/1899
       def get_item_from_eddy_portal?(item, container)
         # Ensure the eddy is open then look in it to force the contents to be loaded.
-        return false unless DRCI.open_container?('my eddy') && DRCI.look_in_container(container)
+        return false unless DRCI.open_container?('my eddy') && DRCI.look_in_container('portal in my eddy')
 
         from = container
         from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)


### PR DESCRIPTION
Fixes a bug if you're using a container inside the eddy.  You always need to look in the portal, not in the container in the portal to get it to reload.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `get_item_from_eddy_portal?` in `common-items.rb` to correctly look in 'portal in my eddy' for reloading contents.
> 
>   - **Bug Fix**:
>     - Fixes `get_item_from_eddy_portal?` in `common-items.rb` to correctly look in 'portal in my eddy' instead of using the container parameter directly.
>     - Ensures contents are reloaded properly when retrieving items from the eddy portal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for afd5928a84fa5280a10c8dcd2bd5713679f965b0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->