### PR TITLE
fix(all): xmlparser.rb gate GSL exits sending behind @send_fake_tags

### DIFF
--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -926,10 +926,12 @@ module Lich
             end
             @room_description = @room_description.strip
             @room_exits_string.concat " #{@room_exits.join(', ')}" unless @room_exits.empty?
-            gsl_exits = String.new
-            @room_exits.each { |exit| gsl_exits.concat(DIRMAP[SHORTDIR[exit]].to_s) }
-            $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
-            gsl_exits = nil
+            if @send_fake_tags
+              gsl_exits = String.new
+              @room_exits.each { |exit| gsl_exits.concat(DIRMAP[SHORTDIR[exit]].to_s) }
+              $_CLIENT_.puts "\034GSj#{sprintf('%-20s', gsl_exits)}\r\n"
+              gsl_exits = nil
+            end
             @room_count += 1
             $room_count += 1
           end


### PR DESCRIPTION
Send fake tags with room exits if enabled.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `xmlparser.rb`, sending fake tags for room exits is now conditional on `@send_fake_tags` in `tag_end()`.
> 
>   - **Behavior**:
>     - In `xmlparser.rb`, sending of fake tags for room exits is now gated behind `@send_fake_tags` in `tag_end()`.
>     - If `@send_fake_tags` is true, fake tags for room exits are sent; otherwise, they are not.
>   - **Misc**:
>     - No changes to existing logic for room exit processing, only conditional sending of fake tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for c6fb7f9ded8a1e5be60bc8d8b6a280c2c7a30fe2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->