### PR TITLE
fix(gs): add support for RESERVE xml in GameObj.reserve

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -269,8 +269,7 @@ module Lich
       # Creates and registers a new reserve slot item.
       #
       # +@@reserve+ is +nil+ until the first reserve stream is seen; thereafter
-      # it is always an Array (possibly empty). This mirrors the semantics of
-      # +@@inv+ so callers can distinguish "never seen" from "seen but empty".
+      # it is always an Array (possibly empty).
       #
       # @param id   [Integer, String]
       # @param noun [String, nil]
@@ -466,12 +465,8 @@ module Lich
       # @return [void]
       def self.clear_inv           = @@inv.clear
 
-      # Resets the reserve registry to an empty array once it has been seen.
-      # Has no effect before the first reserve stream is received (+@@reserve+
-      # stays +nil+ so callers can tell the stream has never arrived).
-      #
       # @return [void]
-      def self.clear_reserve       = (@@reserve = [] if @@reserve)
+      def self.clear_reserve       = (@@reserve&.clear)
 
       # @return [void]
       def self.clear_room_desc     = @@room_desc.clear
@@ -959,7 +954,7 @@ module Lich
         # All ordered search registries for +[]+, hands wrapped in an array to
         # use the same +#find+ interface.
         SEARCH_ORDER = proc do
