### PR TITLE
fix(dr): Add CORE_AUTOSTART sentinel to skip dependency.lic autostart helpers

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -9,6 +9,7 @@ module Lich
   module Common
     CORE_GET_SETTINGS = true
     CORE_SCRIPT_LOADER = true
+    CORE_AUTOSTART = true
   end
 end
 

--- a/spec/lib/global_defs_spec.rb
+++ b/spec/lib/global_defs_spec.rb
@@ -311,3 +311,53 @@ RSpec.describe '#fput' do
     end
   end
 end
+
+RSpec.describe 'global_defs.rb sentinel constants' do
+  let(:source) { File.read(File.join(LIB_DIR, 'global_defs.rb')) }
+
+  describe 'CORE_AUTOSTART sentinel' do
+    it 'defines CORE_AUTOSTART in Lich::Common' do
+      expect(source).to match(/^\s+CORE_AUTOSTART\s*=\s*true\b/)
+    end
+
+    it 'is inside the Lich::Common module block' do
+      lich_common_block = source[/module Lich\s+module Common.*?end\s+end/m]
+      expect(lich_common_block).not_to be_nil
+      expect(lich_common_block).to include('CORE_AUTOSTART')
+    end
+
+    it 'passes the exact const_defined? check dependency.lic uses' do
+      # dependency.lic gates with: Lich::Common.const_defined?(:CORE_AUTOSTART, false)
+      # The `false` arg means "don't search ancestors" -- only direct constants.
+      # Verify the source defines it so that check would pass at runtime.
+      expect(source).to match(/CORE_AUTOSTART\s*=\s*true/)
+    end
+  end
+
+  describe 'all sentinel constants' do
+    it 'defines CORE_GET_SETTINGS' do
+      expect(source).to match(/CORE_GET_SETTINGS\s*=\s*true/)
+    end
+
+    it 'defines CORE_SCRIPT_LOADER' do
+      expect(source).to match(/CORE_SCRIPT_LOADER\s*=\s*true/)
+    end
+
+    it 'defines CORE_AUTOSTART' do
+      expect(source).to match(/CORE_AUTOSTART\s*=\s*true/)
+    end
+
+    it 'defines all three sentinels in the same module block' do
+      lich_common_block = source[/module Lich\s+module Common.*?end\s+end/m]
+      expect(lich_common_block).to include('CORE_GET_SETTINGS')
+      expect(lich_common_block).to include('CORE_SCRIPT_LOADER')
+      expect(lich_common_block).to include('CORE_AUTOSTART')
+    end
+  end
+
+  describe 'non-existent sentinels' do
+    it 'does not define CORE_NONEXISTENT' do
+      expect(source).not_to match(/CORE_NONEXISTENT/)
+    end
+  end
+end

--- a/spec/lib/global_defs_spec.rb
+++ b/spec/lib/global_defs_spec.rb
@@ -325,7 +325,6 @@ RSpec.describe 'global_defs.rb sentinel constants' do
       expect(lich_common_block).not_to be_nil
       expect(lich_common_block).to include('CORE_AUTOSTART')
     end
-
   end
 
   describe 'all sentinel constants' do
@@ -337,22 +336,12 @@ RSpec.describe 'global_defs.rb sentinel constants' do
       expect(source).to match(/CORE_SCRIPT_LOADER\s*=\s*true/)
     end
 
-    it 'defines CORE_AUTOSTART' do
-      expect(source).to match(/CORE_AUTOSTART\s*=\s*true/)
-    end
-
     it 'defines all three sentinels in the same module block' do
       lich_common_block = source[/module Lich\s+module Common.*?end\s+end/m]
       expect(lich_common_block).not_to be_nil, 'Could not extract module Lich::Common block from source'
       expect(lich_common_block).to include('CORE_GET_SETTINGS')
       expect(lich_common_block).to include('CORE_SCRIPT_LOADER')
       expect(lich_common_block).to include('CORE_AUTOSTART')
-    end
-  end
-
-  describe 'non-existent sentinels' do
-    it 'does not define CORE_NONEXISTENT' do
-      expect(source).not_to match(/CORE_NONEXISTENT/)
     end
   end
 end

--- a/spec/lib/global_defs_spec.rb
+++ b/spec/lib/global_defs_spec.rb
@@ -326,12 +326,6 @@ RSpec.describe 'global_defs.rb sentinel constants' do
       expect(lich_common_block).to include('CORE_AUTOSTART')
     end
 
-    it 'passes the exact const_defined? check dependency.lic uses' do
-      # dependency.lic gates with: Lich::Common.const_defined?(:CORE_AUTOSTART, false)
-      # The `false` arg means "don't search ancestors" -- only direct constants.
-      # Verify the source defines it so that check would pass at runtime.
-      expect(source).to match(/CORE_AUTOSTART\s*=\s*true/)
-    end
   end
 
   describe 'all sentinel constants' do
@@ -349,6 +343,7 @@ RSpec.describe 'global_defs.rb sentinel constants' do
 
     it 'defines all three sentinels in the same module block' do
       lich_common_block = source[/module Lich\s+module Common.*?end\s+end/m]
+      expect(lich_common_block).not_to be_nil, 'Could not extract module Lich::Common block from source'
       expect(lich_common_block).to include('CORE_GET_SETTINGS')
       expect(lich_common_block).to include('CORE_SCRIPT_LOADER')
       expect(lich_common_block).to include('CORE_AUTOSTART')


### PR DESCRIPTION
## Summary
- Adds `CORE_AUTOSTART = true` sentinel to `Lich::Common` in `global_defs.rb`, alongside the existing `CORE_GET_SETTINGS` and `CORE_SCRIPT_LOADER` sentinels
- dependency.lic gates its autostart helpers block with `unless Lich::Common.const_defined?(:CORE_AUTOSTART, false)` -- this sentinel causes that block to be skipped

## Problem
dependency.lic's autostart helpers contain a one-way merge that copies `Settings['autostart']` into `UserVars.autostart_scripts` on every login. Users who purge `UserVars.autostart_scripts` see the entries reappear on next login because the merge re-populates them. There is no user-facing command to clear `Settings['autostart']`.

Now that autostart.lic v0.67+ handles the DR autostart loop directly (reading `UserVars.autostart_scripts` + YAML `autostarts`), the dependency.lic helpers are redundant:
- The zombie merge of `Settings['autostart']` into UserVars
- `autostart()` / `stop_autostart()` functions
- `handle_obsolete_autostart()` / `dr_obsolete_script?()`
- `dependency_status()`

## Test plan
- [ ] Verify `CORE_AUTOSTART` is defined in `Lich::Common` module
- [ ] Verify all three sentinels coexist in the same module block
- [ ] Verify dependency.lic's `const_defined?(:CORE_AUTOSTART, false)` check would match
- [ ] Run `rspec spec/lib/global_defs_spec.rb` -- 22 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the internal dependency gating and core initialization mechanism to include enhanced autostart configuration handling, providing improved control over system module loading and initialization sequences.

* **Tests**
  * Added comprehensive test coverage to verify proper definition and placement of core configuration sentinel constants, ensuring system initialization integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->