### PR TITLE
fix(all): Add busy_timeout to SessionDatabaseAdapter connections

### DIFF
--- a/lib/common/settings/session_database_adapter.rb
+++ b/lib/common/settings/session_database_adapter.rb
@@ -15,7 +15,11 @@ module Lich
       # @param data_dir [String] directory containing lich.db3 when db is not injected
       # @param table_name [String] session summary table name
       def initialize(db: nil, data_dir: DATA_DIR, table_name: DEFAULT_TABLE_NAME)
-        @db = db || SQLite3::Database.new(File.join(data_dir, 'lich.db3'))
+        @db = db || begin
+          conn = SQLite3::Database.new(File.join(data_dir, 'lich.db3'))
+          conn.busy_timeout = 3000
+          conn
+        end
         @table_name = table_name
       end
 

--- a/spec/lib/common/settings/session_database_adapter_spec.rb
+++ b/spec/lib/common/settings/session_database_adapter_spec.rb
@@ -55,6 +55,35 @@ RSpec.describe Lich::Common::SessionDatabaseAdapter do
       row = sqlite_db.get_first_row("SELECT name FROM sqlite_master WHERE type='table' AND name='session_summary_state';")
       expect(row['name']).to eq('session_summary_state')
     end
+
+    it 'sets busy_timeout on self-created connections' do
+      adapter_dir = Dir.mktmpdir('adapter-bt-spec')
+      begin
+        # Create schema so adapter can operate
+        setup_db = SQLite3::Database.new(File.join(adapter_dir, 'lich.db3'))
+        create_session_summary_schema!(setup_db)
+        setup_db.close
+
+        adapter = described_class.new(data_dir: adapter_dir)
+        # Access the internal connection to verify busy_timeout via PRAGMA
+        internal_db = adapter.instance_variable_get(:@db)
+        timeout = internal_db.get_first_value('PRAGMA busy_timeout;')
+        expect(timeout.to_i).to eq(3000)
+      ensure
+        internal_db&.close
+        FileUtils.remove_entry(adapter_dir, true)
+      end
+    end
+
+    it 'does not override busy_timeout on injected connections' do
+      # When a caller injects their own db handle, the adapter should not
+      # modify its configuration.
+      sqlite_db.busy_timeout = 500
+      described_class.new(db: sqlite_db)
+
+      timeout = sqlite_db.get_first_value('PRAGMA busy_timeout;')
+      expect(timeout.to_i).to eq(500)
+    end
   end
 
   describe '#upsert_session' do


### PR DESCRIPTION
## Summary
- Set `busy_timeout = 3000` on self-created SQLite connections in `SessionDatabaseAdapter`
- Matches the `Lich.db` configuration from #1319 for consistency
- Injected connections (via `db:` parameter) are not modified

The adapter already handles `BusyException` via its `with_retry` loop (5 attempts, exponential backoff). Adding `busy_timeout` is defense-in-depth -- SQLite will wait up to 3s for locks at the driver level before the retry loop even kicks in, reducing unnecessary retry churn.

## Test plan
- [x] New spec: verifies `busy_timeout = 3000` on self-created connections via PRAGMA
- [x] New spec: verifies injected connections are not modified
- [x] All existing adapter specs pass (12 examples, 0 failures)
- [x] Full suite passes (3755 examples, 0 failures)
- [x] Rubocop clean

Follow-up to #1319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection stability by configuring timeout handling for concurrent access, reducing potential timeout-related errors during simultaneous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->