### PR TITLE
chore(all): Improve release notes workflow recovery resilience

### DIFF
--- a/.github/workflows/format-release-notes.yaml
+++ b/.github/workflows/format-release-notes.yaml
@@ -52,9 +52,9 @@ jobs:
               const { data } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
               return data;
             }
-            async function latestStable() {
+            async function latestStable(includeDraft = false) {
               const { data } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
-              const hit = (data || []).find(r => !r.draft && !r.prerelease);
+              const hit = (data || []).find(r => !r.prerelease && (includeDraft || !r.draft));
               if (!hit) throw new Error('No stable release found');
               return hit;
             }
@@ -75,7 +75,7 @@ jobs:
             } else if (ev === 'workflow_run') {
               // Infer target channel from the upstream workflow name
               const wantPrerelease = /prerelease/i.test(wfName);
-              try { rel = wantPrerelease ? await latestPrerelease() : await latestStable(); } catch (e) {
+              try { rel = wantPrerelease ? await latestPrerelease() : await latestStable(true); } catch (e) {
                 core.setFailed(`Could not resolve a ${wantPrerelease ? 'prerelease' : 'stable'} release: ${e.message}`); return;
               }
             } else {
@@ -209,10 +209,11 @@ jobs:
             const prb = process.env.PR_BODY || '';
             const rel = process.env.REL_BODY || '';
 
-            // Always prefer the matched Release Please PR body when available.
-            // This keeps manual sentinel removal self-healing even if the
-            // current release body is stale or was previously truncated.
-            const seed = prb || rel;
+            // Always prefer the matched Release Please PR body when it has
+            // meaningful content. This keeps manual sentinel removal
+            // self-healing even if the current release body is stale or was
+            // previously truncated.
+            const seed = prb.trim().length > 0 ? prb : rel;
             core.setOutput('body', seed);
 
       - name: Transform body (normalize header, drop RP boilerplate, plain PR refs, append footer + sentinel)

--- a/.github/workflows/format-release-notes.yaml
+++ b/.github/workflows/format-release-notes.yaml
@@ -132,6 +132,11 @@ jobs:
             const rawVersion = process.env.VERSION || '';
             const base = process.env.BASE || 'main';
 
+            if (!rawVersion.trim()) {
+              core.setFailed('Missing release version for release notes PR lookup');
+              return;
+            }
+
             // Escape VERSION for use in RegExp
             const v = rawVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
             const titleRe = new RegExp(`\\b(?:release|Lich)\\s+v?${v}\\b`, 'i');

--- a/.github/workflows/format-release-notes.yaml
+++ b/.github/workflows/format-release-notes.yaml
@@ -201,13 +201,13 @@ jobs:
           REL_BODY: ${{ steps.seed.outputs.body }}
         with:
           script: |
-            const ev = context.eventName;
-            const action = (context.payload && context.payload.action) || '';
             const prb = process.env.PR_BODY || '';
             const rel = process.env.REL_BODY || '';
 
-            // On manual edit, prefer the current release body; otherwise prefer PR body.
-            const seed = (ev === 'release' && action === 'edited') ? (rel || prb) : (prb || rel);
+            // Always prefer the matched Release Please PR body when available.
+            // This keeps manual sentinel removal self-healing even if the
+            // current release body is stale or was previously truncated.
+            const seed = prb || rel;
             core.setOutput('body', seed);
 
       - name: Transform body (normalize header, drop RP boilerplate, plain PR refs, append footer + sentinel)

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -102,7 +102,7 @@ jobs:
             core.setOutput('version', version);
             core.setOutput('published_at', new Date().toISOString());
 
-      - name: Find Release Please PR by commit SHA
+      - name: Find merged Release Please PR for this tag
         if: ${{ steps.rp.outputs.release_created == 'true' }}
         id: find_pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -111,43 +111,73 @@ jobs:
         with:
           script: |
             const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const sha = context.sha;
-            const version = process.env.VERSION || '';
-            
-            core.info(`Looking for PR associated with commit ${sha}`);
-            
-            // Find PRs associated with this commit (the merge commit that triggered this workflow)
-            let prs = [];
-            try {
-              const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            const repo  = context.repo.repo;
+            const rawVersion = process.env.VERSION || '';
+
+            // Match standard Release Please titles for the release version.
+            const v = rawVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const titleRe = new RegExp(`\\b(?:release|Lich)\\s+v?${v}\\b`, 'i');
+
+            async function listClosed(opts) {
+              return github.rest.pulls.list({
                 owner,
                 repo,
-                commit_sha: sha
-              });
-              prs = data || [];
-              core.info(`Found ${prs.length} PR(s) associated with commit`);
-            } catch (e) {
-              core.warning(`Failed to find PRs by commit: ${e.message}`);
+                state: 'closed',
+                per_page: 100,
+                ...opts
+              }).then(r => r.data || []);
             }
-            
-            // Filter for merged release-please PRs matching this version
-            const esc = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            const v = esc(version);
-            const titleRe = new RegExp(`\\b(?:release|Lich)\\s+v?${v}\\b`, 'i');
-            
-            const hit = prs.find(pr => 
-              pr.merged_at && 
+
+            // Prefer the standard stable Release Please branch first.
+            const head = `${owner}:release-please--branches--main`;
+            let pulls = await listClosed({ base: 'main', head });
+            if (!pulls.length) pulls = await listClosed({ base: 'main' });
+
+            let hit = pulls.find(pr =>
+              pr.merged_at &&
               titleRe.test(pr.title || '')
             );
-            
+
+            // Fall back to search in case the branch association is unavailable.
+            if (!hit) {
+              const q = `repo:${owner}/${repo} is:pr is:merged "${rawVersion}" in:title base:main`;
+              try {
+                const search = await github.rest.search.issuesAndPullRequests({
+                  q,
+                  per_page: 10,
+                  sort: 'updated',
+                  order: 'desc'
+                });
+                const item = (search.data.items || [])[0];
+                if (item) {
+                  hit = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: item.number
+                  }).then(r => r.data);
+                }
+              } catch (e) {
+                core.info(`Search fallback did not resolve a PR: ${e.message}`);
+              }
+            }
+
+            // Final fallback: any merged Release Please branch PR matching the version.
+            if (!hit) {
+              pulls = await listClosed({});
+              hit = pulls.find(pr =>
+                pr.merged_at &&
+                /release-please--branches--/.test(pr.head && pr.head.ref || '') &&
+                titleRe.test(pr.title || '')
+              );
+            }
+
             if (hit) {
               core.info(`Found PR #${hit.number}: ${hit.title}`);
               core.setOutput('found', 'true');
               core.setOutput('number', String(hit.number));
               core.setOutput('body', hit.body || '');
             } else {
-              core.warning(`No matching merged PR found for version ${version}`);
+              core.warning(`No matching merged PR found for version ${rawVersion}`);
               core.setOutput('found', 'false');
             }
 

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -186,16 +186,43 @@ jobs:
               core.setOutput('found', 'false');
             }
 
