### PR TITLE
fix(gs): cman.rb hamstring regex update when can't perform on target

### DIFF
--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -289,7 +289,7 @@ module Lich
           :regex      => Regexp.union(/You lunge forward and try to hamstring .+ with your .+!/,
                                       /The .+ is too unwieldy for that\./,
                                       /You need to be holding a weapon capable of slashing to do that\./,
-                                      /You cannot hamstring .+\./),
+                                      /You cannot hamstring .+\./,
                                       /is lying down \-\- attempting to hamstring .+ would be a rather awkward proposition\./),
           :usage      => "hamstring"
         },


### PR DESCRIPTION
Updated hamstring results
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update regex for `hamstring` maneuver in `cman.rb` to handle cases where the action cannot be performed.
> 
>   - **Behavior**:
>     - Updated regex for `hamstring` maneuver in `cman.rb` to include `/You cannot hamstring .+\./` pattern.
>     - Handles cases where hamstring action cannot be performed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 3e12fd890abe9fbf79fa30fb6378dfa8aab3c123. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->