### PR TITLE
fix(all): Add top-level parse_args/display_args bridge to global_defs

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -77,6 +77,24 @@ def get_data(type)
   $setupfiles.get_data(type)
 end
 
+# Parses script arguments against definition patterns.
+# Delegates to Lich::Common::ArgParser.
+#
+# @param defn [Array<Array<Hash>>] argument definition sets
+# @param flex_args [Boolean] whether to allow unmatched args
+# @return [OpenStruct] matched arguments, or exits with help
+def parse_args(defn, flex_args = false)
+  Lich::Common::ArgParser.new.parse_args(defn, flex_args)
+end
+
+# Displays help/usage information for a script's arguments.
+# Delegates to Lich::Common::ArgParser.
+#
+# @param defn [Array<Array<Hash>>] argument definition sets
+def display_args(defn)
+  Lich::Common::ArgParser.new.display_args(defn)
+end
+
 def before_dying(&code)
   Script.at_exit(&code)
 end

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -9,6 +9,7 @@ module Lich
   module Common
     CORE_GET_SETTINGS = true
     CORE_SCRIPT_LOADER = true
+    CORE_PARSE_ARGS = true
   end
 end
 

--- a/spec/lib/global_defs_spec.rb
+++ b/spec/lib/global_defs_spec.rb
@@ -311,3 +311,46 @@ RSpec.describe '#fput' do
     end
   end
 end
+
+require 'common/arg_parser'
+
+RSpec.describe '#parse_args / #display_args bridge' do
+  def parse_args(defn, flex_args = false)
+    Lich::Common::ArgParser.new.parse_args(defn, flex_args)
+  end
+
+  def display_args(defn)
+    Lich::Common::ArgParser.new.display_args(defn)
+  end
+
+  let(:parser) { instance_double(Lich::Common::ArgParser) }
+
+  before do
+    allow(Lich::Common::ArgParser).to receive(:new).and_return(parser)
+  end
+
+  describe '#parse_args' do
+    it 'delegates to Lich::Common::ArgParser#parse_args' do
+      defs = [[:some_defs]]
+      expect(parser).to receive(:parse_args).with(defs, false)
+
+      parse_args(defs)
+    end
+
+    it 'forwards the flex_args parameter' do
+      defs = [[:some_defs]]
+      expect(parser).to receive(:parse_args).with(defs, true)
+
+      parse_args(defs, true)
+    end
+  end
+
+  describe '#display_args' do
+    it 'delegates to Lich::Common::ArgParser#display_args' do
+      defs = [[:some_defs]]
+      expect(parser).to receive(:display_args).with(defs)
+
+      display_args(defs)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `parse_args()` and `display_args()` as top-level functions in `global_defs.rb`, following the same delegation pattern as `get_settings()` and `get_data()`
- Both delegate to `Lich::Common::ArgParser` which already exists in `lib/common/arg_parser.rb`
- Fixes `NoMethodError: undefined method 'parse_args'` when scripts start before `dependency.lic` loads

## Context

`parse_args()` is called by dozens of DR scripts (tome, moonwatch, etc.) as a bare top-level method. Currently this bridge only exists in `dependency.lic:148` -- core lich provides `Lich::Common::ArgParser` class but no top-level wrapper. If any script starts before dependency loads, it crashes:

```
--- Lich: error: undefined method 'parse_args' for an instance of Lich::Common::Tome
--- Lich: error: undefined method 'parse_args' for module Lich::Common
```

This mirrors how `get_settings()` delegates to `Lich::Common::SetupFiles` -- `parse_args()` should be available from core without requiring dependency to load first.

## Test plan

- [ ] Verify scripts calling `parse_args()` work regardless of dependency load order
- [ ] Verify `display_args()` (help output) works via the core bridge
- [ ] Confirm dependency.lic's duplicate definition is harmless (last-defined wins, identical behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper utilities to parse command arguments and display usage/argument information for scripts.

* **Tests**
  * Added test coverage verifying argument parsing and usage-display behavior and their integration with the argument parser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->