### PR TITLE
chore(all): prepare-prerelease workflow semantic version correction

### DIFF
--- a/.github/workflows/prepare-prerelease.yaml
+++ b/.github/workflows/prepare-prerelease.yaml
@@ -252,39 +252,31 @@ jobs:
           # Use --force-if-includes to ensure atomic push (fails if remote changed)
           git push --force-if-includes origin "${{ steps.guard_validate.outputs.target_safe }}"
 
-      - name: Pin Release-As to next beta.N on same train (if prior prerelease exists)
+      - name: Pin Release-As to next beta.N based on latest stable (start next minor)
         shell: bash
         run: |
           set -euo pipefail
-          # Find latest reachable prerelease tag like vMA.MI.0-beta.M
-          last_beta="$(git tag -l 'v[0-9]*.[0-9]*.0-beta.[0-9]*' --merged HEAD --sort=-version:refname | head -n1 || true)"
-          echo "DEBUG(pin): last_beta(reachable)='${last_beta}'"
-          if [ -z "$last_beta" ]; then
-            echo "No reachable prerelease tag; nothing to pin."
+          # Determine latest stable on main and start prerelease for NEXT MINOR (patch 0)
+          git fetch --tags origin main >/dev/null 2>&1 || true
+          stable="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --merged origin/main --sort=-version:refname | head -n1 || true)"
+          if [[ ! "$stable" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            echo "No stable tag detected on main; skipping pin."
             exit 0
           fi
-          if [[ ! "$last_beta" =~ ^v([0-9]+)\.([0-9]+)\.0-beta\.([0-9]+)$ ]]; then
-            echo "Latest reachable prerelease tag '$last_beta' is not MA.MI.0-beta.M; skipping pin."
-            exit 0
+          S_MAJ="${BASH_REMATCH[1]}"; S_MIN="${BASH_REMATCH[2]}"
+          TARGET_MIN=$((S_MIN+1))
+          base="v${S_MAJ}.${TARGET_MIN}.0"
+
+          # If a prerelease train already exists for this base, bump N; else start at beta.0
+          last_base_beta="$(git tag -l "${base}-beta.[0-9]*" --sort=-version:refname | head -n1 || true)"
+          if [[ "$last_base_beta" =~ ^v[0-9]+\.[0-9]+\.0-beta\.([0-9]+)$ ]]; then
+            NEXT_N=$((BASH_REMATCH[1]+1))
+          else
+            NEXT_N=0
           fi
-          MA="${BASH_REMATCH[1]}"; MI="${BASH_REMATCH[2]}"; M="${BASH_REMATCH[3]}"
-          base="v${MA}.${MI}.0"
-          next="v${MA}.${MI}.0-beta.$((M+1))"
-          cnt="$(git rev-list --count "${last_beta}..HEAD" || echo 0)"
-          echo "DEBUG(pin): commits since ${last_beta} -> ${cnt}"
-          echo "DEBUG(pin): next=${next}"
-          # If HEAD already contains next tag (unlikely), skip
-          if git rev-parse -q --verify "refs/tags/${next}" >/dev/null; then
-            echo "Tag ${next} already exists; skipping pin."
-            exit 0
-          fi
-          # Ensure there is at least one new commit since last_beta; otherwise skip
-          if [ "$(git rev-list --count "${last_beta}..HEAD")" -eq 0 ]; then
-            echo "No new commits since ${last_beta}; skipping pin."
-            exit 0
-          fi
-          echo "Pinning Release-As to ${next} to maintain same prerelease train."
-          git config user.name  "github-actions[bot]"
+          next="${base}-beta.${NEXT_N}"
+          echo "Pinning prerelease to ${next} (derived from latest stable ${stable})"
+          git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit --allow-empty -m "chore: pin prerelease ${next}" -m "Release-As: ${next}"
           git push origin HEAD:${{ steps.guard_validate.outputs.target_safe }}


### PR DESCRIPTION
Updated the logic for pinning the Release-As tag to use the latest stable version instead of the last beta prerelease. This change ensures that the next prerelease starts from the next minor version based on the latest stable tag.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `prepare-prerelease.yaml` to pin prerelease versions based on the latest stable tag, starting the next minor version.
> 
>   - **Behavior**:
>     - Updates `prepare-prerelease.yaml` to pin `Release-As` to the next minor version based on the latest stable tag.
>     - Removes logic for pinning based on the last beta prerelease.
>     - Handles cases where no stable tag is detected by skipping the pinning process.
>   - **Logic**:
>     - Fetches latest stable tag from `origin/main` and calculates the next minor version.
>     - Determines if a prerelease train exists for the new base and increments beta version accordingly.
>     - Commits and pushes the new prerelease pin using `github-actions[bot]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 3f4e4c2fb122b52c3c4fcd2a1ee8670e8f7e0d7d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->