### PR TITLE
refactor(all): update sleep to Kernel.sleep

### DIFF
--- a/lib/common/buffer.rb
+++ b/lib/common/buffer.rb
@@ -28,7 +28,7 @@ module Lich
         line = nil
         loop {
           if (@@index[thread_id] - @@offset) >= @@buffer.length
-            sleep 0.05 while ((@@index[thread_id] - @@offset) >= @@buffer.length)
+            Kernel.sleep 0.05 while ((@@index[thread_id] - @@offset) >= @@buffer.length)
           end
           @@mutex.synchronize {
             if @@index[thread_id] < @@offset

--- a/lib/common/db_store.rb
+++ b/lib/common/db_store.rb
@@ -48,7 +48,7 @@ module Lich
           begin
             Lich.db.execute('INSERT OR REPLACE INTO script_auto_settings(script,scope,hash) VALUES(?,?,?);', [script.encode('UTF-8'), scope.encode('UTF-8'), blob])
           rescue SQLite3::BusyException
-            sleep 0.05
+            Kernel.sleep 0.05
             retry
           rescue StandardError
             respond "--- Lich: error: #{$ERROR_INFO}"
@@ -65,7 +65,7 @@ module Lich
           begin
             Lich.db.execute('INSERT OR REPLACE INTO uservars(scope,hash) VALUES(?,?);', [scope.encode('UTF-8'), blob])
           rescue SQLite3::BusyException
-            sleep 0.05
+            Kernel.sleep 0.05
             retry
           rescue StandardError
             respond "--- Lich: error: #{$ERROR_INFO}"

--- a/lib/common/front-end.rb
+++ b/lib/common/front-end.rb
@@ -167,7 +167,7 @@ module Lich
         $_CLIENTBUFFER_.push(version_string.dup)
         Game._puts(version_string)
         2.times do
-          sleep 0.3
+          Kernel.sleep 0.3
           $_CLIENTBUFFER_.push("#{$cmd_prefix}\r\n")
           Game._puts($cmd_prefix)
         end

--- a/lib/common/gameloader.rb
+++ b/lib/common/gameloader.rb
@@ -76,7 +76,7 @@ module Lich
       end
 
       def self.load!
-        sleep 0.1 while XMLData.game.nil? or XMLData.game.empty?
+        Kernel.sleep 0.1 while XMLData.game.nil? or XMLData.game.empty?
         return self.dragon_realms if XMLData.game =~ /DR/
         return self.gemstone if XMLData.game =~ /GS/
         echo "could not load game specifics for %s" % XMLData.game

--- a/lib/common/gtk.rb
+++ b/lib/common/gtk.rb
@@ -149,7 +149,7 @@ module Lich
         @default_icon = GdkPixbuf::Pixbuf.new(:file => 'logo.png')
         # Add a function to call for when GTK is idle
         GLib::Idle.add do
-          sleep 0.01
+          Kernel.sleep 0.01
         end
         @theme_state = Lich.track_dark_mode
       }

--- a/lib/common/gui/authentication.rb
+++ b/lib/common/gui/authentication.rb
@@ -75,7 +75,7 @@ module Lich
                 delay = AUTH_RETRY_BASE_DELAY * (2**attempt)
                 Lich.log "warn: Authentication attempt #{attempt + 1}/#{MAX_AUTH_RETRIES} failed: " \
                          "#{e.message}, retrying in #{delay}s..."
-                sleep(delay)
+                Kernel.sleep(delay)
               end
             end
           end

--- a/lib/common/gui/conversion_ui.rb
+++ b/lib/common/gui/conversion_ui.rb
@@ -226,13 +226,13 @@ module Lich
                     progress_bar.fraction = 0.2
                     status_label.text = "Reading existing data..."
                   end
-                  sleep(0.5)
+                  Kernel.sleep(0.5)
 
                   Gtk.queue do
                     progress_bar.fraction = 0.5
                     status_label.text = "Converting data format..."
                   end
-                  sleep(0.5)
+                  Kernel.sleep(0.5)
 
                   # Perform the actual conversion using existing method with selected mode
                   success = YamlState.migrate_from_legacy(data_dir, encryption_mode: selected_mode)
@@ -241,7 +241,7 @@ module Lich
                     progress_bar.fraction = 0.8
                     status_label.text = "Validating conversion..."
                   end
-                  sleep(0.5)
+                  Kernel.sleep(0.5)
 
                   # Update UI based on result
                   Gtk.queue do

--- a/lib/common/log.rb
+++ b/lib/common/log.rb
@@ -15,7 +15,7 @@ module Lich
           Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('log_enabled',?);", [@@log_enabled.to_s.encode('UTF-8')])
           Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('log_filter',?);", [@@log_filter.to_s.encode('UTF-8')])
         rescue SQLite3::BusyException
-          sleep 0.1
+          Kernel.sleep 0.1
           retry
         end
         return nil
@@ -28,7 +28,7 @@ module Lich
           Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('log_enabled',?);", [@@log_enabled.to_s.encode('UTF-8')])
           Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('log_filter',?);", [@@log_filter.to_s.encode('UTF-8')])
         rescue SQLite3::BusyException
-          sleep 0.1
+          Kernel.sleep 0.1
           retry
         end
         return nil
@@ -39,7 +39,7 @@ module Lich
           begin
             val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='log_enabled';")
           rescue SQLite3::BusyException
-            sleep 0.1
+            Kernel.sleep 0.1
             retry
           end
           val = false if val.nil?
@@ -53,7 +53,7 @@ module Lich
           begin
             val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='log_filter';")
           rescue SQLite3::BusyException
-            sleep 0.1
+            Kernel.sleep 0.1
             retry
           end
           val = // if val.nil?

--- a/lib/common/postload.rb
+++ b/lib/common/postload.rb
@@ -44,11 +44,11 @@ module Lich
         @thread ||= Thread.new do
           begin
             # Phase 1: Wait for base readiness (same as other watchers)
-            sleep 0.1 until GameBase::Game.autostarted? &&
+            Kernel.sleep 0.1 until GameBase::Game.autostarted? &&
                             XMLData.name && !XMLData.name.empty?
 
             # Phase 2: Wait for game-specific init to signal completion
-            sleep 0.1 until @@game_loaded
+            Kernel.sleep 0.1 until @@game_loaded
 
             # Phase 3: Run registered callbacks
             run_callbacks

--- a/lib/common/postload.rb
+++ b/lib/common/postload.rb
@@ -45,7 +45,7 @@ module Lich
           begin
             # Phase 1: Wait for base readiness (same as other watchers)
             Kernel.sleep 0.1 until GameBase::Game.autostarted? &&
-                            XMLData.name && !XMLData.name.empty?
+                                   XMLData.name && !XMLData.name.empty?
 
             # Phase 2: Wait for game-specific init to signal completion
             Kernel.sleep 0.1 until @@game_loaded

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -102,7 +102,7 @@ module Lich
         end
         script_obj.quiet = true if options[:quiet]
         new_thread = Thread.new {
-          100.times { break if Script.current == script_obj; sleep 0.01 }
+          100.times { break if Script.current == script_obj; Kernel.sleep 0.01 }
 
           if (script = Script.current)
             eval('script = Script.current', script_binding, script.name)
@@ -336,7 +336,7 @@ module Lich
 
       def Script.current
         if (script = @@running.find { |s| s.has_thread?(Thread.current) })
-          sleep 0.2 while script.paused? and not script.ignore_pause
+          Kernel.sleep 0.2 while script.paused? and not script.ignore_pause
           script
         else
           nil
@@ -349,7 +349,7 @@ module Lich
 
       def Script.run(*args)
         if (s = @@elevated_script_start.call(args))
-          sleep 0.1 while @@running.include?(s)
+          Kernel.sleep 0.1 while @@running.include?(s)
         end
       end
 
@@ -420,7 +420,7 @@ module Lich
             script.watchfor.each_pair { |trigger, action|
               if line =~ trigger
                 new_thread = Thread.new {
-                  sleep 0.011 until Script.current
+                  Kernel.sleep 0.011 until Script.current
                   begin
                     action.call
                   rescue
@@ -515,7 +515,7 @@ module Lich
             begin
               Lich.db.execute('INSERT OR REPLACE INTO trusted_scripts(name) values(?);', [script_name.encode('UTF-8')])
             rescue SQLite3::BusyException
-              sleep 0.1
+              Kernel.sleep 0.1
               retry
             end
             true
@@ -529,14 +529,14 @@ module Lich
           begin
             there = Lich.db.get_first_value('SELECT name FROM trusted_scripts WHERE name=?;', [script_name.encode('UTF-8')])
           rescue SQLite3::BusyException
-            sleep 0.1
+            Kernel.sleep 0.1
             retry
           end
           if there
             begin
               Lich.db.execute('DELETE FROM trusted_scripts WHERE name=?;', [script_name.encode('UTF-8')])
             rescue SQLite3::BusyException
-              sleep 0.1
+              Kernel.sleep 0.1
               retry
             end
             true
@@ -550,7 +550,7 @@ module Lich
           begin
             Lich.db.execute('SELECT name FROM trusted_scripts;').each { |name| list.push(name[0]) }
           rescue SQLite3::BusyException
-            sleep 0.1
+            Kernel.sleep 0.1
             retry
           end
           list
@@ -773,11 +773,11 @@ module Lich
       def gets
         # fixme: no xml gets
         if @want_downstream or @want_downstream_xml or @want_script_output
-          sleep 0.05 while @downstream_buffer.empty?
+          Kernel.sleep 0.05 while @downstream_buffer.empty?
           @downstream_buffer.shift
         else
           echo 'this script is set as unique but is waiting for game data...'
-          sleep 2
+          Kernel.sleep 2
           false
         end
       end
@@ -791,13 +791,13 @@ module Lich
           end
         else
           echo 'this script is set as unique but is waiting for game data...'
-          sleep 2
+          Kernel.sleep 2
           false
         end
       end
 
       def upstream_gets
-        sleep 0.05 while @upstream_buffer.empty?
+        Kernel.sleep 0.05 while @upstream_buffer.empty?
         @upstream_buffer.shift
       end
 
@@ -810,7 +810,7 @@ module Lich
       end
 
       def unique_gets
-        sleep 0.05 while @unique_buffer.empty?
+        Kernel.sleep 0.05 while @unique_buffer.empty?
         @unique_buffer.shift
       end
 
@@ -856,7 +856,7 @@ module Lich
           return false
         end
         new_thread = Thread.new {
-          100.times { break if Script.current == new_script; sleep 0.01 }
+          100.times { break if Script.current == new_script; Kernel.sleep 0.01 }
 
           if (script = Script.current)
             Thread.current.priority = 1

--- a/lib/common/sharedbuffer.rb
+++ b/lib/common/sharedbuffer.rb
@@ -22,7 +22,7 @@ module Lich
           @buffer_mutex.synchronize { @buffer_index[thread_id] = (@buffer_offset + @buffer.length) }
         end
         if (@buffer_index[thread_id] - @buffer_offset) >= @buffer.length
-          sleep 0.05 while ((@buffer_index[thread_id] - @buffer_offset) >= @buffer.length)
+          Kernel.sleep 0.05 while ((@buffer_index[thread_id] - @buffer_offset) >= @buffer.length)
         end
         line = nil
         @buffer_mutex.synchronize {

--- a/lib/common/spell.rb
+++ b/lib/common/spell.rb
@@ -556,7 +556,7 @@ module Lich
         script = Script.current
         @@cast_lock.push(script)
         until (@@cast_lock.first == script) or @@cast_lock.empty?
-          sleep 0.1
+          Kernel.sleep 0.1
           Script.current # allows this loop to be paused
           @@cast_lock.delete_if { |s| s.paused or not Script.list.include?(s) }
         end
@@ -572,31 +572,31 @@ module Lich
           if Feat.known?(:mental_acuity)
             unless (self.mana_cost <= 0) or Char.stamina >= (self.mana_cost * 2)
               echo 'cast: not enough stamina there, Monk!'
-              sleep 0.1
+              Kernel.sleep 0.1
               return false
             end
           else
             unless (self.mana_cost <= 0) or Char.mana >= self.mana_cost
               echo 'cast: not enough mana'
-              sleep 0.1
+              Kernel.sleep 0.1
               return false
             end
           end
           unless (self.spirit_cost <= 0) or Char.spirit >= (self.spirit_cost + 1 + [9912, 9913, 9914, 9916, 9916, 9916].delete_if { |num| !Spell[num].active? }.length)
             echo 'cast: not enough spirit'
-            sleep 0.1
+            Kernel.sleep 0.1
             return false
           end
           unless (self.stamina_cost <= 0) or Char.stamina >= self.stamina_cost
             echo 'cast: not enough stamina'
-            sleep 0.1
+            Kernel.sleep 0.1
             return false
           end
         }
         script = Script.current
         if @type.nil?
           echo "cast: spell missing type (#{@name})"
-          sleep 0.1
+          Kernel.sleep 0.1
           return false
         end
         check_energy.call
@@ -607,7 +607,7 @@ module Lich
           script.want_downstream_xml = false
           @@cast_lock.push(script)
           until (@@cast_lock.first == script) or @@cast_lock.empty?
-            sleep 0.1
+            Kernel.sleep 0.1
             Script.current # allows this loop to be paused
             @@cast_lock.delete_if { |s| s.paused or not Script.list.include?(s) }
           end
@@ -666,17 +666,17 @@ module Lich
                     dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
                     unless (self.mana_cost <= 0) or Char.mana >= self.mana_cost
                       echo 'cast: not enough mana'
-                      sleep 0.1
+                      Kernel.sleep 0.1
                       return false
                     end
                     unless (self.spirit_cost <= 0) or Char.spirit >= (self.spirit_cost + 1 + (if checkspell(9912) then 1 else 0 end) + (if checkspell(9913) then 1 else 0 end) + (if checkspell(9914) then 1 else 0 end) + (if checkspell(9916) then 5 else 0 end))
                       echo 'cast: not enough spirit'
-                      sleep 0.1
+                      Kernel.sleep 0.1
                       return false
                     end
                     unless (self.stamina_cost <= 0) or Char.stamina >= self.stamina_cost
                       echo 'cast: not enough stamina'
-                      sleep 0.1
+                      Kernel.sleep 0.1
                       return false
                     end
                   end
@@ -690,11 +690,11 @@ module Lich
                       dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
                       unless (self.mana_cost <= 0) or Char.mana >= self.mana_cost
                         echo 'cast: not enough mana'
-                        sleep 0.1
+                        Kernel.sleep 0.1
                         return false
                       end
                     elsif prepare_result =~ /^You can't think clearly enough to prepare a spell!$|^You are concentrating too intently .*?to prepare a spell\.$|^You are too injured to make that dextrous of a movement|^The searing pain in your throat makes that impossible|^But you don't have any mana!\.$|^You can't make that dextrous of a move!$|^As you begin to prepare the spell the wind blows small objects at you thwarting your attempt\.$|^You do not know that spell!$|^All you manage to do is cough up some blood\.$|The incantations of countless spells swirl through your mind as a golden light flashes before your eyes\./
-                      sleep 0.1
+                      Kernel.sleep 0.1
                       return prepare_result
                     end
                   }
@@ -718,11 +718,11 @@ module Lich
               end
               cast_result = dothistimeout cast_cmd, 5, merged_results_regex
               if cast_result == "You don't seem to be able to move to do that."
-                100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+                100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; Kernel.sleep 0.1 }
                 cast_result = dothistimeout cast_cmd, 5, merged_results_regex
               end
               if cast_cmd =~ /^incant/i && cast_result =~ /^\[Spell preparation time: (\d) seconds?\]$/
-                sleep(Regexp.last_match(1).to_i + 0.5)
+                Kernel.sleep(Regexp.last_match(1).to_i + 0.5)
                 cast_result = dothistimeout cast_cmd, 5, merged_results_regex
               end
               if ((@stance && force_stance != false) || force_stance == true)

--- a/lib/common/vars.rb
+++ b/lib/common/vars.rb
@@ -52,7 +52,7 @@ module Lich
                 ["#{XMLData.game}:#{XMLData.name}".encode('UTF-8')]
               )
             rescue SQLite3::BusyException
-              sleep 0.1
+              Kernel.sleep 0.1
               retry
             end
 
@@ -87,7 +87,7 @@ module Lich
                   ["#{XMLData.game}:#{XMLData.name}".encode('UTF-8'), blob]
                 )
               rescue SQLite3::BusyException
-                sleep 0.1
+                Kernel.sleep 0.1
                 retry
               end
             end
@@ -99,7 +99,7 @@ module Lich
       # Background thread that auto-saves variables every 5 minutes
       Thread.new {
         loop {
-          sleep 300
+          Kernel.sleep 300
           begin
             @@save.call
           rescue StandardError => e

--- a/lib/common/watchable.rb
+++ b/lib/common/watchable.rb
@@ -13,7 +13,7 @@
 #
 #     def self.watch!
 #       @thread ||= Thread.new do
-#         sleep 0.1 until conditions_met?
+#         Kernel.sleep 0.1 until conditions_met?
 #         initialize!
 #       end
 #     end

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -630,9 +630,9 @@ module Lich
             end
             if Frontend.supports_gsl?
               Game._puts "#{$cmd_prefix}_flag Display Dialog Boxes 0"
-              sleep 0.05
+              Kernel.sleep 0.05
               Game._puts "#{$cmd_prefix}_injury 2"
-              sleep 0.05
+              Kernel.sleep 0.05
               # fixme: game name hardcoded as Gemstone IV; maybe doesn't make any difference to the client
               $_CLIENT_.puts "\034GSB0000000000#{attributes['char']}\r\n\034GSA#{Time.now.to_i}GemStone IV\034GSD\r\n"
               # Sending fake GSL tags to the Wizard FE is disabled until now, because it doesn't accept the tags and just gives errors until initialized with the above line
@@ -660,7 +660,7 @@ module Lich
         rescue
           $stdout.puts "--- error: XMLParser.tag_start: #{$!}"
           Lich.log "error: XMLParser.tag_start: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-          sleep 0.1
+          Kernel.sleep 0.1
           reset
         end
       end
@@ -880,7 +880,7 @@ module Lich
         rescue
           $stdout.puts "--- error: XMLParser.text: #{$!}"
           Lich.log "error: XMLParser.text: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-          sleep 0.1
+          Kernel.sleep 0.1
           reset
         end
       end
@@ -944,7 +944,7 @@ module Lich
         rescue
           $stdout.puts "--- error: XMLParser.tag_end: #{$!}"
           Lich.log "error: XMLParser.tag_end: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-          sleep 0.1
+          Kernel.sleep 0.1
           reset
         end
       end

--- a/lib/dragonrealms/commons/slackbot.rb
+++ b/lib/dragonrealms/commons/slackbot.rb
@@ -225,7 +225,7 @@ module Lich
           end
 
           Lich.log "SlackBot: Throttled by Slack API. Retrying in #{delay} seconds..."
-          sleep delay
+          Kernel.sleep delay
           retries += 1
           retry
         rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
@@ -238,7 +238,7 @@ module Lich
           end
 
           Lich.log "SlackBot: Network error: #{e.message}. Retrying in #{delay} seconds..."
-          sleep delay
+          Kernel.sleep delay
           retries += 1
           retry
         end

--- a/lib/dragonrealms/drinfomon/drexpmonitor.rb
+++ b/lib/dragonrealms/drinfomon/drexpmonitor.rb
@@ -61,11 +61,11 @@ module Lich
 
               begin
                 report_skill_gains
-                sleep @@report_interval
+                Kernel.sleep @@report_interval
               rescue StandardError => e
                 Lich::Messaging.msg('error', "DRExpMonitor: Error: #{e.message}") if $DREXPMONITOR_DEBUG
                 Lich.log "DRExpMonitor error: #{e.message}\n\t#{e.backtrace.join("\n\t")}"
-                sleep @@report_interval
+                Kernel.sleep @@report_interval
               end
             end
           ensure
@@ -112,7 +112,7 @@ module Lich
               @@inline_display = false
               return @@inline_display
             end
-            sleep 0.1
+            Kernel.sleep 0.1
             retry
           end
           # Default to false - inline display must be explicitly enabled
@@ -136,7 +136,7 @@ module Lich
             Lich::Messaging.msg('error', "DRExpMonitor: SQLite busy after #{MAX_SQLITE_RETRIES} retries, inline_display setting may not be persisted")
             return
           end
-          sleep 0.1
+          Kernel.sleep 0.1
           retry
         end
       end

--- a/lib/dragonrealms/drinfomon/startup.rb
+++ b/lib/dragonrealms/drinfomon/startup.rb
@@ -31,7 +31,7 @@ module Lich
         @startup_thread ||= Thread.new do
           begin
             # Wait for character to be ready
-            sleep 0.1 until GameBase::Game.autostarted? && XMLData.name && !XMLData.name.empty?
+            Kernel.sleep 0.1 until GameBase::Game.autostarted? && XMLData.name && !XMLData.name.empty?
 
             # Run startup once
             startup

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -281,7 +281,7 @@ module Lich
             @last_recv = Time.now
             until @@autostarted || (Time.now - @last_recv >= 6)
               break if @@autostarted
-              sleep 0.2
+              Kernel.sleep 0.2
             end
 
             puts 'look' unless @@autostarted
@@ -373,7 +373,7 @@ module Lich
                   end
 
                   # Small sleep before retry
-                  sleep 0.1
+                  Kernel.sleep 0.1
                   retry
                 rescue Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNABORTED => conn_error
                   # Connection was reset/broken - these are fatal
@@ -389,7 +389,7 @@ module Lich
               if should_continue && !@socket.closed? && !$_CLIENT_.closed?
                 Lich.log "Retrying server thread after error..."
                 consecutive_timeouts = 0 # Reset counter on retry
-                sleep 1 # Brief pause before retry
+                Kernel.sleep 1 # Brief pause before retry
                 retry
               else
                 Lich.log "Server thread exiting due to unrecoverable error"
@@ -612,7 +612,7 @@ module Lich
         def handle_thread_error(error)
           Lich.log "error: server_thread: #{error}\n\t#{error.backtrace.join("\n\t")}"
           $stdout.puts "error: server_thread: #{error}\n\t#{error.backtrace.slice(0..10).join("\n\t")}"
-          sleep 0.2
+          Kernel.sleep 0.2
 
           # Determine if we should retry
           case error
@@ -660,17 +660,17 @@ module Lich
           when 'scar', 'scars'
             unless XMLData.injury_mode == 1
               Game._puts '_injury 1'
-              150.times { sleep 0.05; break if XMLData.injury_mode == 1 }
+              150.times { Kernel.sleep 0.05; break if XMLData.injury_mode == 1 }
             end
           when 'wound', 'wounds' # future proof leaving in place, but this will likely not be used
             unless XMLData.injury_mode == 0
               Game._puts '_injury 0'
-              150.times { sleep 0.05; break if XMLData.injury_mode == 0 }
+              150.times { Kernel.sleep 0.05; break if XMLData.injury_mode == 0 }
             end
           when 'both'
             unless XMLData.injury_mode == 2
               Game._puts '_injury 2'
-              150.times { sleep 0.05; break if XMLData.injury_mode == 2 }
+              150.times { Kernel.sleep 0.05; break if XMLData.injury_mode == 2 }
             end
           else
             raise ArgumentError, "Invalid mode: #{mode}. Use 'scar', 'wound', or 'both'."

--- a/lib/gemstone/combat/async_processor.rb
+++ b/lib/gemstone/combat/async_processor.rb
@@ -26,7 +26,7 @@ module Lich
 
           # Wait if at capacity
           while @active_count.value >= @max_threads
-            sleep(0.01)
+            Kernel.sleep(0.01)
           end
 
           @active_count.increment

--- a/lib/gemstone/combat/tracker.rb
+++ b/lib/gemstone/combat/tracker.rb
@@ -326,7 +326,7 @@ module Lich
             return if @initialized
 
             # Wait until XMLData is ready (avoid wrong scope)
-            sleep 0.1 until !XMLData.game.nil? && !XMLData.game.empty? && !XMLData.name.nil? && !XMLData.name.empty?
+            Kernel.sleep 0.1 until !XMLData.game.nil? && !XMLData.game.empty? && !XMLData.name.nil? && !XMLData.name.empty?
 
             @initialized = true
             load_settings

--- a/lib/gemstone/group.rb
+++ b/lib/gemstone/group.rb
@@ -260,7 +260,7 @@ module Lich
       #
       # @return [Boolean] true if group state is inconsistent
       def self.broken?
-        sleep(0.1) while Lich::Gemstone::Claim::Lock.locked?
+        Kernel.sleep(0.1) while Lich::Gemstone::Claim::Lock.locked?
         if Group.leader?
           return true if (GameObj.pcs.empty? || GameObj.pcs.nil?) && !@@members.empty?
           return false if (GameObj.pcs.empty? || GameObj.pcs.nil?) && @@members.empty?

--- a/lib/gemstone/infomon.rb
+++ b/lib/gemstone/infomon.rb
@@ -260,7 +260,7 @@ module Lich
           begin
             # Wait for character to be ready and dialogs to load
             Kernel.sleep 0.1 until GameBase::Game.autostarted? && XMLData.name && !XMLData.name.empty? &&
-                            !XMLData.dialogs.empty?
+                                   !XMLData.dialogs.empty?
 
             # Run initial setup if needed (GS-specific only, skip for DR)
             if XMLData.game !~ /^DR/ && db_refresh_needed?

--- a/lib/gemstone/infomon.rb
+++ b/lib/gemstone/infomon.rb
@@ -120,7 +120,7 @@ module Lich
       end
 
       def self.cache_load
-        sleep(0.01) if XMLData.name.empty?
+        Kernel.sleep(0.01) if XMLData.name.empty?
         dataset = Infomon.table
         h = dataset.map(:key).zip(dataset.map(:value)).to_h
         self.cache.merge!(h)
@@ -147,7 +147,7 @@ module Lich
         self.cache_load if !@cache_loaded
         key = self._key(key)
         val = self.cache.get(key) {
-          sleep 0.01 until self.queue.empty?
+          Kernel.sleep 0.01 until self.queue.empty?
           begin
             self.mutex.synchronize do
               begin
@@ -259,7 +259,7 @@ module Lich
         @init_thread ||= Thread.new do
           begin
             # Wait for character to be ready and dialogs to load
-            sleep 0.1 until GameBase::Game.autostarted? && XMLData.name && !XMLData.name.empty? &&
+            Kernel.sleep 0.1 until GameBase::Game.autostarted? && XMLData.name && !XMLData.name.empty? &&
                             !XMLData.dialogs.empty?
 
             # Run initial setup if needed (GS-specific only, skip for DR)

--- a/lib/gemstone/infomon/cli.rb
+++ b/lib/gemstone/infomon/cli.rb
@@ -12,7 +12,7 @@ module Lich
           respond 'ATTENTION:  SHROUD DETECTED - disabling Shroud of Deception to sync character\'s infomon setting'
           while Effects::Spells.active?(1212)
             dothistimeout('STOP 1212', 3, /^With a moment's concentration, you terminate the Shroud of Deception spell\.$|^Stop what\?$/)
-            sleep(0.5)
+            Kernel.sleep(0.5)
           end
           shroud_detected = true
         end

--- a/lib/gemstone/psms/armor.rb
+++ b/lib/gemstone/psms/armor.rb
@@ -246,7 +246,7 @@ module Lich
 
         usage_result = dothistimeout usage_cmd, 5, results_regex
         if usage_result == "You don't seem to be able to move to do that."
-          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; Kernel.sleep 0.1 }
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
         usage_result

--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -806,7 +806,7 @@ module Lich
 
         usage_result = dothistimeout usage_cmd, 5, results_regex
         if usage_result == "You don't seem to be able to move to do that."
-          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; Kernel.sleep 0.1 }
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
 

--- a/lib/gemstone/psms/feat.rb
+++ b/lib/gemstone/psms/feat.rb
@@ -399,7 +399,7 @@ module Lich
 
         usage_result = dothistimeout usage_cmd, 5, results_regex
         if usage_result == "You don't seem to be able to move to do that."
-          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; Kernel.sleep 0.1 }
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
         usage_result

--- a/lib/gemstone/psms/shield.rb
+++ b/lib/gemstone/psms/shield.rb
@@ -385,7 +385,7 @@ module Lich
 
         usage_result = dothistimeout usage_cmd, 5, results_regex
         if usage_result == "You don't seem to be able to move to do that."
-          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; Kernel.sleep 0.1 }
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
 

--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -211,7 +211,7 @@ module Lich
 
         usage_result = dothistimeout(usage_cmd, 5, results_regex)
         if usage_result == "You don't seem to be able to move to do that."
-          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+          100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; Kernel.sleep 0.1 }
           usage_result = dothistimeout(usage_cmd, 5, results_regex)
         end
         usage_result

