### PR TITLE
fix(all): Add in-memory TTL cache to FeatureFlags

### DIFF
--- a/lib/common/feature_flags.rb
+++ b/lib/common/feature_flags.rb
@@ -24,6 +24,16 @@ module Lich
       # persisted value in `lich_settings` always overrides the default.
       DEFAULTS = {}.freeze
 
+      # Cached flag values are considered fresh for this many seconds.
+      # Feature flags change infrequently; this avoids repeated DB reads
+      # on every heartbeat cycle.
+      #
+      # @return [Integer]
+      CACHE_TTL_SECONDS = 60
+
+      @cache = {}
+      @cache_mutex = Mutex.new
+
       # Returns whether a feature flag is enabled.
       #
       # @param name [String, Symbol] the feature flag name
@@ -33,11 +43,14 @@ module Lich
       #   characters
       def self.enabled?(name)
         flag_name = validate_flag_name!(normalize_name(name))
+        cached = cache_read(flag_name)
+        return cached unless cached.nil?
+
         begin
           stored = read_flag(flag_name)
-          return default_for(flag_name) if stored.nil?
-
-          truthy?(stored)
+          resolved = stored.nil? ? default_for(flag_name) : truthy?(stored)
+          cache_write(flag_name, resolved)
+          resolved
         rescue StandardError => e
           log_failure('read', flag_name, e)
           default_for(flag_name)
@@ -58,11 +71,21 @@ module Lich
       def self.set(name, value)
         flag_name = validate_flag_name!(normalize_name(name))
         begin
-          write_flag(flag_name, value)
+          result = write_flag(flag_name, value)
+          cache_invalidate(flag_name) if result
+          result
         rescue StandardError => e
           log_failure('write', flag_name, e)
           false
         end
+      end
+
+      # Clears all cached feature flag values, forcing the next read to
+      # hit the database.
+      #
+      # @return [void]
+      def self.clear_cache!
+        @cache_mutex.synchronize { @cache.clear }
       end
 
       # Normalizes a feature flag identifier before validation.
@@ -153,6 +176,43 @@ module Lich
         Lich.db
       end
       private_class_method :fetch_db
+
+      # Returns the cached boolean value for a flag, or nil if the cache
+      # entry is missing or expired.
+      #
+      # @param flag_name [String]
+      # @return [Boolean, nil]
+      def self.cache_read(flag_name)
+        @cache_mutex.synchronize do
+          entry = @cache[flag_name]
+          return nil unless entry
+          return nil if Time.now.to_f - entry[:at] > CACHE_TTL_SECONDS
+          entry[:value]
+        end
+      end
+      private_class_method :cache_read
+
+      # Stores a resolved flag value in the cache.
+      #
+      # @param flag_name [String]
+      # @param value [Boolean]
+      # @return [void]
+      def self.cache_write(flag_name, value)
+        @cache_mutex.synchronize do
+          @cache[flag_name] = { value: value, at: Time.now.to_f }
+        end
+      end
+      private_class_method :cache_write
+
+      # Removes a single flag from the cache, forcing the next read to
+      # hit the database.
+      #
+      # @param flag_name [String]
+      # @return [void]
+      def self.cache_invalidate(flag_name)
+        @cache_mutex.synchronize { @cache.delete(flag_name) }
+      end
+      private_class_method :cache_invalidate
 
       # Logs a read or write failure without raising a second error.
       #

--- a/lib/common/feature_flags.rb
+++ b/lib/common/feature_flags.rb
@@ -14,6 +14,14 @@ module Lich
     #
     # Keeping the API narrow makes it easier to adopt feature flags incrementally
     # without introducing a second configuration framework.
+    #
+    # == Caching
+    #
+    # Resolved flag values are cached in-memory with a TTL of
+    # {CACHE_TTL_SECONDS}. Each Lich process maintains its own independent
+    # cache, so a {.set} in one process is not visible to other processes
+    # until their cached entries expire. Cross-process convergence is
+    # bounded by the TTL.
     module FeatureFlags
       SETTINGS_PREFIX = 'feature_flag:'
       VALID_NAME_PATTERN = /\A[a-z0-9_]+\z/
@@ -47,6 +55,8 @@ module Lich
         return cached unless cached.nil?
 
         begin
+          return default_for(flag_name) unless fetch_db
+
           stored = read_flag(flag_name)
           resolved = stored.nil? ? default_for(flag_name) : truthy?(stored)
           cache_write(flag_name, resolved)
