### PR TITLE
fix(gs): Bounty parser.rb FWI guard regex update

### DIFF
--- a/lib/gemstone/bounty/parser.rb
+++ b/lib/gemstone/bounty/parser.rb
@@ -16,7 +16,8 @@ module Lich
           /the sentry just outside (?<town>Kraken's Fall)/,
           /the purser of (?<town>River's Rest)/,
           /the tavernkeeper at Rawknuckle's Common House/,
-          /the captain of the (?<town>Contempt)/
+          /the captain of the (?<town>Contempt)/,
+          /the elderly guard in the East Guardtower/
         )
         CONCOCTION_REGEX = /is working on a concoction that requires (?:an?|some|several) (?<herb>[^.]+?) found [oi]n (?:the\s+)?(?<area>[^.]+?)(?:\s+(?:near|under|between) [^.]+)?\.  These samples must be in pristine condition\.  You have been tasked to retrieve (?<number>\d+) (?:more\s+)?samples?\./
         TASK_MAYBE_REGEX = /^(?:The taskmaster told you:  ")/
@@ -140,6 +141,8 @@ module Lich
             "Kraken's Fall"
           elsif description =~ /the tavernkeeper at Rawknuckle's Common House\.$/
             "Cold River"
+          elsif description =~ /the elderly guard in the East Guardtower\.$/
+            "Mist Harbor"
           elsif description =~ /\b(?:Captain|Reiya|Ataum|Galeb)\b/ || description =~ /gem dealer in has received/
             # the latter is a temporary workaround because of an actual typo in the messaging
             # that should be removed if it is ever actually fixed


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates `parser.rb` to include 'the elderly guard in the East Guardtower' in `GUARD_REGEX` and map it to 'Mist Harbor' in `determine_town`.
> 
>   - **Behavior**:
>     - Updates `GUARD_REGEX` in `parser.rb` to include `/the elderly guard in the East Guardtower/`.
>     - Updates `determine_town` method in `parser.rb` to map 'the elderly guard in the East Guardtower' to 'Mist Harbor'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for cf4c5266af9363b3a5a16c336b81288bad13aa25. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->