### PR TITLE
chore(all): update curate detection for PR curation process

### DIFF
--- a/.github/scripts/curate-pre-branch.sh
+++ b/.github/scripts/curate-pre-branch.sh
@@ -223,12 +223,18 @@ process_single_pr() {
 
   # Detect whether this PR has already been curated into DEST_SAFE
   local pr_already_curated=false
-  if git log --format=%s HEAD | grep -qE "\(#${pr_num}\)$"; then
+  # Proper behavior through process would be to provide fixes in new PRs
+  # to any feature PRs that are being beta tested.  For now, we will make
+  # the call that if a PR is added to beta, at any point in the beta train,
+  # any changes brought back through the curate process need to be 'update'
+  # type changes, and the merge strategy must be '-X theirs' to avoid
+  # duplicating code into syntax errors from the Hinterlands. So always check
+  # against the 'origin/${DEST_SAFE}' to avoid branch merge shinanigans.
+  if git log --format=%s "origin/${DEST_SAFE}" | grep -qE "\(#${pr_num}\)$"; then
     pr_already_curated=true
-    log_info "PR #${pr_num} already present in ${DEST_SAFE}; treating as update."
+    log_info "PR #${pr_num} already present in origin/${DEST_SAFE}; treating as update."
   else
-    # more logging
-    log_info "DEBUG: did NOT detect prior curated commit for #${pr_num}"
+    log_info "DEBUG: did NOT detect prior curated commit for #${pr_num} in origin/${DEST_SAFE}"
   fi
 
   local pr_json


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `curate-pre-branch.sh` to check curated PRs against `origin/${DEST_SAFE}` and adjust logging.
> 
>   - **Behavior**:
>     - Update `process_single_pr()` in `curate-pre-branch.sh` to check against `origin/${DEST_SAFE}` instead of `HEAD` for curated PR detection.
>     - Ensures merge strategy uses '-X theirs' to avoid syntax errors from code duplication.
>   - **Logging**:
>     - Update log messages in `curate-pre-branch.sh` to reflect checks against `origin/${DEST_SAFE}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 2023e8ce17a1c6cdd479bea985568dc1a8c55590. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->