### PR TITLE
fix(all): decouple listener state from feature flag guard in Lifecycle

### DIFF
--- a/lib/internal_api/active_sessions/lifecycle.rb
+++ b/lib/internal_api/active_sessions/lifecycle.rb
@@ -158,14 +158,12 @@ module Lich
         # @param connected [Boolean]
         # @return [void]
         def self.update_listener(host:, port:, connected:)
-          return unless ActiveSessions.enabled?
-
           @mutex.synchronize do
             @listener_host = host
             @listener_port = port
             @listener_connected = connected
           end
-          upsert_current_session
+          upsert_current_session if ActiveSessions.enabled?
         end
 
         # Clears detachable listener metadata for the current session.
@@ -175,8 +173,6 @@ module Lich
         #
         # @return [void]
         def self.clear_listener
-          return unless ActiveSessions.enabled?
-
           started = false
           @mutex.synchronize do
             @listener_host = nil
@@ -184,7 +180,7 @@ module Lich
             @listener_connected = false
             started = @started
           end
-          upsert_current_session if started
+          upsert_current_session if started && ActiveSessions.enabled?
         end
 
         # Returns the current process session payload.

--- a/spec/lib/internal_api/active_sessions/lifecycle_listener_guard_spec.rb
+++ b/spec/lib/internal_api/active_sessions/lifecycle_listener_guard_spec.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require_relative '../../../../lib/internal_api/active_sessions'
+
+# Resets the process-local lifecycle singleton state between examples so each
+# example can describe one lifecycle scenario without inheriting thread or
+# listener state from previous runs.
+#
+# @param lifecycle [Module]
+# @return [void]
+def reset_lifecycle!(lifecycle)
+  lifecycle.instance_variable_set(:@heartbeat_thread, nil)
+  lifecycle.instance_variable_set(:@running, false)
+  lifecycle.instance_variable_set(:@started, false)
+  lifecycle.instance_variable_set(:@listener_host, nil)
+  lifecycle.instance_variable_set(:@listener_port, nil)
+  lifecycle.instance_variable_set(:@listener_connected, false)
+  lifecycle.instance_variable_set(:@session_name, nil)
+  lifecycle.instance_variable_set(:@role, nil)
+  lifecycle.instance_variable_set(:@started_at, nil)
+  lifecycle.instance_variable_set(:@mutex, Mutex.new)
+  lifecycle.instance_variable_set(:@registration_mutex, Mutex.new)
+  lifecycle.instance_variable_set(:@lifecycle_generation, 0)
+end
+
+# Adversarial spec suite targeting the listener state guard bug.
+#
+# Root cause: update_listener and clear_listener guarded local instance
+# variable writes behind ActiveSessions.enabled?, so a transient feature flag
+# failure (DB not ready, SQLite contention, etc.) permanently lost the
+# listener port. Every subsequent heartbeat sent listener_port: nil.
+RSpec.describe Lich::InternalAPI::ActiveSessions::Lifecycle, 'listener state guards' do
+  let(:lifecycle) { described_class }
+
+  before do
+    reset_lifecycle!(lifecycle)
+
+    # Simulate a started lifecycle (heartbeat running, session registered)
+    lifecycle.instance_variable_set(:@started, true)
+    lifecycle.instance_variable_set(:@running, true)
+    lifecycle.instance_variable_set(:@session_name, 'Gnarta')
+    lifecycle.instance_variable_set(:@role, 'headless')
+    lifecycle.instance_variable_set(:@started_at, 1_775_850_546)
+    lifecycle.instance_variable_set(:@lifecycle_generation, 1)
+  end
+
+  # -- update_listener --------------------------------------------------------
+
+  describe '.update_listener' do
+    context 'when enabled? is true' do
+      before do
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(true)
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session).and_return(true)
+      end
+
+      it 'sets local state and upserts' do
+        lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+
+        payload = lifecycle.current_payload
+        expect(payload[:listener_host]).to eq('127.0.0.1')
+        expect(payload[:listener_port]).to eq(44021)
+        expect(payload[:connected]).to eq(false)
+        expect(Lich::InternalAPI::ActiveSessions).to have_received(:register_session).once
+      end
+    end
+
+    context 'when enabled? is false (the bug scenario)' do
+      before do
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(false)
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session)
+      end
+
+      it 'still sets local state so heartbeats carry the port' do
+        lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+
+        payload = lifecycle.current_payload
+        expect(payload[:listener_port]).to eq(44021)
+        expect(payload[:listener_host]).to eq('127.0.0.1')
+        expect(payload[:connected]).to eq(false)
+      end
+
+      it 'does not attempt a remote upsert' do
+        lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+
+        expect(Lich::InternalAPI::ActiveSessions).not_to have_received(:register_session)
+      end
+    end
+
+    context 'when enabled? transitions from false to true across heartbeats' do
+      it 'heartbeat picks up the port that update_listener saved while disabled' do
+        call_count = 0
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?) do
+          call_count += 1
+          # First call (from update_listener): false
+          # Subsequent calls (from heartbeat upserts): true
+          call_count > 1
+        end
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session).and_return(true)
+
+        # update_listener called while enabled? is false
+        lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+
+        # Simulate heartbeat: build_current_payload reads local state, upserts
+        # (This exercises upsert_current_session directly via the public payload
+        # to confirm the local state is correct for future upserts.)
+        payload = lifecycle.current_payload
+        expect(payload[:listener_port]).to eq(44021),
+          'heartbeat payload must include port saved during disabled window'
+      end
+    end
+
+    context 'when enabled? raises (transient DB error)' do
+      before do
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_raise(StandardError, 'SQLite3::BusyException')
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session)
+      end
+
+      it 'still saves local state (exception only affects upsert)' do
+        # The enabled? call is in the upsert guard, not the state-setting path.
+        # An exception there should not prevent local state from being updated.
+        # If this raises, the caller (detachable_client_thread) rescues it, but
+        # the local state must already be set before the exception can occur.
+        lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false) rescue nil
+
+        payload = lifecycle.current_payload
+        expect(payload[:listener_port]).to eq(44021),
+          'local state must be set before enabled? is evaluated'
+      end
+    end
+
+    context 'when update_listener is called multiple times (reconnect cycle)' do
+      before do
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(true)
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session).and_return(true)
+      end
+
+      it 'tracks the latest port through create/accept/disconnect/recreate' do
+        # Server created on port 44021
+        lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+        expect(lifecycle.current_payload[:listener_port]).to eq(44021)
+
+        # Client connects
+        lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: true)
+        expect(lifecycle.current_payload[:connected]).to eq(true)
+
+        # Client disconnects, server torn down
+        lifecycle.clear_listener
+
+        # Server recreated on new port (OS assigned)
+        lifecycle.update_listener(host: '127.0.0.1', port: 39887, connected: false)
+        payload = lifecycle.current_payload
+        expect(payload[:listener_port]).to eq(39887)
+        expect(payload[:connected]).to eq(false)
+      end
+    end
+  end
+
+  # -- clear_listener ---------------------------------------------------------
+
+  describe '.clear_listener' do
+    before do
+      # Pre-set listener state
+      lifecycle.instance_variable_set(:@listener_host, '127.0.0.1')
+      lifecycle.instance_variable_set(:@listener_port, 44021)
+      lifecycle.instance_variable_set(:@listener_connected, true)
+    end
+
+    context 'when enabled? is true' do
+      before do
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(true)
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session).and_return(true)
+      end
+
+      it 'clears local state and upserts' do
+        lifecycle.clear_listener
+
+        payload = lifecycle.current_payload
+        expect(payload[:listener_host]).to be_nil
+        expect(payload[:listener_port]).to be_nil
+        expect(Lich::InternalAPI::ActiveSessions).to have_received(:register_session).once
+      end
+    end
+
+    context 'when enabled? is false' do
+      before do
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(false)
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session)
+      end
+
+      it 'still clears local state so heartbeats reflect teardown' do
+        lifecycle.clear_listener
+
+        payload = lifecycle.current_payload
+        expect(payload[:listener_port]).to be_nil
+        expect(payload[:listener_host]).to be_nil
+      end
+
+      it 'does not attempt a remote upsert' do
+        lifecycle.clear_listener
+
+        expect(Lich::InternalAPI::ActiveSessions).not_to have_received(:register_session)
+      end
+    end
+
+    context 'when lifecycle is not started' do
+      before do
+        lifecycle.instance_variable_set(:@started, false)
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(true)
+        allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session)
+      end
+
+      it 'clears local state but skips upsert' do
+        lifecycle.clear_listener
+
+        payload = lifecycle.current_payload
+        expect(payload[:listener_port]).to be_nil
+        expect(Lich::InternalAPI::ActiveSessions).not_to have_received(:register_session)
+      end
+    end
+  end
+
+  # -- Race condition: heartbeat vs update_listener ---------------------------
+
+  describe 'heartbeat interleaving with update_listener' do
+    before do
+      allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(true)
+    end
+
+    it 'heartbeat payload always reflects the latest local state' do
+      # Simulate: update_listener sets port, then heartbeat reads payload
+      payloads = []
+      allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session) do |payload|
+        payloads << payload.dup
+        true
+      end
+
+      lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+
+      # Heartbeat fires -- payload must include port 44021
+      heartbeat_payload = lifecycle.current_payload
+      expect(heartbeat_payload[:listener_port]).to eq(44021)
+      expect(payloads.last[:listener_port]).to eq(44021)
+    end
+
+    it 'after clear_listener, heartbeat payload has nil port' do
+      allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session).and_return(true)
+
+      lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+      lifecycle.clear_listener
+
+      heartbeat_payload = lifecycle.current_payload
+      expect(heartbeat_payload[:listener_port]).to be_nil
+    end
+  end
+
+  # -- connected field derivation ---------------------------------------------
+
+  describe 'connected field in payload' do
+    before do
+      allow(Lich::InternalAPI::ActiveSessions).to receive(:enabled?).and_return(true)
+      allow(Lich::InternalAPI::ActiveSessions).to receive(:register_session).and_return(true)
+    end
+
+    it 'defaults to true when no listener port is set (headless)' do
+      payload = lifecycle.current_payload
+      expect(payload[:listener_port]).to be_nil
+      expect(payload[:connected]).to eq(true),
+        'headless sessions with no listener report connected: true'
+    end
+
+    it 'reflects listener_connected when a port is set' do
+      lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+      expect(lifecycle.current_payload[:connected]).to eq(false)
+
+      lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: true)
+      expect(lifecycle.current_payload[:connected]).to eq(true)
+    end
+
+    it 'reverts to true after clear_listener removes the port' do
+      lifecycle.update_listener(host: '127.0.0.1', port: 44021, connected: false)
+      expect(lifecycle.current_payload[:connected]).to eq(false)
+
+      lifecycle.clear_listener
+      expect(lifecycle.current_payload[:connected]).to eq(true),
+        'after clear_listener, connected should derive from nil port (true)'
+    end
+  end
+end

