### PR TITLE
fix(gs): Add InnCheckedOut pattern to parser

### DIFF
--- a/lib/gemstone/infomon/parser.rb
+++ b/lib/gemstone/infomon/parser.rb
@@ -317,7 +317,7 @@ module Lich
             when Pattern::InnCheckedOut
               respond
               _respond Lich::Messaging.monsterbold('You just left an Inn.  Lich will gather your updated Stats and skills.')
-              respond 
+              respond
               respond "[infomon_sync]#{$SEND_CHARACTER}skills"
               Game._puts("#{$cmd_prefix}skills")
               respond "[infomon_sync]#{$SEND_CHARACTER}info"

--- a/lib/gemstone/infomon/parser.rb
+++ b/lib/gemstone/infomon/parser.rb
@@ -25,6 +25,7 @@ module Lich
           SkillEnd = /^Training Points: \d+ Phy \d+ Mnt/.freeze
           GoalsDetected = /^Skill goals updated!$/.freeze
           GoalsEnded = /^Further information can be found in the FAQs\.$/.freeze
+          InnCheckedOut = /^Leaving your room, you check back out of .*, wander over to the front desk and hand the room key back to the innkeeper\./.freeze
           PSMStart = /^\w+, the following (?<cat>Ascension Abilities|Armor Specializations|Combat Maneuvers|Feats|Shield Specializations|Weapon Techniques) are available:$/.freeze
           PSM = /^\s+(?<name>[A-z\s\-':]+)\s+(?<command>[a-z]+)\s+(?<ranks>\d+)\/(?<max>\d+).*$/.freeze
           PSMEnd = /^   Subcategory: all$/.freeze
@@ -130,7 +131,7 @@ module Lich
                              SocietyResign, LearnPSM, UnlearnPSM, LostTechnique, LearnTechnique, UnlearnTechnique,
                              Resource, Suffused, VolnFavor, GigasArtifactFragments, RedsteelMarks, TicketGeneral, TicketGold,
                              TicketBlackscrip, TicketBloodscrip, TicketEtherealScrip, TicketSoulShards, TicketRaikhen,
-                             WealthSilver, WealthSilverContainer, GoalsDetected, GoalsEnded, SpellsongRenewed,
+                             WealthSilver, WealthSilverContainer, GoalsDetected, GoalsEnded, InnCheckedOut, SpellsongRenewed,
                              ThornPoisonStart, ThornPoisonProgression, ThornPoisonDeprogression, ThornPoisonEnd, CovertArtsCharges,
                              AccountName, AccountSubscription, ProfileStart, ProfileName, ProfileHouseCHE, ResignCHE, ResignConfirmCHE,
                              ShadowEssence, ShadowEssenceGain, ShadowEssenceCap, SacrificeMana, SacrificeChannel, SacrificeInfest,
@@ -313,6 +314,15 @@ module Lich
               else
                 :noop
               end
+            when Pattern::InnCheckedOut
+              respond
+              _respond Lich::Messaging.monsterbold('You just left an Inn.  Lich will gather your updated Stats and skills.')
+              respond 
+              respond "[infomon_sync]#{$SEND_CHARACTER}skills"
+              Game._puts("#{$cmd_prefix}skills")
+              respond "[infomon_sync]#{$SEND_CHARACTER}info"
+              Game._puts("#{$cmd_prefix}info")
+              :ok
             when Pattern::PSMStart
               match = Regexp.last_match
               @psm_hold = []


### PR DESCRIPTION
InnCheckedOut will run 'skills' and 'info' after checking out from an inn

Resolves #1308 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The game now displays a bold "left an Inn" message when you exit an Inn.
  * Upon leaving an Inn, your character’s skills and info are automatically synchronized so stats and profile display update immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->