### PR TITLE
chore(all): enhance logging in curate-pre-branch script

### DIFF
--- a/.github/scripts/curate-pre-branch.sh
+++ b/.github/scripts/curate-pre-branch.sh
@@ -226,6 +226,9 @@ process_single_pr() {
   if git log --format=%s HEAD | grep -qE "\(#${pr_num}\)$"; then
     pr_already_curated=true
     log_info "PR #${pr_num} already present in ${DEST_SAFE}; treating as update."
+  else
+    # more logging
+    log_info "DEBUG: did NOT detect prior curated commit for #${pr_num}"
   fi
 
   local pr_json
@@ -251,6 +254,9 @@ process_single_pr() {
     USE_UNION=false
     log_info "Using -X theirs strategy for updated PR #${pr_num}"
   fi
+
+  # and more logging
+  log_info "DEBUG: strategy for PR #${pr_num}: STRAT_SAFE=$STRAT_SAFE GIT_STRATEGY_FLAG='${GIT_STRATEGY_FLAG:-<none>}' USE_UNION=${USE_UNION}"
 
   # Determine cherry-pick mode
   if [[ "$MODE_SAFE" == "merged" ]] || { [[ "$MODE_SAFE" == "auto" ]] && pr_is_merged "$pr_json" && [[ "$merge_sha" != "null" ]]; }; then


### PR DESCRIPTION
Added additional logging for PR curation process.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances logging in `curate-pre-branch.sh` by adding debug logs for PR curation process.
> 
>   - **Logging Enhancements**:
>     - Adds debug log in `process_single_pr()` in `curate-pre-branch.sh` to indicate when a prior curated commit is not detected for a PR.
>     - Adds debug log to show the strategy used for a PR, including `STRAT_SAFE`, `GIT_STRATEGY_FLAG`, and `USE_UNION`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 41307b2bf1b87987e94c942ccda35ddce8eda555. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->