### PR TITLE
fix(dr): Fix hang in equipment manager when game doesn't respond to commands

### DIFF
--- a/lib/dragonrealms/commons/equipmanager.rb
+++ b/lib/dragonrealms/commons/equipmanager.rb
@@ -299,7 +299,7 @@ module Lich
         {
           worn: {
             verb: 'remove',
-            matches: [/^You .*#{item.short_regex}/, /^You (get|sling|pull|work|loosen|slide|remove|yank|unbuckle).*#{item.name}/, 'you tug', 'Remove what', "You aren't wearing that", 'slide themselves off of your', 'you manage to loosen', /^A brisk chill leaves you as you/],
+            matches: [/^You .*#{item.short_regex}/, /^You (get|sling|pull|work|loosen|slide|remove|yank|unbuckle).*#{item.name}/, 'you tug', 'Remove what', "You aren't wearing that", 'slide themselves off of your', 'you manage to loosen', 'you ready the', /^A brisk chill leaves you as you/],
             failures: [/^You (get|sling|pull|work|slide|remove|yank|unbuckle) $/],
             failure_recovery: proc { |noun| DRC.bput("wear my #{noun}", '^You ') },
             exhausted: ['Remove what', "You aren't wearing that"]


### PR DESCRIPTION
```
2026-01-13 05:01:29 NZDT: [custom/combat-trainer]>get my bola
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: *** No match was found after 15 seconds, dumping info]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: messages seen length: 34]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: [You're winded (100%), mighty (100%), nimbly balanced and in better position.]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: * A void-black umbral moth slices wide at you.  You partially block with a small demonscale shield pyrographed with a map of the Blasted Plains.  ]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: [You're winded (100%), mighty (100%), nimbly balanced and in excellent position.]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: * A void-black umbral moth swings at you.  You dodge.  ]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: [You're winded (100%), mighty (100%), nimbly balanced and in strong position.]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: * A void-black umbral moth snarls soundlessly and lunges at you.  You partially block with a small demonscale shield pyrographed with a map of the Blasted Plains.  ]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Gauge Flow  (60 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Bless  (23 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Harmony  (24 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Redeemer's Pride  (35 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Damaris' Lullaby  (Indefinite)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Echoes of Aether  (73 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Naming of Tears  (23 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Rage of the Clans  (20 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Manifest Force  (10 roisaen)]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: A void-black umbral moth shifts fitfully, its slick proboscis furling and unfurling obscenely.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: You feel fully attuned to the mana streams again.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: You feel fully prepared to cast your spell.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: [You're winded (100%), mighty (100%), adeptly balanced and in excellent position.]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: * A void-black umbral moth swings at you.  You evade.  ]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: The scent of honey fills the air around you as your heartname leather anklecuff tightens briefly, the five-petal blooms of its butterfly vine shifting as if in a slight breeze, leaving you feeling refreshed.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: You've gained a new rank in using small blunt weapons.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: [You're winded (100%), mighty (100%), adeptly balanced and in superior position.]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: * A void-black umbral moth snarls soundlessly and lunges at you.  You partially block with a small demonscale shield pyrographed with a map of the Blasted Plains.  ]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: A void-black umbral moth slumps wearily.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: A void-black umbral moth slumps wearily.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: A void-black umbral moth slumps wearily and drops like a rock, having yielded to your lullaby.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: Your voice sends forth a cascade of languid tones as you continuously alter the depth of vocal tremolo.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: You think you have your best shot possible now.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: [You're winded (100%), mighty (100%), adeptly balanced and overwhelming your opponent.]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: * A void-black umbral moth darts forward and slashes at you.  You dodge.  ]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: A void-black umbral moth's wings beat soundlessly, returning it gracefully to an upright position.]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: [You're winded (100%), mighty (100%), adeptly balanced and in dominating position.]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: message: * A void-black umbral moth snarls soundlessly and lunges at you.  You evade.  ]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: checked against [/^You .*(?i-mx:\bbola)/, /^You .*bola/i, /^The.* slides easily out/i, /^What were you referring/i, /But that is already/i, /You are already/i]]
2026-01-13 05:01:44 NZDT: [custom/combat-trainer: for command get my bola]

```

Fixes the case where combat-trainer just hangs when the game doesn't respond to our command as above.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes hang in `EquipmentManager` by handling nil responses and adding timeouts in `equipmanager.rb`.
> 
>   - **Behavior**:
>     - Fixes hang in `get_item_helper()` in `equipmanager.rb` by handling nil or empty responses as failures and logging a message.
>     - Adds a timeout in `get_item_helper()` to prevent infinite loops when waiting for hands to change.
>   - **Logging**:
>     - Logs a message if no response is received from the game for a command.
>     - Logs a message if hands do not change after a command, indicating potential failure to retrieve an item.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for fb66e0e477ec6b237c421a9e5fe2f6f6cafad091. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->