### PR TITLE
feat(dr): DRParser support for new exp window xml stream elements (rested exp, tdps, favors)

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -380,7 +380,7 @@ module Lich
           when Pattern::TDPValue_XPWindow
             matches = Regexp.last_match
             DRStats.tdps = matches[:tdp].to_i
-          when Pattern::FavorValue_XPWindow = 
+          when Pattern::FavorValue_XPWindow
             matches = Regexp.last_match
             DRStats.favors = matches[:favor].to_i
           else

--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -30,6 +30,10 @@ module Lich
         PlayedSubscription = /Current Account Status: (?<subscription>F2P|Basic|Premium|Platinum)/.freeze
         LastLogoff = /^\s+Logoff :  (?<weekday>[A-Z][a-z]{2}) (?<month>[A-Z][a-z]{2}) (?<day>[\s\d]{2}) (?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}) ET (?<year>\d{4})/.freeze
         RoomIDOff = /^You will no longer see room IDs when LOOKing in the game and room windows\./.freeze
+        Rested_EXP = %r{^<component id='exp rexp'>Rested EXP Stored:\s*(?<stored>.*?)\s*Usable This Cycle:\s*(?<usable>.*?)\s*Cycle Refreshes:\s*(?<refresh>.*)</component>}.freeze
+        Rested_EXP_F2P = %r{^<component id='exp rexp'>\[Unlock Rested Experience}.freeze
+        TDPValue_XPWindow = %r{^<component id='exp tdp'>\s*TDPs:\s*(?<tdp>\d+)</component>}.freeze
+        FavorValue_XPWindow = %r{^<component id='exp favor'>\s*Favors:\s*(?<favor>\d+)</component>}.freeze
       end
 
       @parsing_exp_mods_output = false
@@ -367,6 +371,18 @@ module Lich
             put("flag showroomid on")
             respond("Lich requires ShowRoomID to be ON for mapping to work, please do not turn this off.")
             respond("If you wish to hide the Real ID#, you can toggle it off by doing ;display flaguid")
+          when Pattern::Rested_EXP
+            matches = Regexp.last_match
+            DRSkill.update_rested_exp(matches[:stored].strip, matches[:usable].strip, matches[:refresh].strip)
+          when Pattern::Rested_EXP_F2P
+            # f2p characters without brain boost don't get rested exp
+            DRSkill.update_rested_exp('none', 'none', 'none')
+          when Pattern::TDPValue_XPWindow
+            matches = Regexp.last_match
+            DRStats.tdps = matches[:tdp].to_i
+          when Pattern::FavorValue_XPWindow = 
+            matches = Regexp.last_match
+            DRStats.favors = matches[:favor].to_i
           else
             :noop
           end

--- a/lib/dragonrealms/drinfomon/drskill.rb
+++ b/lib/dragonrealms/drinfomon/drskill.rb
@@ -6,6 +6,12 @@ module Lich
       @@start_time ||= Time.now
       @@list ||= []
       @@exp_modifiers ||= {}
+      # stored in seconds for easier manipulation with Time objects.  values will 
+      #   always be divisible by 60 as we don't get any further precision then that, 
+      #   and heuristically getting finer precision isn't worth the effort
+      @@rexp_stored ||= 0
+      @@rexp_usable ||= 0
+      @@rexp_refresh ||= 0
 
       attr_reader :name, :skillset
       attr_accessor :rank, :exp, :percent, :current, :baseline
@@ -88,8 +94,26 @@ module Lich
         self.exp_modifiers[self.lookup_alias(name)] = rank.to_i
       end
 
+      def self.update_rested_exp(stored, usable, refresh)
+        @@rexp_stored = self.convert_rexp_str_to_seconds(stored)
+        @@rexp_usable = self.convert_rexp_str_to_seconds(usable)
+        @@rexp_refresh = self.convert_rexp_str_to_seconds(refresh)
+      end
+
       def self.exp_modifiers
         @@exp_modifiers
+      end
+
+      def self.rested_exp_stored
+        @@rexp_stored
+      end
+    
+      def self.rested_exp_usable
+        @@rexp_usable
+      end
+    
+      def self.rested_exp_refresh
+        @@rexp_refresh
       end
 
       def self.clear_mind(val)
@@ -134,6 +158,36 @@ module Lich
 
       def self.find_skill(val)
         @@list.find { |data| data.name == self.lookup_alias(val) }
+      end
+
+      def self.convert_rexp_str_to_seconds(time_string)
+        # Handle empty, nil, or specific "zero" cases (less than a minute is zero because it can get stuck there)
+        return 0 if time_string.nil? 
+                    time_string.to_s.strip.empty? || 
+                    time_string.include?("none") || 
+                    time_string.include?("less than a minute")
+    
+        total_seconds = 0
+    
+        # Extract hours and optional minutes (e.g., "4:38 hours" or "6 hour")
+        # Ruby's match returns a MatchData object or nil
+        if (hour_match = time_string.match(/(\d+):?(\d+)?\s*hour/))
+          hours = hour_match[1].to_i
+          total_seconds += hours * 60 * 60
+    
+          # Handle the minutes part of a "4:38" format
+          if hour_match[2]
+            total_seconds += hour_match[2].to_i * 60
+            return total_seconds
+          end
+        end
+    
+        # Extract standalone minutes (e.g., "38 minutes")
+        if (minute_match = time_string.match(/(\d+)\s*minute/))
+          total_seconds += minute_match[1].to_i * 60
+        end
+    
+        total_seconds
       end
 
       # Some guilds rename skills, like Barbarians call "Primary Magic" as "Inner Fire".

--- a/lib/dragonrealms/drinfomon/drskill.rb
+++ b/lib/dragonrealms/drinfomon/drskill.rb
@@ -116,6 +116,10 @@ module Lich
         @@rexp_refresh
       end
 
+      def self.rested_active?
+        @@rexp_stored > 0 && @@rexp_usable > 0
+      end
+
       def self.clear_mind(val)
         self.find_skill(val).exp = 0
       end

--- a/lib/dragonrealms/drinfomon/drskill.rb
+++ b/lib/dragonrealms/drinfomon/drskill.rb
@@ -162,7 +162,7 @@ module Lich
 
       def self.convert_rexp_str_to_seconds(time_string)
         # Handle empty, nil, or specific "zero" cases (less than a minute is zero because it can get stuck there)
-        return 0 if time_string.nil? 
+        return 0 if time_string.nil? ||
                     time_string.to_s.strip.empty? || 
                     time_string.include?("none") || 
                     time_string.include?("less than a minute")

--- a/lib/dragonrealms/drinfomon/drskill.rb
+++ b/lib/dragonrealms/drinfomon/drskill.rb
@@ -6,8 +6,8 @@ module Lich
       @@start_time ||= Time.now
       @@list ||= []
       @@exp_modifiers ||= {}
-      # stored in seconds for easier manipulation with Time objects.  values will 
-      #   always be divisible by 60 as we don't get any further precision then that, 
+      # stored in seconds for easier manipulation with Time objects.  values will
+      #   always be divisible by 60 as we don't get any further precision then that,
       #   and heuristically getting finer precision isn't worth the effort
       @@rexp_stored ||= 0
       @@rexp_usable ||= 0
@@ -107,11 +107,11 @@ module Lich
       def self.rested_exp_stored
         @@rexp_stored
       end
-    
+
       def self.rested_exp_usable
         @@rexp_usable
       end
-    
+
       def self.rested_exp_refresh
         @@rexp_refresh
       end
@@ -163,30 +163,30 @@ module Lich
       def self.convert_rexp_str_to_seconds(time_string)
         # Handle empty, nil, or specific "zero" cases (less than a minute is zero because it can get stuck there)
         return 0 if time_string.nil? ||
-                    time_string.to_s.strip.empty? || 
-                    time_string.include?("none") || 
+                    time_string.to_s.strip.empty? ||
+                    time_string.include?("none") ||
                     time_string.include?("less than a minute")
-    
+
         total_seconds = 0
-    
+
         # Extract hours and optional minutes (e.g., "4:38 hours" or "6 hour")
         # Ruby's match returns a MatchData object or nil
         if (hour_match = time_string.match(/(\d+):?(\d+)?\s*hour/))
           hours = hour_match[1].to_i
           total_seconds += hours * 60 * 60
-    
+
           # Handle the minutes part of a "4:38" format
           if hour_match[2]
             total_seconds += hour_match[2].to_i * 60
             return total_seconds
           end
         end
-    
+
         # Extract standalone minutes (e.g., "38 minutes")
         if (minute_match = time_string.match(/(\d+)\s*minute/))
           total_seconds += minute_match[1].to_i * 60
         end
-    
+
         total_seconds
       end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for parsing new XML elements related to rested experience, TDPs, and favors in DragonRealms, updating `DRSkill` and `DRStats` accordingly.
> 
>   - **Behavior**:
>     - Add support for parsing new XML elements: `Rested_EXP`, `Rested_EXP_F2P`, `TDPValue_XPWindow`, and `FavorValue_XPWindow` in `drparser.rb`.
>     - Update `DRSkill` with new methods `update_rested_exp`, `rested_exp_stored`, `rested_exp_usable`, and `rested_exp_refresh` to handle rested experience data.
>     - Add `convert_rexp_str_to_seconds` in `DRSkill` to convert time strings to seconds.
>   - **Patterns**:
>     - Add regex patterns for new XML elements in `Pattern` module in `drparser.rb`.
>   - **Data Handling**:
>     - Update `DRStats` with TDPs and favors from new XML elements in `drparser.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 3ded752dca9cb887babfc5ec22dbf8a7bdcd4477. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->