--- a/spec/lib/internal_api/active_sessions/lifecycle_listener_guard_spec.rb
+++ b/spec/lib/internal_api/active_sessions/lifecycle_listener_guard_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Lich::InternalAPI::ActiveSessions::Lifecycle, 'listener state gua
         # to confirm the local state is correct for future upserts.)
         payload = lifecycle.current_payload
         expect(payload[:listener_port]).to eq(44021),
-          'heartbeat payload must include port saved during disabled window'
+                                           'heartbeat payload must include port saved during disabled window'
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe Lich::InternalAPI::ActiveSessions::Lifecycle, 'listener state gua
 
         payload = lifecycle.current_payload
         expect(payload[:listener_port]).to eq(44021),
-          'local state must be set before enabled? is evaluated'
+                                           'local state must be set before enabled? is evaluated'
       end
     end
 
@@ -266,7 +266,7 @@ RSpec.describe Lich::InternalAPI::ActiveSessions::Lifecycle, 'listener state gua
       payload = lifecycle.current_payload
       expect(payload[:listener_port]).to be_nil
       expect(payload[:connected]).to eq(true),
-        'headless sessions with no listener report connected: true'
+                                     'headless sessions with no listener report connected: true'
     end
 
     it 'reflects listener_connected when a port is set' do
