### PR TITLE
fix(dr): DRCA allow custom spell prep messaging

### DIFF
--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -185,7 +185,7 @@ module Lich
 
       def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false, runestone_name = nil, runestone_tm = false, custom_prep = nil)
         return false unless abbrev
-        spell_prep_messages = !custom_prep ? get_data('spells').prep_messages : (get_data('spells').prep_messages << custom_prep)
+        spell_prep_messages = !custom_prep ? get_data('spells').prep_messages : (get_data('spells').prep_messages + [custom_prep])
 
         DRC.bput('prepare symbiosis', 'You recall the exact details of the', 'But you\'ve already prepared', 'Please don\'t do that here') if symbiosis
         if runestone_name.nil?


### PR DESCRIPTION
Issue: Customized/altered prep messages are unrecognizable by DRCA.prep?
* Added bonus character yaml setting to add custom spell prep message, too, if you bought one of those or had yours altered
  * `custom_spell_prep` 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for custom spell preparation messages in `prepare?` function by introducing `custom_prep` parameter and updating related functions in `common-arcana.rb`.
> 
>   - **Behavior**:
>     - Adds `custom_prep` parameter to `prepare?` function in `common-arcana.rb` to support custom spell preparation messages.
>     - Updates `ritual`, `cast_spell`, and `crafting_prepare_spell` functions to pass `settings['custom_spell_prep']` to `prepare?`.
>   - **Misc**:
>     - Adjusts spell preparation logic to include custom messages in `spell_prep_messages` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7bab05102f3482780626825befd1f3f13bb748b6. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->