### PR TITLE
chore(all): Add Ruby repair for union merge conflicts 2

### DIFF
--- a/.github/scripts/strategies/conflict/union.sh
+++ b/.github/scripts/strategies/conflict/union.sh
@@ -28,9 +28,6 @@ attempt_ruby_union_repair() {
   # Only run for Ruby-ish files
   [[ "$file" =~ \.rb(w)?$ ]] || return 1
 
-  local tmp
-  tmp="$(mktemp)"
-
   ruby -e '
     path = ARGV[0]
     lines = File.read(path, mode: "r:BOM|UTF-8").lines


### PR DESCRIPTION
Enhance conflict resolution by adding a Ruby repair function to handle duplicate terminators in union merges. This ensures valid Ruby syntax is maintained after merging.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Ruby repair function to `union.sh` for handling duplicate terminators in union merges, ensuring valid Ruby syntax.
> 
>   - **Behavior**:
>     - Adds `attempt_ruby_union_repair()` function in `union.sh` to handle duplicate terminators in Ruby files during union merges.
>     - If union merge produces invalid Ruby, attempts repair by removing consecutive duplicate terminator lines.
>     - Falls back to 'theirs' if repair fails and union result is invalid.
>   - **Conflict Resolution**:
>     - Updates `resolve_conflicts_union()` in `union.sh` to incorporate Ruby repair logic.
>     - Logs repair attempts and outcomes, annotating files with reasons for fallback or repair.
>   - **Misc**:
>     - Captures union merge stages and results for audit trail in `union.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 7bb4b99de1889741d467491bb5b748fa1ee4cc6a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->