@@ -72,7 +82,7 @@ module Lich
         flag_name = validate_flag_name!(normalize_name(name))
         begin
           result = write_flag(flag_name, value)
-          cache_invalidate(flag_name) if result
+          cache_write(flag_name, truthy?(value)) if result
           result
         rescue StandardError => e
           log_failure('write', flag_name, e)
@@ -186,7 +196,8 @@ module Lich
         @cache_mutex.synchronize do
           entry = @cache[flag_name]
           return nil unless entry
-          return nil if Time.now.to_f - entry[:at] > CACHE_TTL_SECONDS
+          age = Time.now.to_f - entry[:at]
+          return nil if age > CACHE_TTL_SECONDS || age.negative?
           entry[:value]
         end
       end
@@ -203,16 +214,6 @@ module Lich
         end
       end
       private_class_method :cache_write
-
-      # Removes a single flag from the cache, forcing the next read to
-      # hit the database.
-      #
-      # @param flag_name [String]
-      # @return [void]
-      def self.cache_invalidate(flag_name)
-        @cache_mutex.synchronize { @cache.delete(flag_name) }
-      end
-      private_class_method :cache_invalidate
 
       # Logs a read or write failure without raising a second error.
       #

--- a/spec/lib/common/feature_flags_spec.rb
+++ b/spec/lib/common/feature_flags_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Lich::Common::FeatureFlags do
     allow(Lich).to receive(:db).and_return(db)
     allow(Lich).to receive(:respond_to?).and_call_original
     allow(Lich).to receive(:respond_to?).with(:db).and_return(true)
+    described_class.clear_cache!
   end
 
   describe '.enabled?' do
@@ -87,6 +88,316 @@ RSpec.describe Lich::Common::FeatureFlags do
 
       expect(described_class.set(:demo_flag, true)).to be(false)
       expect(Lich).to have_received(:log).with(/FeatureFlags write failed/)