@@ -283,7 +283,7 @@ RSpec.describe Lich::InternalAPI::ActiveSessions::Lifecycle, 'listener state gua
 
       lifecycle.clear_listener
       expect(lifecycle.current_payload[:connected]).to eq(true),
-        'after clear_listener, connected should derive from nil port (true)'
+                                                       'after clear_listener, connected should derive from nil port (true)'
     end
   end
 end


### PR DESCRIPTION
## Summary

- `update_listener` and `clear_listener` guarded local instance variable writes behind `ActiveSessions.enabled?`, so a transient feature flag failure (DB not ready, SQLite contention during startup) permanently lost the listener port
- Every subsequent heartbeat sent `listener_port: nil`, making the session unreachable via the launcher even though the detachable client server was listening
- Move the `enabled?` check to gate only the remote upsert -- local state is always updated so the next successful heartbeat carries the correct port

## Root cause

The `enabled?` check reads from `lich_settings` via SQLite. During startup (especially when multiple sessions launch near-simultaneously), `Lich.db` can be nil or the read can fail transiently. Since `active_sessions_api` has no entry in `FeatureFlags::DEFAULTS`, any read failure falls back to `false`. The early return in `update_listener` prevented `@listener_port` from ever being set, and since the detachable client thread then blocks on `server.accept`, no code path retries `update_listener`.

Observed in production: Gnarta (PID 2732907) started 1 second before the service owner (PID 2732936). The session appeared in the Active Sessions snapshot with `listener_port: null` despite `ss` confirming the process was listening on port 44021.

## Test plan

- [x] 15 new adversarial specs covering the fix scenarios (all pass)
- [x] 3 existing lifecycle specs still pass
- [ ] Manual verification: restart a headless session and confirm `listener_port` appears in snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests covering listener state updates, enablement toggles, transient error handling, heartbeat/reconnect scenarios, and payload connection logic.

* **Chores**
  * Improved session lifecycle state management so local listener/connection state is consistently maintained; remote upserts are now invoked only when enabled, and reconnection/clear behavior is more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->