### PR TITLE
fix(dr): equipmanager.rb support for custom messaging in forester's longbow

### DIFF
--- a/lib/dragonrealms/commons/equipmanager.rb
+++ b/lib/dragonrealms/commons/equipmanager.rb
@@ -299,7 +299,7 @@ module Lich
         {
           worn: {
             verb: 'remove',
-            matches: [/^You .*#{item.short_regex}/, /^You (get|sling|pull|work|loosen|slide|remove|yank|unbuckle).*#{item.name}/, 'you tug', 'Remove what', "You aren't wearing that", 'slide themselves off of your', 'you manage to loosen', /^A brisk chill leaves you as you/],
+            matches: [/^You .*#{item.short_regex}/, /^You (get|sling|pull|work|loosen|slide|remove|yank|unbuckle).*#{item.name}/, 'you tug', 'Remove what', "You aren't wearing that", 'slide themselves off of your', 'you manage to loosen', 'you ready the', /^A brisk chill leaves you as you/],
             failures: [/^You (get|sling|pull|work|slide|remove|yank|unbuckle) $/],
             failure_recovery: proc { |noun| DRC.bput("wear my #{noun}", '^You ') },
             exhausted: ['Remove what', "You aren't wearing that"]


### PR DESCRIPTION
Updating for support of custom messaging for forester's longbow with a vibrant patch of clover around the grip:

[combat-trainer]>remove my forester's.longbow
With masterful grace, you ready the forester's longbow and call out, "Lirisa guide my strike, let no evil remain in sight!"
>
[combat-trainer: message: With masterful grace, you ready the forester's longbow and call out, "Lirisa guide my strike, let no evil remain in sight!"] [combat-trainer: checked against [/^You .*(?i-mx:\bforester's.*\blongbow)/, /^You (get|sling|pull|work|loosen|slide|remove|yank|unbuckle).*longbow/, /you tug/i, /Remove what/i, /You aren't wearing that/i, /slide themselves off of your/i, /you manage to loosen/i, /^A brisk chill leaves you as you/]] [combat-trainer: for command remove my forester's.longbow]
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `equipmanager.rb` to support custom message for forester's longbow by adding 'you ready the' to regex patterns.
> 
>   - **Behavior**:
>     - Update regex in `verb_data()` in `equipmanager.rb` to support custom message for forester's longbow with a vibrant patch of clover.
>     - Adds 'you ready the' to the list of match patterns for removing items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 08f6567b4b91565d97b88fa6bb91df9388db94e2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->