### PR TITLE
fix(all): enable heartbeat-driven failover for ActiveSessions service owner

### DIFF
--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -141,10 +141,15 @@ module Lich
       # Registers or updates a session record from a lifecycle path that
       # already admitted the feature gate at startup.
       #
+      # When the current service owner has exited, this allows a surviving
+      # session to bootstrap a replacement owner so session visibility is
+      # maintained. The kill-switch is still enforced: ensure_service_internal!
+      # re-checks enabled? before creating a new owner.
+      #
       # @param payload [Hash] normalized session metadata
       # @return [Boolean] true when the service accepted the update
       def self.register_session_admitted(payload)
-        return false unless ensure_service_internal!(allow_bootstrap: false)
+        return false unless ensure_service_internal!(allow_bootstrap: true)
 
         service_client&.upsert(payload)&.fetch(:ok, false) || false
       end

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -277,6 +277,40 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
     expect(described_class.send(:register_session_admitted, { pid: 12_345 })).to be(true)
   end
 
+  it 'bootstraps a replacement owner from admitted registration when no healthy service remains' do
+    # No discovery file: simulates the previous owner having exited.
+    fake_server = instance_double(
+      Lich::InternalAPI::ActiveSessions::Server,
+      start: true,
+      stop: nil,
+      auth_token: 'failover-token'
+    )
+    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
+
+    allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(fake_server)
+    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive(:upsert).and_return(ok: true)
+
+    expect(described_class).to receive(:enabled?).and_return(true)
+
+    expect(described_class.send(:register_session_admitted, { pid: Process.pid })).to be(true)
+
+    discovery = JSON.parse(
+      File.read(File.join(temp_dir, 'lich-active-sessions.json')),
+      symbolize_names: true
+    )
+    expect(discovery[:owner_pid]).to eq(Process.pid)
+    expect(discovery[:auth_token]).to eq('failover-token')
+  end
+
+  it 'does not bootstrap from admitted registration when the kill-switch is disabled' do
+    allow(described_class).to receive(:enabled?).and_return(false)
+
+    expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+
+    expect(described_class.send(:register_session_admitted, { pid: Process.pid })).to be(false)
+  end
+
   it 'can reuse an existing service after the caller already admitted the feature gate' do
     fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true)
     File.write(


### PR DESCRIPTION
## Summary

- When the service-owning Lich process exits while other sessions remain, the TCP service dies with no failover. Surviving sessions' heartbeats use `allow_bootstrap: false`, so they cannot elect a new owner.
- External consumers (e.g. the launcher) see `:no_service` and bypass all session safety checks (same-account conflict detection, existing session reuse), potentially starting duplicate logins.
- Changes `register_session_admitted` to `allow_bootstrap: true` so surviving sessions can race to become the new owner on their next heartbeat tick (~5s).
- The kill-switch is preserved: `ensure_service_internal!` independently re-checks `enabled?` before bootstrapping a new owner (line 98), so disabling the feature flag still prevents new owners from being created.
- Leaves `unregister_session_admitted` as `allow_bootstrap: false` -- there is no value in bootstrapping a server just to unregister during shutdown.

### Port-binding race safety

When multiple sessions race to become owner, exactly one wins the `TCPServer.new` bind on port 42857. Losers get `Errno::EADDRINUSE`, caught by `Server#start`'s rescue, silently fail that heartbeat tick, and discover the winner's service via the discovery file on their next tick.

## Test plan

- [ ] Start multiple Lich sessions with `--detachable-client=0`
- [ ] Identify which PID owns the service (`cat temp/lich-active-sessions.json`)
- [ ] Kill the owner process
- [ ] Verify a surviving session bootstraps a new service within ~5s (check discovery file for new PID)
- [ ] Verify the launcher correctly detects existing sessions after failover
- [ ] Verify disabling the feature flag still prevents new owner creation (kill-switch preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of the active sessions system: when no healthy owner is available, the system can now bootstrap a replacement server while still honoring the kill-switch/feature flag safeguards.

* **Tests**
  * Added specs covering the bootstrapping behavior and the negative case when the kill-switch/feature flag is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->