### PR TITLE
chore(all): Refactor git log command for PR check in curate

### DIFF
--- a/.github/scripts/curate-pre-branch.sh
+++ b/.github/scripts/curate-pre-branch.sh
@@ -230,7 +230,9 @@ process_single_pr() {
   # type changes, and the merge strategy must be '-X theirs' to avoid
   # duplicating code into syntax errors from the Hinterlands. So always check
   # against the 'origin/${DEST_SAFE}' to avoid branch merge shinanigans.
-  if git log --format=%s "origin/${DEST_SAFE}" | grep -qE "\(#${pr_num}\)$"; then
+  # Also taking out the color / formatting commands.
+  if git log --no-color --format=%s "origin/${DEST_SAFE}" \
+     | grep -qE "\(#${pr_num}\)[[:space:]]*$"; then
     pr_already_curated=true
     log_info "PR #${pr_num} already present in origin/${DEST_SAFE}; treating as update."
   else


### PR DESCRIPTION
Updated git log command to remove color formatting and adjusted regex for checking PR presence.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `git log` command in `curate-pre-branch.sh` to remove color formatting and adjust regex for PR presence check.
> 
>   - **Behavior**:
>     - Refactor `git log` command in `curate-pre-branch.sh` to remove color formatting using `--no-color`.
>     - Adjust regex in `curate-pre-branch.sh` to check for PR presence with optional trailing spaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 024089cee3cd4852b3626dcb91579c07126d65ed. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->