### PR TITLE
chore(all): remove debug logging and fix grep regex issue

### DIFF
--- a/.github/scripts/curate-pre-branch.sh
+++ b/.github/scripts/curate-pre-branch.sh
@@ -216,14 +216,6 @@ process_single_pr() {
   local pr_num="$1"
   log_group "PR #${pr_num}"
 
-  # Instrumenting to see where failures might occur
-  log_info "DEBUG: HEAD ref = $(git rev-parse --abbrev-ref HEAD)"
-  log_info "DEBUG: Last 200 commits on HEAD:"
-  git log --format='%h %s' -200 HEAD | sed 's/^/DEBUG:   /'
-
-  log_info "DEBUG: Last 200 commits on origin/${DEST_SAFE}:"
-  git log --no-color --format='%h %s' "origin/${DEST_SAFE}" -200 | sed 's/^/DEBUG:   /'
-
   # Detect whether this PR has already been curated into DEST_SAFE
   local pr_already_curated=false
   # Proper behavior through process would be to provide fixes in new PRs
@@ -234,8 +226,8 @@ process_single_pr() {
   # duplicating code into syntax errors from the Hinterlands. So always check
   # against the 'origin/${DEST_SAFE}' to avoid branch merge shinanigans.
   # Also taking out the color / formatting commands.
-  if git log --no-color --format=%s "origin/${DEST_SAFE}" \
-     | grep -qE "\(#${pr_num}\)[[:space:]]*$"; then
+  if git log --no-color --oneline --grep="(#${pr_num})" \
+    "origin/${DEST_SAFE}" > /dev/null 2>&1; then
     pr_already_curated=true
     log_info "PR #${pr_num} already present in origin/${DEST_SAFE}; treating as update."
   else


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove debug logging and fix grep regex issue in `curate-pre-branch.sh`.
> 
>   - **Logging**:
>     - Remove debug logging from `curate-pre-branch.sh` that printed HEAD ref and last 200 commits.
>   - **Regex Fix**:
>     - Fix grep regex in `curate-pre-branch.sh` to use `--oneline --grep` for checking PR presence, avoiding syntax errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 190d217e301f06240f145ea63f332706fd2b461b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->