### PR TITLE
fix(dr): validator.rb change sleep to should_sleep named param

### DIFF
--- a/lib/dragonrealms/commons/common-validation.rb
+++ b/lib/dragonrealms/commons/common-validation.rb
@@ -1,9 +1,9 @@
 module Lich
   module DragonRealms
     class CharacterValidator
-      def initialize(announce, sleep, greet, name)
+      def initialize(announce, should_sleep, greet, name)
         waitrt?
-        fput('sleep') if sleep
+        fput('sleep') if should_sleep
 
         @lnet = (Script.running + Script.hidden).find { |val| val.name == 'lnet' }
         @validated_characters = []


### PR DESCRIPTION
Prevent changing of `sleep` Ruby function to being a method variable.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `sleep` parameter to `should_sleep` in `CharacterValidator` to avoid conflict with Ruby's `sleep` function.
> 
>   - **Parameter Rename**:
>     - In `CharacterValidator` class, rename `sleep` parameter to `should_sleep` in `initialize` method to avoid conflict with Ruby's `sleep` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 6ee06f20bbf3aeb0439be3889e7d6324e1930101. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->