### PR TITLE
chore(all): Fix array declaration for union merge

### DIFF
--- a/.github/scripts/strategies/conflict/union.sh
+++ b/.github/scripts/strategies/conflict/union.sh
@@ -53,7 +53,7 @@ parse_and_resolve_conflicts() {
       # Force associative array type; prevents "bad array subscript" if `seen`
       # exists elsewhere as an indexed array or scalar in this shell context.
       unset -v seen
-      declare -A seen=()
+      local -A seen=()
 
       # Add ours lines
       for ours_line in "${ours_lines[@]}"; do


### PR DESCRIPTION
Initialize associative array 'seen' for union merge.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes array declaration in `union.sh` by initializing `seen` as an associative array to prevent errors.
> 
>   - **Behavior**:
>     - Fixes array declaration in `union.sh` by initializing `seen` as an associative array to prevent "bad array subscript" errors.
>     - Ensures `seen` is unset before declaration to avoid conflicts with existing variables in the shell context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 8fb6629e2b5fc5797228f0f11f71f69e7b635114. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->