--- a/lib/gemstone/psms/weapon.rb
+++ b/lib/gemstone/psms/weapon.rb
@@ -337,7 +337,7 @@ module Lich
             break if usage_result =~ /^#{name} what\?$/i
             break if usage_result =~ in_cooldown_regex
             break if Time.now() > break_out
-            sleep 0.25
+            Kernel.sleep 0.25
           }
         else
           results_regex = Regexp.union(results_regex, technique[:regex], /^Roundtime: [0-9]+ sec\.$/)
@@ -351,7 +351,7 @@ module Lich
 
           usage_result = dothistimeout(usage_cmd, 5, results_regex)
           if usage_result == "You don't seem to be able to move to do that."
-            100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; sleep 0.1 }
+            100.times { break if clear.any? { |line| line =~ /^You regain control of your senses!$/ }; Kernel.sleep 0.1 }
             usage_result = dothistimeout(usage_cmd, 5, results_regex)
           end
         end

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -15,7 +15,7 @@ end
 def start_scripts(*script_names)
   script_names.flatten.each { |script_name|
     start_script(script_name)
-    sleep 0.02
+    Kernel.sleep 0.02
   }
 end
 
@@ -91,7 +91,7 @@ end
 def silence_me
   unless (script = Script.current) then echo 'silence_me: cannot identify calling script.'; return nil; end
   if script.safe? then echo("WARNING: 'safe' script attempted to silence itself.  Ignoring the request.")
