### PR TITLE
fix(all): harden FeatureFlags for closed db handle

### DIFF
--- a/lib/common/feature_flags.rb
+++ b/lib/common/feature_flags.rb
@@ -150,9 +150,26 @@ module Lich
       def self.fetch_db
         return nil unless Lich.respond_to?(:db)
 
-        Lich.db
+        db = Lich.db
+        return nil if db.nil?
+        return nil if db_closed?(db)
+
+        db
       end
       private_class_method :fetch_db
+
+      # Indicates whether a database handle can no longer service queries.
+      #
+      # Feature flag reads are used broadly across startup and shutdown code,
+      # so a closed database should be treated as unavailable rather than
+      # surfacing secondary SQLite errors from teardown paths.
+      #
+      # @param db [Object] database handle returned by {Lich.db}
+      # @return [Boolean]
+      def self.db_closed?(db)
+        db.respond_to?(:closed?) && db.closed?
+      end
+      private_class_method :db_closed?
 
       # Logs a read or write failure without raising a second error.
       #

--- a/spec/lib/common/feature_flags_spec.rb
+++ b/spec/lib/common/feature_flags_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe Lich::Common::FeatureFlags do
       expect(described_class.enabled?(:demo_flag)).to be(false)
     end
 
+    it 'returns false when the database handle is already closed' do
+      allow(db).to receive(:closed?).and_return(true)
+      expect(db).not_to receive(:get_first_value)
+
+      expect(described_class.enabled?(:demo_flag)).to be(false)
+    end
+
     it 'returns the default value and logs when the read raises an error' do
       stub_const("#{described_class}::DEFAULTS", { demo_flag: true }.freeze)
       allow(db).to receive(:get_first_value).and_raise(StandardError, 'read failed')
@@ -77,6 +84,13 @@ RSpec.describe Lich::Common::FeatureFlags do
 
     it 'returns false when the database handle is unavailable' do
       allow(Lich).to receive(:db).and_return(nil)
+
+      expect(described_class.set(:demo_flag, true)).to be(false)
+    end
+
+    it 'returns false when the database handle is already closed' do
+      allow(db).to receive(:closed?).and_return(true)
+      expect(db).not_to receive(:execute)
 
       expect(described_class.set(:demo_flag, true)).to be(false)
     end


### PR DESCRIPTION
## Why

FeatureFlags.enabled? and .set currently assume that Lich.db is always usable once it exists. In shutdown and teardown paths, that is not always true: callers can still hold a DB handle after SQLite has already been closed, which leads to noisy secondary errors like prepare called on a closed database.

## What Changed
 - Hardened Lich::Common::FeatureFlags.fetch_db to treat a closed DB handle as unavailable.
 - Kept the change narrowly scoped to FeatureFlags so callers continue to get the same safe fallback behavior they already expect.
 - Added focused spec coverage for both read and write behavior when the DB handle is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced feature flag system to gracefully handle closed or unavailable databases, preventing errors and ensuring reliable operation during application startup and shutdown sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->