### PR TITLE
chore(all): merge main into feat/login_modernization_and_refactor_to_yaml

### DIFF
--- a/lib/common/buffer.rb
+++ b/lib/common/buffer.rb
@@ -126,9 +126,9 @@ module Lich
       def Buffer.streams=(val)
         if (!val.is_a?(Integer)) or ((val & 63) == 0)
           respond "--- Lich: error: invalid streams value\n\t#{$!.caller[0..2].join("\n\t")}"
-          return nil
+        else
+          @@streams[Thread.current.object_id] = val
         end
-        @@streams[Thread.current.object_id] = val
       end
 
       # rubocop:enable Lint/HashCompareByIdentity

--- a/lib/common/map/map_gs.rb
+++ b/lib/common/map/map_gs.rb
@@ -27,10 +27,10 @@ module Lich
       end
 
       def Map.current_room_id; return @@current_room_id; end
-      def Map.current_room_id=(id); return @@current_room_id = id; end
+      def Map.current_room_id=(id); @@current_room_id = id; end
       def Map.loaded; return @@loaded; end
       def Map.previous_room_id; return @@previous_room_id; end
-      def Map.previous_room_id=(id); return @@previous_room_id = id; end
+      def Map.previous_room_id=(id); @@previous_room_id = id; end
       def fuzzy_room_id; return @@current_room_id; end
       def outside?; return @paths.last =~ /^Obvious paths:/ ? true : false; end
       def to_i; return @id; end

--- a/lib/common/settings.rb
+++ b/lib/common/settings.rb
@@ -172,7 +172,7 @@ module Lich
         # Local helper to keep cache in sync with the just-persisted root
         sync_cache = lambda do |root_obj|
           cached = @settings_cache[cache_key]
-          if cached && cached.object_id != root_obj.object_id
+          if cached && !cached.equal?(root_obj)
             if cached.is_a?(Hash) && root_obj.is_a?(Hash)
               cached.replace(root_obj)
             elsif cached.is_a?(Array) && root_obj.is_a?(Array)
@@ -229,7 +229,7 @@ module Lich
           end
 
           # Root identity drift: sync proxy.target into cached root if different objects (same-type containers).
-          if current_root_for_scope.object_id != proxy.target.object_id
+          if !current_root_for_scope.equal?(proxy.target)
             if proxy.target.is_a?(Hash) && current_root_for_scope.is_a?(Hash)
               _log(LOG_LEVEL_DEBUG, @@log_prefix, -> { "save_proxy_changes: Root identity mismatch (cache #{current_root_for_scope.object_id} vs proxy #{proxy.target.object_id}); copying via Hash#replace" })
               current_root_for_scope.replace(proxy.target)

--- a/lib/gemstone/sk.rb
+++ b/lib/gemstone/sk.rb
@@ -21,9 +21,10 @@ module Lich
       end
 
       def self.sk_known=(val)
-        return @sk_known if @sk_known == val
-        DB_Store.save("#{XMLData.game}:#{XMLData.name}", "sk_known", val)
-        @sk_known = val
+        unless @sk_known == val
+          DB_Store.save("#{XMLData.game}:#{XMLData.name}", "sk_known", val)
+          @sk_known = val
+        end
       end
 
       def self.known?(spell)

--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -628,7 +628,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.display_lichid
@@ -653,7 +652,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.hide_uid_flag
@@ -678,7 +676,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.core_updated_with_lich_version
@@ -698,7 +695,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.display_uid
@@ -723,7 +719,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.display_exits
@@ -748,7 +743,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.display_stringprocs
@@ -773,7 +767,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.track_autosort_state
@@ -797,7 +790,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.track_dark_mode
@@ -821,7 +813,6 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 
   def Lich.track_layout_state
@@ -845,6 +836,5 @@ module Lich
       sleep 0.1
       retry
     end
-    return nil
   end
 end


### PR DESCRIPTION
…so… (#1064)

…n violations

- Remove explicit return statements from setter methods (14 violations in lib/lich.rb, lib/common/buffer.rb, lib/common/map/map_gs.rb, lib/gemstone/sk.rb)
- Replace object_id comparisons with equal? method (2 violations in lib/common/settings.rb)
- All fixes maintain semantic equivalence and pass both rubocop 1.73.0 and 1.81.7
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor code to remove unnecessary returns and use `equal?` for object comparison, ensuring rubocop compliance.
> 
>   - **Behavior**:
>     - Removed explicit `return` statements from setter methods in `lib/lich.rb`, `lib/common/buffer.rb`, `lib/common/map/map_gs.rb`, and `lib/gemstone/sk.rb`.
>     - Replaced `object_id` comparisons with `equal?` method in `lib/common/settings.rb`.
>   - **Compliance**:
>     - All changes maintain semantic equivalence and pass rubocop versions 1.73.0 and 1.81.7.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7700a69c140bb6026ea3a10e0877b5c5d4e143bf. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->