### PR TITLE
fix(all): password_cipher.rb upcase account_name for key

### DIFF
--- a/lib/common/gui/password_cipher.rb
+++ b/lib/common/gui/password_cipher.rb
@@ -127,7 +127,7 @@ module Lich
           # Select passphrase based on mode
           passphrase = case mode
                        when :standard
-                         account_name
+                         account_name.upcase
                        when :enhanced
                          master_password
                        end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert `account_name` to uppercase in `PasswordCipher.derive_key` for consistent key derivation in `:standard` mode.
> 
>   - **Behavior**:
>     - In `PasswordCipher.derive_key`, `account_name` is converted to uppercase for `:standard` mode.
>     - Ensures consistent key derivation regardless of `account_name` case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for f806d82ce8cadeb373bdc3072b965f4c2f2a6684. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->