### PR TITLE
feat(dr): DRCS allow custom adjective for summoned weapons

### DIFF
--- a/lib/dragonrealms/commons/common-summoning.rb
+++ b/lib/dragonrealms/commons/common-summoning.rb
@@ -61,7 +61,7 @@ module Lich
             # aren't recognized for shaping summoned elemental weapons, and the error message itself is misleading
             # thankfully breaking, turning, pulling, pushing work fine with custom adj
             unless summoned_weapon.nil?
-              case DRC.bput("shape my #{summoned_weapon.sub(settings&.summoned_weapons_adjective || '','')} to #{skill}", shape_failures)
+              case DRC.bput("shape my #{summoned_weapon.sub(settings&.summoned_weapons_adjective || '', '')} to #{skill}", shape_failures)
               when 'You lack the elemental charge'
                 summon_admittance
                 shape_summoned_weapon(skill, nil, settings)


### PR DESCRIPTION
Issue: DR itself doesn't recognize custom adjectives for shaping warrior mage summoned weapons that have been altered by the tomes from `https://elanthipedia.play.net/Books_of_Binding` as well as Lich's identify_summoned_weapon can't find them either.
* Added a setting for character yaml to let you add your custom adj for consideration in the identify_summoned_weapon function regex
  * `summoned_weapons_adjective`
* Added some graceful handling/retry for when shaping a weapon with custom adj doesn't work at first.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for custom adjectives in summoned weapons and retry logic for shaping failures in `common-summoning.rb`.
> 
>   - **Behavior**:
>     - Adds `summoned_weapons_adjective` setting in character yaml for custom adjectives in `identify_summoned_weapon`.
>     - Implements retry logic in `shape_summoned_weapon` for custom adjective failures.
>   - **Functions**:
>     - Modifies `identify_summoned_weapon` to use `summoned_weapons_adjective` in regex.
>     - Updates `shape_summoned_weapon` to handle custom adjective errors and retry shaping.
>   - **Misc**:
>     - Adds comments explaining handling of custom adjectives from `Books_of_Binding` tomes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 20eed132d85a7cbc16b9fa1be80d4544bd5ff048. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->