### PR TITLE
fix(all): Update module strip markdown comments

### DIFF
--- a/lib/update.rb
+++ b/lib/update.rb
@@ -322,7 +322,7 @@ module Lich
 
         @update_to = latest['tag_name'].to_s.sub('v', '')
         @holder = latest['assets']
-        @new_features = latest['body'].to_s.gsub(/\#\# What's Changed.+$/m, '').gsub(/<!-- .* -->/, '')
+        @new_features = latest['body'].to_s.gsub(/\#\# What's Changed.+$/m, '').gsub(/<!--[\s\S]*?-->/, '')
         release_asset = @holder && @holder.find { |x| x['name'] =~ /\b#{ASSET_TARBALL_NAME}\b/ }
         @zipfile = release_asset.fetch('browser_download_url')
       end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Strip HTML comments from `@new_features` in `prep_betatest()` and `prep_update()` in `lib/update.rb`.
> 
>   - **Behavior**:
>     - In `lib/update.rb`, `prep_betatest()` and `prep_update()` now strip HTML comments from `@new_features` using `gsub(/<!--[\s\S]*?-->/, '')`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 6e95e9444ecefa947c39f820d2dd87514a99e724. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->