+    end
+  end
+
+  describe 'caching' do
+    it 'hits DB on first call but serves from cache on second call within TTL' do
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      described_class.enabled?(:cached_flag)
+      described_class.enabled?(:cached_flag)
+
+      expect(db).to have_received(:get_first_value).once
+    end
+
+    it 'hits DB again after TTL expires' do
+      now = Time.at(1000.0)
+      allow(Time).to receive(:now).and_return(now)
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      described_class.enabled?(:ttl_flag)
+
+      # Advance past TTL
+      allow(Time).to receive(:now).and_return(Time.at(1061.0))
+
+      described_class.enabled?(:ttl_flag)
+
+      expect(db).to have_received(:get_first_value).twice
+    end
+
+    it 'maintains independent cache entries for different flag names' do
+      allow(db).to receive(:get_first_value).and_return('true', 'false')
+
+      described_class.enabled?(:flag_a)
+      described_class.enabled?(:flag_b)
+
+      expect(db).to have_received(:get_first_value).twice
+      expect(described_class.enabled?(:flag_a)).to be(true)
+      expect(described_class.enabled?(:flag_b)).to be(false)
+    end
+
+    it 'stores the resolved boolean, not the raw DB string' do
+      allow(db).to receive(:get_first_value).and_return('YES')
+
+      result = described_class.enabled?(:bool_flag)
+
+      expect(result).to be(true)
+      expect(result).not_to eq('YES')
+    end
+
+    it 'caches nil DB result (unpersisted flag) as the default value' do
+      allow(db).to receive(:get_first_value).and_return(nil)
+
+      described_class.enabled?(:missing_flag)
+      result = described_class.enabled?(:missing_flag)
+
+      expect(result).to be(false)
+      expect(db).to have_received(:get_first_value).once
+    end
+
+    it 'does not cache when DB raises an error so next call retries' do
+      call_count = 0
+      allow(db).to receive(:get_first_value) do
+        call_count += 1
+        raise StandardError, 'db down' if call_count == 1
+
+        'true'
+      end
+      allow(Lich).to receive(:log)
+
+      # First call -- DB error, returns default, not cached
+      expect(described_class.enabled?(:retry_flag)).to be(false)
+
+      # Second call -- DB recovered, should hit DB again
+      expect(described_class.enabled?(:retry_flag)).to be(true)
+      expect(call_count).to eq(2)
+    end
+  end
+
+  describe 'cache invalidation on .set' do
+    it 'invalidates the cached value for the flag being set' do
+      allow(db).to receive(:get_first_value).and_return('true')
+      allow(db).to receive(:execute)
+
+      described_class.enabled?(:inv_flag)
+      described_class.set(:inv_flag, false)
+      # After set, cache is invalidated so enabled? must hit DB again
+      allow(db).to receive(:get_first_value).and_return('false')
+      described_class.enabled?(:inv_flag)
+
+      expect(db).to have_received(:get_first_value).twice
+    end
+
+    it 'does not affect other flags cache entries' do
+      allow(db).to receive(:get_first_value).and_return('true')
+      allow(db).to receive(:execute)
+
+      described_class.enabled?(:keep_flag)
+      described_class.enabled?(:change_flag)
+
+      described_class.set(:change_flag, false)
+
+      # keep_flag should still be cached (no extra DB call)
+      described_class.enabled?(:keep_flag)
+      # get_first_value was called twice (once per flag), not a third time
+      expect(db).to have_received(:get_first_value).twice
+    end
+
+    it 'does not invalidate cache when .set fails with a DB error' do
+      allow(db).to receive(:get_first_value).and_return('true')
+      allow(db).to receive(:execute).and_raise(StandardError, 'write failed')
+      allow(Lich).to receive(:log)
+
+      described_class.enabled?(:stable_flag)
+      described_class.set(:stable_flag, false)
+
+      # Cache should still be intact -- no extra DB read
+      described_class.enabled?(:stable_flag)
+      expect(db).to have_received(:get_first_value).once
+    end
+  end
+
+  describe '.clear_cache!' do
+    it 'clears all cached entries, forcing DB reads' do
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      described_class.enabled?(:cc_flag)
+      described_class.clear_cache!
+      described_class.enabled?(:cc_flag)
+
+      expect(db).to have_received(:get_first_value).twice
+    end
+
+    it 'is safe to call when cache is already empty' do
+      expect { described_class.clear_cache! }.not_to raise_error
+    end
+
+    it 'is safe to call concurrently from multiple threads' do
+      threads = 10.times.map do
+        Thread.new { 50.times { described_class.clear_cache! } }
+      end
+
+      expect { threads.each(&:join) }.not_to raise_error
+    end
+  end
+
+  describe 'thread safety' do
+    it 'returns valid results when multiple threads call enabled? concurrently' do
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      results = Queue.new
+      threads = 10.times.map do
+        Thread.new do
+          20.times do
+            results << described_class.enabled?(:thread_flag)
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      200.times do
+        expect(results.pop).to be(true)
+      end
+    end
+
+    it 'does not deadlock when threads call enabled? and set concurrently' do
+      allow(db).to receive(:get_first_value).and_return('true')
+      allow(db).to receive(:execute)
+
+      threads = []
+      5.times do
+        threads << Thread.new { 20.times { described_class.enabled?(:dl_flag) } }
+        threads << Thread.new { 20.times { described_class.set(:dl_flag, true) } }
+      end
+
+      # Use a timeout to detect deadlock -- if threads don't finish in
+      # 5 seconds, something is stuck
+      finished = threads.map { |t| t.join(5) }
+      expect(finished).to all(be_truthy)
+    end
+
+    it 'cache mutex does not cause starvation under contention' do
+      allow(db).to receive(:get_first_value).and_return('on')
+      allow(db).to receive(:execute)
+
+      completed = Concurrent::AtomicFixnum.new(0) if defined?(Concurrent)
+      completed = Queue.new unless defined?(Concurrent)
+
+      threads = 8.times.map do
+        Thread.new do
+          30.times do
+            described_class.enabled?(:contention_flag)
+            described_class.set(:contention_flag, true)
+          end
+          if completed.is_a?(Queue)
+            completed << 1
+          else
+            completed.increment
+          end
+        end
+      end
+
+      timed_out = threads.any? { |t| t.join(10).nil? }
+      expect(timed_out).to be(false)
+
+      count = completed.is_a?(Queue) ? completed.size : completed.value
+      expect(count).to eq(8)
+    end
+  end
+
+  describe 'TTL edge cases' do
+    it 'considers a cache entry expired at exactly the TTL boundary' do
+      now = Time.at(2000.0)
+      allow(Time).to receive(:now).and_return(now)
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      described_class.enabled?(:boundary_flag)
+
+      # Advance to exactly TTL seconds later
+      ttl = described_class::CACHE_TTL_SECONDS
+      allow(Time).to receive(:now).and_return(Time.at(2000.0 + ttl + 0.001))
+
+      described_class.enabled?(:boundary_flag)
+
+      expect(db).to have_received(:get_first_value).twice
+    end
+
+    it 'does not crash with a negative TTL and always goes to DB' do
+      stub_const("#{described_class}::CACHE_TTL_SECONDS", -1)
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      3.times { described_class.enabled?(:neg_ttl_flag) }
+
+      expect(db).to have_received(:get_first_value).exactly(3).times
+    end
+
+    it 'treats backward clock movement as cache expiration (correct behavior)' do
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      # Cache at t=2000
+      allow(Time).to receive(:now).and_return(Time.at(2000.0))
+      described_class.enabled?(:clock_flag)
+
+      # Clock jumps backward to t=1000, so (1000 - 2000) = -1000 which
+      # is NOT > CACHE_TTL_SECONDS, so cache is still valid
+      allow(Time).to receive(:now).and_return(Time.at(1000.0))
+      described_class.enabled?(:clock_flag)
+
+      # Only one DB call -- the backward clock doesn't expire the entry
+      # (negative difference is less than TTL). This is acceptable:
+      # in the worst case the entry expires after TTL seconds from the
+      # original write time, which is correct.
+      expect(db).to have_received(:get_first_value).once
+    end
+  end
+
+  describe 'adversarial scenarios' do
+    it 'serves stale value until TTL then returns fresh value' do
+      now = Time.at(3000.0)
+      allow(Time).to receive(:now).and_return(now)
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      expect(described_class.enabled?(:stale_flag)).to be(true)
+
+      # DB value changes behind our back
+      allow(db).to receive(:get_first_value).and_return('false')
+
+      # Still within TTL -- stale cached value served
+      allow(Time).to receive(:now).and_return(Time.at(3030.0))
+      expect(described_class.enabled?(:stale_flag)).to be(true)
+
+      # Past TTL -- fresh DB value served
+      allow(Time).to receive(:now).and_return(Time.at(3061.0))
+      expect(described_class.enabled?(:stale_flag)).to be(false)
+    end
+
+    it 'serves fresh value after rapid set/enabled? interleaving' do
+      allow(db).to receive(:get_first_value).and_return('true')
+      allow(db).to receive(:execute)
+
+      described_class.enabled?(:rapid_flag)
+
+      # set invalidates cache
+      described_class.set(:rapid_flag, false)
+
+      # Next enabled? must hit DB for fresh value
+      allow(db).to receive(:get_first_value).and_return('false')
+      expect(described_class.enabled?(:rapid_flag)).to be(false)
+
+      expect(db).to have_received(:get_first_value).twice
+    end
+
+    it 'serves cached values when DB goes down, then falls back to default after TTL' do
+      now = Time.at(4000.0)
+      allow(Time).to receive(:now).and_return(now)
+      allow(db).to receive(:get_first_value).and_return('true')
+      allow(Lich).to receive(:log)
+
+      # Populate cache
+      expect(described_class.enabled?(:downtime_flag)).to be(true)
+
+      # DB goes down
+      allow(db).to receive(:get_first_value).and_raise(StandardError, 'connection refused')
+
+      # Within TTL -- cached value still served, no DB call
+      allow(Time).to receive(:now).and_return(Time.at(4030.0))
+      expect(described_class.enabled?(:downtime_flag)).to be(true)
+
+      # Past TTL -- cache expired, DB call fails, fallback to default
+      allow(Time).to receive(:now).and_return(Time.at(4061.0))
+      expect(described_class.enabled?(:downtime_flag)).to be(false)
     end
   end
 end

