### PR TITLE
fix(dr): common-items.rb - move pattern from failure to success block

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -237,6 +237,7 @@ module Lich
         /you unlace/,
         /^You slam the heels/,
         /^You work your way out/,
+        /^Grunting with momentary exertion/, # Grunting with momentary exertion, you grip each of your heavy combat boots in turn by the heel, and pull them off.
         /^With masterful grace, you ready/
       ].freeze
 
@@ -247,7 +248,6 @@ module Lich
         /^You don't seem to be able to move/,
         /^Remove what/,
         /^I could not/,
-        /^Grunting with momentary exertion/, # Grunting with momentary exertion, you grip each of your heavy combat boots in turn by the heel, and pull them off.
         /^What were you/
       ].freeze
 


### PR DESCRIPTION
The pattern for removal of the heavy combat boots from MT instructions are added as a failure pattern rather than a success pattern.