### PR TITLE
fix(dr): Fix exp mods parsing for DR

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -49,20 +49,21 @@ module Lich
       def self.check_exp_mods(server_string)
         # This method parses the output from `exp mods` command
         # and updates the DRSkill.exp_modifiers hash with the skill and value.
-        # This is primarily used by the `skill-recorder` script.
-        #
         # Example output without any modifiers:
-        #     The following skills are currently under the influence of a modifier:
-        #     <output class="mono"/>
-        #       None
-        #     <output class=""/>
+        # The following skills are currently under the influence of a modifier:
+        # <output class="mono"/>
+        #   None
+        # <output class=""/>
+        # <prompt time="1767298457">&gt;</prompt>
         #
         # Example output with modifiers:
-        #     The following skills are currently under the influence of a modifier:
-        #     <output class="mono"/>
-        #     +75 Athletics
-        #     -10 Evasion
-        #     <output class=""/>
+        # The following skills are currently under the influence of a modifier:
+        # <output class="mono"/>
+        # <preset id="speech">+79 Attunement</preset>
+        # <preset id="speech">+350 Evasion</preset>
+        # <preset id="speech">+350 Perception</preset>
+        # <output class=""/>
+        # <prompt time="1767296999">&gt;</prompt>
         #
         # Zero or more skills may be listed between the <output> tags
         # but exactly one skill and its skill modifier are listed per line.
@@ -75,8 +76,8 @@ module Lich
           end
         else
           if @parsing_exp_mods_output
-            # https://regex101.com/r/5ZE8lq/1
-            match = /^(?<sign>[+-])(?<value>\d+)\s+(?<skill>[\w\s]+)$/.match(server_string)
+            # https://rubular.com/r/hg7SFvVNUtdLdh
+            match = /^(?:<preset id="speech">)?(?<sign>[+-])(?<value>\d+)\s+(?<skill>[\w\s]+)(?:<\/preset>)?$/.match(server_string.strip)
             if match
               skill = match[:skill].strip
               sign = match[:sign]


### PR DESCRIPTION
This must have been broken since the move to core lich from the original script.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes parsing in `check_exp_mods` in `drparser.rb` to handle `<preset>` tags in skill modifiers.
> 
>   - **Behavior**:
>     - Fixes parsing in `check_exp_mods` in `drparser.rb` to handle `<preset>` tags in skill modifiers.
>     - Updates regular expression to match optional `<preset>` tags around skill modifiers.
>   - **Regex**:
>     - Changes regex in `check_exp_mods` to `/^(?:<preset id="speech">)?(?<sign>[+-])(?<value>\d+)\s+(?<skill>[\w\s]+)(?:<\/preset>)?$/`.
>   - **Misc**:
>     - Updates example comments in `check_exp_mods` to reflect new output format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 801e31abf30f3343dbea791435868d09bf499941. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->