--- a/spec/lib/common/feature_flags_spec.rb
+++ b/spec/lib/common/feature_flags_spec.rb
@@ -146,6 +146,18 @@ RSpec.describe Lich::Common::FeatureFlags do
       expect(db).to have_received(:get_first_value).once
     end
 
+    it 'does not cache when the database handle is unavailable' do
+      allow(Lich).to receive(:db).and_return(nil)
+
+      described_class.enabled?(:no_db_flag)
+
+      # DB becomes available
+      allow(Lich).to receive(:db).and_return(db)
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      expect(described_class.enabled?(:no_db_flag)).to be(true)
+    end
+
     it 'does not cache when DB raises an error so next call retries' do
       call_count = 0
       allow(db).to receive(:get_first_value) do
@@ -165,18 +177,17 @@ RSpec.describe Lich::Common::FeatureFlags do
     end
   end
 
-  describe 'cache invalidation on .set' do
-    it 'invalidates the cached value for the flag being set' do
+  describe 'cache write-through on .set' do
+    it 'writes the new resolved value to cache on successful set' do
       allow(db).to receive(:get_first_value).and_return('true')
       allow(db).to receive(:execute)
 
       described_class.enabled?(:inv_flag)
       described_class.set(:inv_flag, false)
-      # After set, cache is invalidated so enabled? must hit DB again
-      allow(db).to receive(:get_first_value).and_return('false')
-      described_class.enabled?(:inv_flag)
 