-                       sleep 1
+                       Kernel.sleep 1
                        return true
   end
   script.silent = !script.silent
@@ -116,7 +116,7 @@ def upstream_get
   unless (script = Script.current) then echo 'upstream_get: cannot identify calling script.'; return nil; end
   unless script.want_upstream
     echo("This script wants to listen to the upstream, but it isn't set as receiving the upstream! This will cause a permanent hang, aborting (ask for the upstream with 'toggle_upstream' in the script)")
-    sleep 0.3
+    Kernel.sleep 0.3
     return false
   end
   script.upstream_gets
@@ -184,7 +184,7 @@ end
 def fix_injury_mode
   unless XMLData.injury_mode == 2
     Game._puts '_injury 2'
-    150.times { sleep 0.05; break if XMLData.injury_mode == 2 }
+    150.times { Kernel.sleep 0.05; break if XMLData.injury_mode == 2 }
   end
 end
 
@@ -203,12 +203,12 @@ end
 
 def waitrt
   wait_until { (XMLData.roundtime_end.to_f - Time.now.to_f + XMLData.server_time_offset.to_f) > 0 }
-  sleep checkrt
+  Kernel.sleep checkrt
 end
 
 def waitcastrt
   wait_until { (XMLData.cast_roundtime_end.to_f - Time.now.to_f + XMLData.server_time_offset.to_f) > 0 }
