### PR TITLE
fix(all): use :__unset for --without-frontend CLI request YAML matches

### DIFF
--- a/lib/common/authentication/login_helpers.rb
+++ b/lib/common/authentication/login_helpers.rb
@@ -507,6 +507,23 @@ module Lich
           [instance, frontend, custom_launch]
         end
 
+        # Resolves which frontend should be used when matching a saved entry for
+        # CLI login.
+        #
+        # Headless CLI launches still carry an intended frontend for downstream
+        # runtime behavior, but saved-entry matching should not reject an entry
+        # solely because `--without-frontend` was passed.
+        #
+        # @param requested_frontend [String, Symbol] frontend parsed from CLI args
+        # @param argv [Array<String>] command line arguments
+        # @return [String, Symbol] frontend for saved-entry lookup, or :__unset
+        #   when headless mode should ignore frontend during matching
+        def self.resolve_lookup_frontend(requested_frontend, argv)
+          return :__unset if argv.include?('--without-frontend')
+
+          requested_frontend
+        end
+
         # Formats the game instance launch flag for Lich based on version.
         #
         # Older versions of Lich (pre-5.12) only recognize specific lowercase flags

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -57,15 +57,18 @@ reconnect_if_wanted = proc {
     # Extract character name from --login argument
     requested_character = ARGV[ARGV.index('--login') + 1].capitalize
 
-    # Parse game code, frontend, and custom_launch from remaining arguments
+    # Parse game code, frontend, and custom_launch from remaining arguments.
+    # In headless mode, the requested frontend still matters to runtime startup
+    # semantics, but it should not constrain saved-entry lookup.
     modifiers = ARGV.dup
     requested_instance, requested_fe, requested_custom_launch = Lich::Common::Authentication::LoginHelpers.resolve_login_args(modifiers)
+    lookup_frontend = Lich::Common::Authentication::LoginHelpers.resolve_lookup_frontend(requested_fe, ARGV)
 
     # Execute CLI login flow and get launch data
     launch_data_array = Lich::Common::Authentication::CLI.execute(
       requested_character,
       game_code: requested_instance,
-      frontend: requested_fe,
+      frontend: lookup_frontend,
       custom_launch: requested_custom_launch,
       data_dir: DATA_DIR
     )

--- a/spec/lib/common/authentication/login_helpers_spec.rb
+++ b/spec/lib/common/authentication/login_helpers_spec.rb
@@ -478,6 +478,22 @@ RSpec.describe Lich::Common::Authentication::LoginHelpers do
     end
   end
 
+  describe '.resolve_lookup_frontend' do
+    it 'returns the requested frontend for normal CLI saved-entry matching' do
+      expect(described_class.resolve_lookup_frontend('frostbite', ['--login', 'pickasso'])).to eq('frostbite')
+    end
+
+    it 'ignores the requested frontend for headless CLI saved-entry matching' do
+      expect(
+        described_class.resolve_lookup_frontend('frostbite', ['--login', 'pickasso', '--without-frontend'])
+      ).to eq(:__unset)
+    end
+
+    it 'preserves an unset frontend when no frontend was requested' do
+      expect(described_class.resolve_lookup_frontend(:__unset, ['--login', 'pickasso'])).to eq(:__unset)
+    end
+  end
+
   describe '.format_launch_flag' do
     it 'returns nil for empty game code' do
       expect(described_class.format_launch_flag('')).to be_nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI login behavior to properly handle the `--without-frontend` flag when looking up saved login entries. The system now ensures that headless mode settings don't incorrectly constrain saved-entry lookup, providing more consistent behavior during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->