### PR TITLE
chore(all): update union.sh to drop duplicate terminators

### DIFF
--- a/.github/workflows/curate-pre-branch.yaml
+++ b/.github/workflows/curate-pre-branch.yaml
@@ -117,7 +117,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
           path: |
-            **/*.union-merge
+            **/*.union-merge*
             ${{ env.CONFLICT_LOG_FILE }}
             conflict-log*.md
             conflict-log*.txt


### PR DESCRIPTION
Drop duplicate `)` and `}` terminators on union merge, and improve artifact retention to lossless line duplication and merged file results.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `union.sh` to drop duplicate terminators and improve artifact retention in `curate-pre-branch.yaml`.
> 
>   - **Behavior**:
>     - `union.sh` updated to drop duplicate `)` and `}` terminators during union merge.
>     - Improves artifact retention to ensure lossless line duplication and merged file results.
>   - **GitHub Workflow**:
>     - Updates `curate-pre-branch.yaml` to change artifact path pattern from `**/*.union-merge` to `**/*.union-merge*` for better retention.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 01076bddbf598f34137b941980ca64d6b191c9cd. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->