-  sleep checkcastrt
+  Kernel.sleep checkcastrt
 end
 
 def checkrt
@@ -220,16 +220,16 @@ def checkcastrt
 end
 
 def waitrt?
-  sleep checkrt
+  Kernel.sleep checkrt
   return true if checkrt > 0.0
   return false if checkrt == 0
 end
 
 def waitcastrt?
-  #  sleep checkcastrt
+  #  Kernel.sleep checkcastrt
   current_castrt = checkcastrt
   if current_castrt.to_f > 0.0
-    sleep(current_castrt)
+    Kernel.sleep(current_castrt)
     return true
   else
     return false
@@ -365,7 +365,7 @@ def selectput(string, success, failure, timeout = nil)
   thr = Thread.current
 
   timethr = Thread.new {
-    timeout -= sleep("0.1".to_f) until timeout <= 0
+    timeout -= Kernel.sleep("0.1".to_f) until timeout <= 0
     thr.raise(StandardError)
   } if timeout
 
@@ -531,7 +531,7 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
       line_count += 1
     end
     if line.nil?
-      sleep 0.1
+      Kernel.sleep 0.1
     elsif line =~ /^You realize that would be next to impossible while in combat.|^You can't do that while engaged!|^You are engaged to |^You need to retreat out of combat first!|^You try to move, but you're engaged|^While in combat\?  You'll have better luck if you first retreat/
       # DragonRealms
       fput 'retreat'