-      expect(db).to have_received(:get_first_value).twice
+      # Cache now holds the set value -- no DB read needed
+      expect(described_class.enabled?(:inv_flag)).to be(false)
+      expect(db).to have_received(:get_first_value).once
     end
 
     it 'does not affect other flags cache entries' do
@@ -194,7 +205,7 @@ RSpec.describe Lich::Common::FeatureFlags do
       expect(db).to have_received(:get_first_value).twice
     end
 
-    it 'does not invalidate cache when .set fails with a DB error' do
+    it 'does not update cache when .set fails with a DB error' do
       allow(db).to receive(:get_first_value).and_return('true')
       allow(db).to receive(:execute).and_raise(StandardError, 'write failed')
       allow(Lich).to receive(:log)
@@ -202,8 +213,8 @@ RSpec.describe Lich::Common::FeatureFlags do
       described_class.enabled?(:stable_flag)
       described_class.set(:stable_flag, false)
 
-      # Cache should still be intact -- no extra DB read
-      described_class.enabled?(:stable_flag)
+      # Cache should still hold the original value -- no extra DB read
+      expect(described_class.enabled?(:stable_flag)).to be(true)
       expect(db).to have_received(:get_first_value).once
     end
   end
@@ -298,14 +309,29 @@ RSpec.describe Lich::Common::FeatureFlags do
   end
 
   describe 'TTL edge cases' do
-    it 'considers a cache entry expired at exactly the TTL boundary' do
+    it 'keeps cache entry valid at exactly the TTL boundary' do
       now = Time.at(2000.0)
       allow(Time).to receive(:now).and_return(now)
       allow(db).to receive(:get_first_value).and_return('true')
 
       described_class.enabled?(:boundary_flag)
 
-      # Advance to exactly TTL seconds later
+      # At exactly TTL seconds, age == TTL, and the > check is false
+      ttl = described_class::CACHE_TTL_SECONDS
+      allow(Time).to receive(:now).and_return(Time.at(2000.0 + ttl))
+
+      described_class.enabled?(:boundary_flag)
+
+      expect(db).to have_received(:get_first_value).once
+    end
+
+    it 'expires cache entry just past the TTL boundary' do
+      now = Time.at(2000.0)
+      allow(Time).to receive(:now).and_return(now)
+      allow(db).to receive(:get_first_value).and_return('true')
+
+      described_class.enabled?(:boundary_flag)
+
       ttl = described_class::CACHE_TTL_SECONDS
       allow(Time).to receive(:now).and_return(Time.at(2000.0 + ttl + 0.001))
 
@@ -323,23 +349,19 @@ RSpec.describe Lich::Common::FeatureFlags do
       expect(db).to have_received(:get_first_value).exactly(3).times
     end
 
-    it 'treats backward clock movement as cache expiration (correct behavior)' do
+    it 'treats backward clock movement as cache expiration' do
       allow(db).to receive(:get_first_value).and_return('true')
 
       # Cache at t=2000
       allow(Time).to receive(:now).and_return(Time.at(2000.0))
       described_class.enabled?(:clock_flag)
 
-      # Clock jumps backward to t=1000, so (1000 - 2000) = -1000 which
-      # is NOT > CACHE_TTL_SECONDS, so cache is still valid
+      # Clock jumps backward to t=1000, age = (1000 - 2000) = -1000
+      # Negative age is treated as expired to avoid unbounded staleness
       allow(Time).to receive(:now).and_return(Time.at(1000.0))
       described_class.enabled?(:clock_flag)
 
-      # Only one DB call -- the backward clock doesn't expire the entry
-      # (negative difference is less than TTL). This is acceptable:
-      # in the worst case the entry expires after TTL seconds from the
-      # original write time, which is correct.
-      expect(db).to have_received(:get_first_value).once
+      expect(db).to have_received(:get_first_value).twice
     end
   end
 
