### PR TITLE
chore(all): Increase debug log to show last 200 commits

### DIFF
--- a/.github/scripts/curate-pre-branch.sh
+++ b/.github/scripts/curate-pre-branch.sh
@@ -218,8 +218,11 @@ process_single_pr() {
 
   # Instrumenting to see where failures might occur
   log_info "DEBUG: HEAD ref = $(git rev-parse --abbrev-ref HEAD)"
-  log_info "DEBUG: Last 10 commits on HEAD:"
-  git log --format='%h %s' -10 HEAD | sed 's/^/DEBUG:   /'
+  log_info "DEBUG: Last 200 commits on HEAD:"
+  git log --format='%h %s' -200 HEAD | sed 's/^/DEBUG:   /'
+
+  log_info "DEBUG: Last 200 commits on origin/${DEST_SAFE}:"
+  git log --no-color --format='%h %s' "origin/${DEST_SAFE}" -200 | sed 's/^/DEBUG:   /'
 
   # Detect whether this PR has already been curated into DEST_SAFE
   local pr_already_curated=false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase debug log to show last 200 commits in `curate-pre-branch.sh`.
> 
>   - **Logging**:
>     - Increase number of commits shown in debug logs from 10 to 200 in `curate-pre-branch.sh`.
>     - Affects logging for both `HEAD` and `origin/${DEST_SAFE}` branches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for c817da9d2df65f7661bfe24e7c329f559073e683. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->