### PR TITLE
fix(gs): cman.rb add hamstring regex for already lying down target

### DIFF
--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -288,7 +288,8 @@ module Lich
           :cost       => { stamina: 9 },
           :regex      => Regexp.union(/You lunge forward and try to hamstring .+ with your .+!/,
                                       /The .+ is too unwieldy for that\./,
-                                      /You need to be holding a weapon capable of slashing to do that\./),
+                                      /You need to be holding a weapon capable of slashing to do that\./,
+                                      /is lying down \-\- attempting to hamstring .+ would be a rather awkward proposition\./),
           :usage      => "hamstring"
         },
         "haymaker"               => {


### PR DESCRIPTION
Hamstring will stall when attempting to hamstring a creature that is already prone.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `hamstring` maneuver regex in `cman.rb` to handle prone targets and prevent stalling.
> 
>   - **Behavior**:
>     - Update regex for `hamstring` maneuver in `cman.rb` to handle cases where the target is already prone.
>     - Adds pattern `/is lying down \-\- attempting to hamstring .+ would be a rather awkward proposition\./` to prevent stalling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 52f2b21cf53d6ebeb1c7cb02d14c66575117b171. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->