### PR TITLE
fix(gs): Infomon xmlparser additional npc death messaging

### DIFF
--- a/lib/gemstone/infomon/xmlparser.rb
+++ b/lib/gemstone/infomon/xmlparser.rb
@@ -86,7 +86,7 @@ module Lich
             /falls on its side and lets out one last whimpering sigh of water droplets/,
             /lets out one last whimpering sigh of chartreuse vapors and dies/,
             /lets out one last whimpering sigh of sparks and blue mist and dies/,
-            /lets out one last whimpering sigh of water droplets and dies/,            
+            /lets out one last whimpering sigh of water droplets and dies/,
           )
           NpcDeathMessage = /^(?:<pushBold\/>)?#{NpcDeathPrefix} (?:<pushBold\/>)?<a.*?exist=["'](?<npc_id>\-?[0-9]+)["'].*?>.*?<\/a>(?:<popBold\/>)?(?:'s)? #{NpcDeathPostfix}[\.!]\r?\n?$/
 

--- a/lib/gemstone/infomon/xmlparser.rb
+++ b/lib/gemstone/infomon/xmlparser.rb
@@ -84,6 +84,9 @@ module Lich
             /falls on its side and lets out one last whimpering sigh of chartreuse vapors/,
             /falls on its side and lets out one last whimpering sigh of sparks and blue mist/,
             /falls on its side and lets out one last whimpering sigh of water droplets/,
+            /lets out one last whimpering sigh of chartreuse vapors and dies/,
+            /lets out one last whimpering sigh of sparks and blue mist and dies/,
+            /lets out one last whimpering sigh of water droplets and dies/,            
           )
           NpcDeathMessage = /^(?:<pushBold\/>)?#{NpcDeathPrefix} (?:<pushBold\/>)?<a.*?exist=["'](?<npc_id>\-?[0-9]+)["'].*?>.*?<\/a>(?:<popBold\/>)?(?:'s)? #{NpcDeathPostfix}[\.!]\r?\n?$/
 


### PR DESCRIPTION
Adding 3 additional death messages for storm hounds, water hounds, vapor hounds.

If they are already prone they omit the 'falls on its side and' at the start and gain 'and dies' at the end.

All 6 messages (these 3 and the 3 before them) could be condensed down into one regex if preferred.