+      - name: Read current draft release body
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        id: read_release
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TAG: ${{ steps.rp.outputs.tag_name }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = (process.env.TAG || '').trim();
+
+            if (!tag) {
+              core.setFailed('Missing tag for stable release body lookup');
+              return;
+            }
+
+            const release = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag
+            }).then(r => r.data);
+
+            core.setOutput('body', release.body || '');
+
       - name: Choose seed body (PR preferred)
         if: ${{ steps.rp.outputs.release_created == 'true' }}
         id: choose_seed
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_BODY: ${{ steps.find_pr.outputs.body }}
+          REL_BODY: ${{ steps.read_release.outputs.body }}
         with:
           script: |
             const prb = process.env.PR_BODY || '';
-            core.setOutput('body', prb);
+            const rel = process.env.REL_BODY || '';
+            core.setOutput('body', prb.trim().length > 0 ? prb : rel);
 
       - name: Transform body (header + cleanup + footer)
         if: ${{ steps.rp.outputs.release_created == 'true' }}

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -114,6 +114,11 @@ jobs:
             const repo  = context.repo.repo;
             const rawVersion = process.env.VERSION || '';
 
+            if (!rawVersion.trim()) {
+              core.setFailed('Missing release version for stable release notes PR lookup');
+              return;
+            }
+
             // Match standard Release Please titles for the release version.
             const v = rawVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
             const titleRe = new RegExp(`\\b(?:release|Lich)\\s+v?${v}\\b`, 'i');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prefer the Release PR body as the primary source for release notes when present; otherwise use the release/draft body.
  * Made release discovery more robust by improving how the workflow finds merged release updates via tag/version matching.
* **Bug Fixes**
  * Fail early if the release version input is missing or blank to avoid incorrect lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->