### PR TITLE
chore(all): Refine export-ignore settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,11 +2,12 @@
 
 # let's gussy this up a bit for a working zip / tarball release
 # first, let's ignore files we don't want in the zip
-.git*           export-ignore
-.ruby-version   export-ignore
-README.adoc     export-ignore
-Gemfile*        export-ignore
-/*.toml         export-ignore
+.git*            export-ignore
+.claude*         export-ignore
+.ruby-version    export-ignore
+Gemfile*         export-ignore
+/*.adoc          export-ignore
+/*.toml          export-ignore
 /*.yml           export-ignore
 /*.yaml          export-ignore
 /*.ico           export-ignore
@@ -15,8 +16,8 @@ Gemfile*        export-ignore
 /*.md            export-ignore
 
 # second, let's take a running stab at ignoring a directory
-/spec           export-ignore
-/.github        export-ignore
+/spec            export-ignore
+/.github         export-ignore
 
 # third, let's ignore a file in a directory
 


### PR DESCRIPTION
Updated export-ignore rules for various file types and directories.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refines export-ignore settings in `.gitattributes` by adding specific file types and directories.
> 
>   - **Export-Ignore Settings**:
>     - Updated `.gitattributes` to refine export-ignore settings.
>     - Added `/*.toml`, `/*.yml`, `/*.yaml`, `/*.ico`, `/*.iss`, `/*.json`, `/*.md` to export-ignore.
>     - Added `/.github` directory to export-ignore.
>     - Removed `*.yml`, `*.yaml`, `*.ico`, `*.iss` from export-ignore (now using path-specific rules).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 9dd4c96a6723558f3fd71bb16755b6e180737930. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->