### PR TITLE
chore(all): refactor PR match in curate pre/branch

### DIFF
--- a/.github/scripts/curate-pre-branch.sh
+++ b/.github/scripts/curate-pre-branch.sh
@@ -226,8 +226,11 @@ process_single_pr() {
   # duplicating code into syntax errors from the Hinterlands. So always check
   # against the 'origin/${DEST_SAFE}' to avoid branch merge shinanigans.
   # Also taking out the color / formatting commands.
-  if git log --no-color --oneline --grep="(#${pr_num})" \
-    "origin/${DEST_SAFE}" > /dev/null 2>&1; then
+  local pr_match
+  pr_match="$(git log --no-color --oneline --grep="(#${pr_num})" \
+                  -1 "origin/${DEST_SAFE}" || true)"
+
+  if [[ -n "$pr_match" ]]; then
     pr_already_curated=true
     log_info "PR #${pr_num} already present in origin/${DEST_SAFE}; treating as update."
   else


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor PR matching logic in `curate-pre-branch.sh` by using a local variable to store `git log` results.
> 
>   - **Refactor**:
>     - In `curate-pre-branch.sh`, refactor PR matching logic by introducing `pr_match` variable to store `git log` result.
>     - Check if `pr_match` is non-empty to set `pr_already_curated` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for aa394ce3c6815e244c83d2b40578f64c0111cca9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->