### PR TITLE
fix(gs): stash.rb additional improvements with ReadyList/StowList

### DIFF
--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -196,7 +196,7 @@ module Lich
               dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
             end
           }
-          if (ready_item = ReadyList.ready_list.find{ |k, v| v.id.eql?(GameObj.left_hand.id) }) && ReadyList.store_list[ready_item[0]]
+          if (ready_item = ReadyList.ready_list.find { |_k, v| v.id.eql?(GameObj.left_hand.id) }) && ReadyList.store_list[ready_item[0]]
             result = Lich::Stash.add_to_bag(sheath, GameObj.left_hand) if ReadyList.store_list[ready_item[0]].eql?("put in sheath")
             result = Lich::Stash.add_to_bag(second_sheath, GameObj.left_hand) if ReadyList.store_list[ready_item[0]].eql?("put in secondary sheath")
             result = Lich::Stash.add_to_bag(StowList.default, GameObj.left_hand) if ["worn if possible, stowed otherwise", "stowed"].include?(ReadyList.store_list[ready_item[0]])
@@ -235,7 +235,7 @@ module Lich
             dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
           end
         }
-        if (ready_item = ReadyList.ready_list.find{ |k, v| v.id.eql?(GameObj.right_hand.id) }) && ReadyList.store_list[ready_item[0]]
+        if (ready_item = ReadyList.ready_list.find { |_k, v| v.id.eql?(GameObj.right_hand.id) }) && ReadyList.store_list[ready_item[0]]
           result = Lich::Stash.add_to_bag(sheath, GameObj.right_hand) if ReadyList.store_list[ready_item[0]].eql?("put in sheath")
           result = Lich::Stash.add_to_bag(second_sheath, GameObj.right_hand) if ReadyList.store_list[ready_item[0]].eql?("put in secondary sheath")
           result = Lich::Stash.add_to_bag(StowList.default, GameObj.right_hand) if ["worn if possible, stowed otherwise", "stowed"].include?(ReadyList.store_list[ready_item[0]])

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -133,6 +133,10 @@ module Lich
       unless ReadyList.valid?
         ReadyList.check(silent: true, quiet: true)
       end
+      # extending to use default stow container wherever possible
+      unless StowList.valid?
+        StowList.check(silent: true, quiet: true)
+      end
       if ReadyList.sheath
         unless ReadyList.secondary_sheath
           sheath = second_sheath = ReadyList.sheath
@@ -192,7 +196,11 @@ module Lich
               dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
             end
           }
-          if !second_sheath.nil? && GameObj.left_hand.type =~ /weapon/
+          if (ready_item = ReadyList.ready_list.find{ |k, v| v.id.eql?(GameObj.left_hand.id) }) && ReadyList.store_list[ready_item[0]]
+            result = Lich::Stash.add_to_bag(sheath, GameObj.left_hand) if ReadyList.store_list[ready_item[0]].eql?("put in sheath")
+            result = Lich::Stash.add_to_bag(second_sheath, GameObj.left_hand) if ReadyList.store_list[ready_item[0]].eql?("put in secondary sheath")
+            result = Lich::Stash.add_to_bag(StowList.default, GameObj.left_hand) if ["worn if possible, stowed otherwise", "stowed"].include?(ReadyList.store_list[ready_item[0]])
+          elsif !second_sheath.nil? && GameObj.left_hand.type =~ /weapon/
             result = Lich::Stash.add_to_bag(second_sheath, GameObj.left_hand)
           elsif weaponsack && GameObj.left_hand.type =~ /weapon/
             result = Lich::Stash::add_to_bag(weaponsack, GameObj.left_hand)
@@ -227,8 +235,11 @@ module Lich
             dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
           end
         }
-
-        if !sheath.nil? && GameObj.right_hand.type =~ /weapon/
+        if (ready_item = ReadyList.ready_list.find{ |k, v| v.id.eql?(GameObj.right_hand.id) }) && ReadyList.store_list[ready_item[0]]
+          result = Lich::Stash.add_to_bag(sheath, GameObj.right_hand) if ReadyList.store_list[ready_item[0]].eql?("put in sheath")
+          result = Lich::Stash.add_to_bag(second_sheath, GameObj.right_hand) if ReadyList.store_list[ready_item[0]].eql?("put in secondary sheath")
+          result = Lich::Stash.add_to_bag(StowList.default, GameObj.right_hand) if ["worn if possible, stowed otherwise", "stowed"].include?(ReadyList.store_list[ready_item[0]])
+        elsif !sheath.nil? && GameObj.right_hand.type =~ /weapon/
           result = Lich::Stash.add_to_bag(sheath, GameObj.right_hand)
         elsif weaponsack && GameObj.right_hand.type =~ /weapon/
           result = Lich::Stash::add_to_bag(weaponsack, GameObj.right_hand)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `stash_hands` in `stash.rb` to utilize `StowList` for default stow containers, improving item storage logic.
> 
>   - **Behavior**:
>     - Extend `stash_hands` in `stash.rb` to use `StowList` for default stow containers.
>     - Add checks for `StowList.valid?` and call `StowList.check()` if not valid.
>     - Modify logic to store items in `StowList.default` if specified in `ReadyList.store_list`.
>   - **Logic**:
>     - Update conditions in `stash_hands` to handle cases where items should be put in sheath, secondary sheath, or stowed.
>     - Use `Lich::Stash.add_to_bag` to move items based on `ReadyList` and `StowList` configurations.
>   - **Misc**:
>     - Minor adjustments to item handling logic in `stash_hands` for both left and right hands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 6719f3dbf71e89ad0a3f9779485fb9d25ec73801. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->