### PR TITLE
fix(all): Change server_time_offset in XMLParser to be float instead of int

### DIFF
--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -82,7 +82,7 @@ module Lich
         @nerve_tracker_num = 0
         @nerve_tracker_active = 'no'
         @server_time = Time.now.to_i
-        @server_time_offset = 0
+        @server_time_offset = 0.0
         @roundtime_end = 0
         @cast_roundtime_end = 0
         @last_pulse = Time.now.to_i
@@ -381,7 +381,7 @@ module Lich
 
           if name == 'prompt'
             @server_time = attributes['time'].to_i
-            @server_time_offset = (Time.now.to_i - @server_time)
+            @server_time_offset = (Time.now.to_f - @server_time)
             $_CLIENT_.puts "\034GSq#{sprintf('%010d', @server_time)}\r\n" if @send_fake_tags
 
             if @dr_active_spell_tracking


### PR DESCRIPTION
Accounts for fractional drift and doesn't toss sub 1.0 second drift
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `@server_time_offset` in `XMLParser` to float for precise fractional second drift handling.
> 
>   - **Behavior**:
>     - Change `@server_time_offset` from `int` to `float` in `XMLParser` to handle fractional second drifts.
>     - Update calculation of `@server_time_offset` in `tag_start()` to use `Time.now.to_f` for precise drift handling.
>   - **Misc**:
>     - Update `@server_time_offset` initialization to `0.0` in `initialize()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for bb9fc8375b5b920093f3cf057872514eb9305327. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->