-          [@@inv, @@reserve, @@loot, @@npcs, @@pcs,
+          [@@inv, Array(@@reserve), @@loot, @@npcs, @@pcs,
            [@@right_hand, @@left_hand].compact,
            @@room_desc,
            @@contents.values.flatten]

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -466,7 +466,7 @@ module Lich
       def self.clear_inv           = @@inv.clear
 
       # @return [void]
-      def self.clear_reserve       = (@@reserve&.clear)
+      def self.clear_reserve       = (@@reserve = [])
 
       # @return [void]
       def self.clear_room_desc     = @@room_desc.clear

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -27,6 +27,7 @@ module Lich
       @@pcs           = []
       @@pc_status     = {}
       @@inv           = []
+      @@reserve       = nil
       @@contents      = {}
       @@right_hand    = nil
       @@left_hand     = nil
@@ -265,6 +266,21 @@ module Lich
         end
       end
 
+      # Creates and registers a new reserve slot item.
+      #
+      # +@@reserve+ is +nil+ until the first reserve stream is seen; thereafter
+      # it is always an Array (possibly empty). This mirrors the semantics of
+      # +@@inv+ so callers can distinguish "never seen" from "seen but empty".
+      #
+      # @param id   [Integer, String]
+      # @param noun [String, nil]
+      # @param name [String, nil]
+      # @return [GameObj]
+      def self.new_reserve(id, noun, name)
+        @@reserve ||= []
+        find_or_create(@@reserve, id, noun, name)
+      end
+
       # Creates and registers a new room description object.
       #
       # @param id   [Integer, String]
@@ -414,6 +430,9 @@ module Lich
       def self.inv         = registry_or_nil(@@inv)
 
       # @return [Array<GameObj>, nil]
+      def self.reserve     = @@reserve&.dup
+
+      # @return [Array<GameObj>, nil]
       def self.room_desc   = registry_or_nil(@@room_desc)
 
       # @return [Array<GameObj>, nil]
@@ -446,6 +465,13 @@ module Lich
 
       # @return [void]
       def self.clear_inv           = @@inv.clear
+
+      # Resets the reserve registry to an empty array once it has been seen.
+      # Has no effect before the first reserve stream is received (+@@reserve+
+      # stays +nil+ so callers can tell the stream has never arrived).
+      #
+      # @return [void]
+      def self.clear_reserve       = (@@reserve = [] if @@reserve)
 
       # @return [void]
       def self.clear_room_desc     = @@room_desc.clear
@@ -918,7 +944,7 @@ module Lich
       #
       # @return [Array<GameObj>]
       def all_flat_registries
-        [*@@loot, *@@inv, *@@room_desc,
+        [*@@loot, *@@inv, *@@reserve, *@@room_desc,
          *@@fam_loot, *@@fam_npcs, *@@fam_pcs, *@@fam_room_desc,
          @@right_hand, @@left_hand].compact
       end
@@ -933,7 +959,7 @@ module Lich
         # All ordered search registries for +[]+, hands wrapped in an array to
         # use the same +#find+ interface.
         SEARCH_ORDER = proc do
-          [@@inv, @@loot, @@npcs, @@pcs,
+          [@@inv, @@reserve, @@loot, @@npcs, @@pcs,
            [@@right_hand, @@left_hand].compact,
            @@room_desc,
            @@contents.values.flatten]
@@ -1014,7 +1040,7 @@ module Lich
         # @return [Set<String>, Array<String>]
         def live_registry_ids
           ids = [
-            *@@loot, *@@npcs, *@@pcs, *@@inv,
+            *@@loot, *@@npcs, *@@pcs, *@@inv, *@@reserve,
             *@@room_desc, *@@fam_loot, *@@fam_npcs, *@@fam_pcs, *@@fam_room_desc,
             *@@contents.values.flatten,
             @@right_hand, @@left_hand

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -326,6 +326,7 @@ module Lich
             @current_stream = attributes['id'].to_s
             if XMLData.game =~ /^GS/
               GameObj.clear_inv if attributes['id'].to_s == 'inv'
+              GameObj.clear_reserve if attributes['id'].to_s == 'reserve'
             end
           end
           if name == 'popStream'
@@ -831,6 +832,8 @@ module Lich
             @society_task = text_string
           elsif (@current_stream == 'inv') and @active_tags.include?('a')
             GameObj.new_inv(@obj_exist, @obj_noun, text_string, nil)
+          elsif (@current_stream == 'reserve') and @active_tags.include?('a')
+            GameObj.new_reserve(@obj_exist, @obj_noun, text_string)
           elsif @check_obvious_hiding && text_string =~ /obvious signs of someone hiding/
             @room_player_hidden = true
           elsif @current_stream == 'familiar'

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Lich::Common::GameObj do
     end
     described_class.class_variable_set(:@@right_hand, nil)
     described_class.class_variable_set(:@@left_hand, nil)
+    described_class.class_variable_set(:@@reserve, nil)
 
     described_class.new_right_hand('r1', 'empty', 'Empty')
     described_class.new_left_hand('l1', 'empty', 'Empty')
@@ -150,6 +151,91 @@ RSpec.describe Lich::Common::GameObj do
       described_class.clear_inv
 
       expect(described_class.containers).to have_key('container1')
+    end
+  end
+
+  describe '.new_reserve' do
+    let(:item_id)   { '279838' }
+    let(:item_noun) { 'lilac' }
+    let(:item_name) { 'sprig of wild lilac' }
+
+    it 'adds the item to @@reserve' do
+      obj = described_class.new_reserve(item_id, item_noun, item_name)
+
+      expect(described_class.reserve).to include(obj)
+      expect(obj.id).to eq(item_id)
+      expect(obj.noun).to eq(item_noun)
+      expect(obj.name).to eq(item_name)
+    end
+
+    it 'initializes @@reserve from nil on first call' do
+      expect(described_class.reserve).to be_nil
+
+      described_class.new_reserve(item_id, item_noun, item_name)
+
+      expect(described_class.reserve).to be_an(Array)
+    end
+
+    it 'appends multiple items' do
+      first  = described_class.new_reserve('1', 'herb', 'golden herb')
+      second = described_class.new_reserve('2', 'potion', 'blue potion')
+
+      expect(described_class.reserve).to contain_exactly(first, second)
+    end
+
+    it 'converts integer id to string' do
+      obj = described_class.new_reserve(279838, item_noun, item_name)
+
+      expect(obj.id).to eq('279838')
+    end
+  end
+
+  describe '.reserve' do
+    it 'returns nil when @@reserve has never been seen' do
+      expect(described_class.reserve).to be_nil
+    end
+
+    it 'returns an empty array after clear_reserve transitions nil to []' do
+      described_class.clear_reserve # no-op while nil
+      expect(described_class.reserve).to be_nil
+
+      described_class.new_reserve('1', 'herb', 'golden herb')
+      described_class.clear_reserve
+      expect(described_class.reserve).to eq([])
+    end
+
+    it 'returns a duplicate so mutations do not affect the registry' do
+      obj = described_class.new_reserve('1', 'herb', 'golden herb')
+
+      copy = described_class.reserve
+      copy.clear
+
+      expect(described_class.reserve).to include(obj)
+    end
+  end
+
+  describe '.clear_reserve' do
+    it 'is a no-op when @@reserve is nil (stream never seen)' do
+      expect { described_class.clear_reserve }.not_to raise_error
+      expect(described_class.reserve).to be_nil
+    end
+
+    it 'resets @@reserve to an empty array once it has been seen' do
+      described_class.new_reserve('1', 'herb', 'golden herb')
+      expect(described_class.reserve).not_to be_nil
+
+      described_class.clear_reserve
+
+      expect(described_class.reserve).to eq([])
+    end
+
+    it 'allows new items to be added after clearing' do
+      described_class.new_reserve('1', 'herb', 'golden herb')
+      described_class.clear_reserve
+
+      obj = described_class.new_reserve('2', 'potion', 'blue potion')
+
+      expect(described_class.reserve).to contain_exactly(obj)
     end
   end
 

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -206,12 +206,15 @@ RSpec.describe Lich::Common::GameObj do
   end
 
   describe '.clear_reserve' do
-    it 'is a no-op when @@reserve has never been seen' do
-      expect { described_class.clear_reserve }.not_to raise_error
+    it 'initializes @@reserve to [] even when never seen' do
       expect(described_class.reserve).to be_nil
+
+      described_class.clear_reserve
+
+      expect(described_class.reserve).to eq([])
     end
 
-    it 'empties @@reserve once it has been seen' do
+    it 'empties @@reserve when it already has items' do
       described_class.new_reserve('1', 'herb', 'golden herb')
       expect(described_class.reserve).not_to be_nil
 

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -195,15 +195,6 @@ RSpec.describe Lich::Common::GameObj do
       expect(described_class.reserve).to be_nil
     end
 
-    it 'returns an empty array after clear_reserve transitions nil to []' do
-      described_class.clear_reserve # no-op while nil
-      expect(described_class.reserve).to be_nil
-
-      described_class.new_reserve('1', 'herb', 'golden herb')
-      described_class.clear_reserve
-      expect(described_class.reserve).to eq([])
-    end
-
     it 'returns a duplicate so mutations do not affect the registry' do
       obj = described_class.new_reserve('1', 'herb', 'golden herb')
 
@@ -215,12 +206,12 @@ RSpec.describe Lich::Common::GameObj do
   end
 
   describe '.clear_reserve' do
-    it 'is a no-op when @@reserve is nil (stream never seen)' do
+    it 'is a no-op when @@reserve has never been seen' do
       expect { described_class.clear_reserve }.not_to raise_error
       expect(described_class.reserve).to be_nil
     end
 
-    it 'resets @@reserve to an empty array once it has been seen' do
+    it 'empties @@reserve once it has been seen' do
       described_class.new_reserve('1', 'herb', 'golden herb')
       expect(described_class.reserve).not_to be_nil
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new reserve registry system for game objects, enabling creation, access, and management of reserved items.
  * Reserve objects are now fully integrated into game object lookups and remain protected from index cleanup.
  * Game stream parser now automatically handles reserve item population and clearing during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->