@@ -369,14 +391,12 @@ RSpec.describe Lich::Common::FeatureFlags do
 
       described_class.enabled?(:rapid_flag)
 
-      # set invalidates cache
+      # set writes through to cache
       described_class.set(:rapid_flag, false)
 
-      # Next enabled? must hit DB for fresh value
-      allow(db).to receive(:get_first_value).and_return('false')
+      # Next enabled? serves from cache with the set value
       expect(described_class.enabled?(:rapid_flag)).to be(false)
-
-      expect(db).to have_received(:get_first_value).twice
+      expect(db).to have_received(:get_first_value).once
     end
 
     it 'serves cached values when DB goes down, then falls back to default after TTL' do

--- a/spec/lib/common/feature_flags_spec.rb
+++ b/spec/lib/common/feature_flags_spec.rb
@@ -283,8 +283,7 @@ RSpec.describe Lich::Common::FeatureFlags do
       allow(db).to receive(:get_first_value).and_return('on')
       allow(db).to receive(:execute)
 
-      completed = Concurrent::AtomicFixnum.new(0) if defined?(Concurrent)
-      completed = Queue.new unless defined?(Concurrent)
+      completed = defined?(Concurrent) ? Concurrent::AtomicFixnum.new(0) : Queue.new
 
       threads = 8.times.map do
         Thread.new do


### PR DESCRIPTION
## Summary

- Adds a mutex-protected in-memory cache with 60-second TTL to `FeatureFlags.enabled?`, eliminating repeated SQLite reads for values that rarely change
- On `.set`, the resolved value is written through to the cache (not just invalidated), closing a TOCTOU race where a concurrent read could re-cache a stale value
- DB errors and nil DB handles are intentionally not cached so the next call retries immediately
- A public `.clear_cache!` method is provided for operational/testing use

## Motivation

`FeatureFlags.enabled?` hits the SQLite database on every call. With the `ActiveSessions` heartbeat running every 5 seconds per process and N characters running, this creates unnecessary DB load for values that are set once and read thousands of times. A short TTL cache is a natural fit -- flags propagate within 60 seconds while DB reads drop by an order of magnitude.

## Implementation details

- `CACHE_TTL_SECONDS = 60` -- configurable constant
- `@cache_mutex` protects all cache reads/writes for thread safety
- `cache_read` returns `nil` for missing, expired, or negative-age (backward clock) entries
- `cache_write` stores `{ value: <bool>, at: <float> }` keyed by flag name
- On successful `.set`, the resolved boolean is written through to the cache
- Failed `.set` (DB error) does **not** update the cache
- When `fetch_db` returns nil (runtime not yet initialized), the default is returned without caching
- Each Lich process maintains its own independent cache; cross-process convergence is bounded by the TTL

## Test plan

- [x] First call hits DB, second call within TTL serves from cache
- [x] After TTL expires, next call re-reads from DB
- [x] Different flag names have independent cache entries
- [x] Cache stores resolved boolean, not raw DB string
- [x] nil DB result (unpersisted flag) is cached as default value
- [x] DB unavailable (nil handle) does NOT cache -- next call retries
- [x] DB error does NOT cache fallback (next call retries)
- [x] `.set` writes the resolved value through to cache
- [x] Failed `.set` does NOT update cache
- [x] `.clear_cache!` forces DB reads; safe when empty; safe under concurrent calls
- [x] Thread safety: concurrent `enabled?` returns valid results
- [x] Thread safety: concurrent `enabled?` + `set` -- no deadlocks
- [x] Thread safety: no starvation under mutex contention (timeout guard)
- [x] TTL boundary: entry at exactly TTL is still valid (strict >)
- [x] TTL boundary: entry just past TTL is expired
- [x] Negative TTL: every read goes to DB, no crash
- [x] Clock moving backward: negative age treated as expired
- [x] Stale value served until TTL, then fresh value returned
- [x] Rapid set/enabled? interleaving: write-through serves correct value
- [x] DB goes down after cache warm: cached values served until TTL, then fallback

All 41 specs pass (18 existing + 23 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature flags now use an in-memory cache with expiration for faster checks and reduced backend reads.
  * Cache updates when flags are changed, and a manual cache-clear capability was added.

* **Reliability**
  * Improved behavior when backend is unavailable and safer handling around cache expiry and clock edge cases.

* **Tests**
  * Extensive tests added for caching semantics, TTL edge cases, concurrency, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->