### PR TITLE
chore(all): Add debug information in curate-pre-branch.sh

### DIFF
--- a/.github/scripts/curate-pre-branch.sh
+++ b/.github/scripts/curate-pre-branch.sh
@@ -216,6 +216,11 @@ process_single_pr() {
   local pr_num="$1"
   log_group "PR #${pr_num}"
 
+  # Instrumenting to see where failures might occur
+  log_info "DEBUG: HEAD ref = $(git rev-parse --abbrev-ref HEAD)"
+  log_info "DEBUG: Last 10 commits on HEAD:"
+  git log --format='%h %s' -10 HEAD | sed 's/^/DEBUG:   /'
+
   # Detect whether this PR has already been curated into DEST_SAFE
   local pr_already_curated=false
   if git log --format=%s HEAD | grep -qE "\(#${pr_num}\)$"; then


### PR DESCRIPTION
Added debug logging to track HEAD ref and recent commits.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add debug logging to `curate-pre-branch.sh` to track HEAD ref and recent commits.
> 
>   - **Debug Logging**:
>     - Adds debug logging in `curate-pre-branch.sh` to track HEAD ref and last 10 commits.
>     - Uses `git rev-parse` and `git log` to gather information.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 4da01dc97544af63265162f8a6a52fa25266c8c3. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->