@@ -564,11 +564,11 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
       # return nil instead of false to show the direction shouldn't be removed from the map database
       return nil
     elsif line =~ /^You grab [A-Z][a-z]+ and try to drag h(?:im|er), but s?he (?:is too heavy|doesn't budge)\.$|^Tentatively, you attempt to swim through the nook\.  After only a few feet, you begin to sink!  Your lungs burn from lack of air, and you begin to panic!  You frantically paddle back to safety!$|^Guards(?:wo)?man [A-Z][a-z]+ stops you and says, "(?:Stop\.|Halt!)  You need to make sure you check in|^You step into the root, but can see no way to climb the slippery tendrils inside\.  After a moment, you step back out\.$|^As you start .*? back to safe ground\.$|^You stumble a bit as you try to enter the pool but feel that your persistence will pay off\.$|^A shimmering field of magical crimson and gold energy flows through the area\.$|^You attempt to navigate your way through the fog, but (?:quickly become entangled|get turned around)|^Trying to judge the climb, you peer over the edge\.\s*A wave of dizziness hits you, and you back away from the .*\.$|^You approach the .*, but the steepness is intimidating\.$|^You make your way (?:up|down) the .*\.\s*Partway (?:up|down), you make the mistake of looking down\. Struck by vertigo, you cling to the .* for a few moments, then slowly climb back (?:up|down)\.$|^You pick your way up the .*, but reach a point where your footing is questionable.\s*Reluctantly, you climb back down.$/
-      sleep 1
+      Kernel.sleep 1
       waitrt?
       put_dir.call
     elsif line =~ /^Climbing.*(?:plunge|fall)|^Tentatively, you attempt to climb.*(?:fall|slip)|^You start up the .* but slip after a few feet and fall to the ground|^You start.*but quickly realize|^You.*drop back to the ground|^You leap .* fall unceremoniously to the ground in a heap\.$|^You search for a way to make the climb .*? but without success\.$|^You start to climb .* you fall to the ground|^You attempt to climb .* wrong approach|^You run towards .*? slowly retreat back, reassessing the situation\.|^You attempt to climb down the .*, but you can't seem to find purchase\.|^You start down the .*, but you find it hard going.\s*Rather than risking a fall, you make your way back up\./
-      sleep 1
+      Kernel.sleep 1
       waitrt?
       fput 'stand' unless standing?
       waitrt?
@@ -577,7 +577,7 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
       # swims in Sailor's Grief
       return true
     elsif line =~ /^You begin to climb up the silvery thread.* you tumble to the ground/
-      sleep 0.5
+      Kernel.sleep 0.5
       waitrt?
       fput 'stand' unless standing?
       waitrt?
@@ -635,9 +635,9 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
       end
     elsif line =~ /^(\.\.\.w|W)ait ([0-9]+) sec(onds)?\.$/
       if $2.to_i > 1
-        sleep($2.to_i - "0.2".to_f)
+        Kernel.sleep($2.to_i - "0.2".to_f)
       else
-        sleep 0.3
+        Kernel.sleep 0.3
       end
       put_dir.call
     elsif line =~ /will have to stand up first|must be standing first|^You'll have to get up first|^But you're already sitting!|^Shouldn't you be standing first|^That would be quite a trick from that position\.  Try standing up\.|^Perhaps you should stand up|^Standing up might help|^You should really stand up first|You can't do that while sitting|You must be standing to do that|You can't do that while lying down|^You must be standing/
@@ -645,18 +645,18 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
       waitrt?
       put_dir.call
     elsif line =~ /^You're still recovering from your recent/
-      sleep 2
+      Kernel.sleep 2
       put_dir.call
     elsif line =~ /^The ground approaches you at an alarming rate/
-      sleep 1
+      Kernel.sleep 1
       fput 'stand' unless standing?
       put_dir.call
     elsif line =~ /You go flying down several feet, landing with a/
-      sleep 1
+      Kernel.sleep 1
       fput 'stand' unless standing?
       put_dir.call
     elsif line =~ /^Sorry, you may only type ahead/
-      sleep 1
+      Kernel.sleep 1
       put_dir.call
     elsif line == 'You are still stunned.'
       wait_while { stunned? }
@@ -673,10 +673,10 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
       put_dir.call
     elsif line =~ /^(You notice .* at your feet, and do not wish to leave it behind|As you prepare to move away, you remember)/
       fput "stow feet"
-      sleep 1
+      Kernel.sleep 1
       put_dir.call
     elsif line =~ /The electricity courses through you in a raging torrent, its power singing in your veins!  Spent, the boltstone apparatus shatters into glinting fragments\.|The lightning strikes you in an agonizing eruption of liquid radiance!/
-      sleep(0.5)
+      Kernel.sleep(0.5)
       wait_while { stunned? }
       waitrt?
       fput 'stand' unless standing?
@@ -686,7 +686,7 @@ def move(dir = 'none', giveup_seconds = 10, giveup_lines = 30)
       30.times {
         break if clear.include?('You regain control of your senses!')
 
-        sleep 0.1
+        Kernel.sleep 0.1
       }
       put_dir.call
     elsif line =~ /^It's pitch dark and you can't see a thing!/
@@ -739,7 +739,7 @@ def wait_until(announce = nil)
     respond(announce)
   end
   until yield
-    sleep 0.25
+    Kernel.sleep 0.25
   end
   Thread.current.priority = priosave
 end
@@ -751,7 +751,7 @@ def wait_while(announce = nil)
     respond(announce)
   end
   while yield
-    sleep 0.25
+    Kernel.sleep 0.25
   end
   Thread.current.priority = priosave
 end
@@ -836,7 +836,7 @@ def check_mind(string = nil)
   elsif string.to_i.between?(0, 100)
     return string.to_i <= XMLData.mind_value.to_i
   else
-    echo("check_mind error! You must provide an integer ranging from 0-100, the common abbreviation of how full your head is, or provide no input to have check_mind return an abbreviation of how filled your head is."); sleep 1
+    echo("check_mind error! You must provide an integer ranging from 0-100, the common abbreviation of how full your head is, or provide no input to have check_mind return an abbreviation of how filled your head is."); Kernel.sleep 1
     return false
   end
 end
@@ -860,7 +860,7 @@ def checkmind(string = nil)
       nil
     end
   else
-    echo("Checkmind error! You must provide an integer ranging from 1-8 (7 is fried, 8 is 100% fried), the common abbreviation of how full your head is, or provide no input to have checkmind return an abbreviation of how filled your head is."); sleep 1
+    echo("Checkmind error! You must provide an integer ranging from 1-8 (7 is fried, 8 is 100% fried), the common abbreviation of how full your head is, or provide no input to have checkmind return an abbreviation of how filled your head is."); Kernel.sleep 1
     return false
   end
 end
@@ -1330,13 +1330,13 @@ end
 
 def pause(num = 1)
   if num.to_s =~ /m/
-    sleep((num.sub(/m/, '').to_f * 60))
+    Kernel.sleep((num.sub(/m/, '').to_f * 60))
   elsif num.to_s =~ /h/
-    sleep((num.sub(/h/, '').to_f * 3600))
+    Kernel.sleep((num.sub(/h/, '').to_f * 3600))
   elsif num.to_s =~ /d/
-    sleep((num.sub(/d/, '').to_f * 86400))
+    Kernel.sleep((num.sub(/d/, '').to_f * 86400))
   else
-    sleep(num.to_f)
+    Kernel.sleep(num.to_f)
   end
 end
 
@@ -1364,7 +1364,7 @@ def match(label, string)
   strings = [label, string]
   strings.flatten!
   unless (script = Script.current) then echo("An unknown script thread tried to fetch a game line from the queue, but Lich can't process the call without knowing which script is calling! Aborting..."); Thread.current.kill; return false end
-  if strings.empty? then echo("Error! 'match' was given no strings to look for!"); sleep 1; return false end
+  if strings.empty? then echo("Error! 'match' was given no strings to look for!"); Kernel.sleep 1; return false end
   unless strings.length == 2
     while (line_in = script.gets)
       strings.each { |string|
@@ -1390,7 +1390,7 @@ def matchtimeout(secs, *strings)
   strings.flatten!
   if strings.empty?
     echo("matchtimeout without any strings to wait for!")
-    sleep 1
+    Kernel.sleep 1
     return false
   end
   regexpstr = strings.join('|')
@@ -1398,7 +1398,7 @@ def matchtimeout(secs, *strings)
   loop {
     line = get?
     if line.nil?
-      sleep 0.1
+      Kernel.sleep 0.1
     elsif line =~ /#{regexpstr}/i
       return line
     end
@@ -1458,7 +1458,7 @@ end
 
 def waitforre(regexp)
   unless (script = Script.current) then respond('--- waitforre: Unable to identify calling script.'); return false; end
-  unless regexp.is_a?(Regexp) then echo("Script error! You have given 'waitforre' something to wait for, but it isn't a Regular Expression! Use 'waitfor' if you want to wait for a string."); sleep 1; return nil end
+  unless regexp.is_a?(Regexp) then echo("Script error! You have given 'waitforre' something to wait for, but it isn't a Regular Expression! Use 'waitfor' if you want to wait for a string."); Kernel.sleep 1; return nil end
   regobj = regexp.match(script.gets) until regobj
 end
 
@@ -1545,7 +1545,7 @@ def fput(message, *waitingfor)
   while (string = get)
     if string =~ /(?:\.\.\.wait |Wait )(?<wait_time>[0-9]+)/
       hold_up = Regexp.last_match[:wait_time].to_i
-      sleep(hold_up) unless hold_up.nil?
+      Kernel.sleep(hold_up) unless hold_up.nil?
       clear
       put(message)
       next
@@ -1556,21 +1556,21 @@ def fput(message, *waitingfor)
     elsif string =~ /stunned|can't do that while|cannot seem|^(?!You rummage).*can't seem|don't seem|Sorry, you may only type ahead/
       if dead?
         echo "You're dead...! You can't do that!"
-        sleep 1
+        Kernel.sleep 1
         script.downstream_buffer.unshift(string)
         return false
       elsif checkstunned
         while checkstunned
-          sleep("0.25".to_f)
+          Kernel.sleep("0.25".to_f)
         end
       elsif checkwebbed
         while checkwebbed
-          sleep("0.25".to_f)
+          Kernel.sleep("0.25".to_f)
         end
       elsif string =~ /Sorry, you may only type ahead/
-        sleep 1
+        Kernel.sleep 1
       else
-        sleep 0.1
+        Kernel.sleep 0.1
         script.downstream_buffer.unshift(string)
         return false
       end
@@ -1586,7 +1586,7 @@ def fput(message, *waitingfor)
           script.downstream_buffer.unshift(string)
           return foundit
         end
-        sleep 1
+        Kernel.sleep 1
         clear
         put(message)
         next
@@ -1607,7 +1607,7 @@ end
 def matchfindexact(*strings)
   strings.flatten!
   unless (script = Script.current) then echo("An unknown script thread tried to fetch a game line from the queue, but Lich can't process the call without knowing which script is calling! Aborting..."); Thread.current.kill; return false end
-  if strings.empty? then echo("error! 'matchfind' with no strings to look for!"); sleep 1; return false end
+  if strings.empty? then echo("error! 'matchfind' with no strings to look for!"); Kernel.sleep 1; return false end
   looking = Array.new
   strings.each { |str| looking.push(str.gsub('?', '(\b.+\b)')) }
   if looking.empty? then echo("matchfind without any strings to wait for!"); return false end
@@ -1869,13 +1869,13 @@ def dothis(action, success_line)
         return line
       elsif line =~ /^(\.\.\.w|W)ait ([0-9]+) sec(onds)?\.$/
         if $2.to_i > 1
-          sleep($2.to_i - "0.5".to_f)
+          Kernel.sleep($2.to_i - "0.5".to_f)
         else
-          sleep 0.3
+          Kernel.sleep 0.3
         end
         break
       elsif line == 'Sorry, you may only type ahead 1 command.'
-        sleep 1
+        Kernel.sleep 1
         break
       elsif line == 'You are still stunned.'
         wait_while { stunned? }
@@ -1883,7 +1883,7 @@ def dothis(action, success_line)
       elsif line == 'That is impossible to do while unconscious!'
         100.times {
           unless (line = get?)
-            sleep 0.1
+            Kernel.sleep 0.1
           else
             break if line =~ /Your thoughts slowly come back to you as you find yourself lying on the ground\.  You must have been sleeping\.$|^You wake up from your slumber\.$/
           end
@@ -1892,7 +1892,7 @@ def dothis(action, success_line)
       elsif line == "You don't seem to be able to move to do that."
         100.times {
           unless (line = get?)
-            sleep 0.1
+            Kernel.sleep 0.1
           else
             break if line == 'The restricting force that envelops you dissolves away.'
           end
@@ -1904,7 +1904,7 @@ def dothis(action, success_line)
       elsif line == 'You find that impossible under the effects of the lullabye.'
         100.times {
           unless (line = get?)
-            sleep 0.1
+            Kernel.sleep 0.1
           else
             # fixme
             break if line == 'You shake off the effects of the lullabye.'
@@ -1925,19 +1925,19 @@ def dothistimeout(action, timeout, success_line)
     loop {
       line = get?
       if line.nil?
-        sleep 0.1
+        Kernel.sleep 0.1
       elsif line =~ success_line
         return line
       elsif line =~ /^(\.\.\.w|W)ait ([0-9]+) sec(onds)?\.$/
         if $2.to_i > 1
-          sleep($2.to_i - "0.5".to_f)
+          Kernel.sleep($2.to_i - "0.5".to_f)
         else
-          sleep 0.3
+          Kernel.sleep 0.3
         end
         end_time = Time.now.to_f + timeout
         break
       elsif line == 'Sorry, you may only type ahead 1 command.'
-        sleep 1
+        Kernel.sleep 1
         end_time = Time.now.to_f + timeout
         break
       elsif line == 'You are still stunned.'
@@ -1947,7 +1947,7 @@ def dothistimeout(action, timeout, success_line)
       elsif line == 'That is impossible to do while unconscious!'
         100.times {
           unless (line = get?)
-            sleep 0.1
+            Kernel.sleep 0.1
           else
             break if line =~ /Your thoughts slowly come back to you as you find yourself lying on the ground\.  You must have been sleeping\.$|^You wake up from your slumber\.$/
           end
@@ -1956,7 +1956,7 @@ def dothistimeout(action, timeout, success_line)
       elsif line == "You don't seem to be able to move to do that."
         100.times {
           unless (line = get?)
-            sleep 0.1
+            Kernel.sleep 0.1
           else
             break if line == 'The restricting force that envelops you dissolves away.'
           end
@@ -1968,7 +1968,7 @@ def dothistimeout(action, timeout, success_line)
       elsif line == 'You find that impossible under the effects of the lullabye.'
         100.times {
           unless (line = get?)
-            sleep 0.1
+            Kernel.sleep 0.1
           else
             # fixme
             break if line == 'You shake off the effects of the lullabye.'
@@ -2276,7 +2276,7 @@ def do_client(client_string)
         Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values(?,?);", [toggle_var.to_s.encode('UTF-8'), set_state.to_s.encode('UTF-8')])
         did_something = true
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       respond("--- Lich: toggle #{toggle_var} set #{set_state}") if did_something

--- a/lib/init.rb
+++ b/lib/init.rb
@@ -481,7 +481,7 @@ rescue LoadError
           r = Win32.ShellExecuteEx(:fMask => Win32::SEE_MASK_NOCLOSEPROCESS, :lpVerb => verb, :lpFile => "#{ruby_bin_dir}\\#{gem_file}", :lpParameters => 'install sqlite3 --no-ri --no-rdoc')
           if r[:return] > 0
             pid = r[:hProcess]
-            sleep 1 while Win32.GetExitCodeProcess(:hProcess => pid)[:lpExitCode] == Win32::STILL_ACTIVE
+            Kernel.sleep 1 while Win32.GetExitCodeProcess(:hProcess => pid)[:lpExitCode] == Win32::STILL_ACTIVE
             r = Win32.MessageBox(:lpText => "Install finished.  Lich will restart now.", :lpCaption => "Lich v#{LICH_VERSION}", :uType => Win32::MB_OKCANCEL)
           else
             # ShellExecuteEx failed: this seems to happen with an access denied error even while elevated on some random systems
@@ -541,7 +541,7 @@ unless (ARGV.grep(/^--no-(?:gtk|gui)$/).any? || RUBY_PLATFORM !~ /mingw/ && (ENV
               r = Win32.ShellExecuteEx(:fMask => Win32::SEE_MASK_NOCLOSEPROCESS, :lpVerb => verb, :lpFile => "#{ruby_bin_dir}\\gem.bat", :lpParameters => 'install gtk3 --no-ri --no-rdoc')
               if r[:return] > 0
                 pid = r[:hProcess]
-                sleep 1 while Win32.GetExitCodeProcess(:hProcess => pid)[:lpExitCode] == Win32::STILL_ACTIVE
+                Kernel.sleep 1 while Win32.GetExitCodeProcess(:hProcess => pid)[:lpExitCode] == Win32::STILL_ACTIVE
                 r = Win32.MessageBox(:lpText => "Install finished.  Lich will restart now.", :lpCaption => "Lich v#{LICH_VERSION}", :uType => Win32::MB_OKCANCEL)
               else
                 # ShellExecuteEx failed: this seems to happen with an access denied error even while elevated on some random systems
@@ -722,7 +722,7 @@ if (RUBY_VERSION =~ /^2\.[012]\./)
   begin
     did_trusted_defaults = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='did_trusted_defaults';")
   rescue SQLite3::BusyException
-    sleep 0.1
+    Kernel.sleep 0.1
     retry
   end
   if did_trusted_defaults.nil?
@@ -732,7 +732,7 @@ if (RUBY_VERSION =~ /^2\.[012]\./)
     begin
       Lich.db.execute("INSERT INTO lich_settings(name,value) VALUES('did_trusted_defaults', 'yes');")
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end

--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -12,7 +12,7 @@ module Lich
     begin
       ts = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='db_maint_last_at';")
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     rescue => e
       Lich.log "db_maint_last_at error: #{e}"
@@ -26,7 +26,7 @@ module Lich
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name, value) VALUES('db_maint_last_at', ?);", [iso_utc])
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name, value) VALUES('db_maint_last_note', ?);", [note.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     rescue => e
       Lich.log "db_maint_set! error: #{e}"
@@ -62,12 +62,12 @@ module Lich
       end
       unless got
         while (Time.now - start) < lock_timeout_s && !got
-          sleep 0.1
+          Kernel.sleep 0.1
           begin
             got = f.flock(File::LOCK_EX | File::LOCK_NB)
           rescue SystemCallError, IOError
             # Transient error acquiring lock on some filesystems; back off and retry.
-            sleep 0.05
+            Kernel.sleep 0.05
           end
         end
       end
@@ -182,7 +182,7 @@ module Lich
       Lich.db.execute("CREATE TABLE IF NOT EXISTS simu_game_entry (character TEXT NOT NULL, game_code TEXT NOT NULL, data BLOB, PRIMARY KEY(character, game_code));")
       Lich.db.execute("CREATE TABLE IF NOT EXISTS enable_inventory_boxes (player_id INTEGER NOT NULL, PRIMARY KEY(player_id));")
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -343,11 +343,11 @@ module Lich
           r = Win32.ShellExecuteEx(:lpVerb => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params, :fMask => Win32::SEE_MASK_NOCLOSEPROCESS)
           if r[:return] > 0
             process_id = r[:hProcess]
-            sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
-            sleep 3
+            Kernel.sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
+            Kernel.sleep 3
           else
             Win32.ShellExecute(:lpOperation => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params)
-            sleep 6
+            Kernel.sleep 6
           end
         rescue
           Lich.msgbox(:message => $!)
@@ -402,11 +402,11 @@ module Lich
           r = Win32.ShellExecuteEx(:lpVerb => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params, :fMask => Win32::SEE_MASK_NOCLOSEPROCESS)
           if r[:return] > 0
             process_id = r[:hProcess]
-            sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
-            sleep 3
+            Kernel.sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
+            Kernel.sleep 3
           else
             Win32.ShellExecute(:lpOperation => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params)
-            sleep 6
+            Kernel.sleep 6
           end
         rescue
           Lich.msgbox(:message => $!)
@@ -462,11 +462,11 @@ module Lich
           r = Win32.ShellExecuteEx(:lpVerb => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params, :fMask => Win32::SEE_MASK_NOCLOSEPROCESS)
           if r[:return] > 0
             process_id = r[:hProcess]
-            sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
-            sleep 3
+            Kernel.sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
+            Kernel.sleep 3
           else
             Win32.ShellExecute(:lpOperation => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params)
-            sleep 6
+            Kernel.sleep 6
           end
         rescue
           Lich.msgbox(:message => $!)
@@ -521,11 +521,11 @@ module Lich
           r = Win32.ShellExecuteEx(:lpVerb => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params, :fMask => Win32::SEE_MASK_NOCLOSEPROCESS)
           if r[:return] > 0
             process_id = r[:hProcess]
-            sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
-            sleep 3
+            Kernel.sleep 0.2 while Win32.GetExitCodeProcess(:hProcess => process_id)[:lpExitCode] == Win32::STILL_ACTIVE
+            Kernel.sleep 3
           else
             Win32.ShellExecute(:lpOperation => 'runas', :lpFile => file, :lpDirectory => LICH_DIR.tr("/", "\\"), :lpParameters => params)
-            sleep 6
+            Kernel.sleep 6
           end
         rescue
           Lich.msgbox(:message => $!)
@@ -632,7 +632,7 @@ module Lich
     begin
       v = Lich.db.get_first_value('SELECT player_id FROM enable_inventory_boxes WHERE player_id=?;', [player_id.to_i])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
     if v
@@ -647,14 +647,14 @@ module Lich
       begin
         Lich.db.execute('INSERT OR REPLACE INTO enable_inventory_boxes values(?);', [player_id.to_i])
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
     else
       begin
         Lich.db.execute('DELETE FROM enable_inventory_boxes where player_id=?;', [player_id.to_i])
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
     end
@@ -665,7 +665,7 @@ module Lich
     begin
       val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='win32_launch_method';")
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
     val
@@ -675,7 +675,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('win32_launch_method',?);", [val.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -721,7 +721,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='debug_messaging';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       @@debug_messaging = (val.to_s =~ /on|true|yes/ ? true : false)
@@ -735,7 +735,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('debug_messaging',?);", [@@debug_messaging.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -745,7 +745,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_lichid';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       val = (XMLData.game =~ /^GS/ ? true : false) if val.nil? and XMLData.game != ""; # default false if DR, otherwise default true
@@ -759,7 +759,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_lichid',?);", [@@display_lichid.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -769,7 +769,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='hide_uid_flag';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       val = false if val.nil? and XMLData.game != ""; # default false
@@ -783,7 +783,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('hide_uid_flag',?);", [@@hide_uid_flag.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -792,7 +792,7 @@ module Lich
     begin
       val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='core_updated_with_lich_version';")
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
     return val.to_s
@@ -802,7 +802,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('core_updated_with_lich_version',?);", [val.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -812,7 +812,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_uid';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       val = (XMLData.game =~ /^GS/ ? true : false) if val.nil? and XMLData.game != ""; # default false if DR, otherwise default true
@@ -826,7 +826,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_uid',?);", [@@display_uid.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -836,7 +836,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_exits';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       val = false if val.nil? and XMLData.game != ""; # default false
@@ -850,7 +850,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_exits',?);", [@@display_exits.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -860,7 +860,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_stringprocs';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       val = false if val.nil? and XMLData.game != ""; # default false
@@ -874,7 +874,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_stringprocs',?);", [@@display_stringprocs.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -884,7 +884,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_expgains';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       # Default to true for non-Genie frontends (Genie has built-in exp tracking)
@@ -902,7 +902,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_expgains',?);", [@@display_expgains.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -912,7 +912,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_autosort_state';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       @@track_autosort_state = (val.to_s =~ /on|true|yes/ ? true : false)
@@ -925,7 +925,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_autosort_state',?);", [@@track_autosort_state.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -935,7 +935,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_dark_mode';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       @@track_dark_mode = (val.to_s =~ /on|true|yes/ ? true : false)
@@ -948,7 +948,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_dark_mode',?);", [@@track_dark_mode.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end
@@ -958,7 +958,7 @@ module Lich
       begin
         val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='track_layout_state';")
       rescue SQLite3::BusyException
-        sleep 0.1
+        Kernel.sleep 0.1
         retry
       end
       @@track_layout_state = (val.to_s =~ /on|true|yes/ ? true : false)
@@ -971,7 +971,7 @@ module Lich
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('track_layout_state',?);", [@@track_layout_state.to_s.encode('UTF-8')])
     rescue SQLite3::BusyException
-      sleep 0.1
+      Kernel.sleep 0.1
       retry
     end
   end

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -12,7 +12,7 @@ reconnect_if_wanted = proc {
       reconnect_step = 0
     end
     Lich.log "info: waiting #{reconnect_delay} seconds to reconnect..."
-    sleep reconnect_delay
+    Kernel.sleep reconnect_delay
     Lich.log 'info: reconnecting...'
     if (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
       if Frontend.client.eql?('stormfront')
@@ -272,7 +272,7 @@ reconnect_if_wanted = proc {
         Lich.msgbox(:message => "error: #{$!.to_s.sub(game_key.to_s, '[scrubbed key]')}", :icon => :error)
       end
       Lich.log 'info: waiting for client to connect...'
-      300.times { sleep 0.1; break unless accept_thread.status }
+      300.times { Kernel.sleep 0.1; break unless accept_thread.status }
       accept_thread.kill if accept_thread.status
       Dir.chdir(LICH_DIR)
       unless $_CLIENT_
@@ -308,7 +308,7 @@ reconnect_if_wanted = proc {
         Game.open(gamehost, gameport)
       }
       300.times {
-        sleep 0.1
+        Kernel.sleep 0.1
         break unless connect_thread.status
       }
       if connect_thread.status
@@ -324,7 +324,7 @@ reconnect_if_wanted = proc {
           Game.open(gamehost, gameport)
         }
         300.times {
-          sleep 0.1
+          Kernel.sleep 0.1
           break unless connect_thread.status
         }
         if connect_thread.status
@@ -357,7 +357,7 @@ reconnect_if_wanted = proc {
         Lich.log "warning: setsockopt with SO_REUSEADDR failed: #{$!}"
       end
     rescue
-      sleep 1
+      Kernel.sleep 1
       if (error_count += 1) >= 30
         $stdout.puts 'error: failed to bind to the proper port'
         Lich.log 'error: failed to bind to the proper port'
@@ -376,7 +376,7 @@ reconnect_if_wanted = proc {
     Lich.log "info: waiting for the client to connect..."
 
     timeout_thread = Thread.new {
-      sleep 120
+      Kernel.sleep 120
       listener.close rescue nil
       $stdout.puts 'error: timed out waiting for client to connect'
       Lich.log 'error: timed out waiting for client to connect'
@@ -398,7 +398,7 @@ reconnect_if_wanted = proc {
       @argv_options[:game_host], @argv_options[:game_port] = Lich.fix_game_host_port(@argv_options[:game_host], @argv_options[:game_port])
       begin
         timeout_thread = Thread.new {
-          sleep 30
+          Kernel.sleep 30
           Lich.log "error: timed out connecting to #{@argv_options[:game_host]}:#{@argv_options[:game_port]}"
           $stdout.puts "error: timed out connecting to #{@argv_options[:game_host]}:#{@argv_options[:game_port]}"
           exit
@@ -443,7 +443,7 @@ reconnect_if_wanted = proc {
       # tell the server we're ready
       #
       2.times {
-        sleep 0.3
+        Kernel.sleep 0.3
         $_CLIENTBUFFER_.push("<c>\r\n")
         Game._puts("<c>")
       }
@@ -463,7 +463,7 @@ reconnect_if_wanted = proc {
       if (error_count += 1) > 20
         Lich.log 'warning: giving up...'
       else
-        sleep 0.05
+        Kernel.sleep 0.05
         retry
       end
     end
@@ -516,7 +516,7 @@ reconnect_if_wanted = proc {
           Game._puts(client_string)
 
           2.times {
-            sleep 0.3
+            Kernel.sleep 0.3
             $_CLIENTBUFFER_.push("<c>\r\n")
             Game._puts("<c>")
           }
@@ -595,7 +595,7 @@ reconnect_if_wanted = proc {
         respond "--- Lich: error: client_thread: #{$!}"
         respond $!.backtrace.first
         Lich.log "error: client_thread: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-        sleep 0.2
+        Kernel.sleep 0.2
         retry unless $_CLIENT_.closed? or Game.closed? or !Game.thread.alive? or ($!.to_s =~ /invalid argument|A connection attempt failed|An existing connection was forcibly closed/i)
       ensure
         Frontend.cleanup_session_file
@@ -619,7 +619,7 @@ reconnect_if_wanted = proc {
           server.close rescue nil
           $_DETACHABLE_CLIENT_.close rescue nil
           $_DETACHABLE_CLIENT_ = nil
-          sleep 5
+          Kernel.sleep 5
           next
         ensure
           server.close rescue nil
@@ -630,7 +630,7 @@ reconnect_if_wanted = proc {
             unless ARGV.include?('--genie')
               Frontend.client = 'profanity'
               Thread.new {
-                100.times { sleep 0.1; break if XMLData.indicator['IconJOINED'] }
+                100.times { Kernel.sleep 0.1; break if XMLData.indicator['IconJOINED'] }
                 init_str = "<progressBar id='mana' value='0' text='mana #{XMLData.mana}/#{XMLData.max_mana}'/>"
                 init_str.concat "<progressBar id='health' value='0' text='health #{XMLData.health}/#{XMLData.max_health}'/>"
                 init_str.concat "<progressBar id='spirit' value='0' text='spirit #{XMLData.spirit}/#{XMLData.max_spirit}'/>"
@@ -693,7 +693,7 @@ reconnect_if_wanted = proc {
             $_DETACHABLE_CLIENT_ = nil
           end
         end
-        sleep 0.1
+        Kernel.sleep 0.1
       }
     }
   else
@@ -720,19 +720,19 @@ reconnect_if_wanted = proc {
   Lich.log 'info: stopping scripts...'
   Script.running.each { |script| script.kill }
   Script.hidden.each { |script| script.kill }
-  200.times { sleep 0.1; break if Script.running.empty? and Script.hidden.empty? }
+  200.times { Kernel.sleep 0.1; break if Script.running.empty? and Script.hidden.empty? }
   Lich.log 'info: saving script settings...'
   Infomon::Monitor.save_proc if defined?(Infomon::Monitor)
   Settings.save
   Vars.save
   Lich.log 'info: closing connections...'
   Game.close
-  200.times { sleep 0.1; break if Game.closed? }
+  200.times { Kernel.sleep 0.1; break if Game.closed? }
   pause 0.5
   $_CLIENT_.close
-  200.times { sleep 0.1; break if $_CLIENT_.closed? }
+  200.times { Kernel.sleep 0.1; break if $_CLIENT_.closed? }
   Lich.db.close
-  200.times { sleep 0.1; break if Lich.db.closed? }
+  200.times { Kernel.sleep 0.1; break if Lich.db.closed? }
   reconnect_if_wanted.call # taking this out of play but may need to see if anyone's using it
   Lich.log "info: exiting..."
   Gtk.queue { Gtk.main_quit } if defined?(Gtk)

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -53,7 +53,7 @@ module Lich
           return true if ![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && @weapon_displayer.include?(bag.id)
           return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && bag.contents.to_a.map(&:id).include?(item.id))
           return true if item.name =~ /^ethereal \w+$/ && ![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id)
-          sleep 0.1
+          Kernel.sleep 0.1
         }
         return false
       end
@@ -64,7 +64,7 @@ module Lich
         20.times {
           return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && GameObj.inv.to_a.map(&:id).include?(item.id))
           return true if item.name =~ /^ethereal \w+$/ && ![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id)
-          sleep 0.1
+          Kernel.sleep 0.1
         } unless result =~ /You can only wear two items in that location\./
 
         return @worn_items[item.name] = false
@@ -173,7 +173,7 @@ module Lich
         if (left_hand.noun =~ /shield|buckler|targe|heater|parma|aegis|scutum|greatshield|mantlet|pavis|arbalest|bow|crossbow|yumi|arbalest/) && @worn_items[left_hand.name] != false && Lich::Stash::wear_to_inv(left_hand)
           actions.unshift proc {
             fput "remove ##{left_hand.id}"
-            20.times { break if GameObj.left_hand.id == left_hand.id || GameObj.right_hand.id == left_hand.id; sleep 0.1 }
+            20.times { break if GameObj.left_hand.id == left_hand.id || GameObj.right_hand.id == left_hand.id; Kernel.sleep 0.1 }
 
             if GameObj.right_hand.id == left_hand.id
               dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
@@ -183,13 +183,13 @@ module Lich
           actions.unshift proc {
             if left_hand.name =~ /^ethereal \w+$/
               fput "rub #{left_hand.noun} tattoo"
-              20.times { break if (GameObj.left_hand.name == left_hand.name) || (GameObj.right_hand.name == left_hand.name); sleep 0.1 }
+              20.times { break if (GameObj.left_hand.name == left_hand.name) || (GameObj.right_hand.name == left_hand.name); Kernel.sleep 0.1 }
             elsif @bandolier_weapon[left_hand.name]
               fput "rub ##{find_bandolier_bag(left_hand)}"
-              20.times { break if (GameObj.left_hand.name == left_hand.name) || (GameObj.right_hand.name == left_hand.name); sleep 0.1 }
+              20.times { break if (GameObj.left_hand.name == left_hand.name) || (GameObj.right_hand.name == left_hand.name); Kernel.sleep 0.1 }
             else
               fput "get ##{left_hand.id}"
-              20.times { break if (GameObj.left_hand.id == left_hand.id) || (GameObj.right_hand.id == left_hand.id); sleep 0.1 }
+              20.times { break if (GameObj.left_hand.id == left_hand.id) || (GameObj.right_hand.id == left_hand.id); Kernel.sleep 0.1 }
             end
 
             if GameObj.right_hand.id == left_hand.id || (GameObj.right_hand.name == left_hand.name && left_hand.name =~ /^ethereal \w+$/)
@@ -222,13 +222,13 @@ module Lich
         actions.unshift proc {
           if right_hand.name =~ /^ethereal \w+$/
             fput "rub #{right_hand.noun} tattoo"
-            20.times { break if GameObj.left_hand.name == right_hand.name || GameObj.right_hand.name == right_hand.name; sleep 0.1 }
+            20.times { break if GameObj.left_hand.name == right_hand.name || GameObj.right_hand.name == right_hand.name; Kernel.sleep 0.1 }
           elsif @bandolier_weapon[right_hand.name]
             fput "rub ##{find_bandolier_bag(right_hand)}"
-            20.times { break if GameObj.left_hand.name == right_hand.name || GameObj.right_hand.name == right_hand.name; sleep 0.1 }
+            20.times { break if GameObj.left_hand.name == right_hand.name || GameObj.right_hand.name == right_hand.name; Kernel.sleep 0.1 }
           else
             fput "get ##{right_hand.id}"
-            20.times { break if GameObj.left_hand.id == right_hand.id || GameObj.right_hand.id == right_hand.id; sleep 0.1 }
+            20.times { break if GameObj.left_hand.id == right_hand.id || GameObj.right_hand.id == right_hand.id; Kernel.sleep 0.1 }
           end
 
           if GameObj.left_hand.id == right_hand.id || (GameObj.left_hand.name == right_hand.name && right_hand.name =~ /^ethereal \w+$/)
@@ -248,7 +248,7 @@ module Lich
         else
           result = nil
         end
-        sleep 0.1
+        Kernel.sleep 0.1
         if result.nil? || !result
           for container in other_containers.call
             result = Lich::Stash::add_to_bag(container, GameObj.right_hand)

--- a/lib/util/memoryreleaser.rb
+++ b/lib/util/memoryreleaser.rb
@@ -71,7 +71,7 @@ module Lich
                 command[:manager].enabled = false # Signal graceful stop
                 deadline = Time.now + 2
                 while @worker_thread.alive? && Time.now < deadline
-                  sleep 0.1
+                  Kernel.sleep 0.1
                 end
                 if @worker_thread.alive? # Last resort
                   @worker_thread.kill rescue nil
@@ -95,7 +95,7 @@ module Lich
                   # Sleep in small chunks to be more responsive
                   elapsed = 0
                   while elapsed < interval && manager.enabled
-                    sleep(1)
+                    Kernel.sleep(1)
                     elapsed += 1
                   end
 
@@ -117,7 +117,7 @@ module Lich
                 # Give worker up to 2 seconds to exit gracefully
                 deadline = Time.now + 2
                 while @worker_thread.alive? && Time.now < deadline
-                  sleep 0.1
+                  Kernel.sleep 0.1
                 end
                 # Last resort only
                 if @worker_thread.alive?
@@ -319,7 +319,7 @@ module Lich
           # Wait for worker to start
           timeout = 0
           until running?
-            sleep 0.1
+            Kernel.sleep 0.1
             timeout += 1
             if timeout > 50
               respond "[MemoryReleaser] ERROR: Worker thread failed to start"
@@ -344,7 +344,7 @@ module Lich
             action: :stop_worker
           }
 
-          sleep 0.2
+          Kernel.sleep 0.2
           log "Memory releaser stopped"
         end
 

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -207,7 +207,7 @@ module Lich
           line = get?
           break if line && line =~ end_pattern
           break if Time.now > ttl
-          sleep(0.01) # prevent a tight-loop
+          Kernel.sleep(0.01) # prevent a tight-loop
         }
       ensure
         DownstreamHook.remove(name)

--- a/lib/wine.rb
+++ b/lib/wine.rb
@@ -73,7 +73,7 @@ unless $wine_bin.nil?
             filename = "#{TEMP_DIR}/wine-#{Time.now.to_i}.reg"
             File.open(filename, 'w') { |f| f.write(regedit_data) }
             system("#{BIN} regedit #{filename}")
-            sleep 0.2
+            Kernel.sleep 0.2
             File.delete(filename)
           rescue
             return false

--- a/spec/authentication_spec.rb
+++ b/spec/authentication_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Lich::Common::GUI::Authentication do
   describe ".with_retry" do
     before do
       # Stub sleep to avoid actual delays in tests
-      allow(described_class).to receive(:sleep)
+      allow(Kernel).to receive(:sleep)
       # Stub Lich.log to capture log messages
       allow(Lich).to receive(:log)
     end
@@ -105,7 +105,7 @@ RSpec.describe Lich::Common::GUI::Authentication do
       it "does not call sleep" do
         described_class.with_retry { auth_data }
 
-        expect(described_class).not_to have_received(:sleep)
+        expect(Kernel).not_to have_received(:sleep)
       end
     end
 
@@ -156,7 +156,7 @@ RSpec.describe Lich::Common::GUI::Authentication do
         end
 
         # First retry uses base delay (5 seconds)
-        expect(described_class).to have_received(:sleep).with(5)
+        expect(Kernel).to have_received(:sleep).with(5)
       end
     end
 
@@ -184,8 +184,8 @@ RSpec.describe Lich::Common::GUI::Authentication do
 
         # First retry: 5 * 2^0 = 5 seconds
         # Second retry: 5 * 2^1 = 10 seconds
-        expect(described_class).to have_received(:sleep).with(5).ordered
-        expect(described_class).to have_received(:sleep).with(10).ordered
+        expect(Kernel).to have_received(:sleep).with(5).ordered
+        expect(Kernel).to have_received(:sleep).with(10).ordered
       end
 
       it "logs success on third attempt" do
@@ -286,7 +286,7 @@ RSpec.describe Lich::Common::GUI::Authentication do
 
   describe ".authenticate with retry behavior" do
     before do
-      allow(described_class).to receive(:sleep)
+      allow(Kernel).to receive(:sleep)
       allow(Lich).to receive(:log)
     end
 

--- a/spec/lib/dragonrealms/commons/slackbot_spec.rb
+++ b/spec/lib/dragonrealms/commons/slackbot_spec.rb
@@ -523,7 +523,7 @@ RSpec.describe Lich::DragonRealms::SlackBot do
 
     context 'when NetworkError occurs' do
       it 'returns false' do
-        allow(bot).to receive(:sleep) # prevent real sleep during retry backoff
+        allow(Kernel).to receive(:sleep) # prevent real sleep during retry backoff
         allow(mock_http).to receive(:request).and_raise(Timeout::Error)
         expect(bot.authed?('some-token')).to be false
       end
@@ -658,11 +658,11 @@ RSpec.describe Lich::DragonRealms::SlackBot do
         allow(ok_resp).to receive(:body).and_return('{"ok":true}')
 
         allow(mock_http).to receive(:request).and_return(throttle_resp, ok_resp)
-        allow(bot).to receive(:sleep)
+        allow(Kernel).to receive(:sleep)
 
         result = bot.send(:post, 'test.method', { 'token' => 'test' })
         expect(result['ok']).to be true
-        expect(bot).to have_received(:sleep).with(5)
+        expect(Kernel).to have_received(:sleep).with(5)
       end
     end
 
@@ -673,7 +673,7 @@ RSpec.describe Lich::DragonRealms::SlackBot do
         allow(throttle_resp).to receive(:[]).with('Retry-After').and_return('1')
 
         allow(mock_http).to receive(:request).and_return(throttle_resp)
-        allow(bot).to receive(:sleep)
+        allow(Kernel).to receive(:sleep)
 
         expect {
           bot.send(:post, 'test.method', { 'token' => 'test' })
@@ -709,7 +709,7 @@ RSpec.describe Lich::DragonRealms::SlackBot do
 
           ok_resp
         end
-        allow(bot).to receive(:sleep)
+        allow(Kernel).to receive(:sleep)
 
         result = bot.send(:post, 'test.method', { 'token' => 'test' })
         expect(result['ok']).to be true
@@ -720,7 +720,7 @@ RSpec.describe Lich::DragonRealms::SlackBot do
       it 'raises NetworkError when delay exceeds maximum' do
         # With BASE_RETRY_DELAY_SECONDS=30, delay at retries=3 is 240 > MAX_RETRY_DELAY_SECONDS(120)
         allow(mock_http).to receive(:request).and_raise(Timeout::Error)
-        allow(bot).to receive(:sleep)
+        allow(Kernel).to receive(:sleep)
 
         expect {
           bot.send(:post, 'test.method', { 'token' => 'test' })
@@ -737,7 +737,7 @@ RSpec.describe Lich::DragonRealms::SlackBot do
           call_count += 1
           raise SocketError, 'connection refused'
         end
-        allow(bot).to receive(:sleep)
+        allow(Kernel).to receive(:sleep)
 
         expect {
           bot.send(:post, 'test.method', { 'token' => 'test' })
@@ -780,7 +780,7 @@ RSpec.describe Lich::DragonRealms::SlackBot do
         allow(resp).to receive(:code).and_return('500')
         allow(resp).to receive(:message).and_return('Internal Server Error')
         allow(mock_http).to receive(:request).and_return(resp)
-        allow(bot).to receive(:sleep)
+        allow(Kernel).to receive(:sleep)
 
         expect {
           bot.send(:post, 'test.method', { 'token' => 'test' })


### PR DESCRIPTION
Safeguard against `sleep` namescope collision
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to replace `sleep` with `Kernel.sleep` across the codebase to prevent namescope collisions.
> 
>   - **Behavior**:
>     - Replaces all instances of `sleep` with `Kernel.sleep` to prevent namescope collisions.
>     - Affects various functions across multiple files, including `buffer.rb`, `db_store.rb`, and `front-end.rb`.
>   - **Files**:
>     - `buffer.rb`: Updates `sleep` in buffer handling logic.
>     - `db_store.rb`: Modifies `sleep` in database transaction retries.
>     - `front-end.rb`: Adjusts `sleep` in client handshake logic.
>     - ... and many other files.
>   - **Misc**:
>     - Ensures consistent use of `Kernel.sleep` across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Flich-5&utm_source=github&utm_medium=referral)<sup> for a26f43e5db23a4a63a33627be6ec6091c130f2e7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->