### PR TITLE
fix(dr): Add top-level aliases for ArgParser and SetupFiles

### DIFF
--- a/lib/common/arg_parser.rb
+++ b/lib/common/arg_parser.rb
@@ -139,3 +139,7 @@ module Lich
     end
   end
 end
+
+# Top-level alias so scripts can use bare `ArgParser.new` without
+# fully qualifying the Lich::Common namespace.
+ArgParser = Lich::Common::ArgParser unless defined?(::ArgParser)

--- a/lib/common/setup_files.rb
+++ b/lib/common/setup_files.rb
@@ -285,3 +285,7 @@ module Lich
     end
   end
 end
+
+# Top-level alias so scripts can use bare `SetupFiles.new` without
+# fully qualifying the Lich::Common namespace.
+SetupFiles = Lich::Common::SetupFiles unless defined?(::SetupFiles)


### PR DESCRIPTION
## Summary

- Add `ArgParser = Lich::Common::ArgParser` alias at the bottom of `lib/common/arg_parser.rb`
- Add `SetupFiles = Lich::Common::SetupFiles` alias at the bottom of `lib/common/setup_files.rb`

Core lich defines these classes under `Lich::Common`, but DR scripts (via dependency.lic) reference them as bare top-level constants (`ArgParser.new`, `SetupFiles.new`). When the `CORE_ARGPARSER` / `CORE_SETUPFILES` sentinel gates in dependency.lic detect the core versions and skip their inline definitions, bare constant lookups fail with `NameError`.

This was introduced in #1273 and affects any user on lich >= 5.16.0 running the latest dependency.lic.

## Test plan
- [x] `ruby -c` passes on both files
- [ ] In-game: verify `ArgParser.new` resolves after dependency skips inline definition
- [ ] In-game: verify `SetupFiles.new` resolves after dependency skips inline definition
- [ ] In-game: verify `get_settings` / `parse_args` work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added top-level constant aliases `ArgParser` and `SetupFiles` for more convenient access to argument parsing and setup file management utilities without requiring full namespace references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->