### PR TITLE
chore(all): change setup-ruby to use .ruby-version file

### DIFF
--- a/.github/workflows/curate-pre-branch.yaml
+++ b/.github/workflows/curate-pre-branch.yaml
@@ -81,7 +81,6 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
         with:
-          ruby-version: '4.0.0'
           bundler-cache: true
 
       - name: Install dependencies with pkg cache

--- a/.github/workflows/curate-pre-branch.yaml
+++ b/.github/workflows/curate-pre-branch.yaml
@@ -72,6 +72,8 @@ concurrency:
 jobs:
   curate:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: 'gtk:vscode:profanity'
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -11,9 +11,6 @@ permissions:
 jobs:
   installer:
     runs-on: windows-2022
-    strategy:
-      matrix:
-        ruby: ['4.0.0']
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
@@ -21,8 +18,6 @@ jobs:
           fetch-depth: 0
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
-        with:
-          ruby-version: ${{ matrix.ruby }}
       - name: Create Core Lich-5 package
         id: install_core_scripts
         run: |

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
         with:
           fetch-depth: 0
-      - name: Install Ruby ${{ matrix.ruby }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
       - name: Create Core Lich-5 package
         id: install_core_scripts

--- a/.github/workflows/release-on-push-prerelease.yaml
+++ b/.github/workflows/release-on-push-prerelease.yaml
@@ -386,10 +386,9 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
 
       # Pin Ruby explicitly on windows-latest
-      - name: Set up Ruby (4.0.0)
+      - name: Set up Ruby
         uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
         with:
-          ruby-version: '4.0.0'
           bundler-cache: false
 
       # Install Inno Setup

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -353,10 +353,9 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
 
       # Pin Ruby explicitly on windows-latest
-      - name: Set up Ruby (4.0.0)
+      - name: Set up Ruby
         uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
         with:
-          ruby-version: '4.0.0'
           bundler-cache: false
 
       # Install Inno Setup

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -61,10 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
-    strategy:
-      matrix:
-        ruby: ['4.0']
-    name: Run tests on Ruby ${{ matrix.ruby }}
+    name: Run tests on Ruby
     steps:
       - name: Classify changed files (preflight)
         id: preflight
@@ -132,7 +129,6 @@ jobs:
       - uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
         if: steps.preflight.outputs.should_test == 'true'
         with:
-          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run RSpec tests
         if: steps.preflight.outputs.should_test == 'true'

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
-    name: Run Rubocop on Ruby ${{ matrix.ruby }}
+    name: Run Rubocop on Ruby
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
         with:

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -20,9 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
-    strategy:
-      matrix:
-        ruby: ['4.0']
     name: Run Rubocop on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
@@ -31,7 +28,6 @@ jobs:
       
       - uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
         with:
-          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
       - name: Rubocop

--- a/.github/workflows/ruby_syntax.yaml
+++ b/.github/workflows/ruby_syntax.yaml
@@ -20,9 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
-    strategy:
-      matrix:
-        ruby: ['4.0']
     name: Run tests on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
@@ -40,7 +37,6 @@ jobs:
             
       - uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
         with:
-          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           
       - name: Run Ruby syntax check on changed scripts

--- a/.github/workflows/ruby_syntax.yaml
+++ b/.github/workflows/ruby_syntax.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
-    name: Run tests on Ruby ${{ matrix.ruby }}
+    name: Run tests on Ruby
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switches Ruby setup in GitHub workflows to use `.ruby-version` file and adds `BUNDLE_WITHOUT` to `curate-pre-branch.yaml`.
> 
>   - **Setup Ruby**:
>     - Remove hardcoded `ruby-version` in `curate-pre-branch.yaml`, `installer.yaml`, `release-on-push-prerelease.yaml`, `release-on-push-stable.yaml`, `rspec_tests.yaml`, `rubocop.yaml`, and `ruby_syntax.yaml`.
>     - Use `.ruby-version` file for Ruby version management.
>   - **Environment Variables**:
>     - Add `BUNDLE_WITHOUT` environment variable to `curate-pre-branch.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 3be62f92f9e2a75eab9e3d593f6ab8b3c12ed3eb. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->