### PR TITLE
fix(all): GameObj force new objects ID to be string

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -23,7 +23,7 @@ module Lich
       attr_accessor :noun, :name, :before_name, :after_name
 
       def initialize(id, noun, name, before = nil, after = nil)
-        @id = id.to_s
+        @id = id.is_a?(Integer) ? id.to_s : id
         @noun = noun
         @noun = 'lapis' if @noun == 'lapis lazuli'
         @noun = 'hammer' if @noun == "Hammer of Kai"


### PR DESCRIPTION
GameObjs expect the .id to be a String, so force it incase a script/whatever accidentally sends ID as an Integer.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure `GameObj` IDs are always strings by converting integers to strings in `initialize` method.
> 
>   - **Behavior**:
>     - In `gameobj.rb`, `GameObj#initialize` now converts `id` to a string if it is an integer, ensuring `id` is always a string.
>   - **Misc**:
>     - No changes to other methods or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7b6d1e788457ed291738a7870ff6310855f7fe48. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->