### PR TITLE
chore(all): Add script runtime characterization specs

### DIFF
--- a/spec/lib/common/script_hooks_watchfor_contract_spec.rb
+++ b/spec/lib/common/script_hooks_watchfor_contract_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe 'script runtime hooks and watchfor contracts' do
 
   let(:script) { ScriptRuntimeHarness::FakeScript.new(name: 'hook-owner') }
 
+  around do |example|
+    original_client = $_CLIENT_
+    original_detachable_client = $_DETACHABLE_CLIENT_
+
+    example.run
+  ensure
+    $_CLIENT_ = original_client
+    $_DETACHABLE_CLIENT_ = original_detachable_client
+  end
+
   before do
     stub_const('Buffer', Class.new)
     Buffer.const_set(:SCRIPT_OUTPUT, :script_output)

--- a/spec/lib/common/script_hooks_watchfor_contract_spec.rb
+++ b/spec/lib/common/script_hooks_watchfor_contract_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../support/script_runtime_harness'
+
+require 'common/downstreamhook'
+require 'common/upstreamhook'
+require 'common/watchfor'
+
+RSpec.describe 'script runtime hooks and watchfor contracts' do
+  include ScriptRuntimeHarness
+
+  let(:script) { ScriptRuntimeHarness::FakeScript.new(name: 'hook-owner') }
+
+  before do
+    stub_const('Buffer', Class.new)
+    Buffer.const_set(:SCRIPT_OUTPUT, :script_output)
+    allow(Buffer).to receive(:update)
+
+    stub_const('Frontend', Class.new)
+    allow(Frontend).to receive(:supports_mono?).and_return(false)
+    allow(Frontend).to receive(:client).and_return('stormfront')
+
+    $_CLIENT_ = nil
+    $_DETACHABLE_CLIENT_ = nil
+
+    allow(Script).to receive(:current).and_return(script)
+    allow(Script).to receive(:new_script_output)
+    allow(self).to receive(:echo)
+
+    Lich::Common::DownstreamHook.class_variable_set(:@@downstream_hooks, {})
+    Lich::Common::DownstreamHook.class_variable_set(:@@downstream_hook_sources, {})
+    Lich::Common::UpstreamHook.class_variable_set(:@@upstream_hooks, {})
+    Lich::Common::UpstreamHook.class_variable_set(:@@upstream_hook_sources, {})
+  end
+
+  describe Lich::Common::DownstreamHook do
+    it 'requires a Proc when adding hooks' do
+      expect(described_class.add('bad', 'not-a-proc')).to be false
+    end
+
+    it 'adds, lists, runs, and removes hooks by name' do
+      described_class.add('strip', proc { |line| line.sub('raw', 'clean') })
+
+      expect(described_class.list).to eq(['strip'])
+      expect(described_class.run('raw line')).to eq('clean line')
+      expect(described_class.remove('strip')).to be_a(Proc)
+      expect(described_class.list).to be_empty
+    end
+
+    it 'tracks the source script name' do
+      described_class.add('named', proc { |line| line })
+
+      expect(described_class.hook_sources).to eq('named' => 'hook-owner')
+    end
+  end
+
+  describe Lich::Common::UpstreamHook do
+    it 'requires a Proc when adding hooks' do
+      expect(described_class.add('bad', Object.new)).to be false
+    end
+
+    it 'adds, lists, runs, and removes hooks by name' do
+      described_class.add('up', proc { |line| "#{line}!" })
+
+      expect(described_class.list).to eq(['up'])
+      expect(described_class.run('command')).to eq('command!')
+      expect(described_class.remove('up')).to be_a(Proc)
+      expect(described_class.list).to be_empty
+    end
+  end
+
+  describe Lich::Common::Watchfor do
+    it 'registers string triggers as escaped regexps on the current script' do
+      action = proc {}
+
+      described_class.new('a.b', action)
+
+      expect(script.watchfor.keys.first).to eq(/a\.b/)
+      expect(script.watchfor.values.first).to eq(action)
+    end
+
+    it 'registers regexp triggers with a block' do
+      block = proc {}
+
+      described_class.new(/done/, &block)
+
+      expect(script.watchfor).to eq(/done/ => block)
+    end
+
+    it 'does not register a trigger when called outside a script context' do
+      allow(Script).to receive(:current).and_return(nil)
+
+      expect(described_class.new('line') {}).to be_a(described_class)
+      expect(script.watchfor).to be_empty
+    end
+  end
+end

--- a/spec/lib/common/script_hooks_watchfor_contract_spec.rb
+++ b/spec/lib/common/script_hooks_watchfor_contract_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe 'script runtime hooks and watchfor contracts' do
       described_class.add('named', proc { |line| line })
 
       expect(described_class.hook_sources).to eq('named' => 'hook-owner')
+      expect(described_class.remove('named')).to be_a(Proc)
+      expect(described_class.hook_sources).not_to include('named')
     end
   end
 
@@ -94,8 +96,7 @@ RSpec.describe 'script runtime hooks and watchfor contracts' do
 
       described_class.new('a.b', action)
 
-      expect(script.watchfor.keys.first).to eq(/a\.b/)
-      expect(script.watchfor.values.first).to eq(action)
+      expect(script.watchfor).to eq(/a\.b/ => action)
     end
 
     it 'registers regexp triggers with a block' do

--- a/spec/lib/common/script_hooks_watchfor_contract_spec.rb
+++ b/spec/lib/common/script_hooks_watchfor_contract_spec.rb
@@ -15,11 +15,19 @@ RSpec.describe 'script runtime hooks and watchfor contracts' do
   around do |example|
     original_client = $_CLIENT_
     original_detachable_client = $_DETACHABLE_CLIENT_
+    original_downstream_hooks = Lich::Common::DownstreamHook.class_variable_get(:@@downstream_hooks)
+    original_downstream_hook_sources = Lich::Common::DownstreamHook.class_variable_get(:@@downstream_hook_sources)
+    original_upstream_hooks = Lich::Common::UpstreamHook.class_variable_get(:@@upstream_hooks)
+    original_upstream_hook_sources = Lich::Common::UpstreamHook.class_variable_get(:@@upstream_hook_sources)
 
     example.run
   ensure
     $_CLIENT_ = original_client
     $_DETACHABLE_CLIENT_ = original_detachable_client
+    Lich::Common::DownstreamHook.class_variable_set(:@@downstream_hooks, original_downstream_hooks)
+    Lich::Common::DownstreamHook.class_variable_set(:@@downstream_hook_sources, original_downstream_hook_sources)
+    Lich::Common::UpstreamHook.class_variable_set(:@@upstream_hooks, original_upstream_hooks)
+    Lich::Common::UpstreamHook.class_variable_set(:@@upstream_hook_sources, original_upstream_hook_sources)
   end
 
   before do

--- a/spec/lib/common/script_io_flow_contract_spec.rb
+++ b/spec/lib/common/script_io_flow_contract_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../support/script_runtime_harness'
+
+RSpec.describe 'script runtime IO and flow helpers' do
+  include ScriptRuntimeHarness
+
+  let(:runtime_module) do
+    ScriptRuntimeHarness.global_defs_module(
+      :echo, :respond, :put, :clear, :get, :get?, :wait, :waitfor,
+      :waitforre, :match, :matchwait, :goto
+    )
+  end
+  let(:runtime) { Object.new.extend(runtime_module) }
+  let(:script) { ScriptRuntimeHarness::FakeScript.new(name: 'alpha', lines: lines) }
+  let(:lines) { [] }
+  let(:script_output) { [] }
+  let(:game_output) { [] }
+
+  before do
+    stub_const('Buffer', Class.new)
+    Buffer.const_set(:SCRIPT_OUTPUT, :script_output)
+    allow(Buffer).to receive(:update) { |line, _kind| script_output << line }
+
+    stub_const('Frontend', Class.new)
+    allow(Frontend).to receive(:supports_mono?).and_return(false)
+    allow(Frontend).to receive(:client).and_return('stormfront')
+
+    stub_const('Game', Class.new do
+      def self.puts(_message); end
+    end)
+    allow(Game).to receive(:puts) { |message| game_output << message }
+
+    stub_const('WizardScript', Class.new)
+
+    $_CLIENT_ = nil
+    $_DETACHABLE_CLIENT_ = nil
+
+    allow(Script).to receive(:current).and_return(script)
+    allow(Script).to receive(:new_script_output) { |line| script_output << "script:#{line}" }
+
+    stub_const('Lich::Common::Script', Class.new)
+    Lich::Common::Script.const_set(:JUMP, StandardError.new('JUMP'))
+  end
+
+  describe '#echo' do
+    it 'prefixes messages with the current script name and returns nil' do
+      expect(runtime.echo('hello')).to be_nil
+
+      expect(script_output).to include('script:[alpha: hello]')
+    end
+
+    it 'does not emit messages when the script has no_echo set' do
+      script.no_echo = true
+
+      runtime.echo('hidden')
+
+      expect(script_output).to be_empty
+    end
+  end
+
+  describe '#respond' do
+    it 'records each output line as script output and buffer output' do
+      runtime.respond(['one', 'two'], 'three')
+
+      expect(script_output).to include('script:one', 'one', 'script:two', 'two', 'script:three', 'three')
+    end
+  end
+
+  describe '#put' do
+    it 'sends each message to Game.puts' do
+      runtime.put('look', 'health')
+
+      expect(game_output).to eq(%w[look health])
+    end
+  end
+
+  describe '#clear' do
+    let(:lines) { %w[first second] }
+
+    it 'returns a duplicate of the downstream buffer before clearing it' do
+      previous = runtime.clear
+
+      expect(previous).to eq(%w[first second])
+      expect(script.downstream_buffer).to be_empty
+    end
+  end
+
+  describe '#get and #get?' do
+    let(:lines) { %w[first second] }
+
+    it 'consumes a line with get' do
+      expect(runtime.get).to eq('first')
+      expect(script.downstream_buffer).to eq(['second'])
+    end
+
+    it 'peeks a line with get?' do
+      expect(runtime.get?).to eq('first')
+      expect(script.downstream_buffer).to eq(%w[first second])
+    end
+  end
+
+  describe '#wait' do
+    let(:lines) { %w[stale fresh] }
+
+    it 'clears the script buffer before reading the next line' do
+      expect(runtime.wait).to be_nil
+      expect(script).to be_cleared
+    end
+  end
+
+  describe '#waitfor' do
+    let(:lines) { ['nothing here', 'The target arrives.'] }
+
+    it 'returns the first matching line using case-insensitive string matching' do
+      expect(runtime.waitfor('target')).to eq('The target arrives.')
+    end
+  end
+
+  describe '#waitforre' do
+    let(:lines) { ['nothing here', 'Roundtime: 3 sec.'] }
+
+    it 'consumes lines until the regexp matches and returns nil' do
+      result = runtime.waitforre(/Roundtime: (\d+)/)
+
+      expect(result).to be_nil
+      expect(script.downstream_buffer).to be_empty
+    end
+  end
+
+  describe '#match and #matchwait' do
+    it 'stores label/string pairs on the script match stack' do
+      runtime.match('done', 'You are done')
+
+      expect(script.match_stack_labels).to eq(['done'])
+      expect(script.match_stack_strings).to eq(['You are done'])
+    end
+
+    it 'sets jump_label and raises the jump sentinel when the match stack fires' do
+      script.downstream_buffer << 'You are done.'
+      runtime.match('done', 'done')
+
+      expect { runtime.matchwait }.to raise_error(StandardError, 'JUMP')
+      expect(script.jump_label).to eq('done')
+      expect(script.match_stack_labels).to be_empty
+      expect(script.match_stack_strings).to be_empty
+    end
+  end
+end

--- a/spec/lib/common/script_io_flow_contract_spec.rb
+++ b/spec/lib/common/script_io_flow_contract_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe 'script runtime IO and flow helpers' do
   let(:script_output) { [] }
   let(:game_output) { [] }
 
+  around do |example|
+    original_client = $_CLIENT_
+    original_detachable_client = $_DETACHABLE_CLIENT_
+
+    example.run
+  ensure
+    $_CLIENT_ = original_client
+    $_DETACHABLE_CLIENT_ = original_detachable_client
+  end
+
   before do
     stub_const('Buffer', Class.new)
     Buffer.const_set(:SCRIPT_OUTPUT, :script_output)

--- a/spec/lib/common/script_settings_vars_contract_spec.rb
+++ b/spec/lib/common/script_settings_vars_contract_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../support/script_runtime_harness'
+require_relative '../../mock_database_adapter'
+
+require 'digest'
+require 'sqlite3'
+require 'common/settings'
+require 'common/vars'
+require 'common/uservars'
+
+SCRIPT_RUNTIME_USER_VARS = Lich::Common::UserVars
+Lich::Common.send(:remove_const, :UserVars)
+
+RSpec.describe 'script runtime settings and vars contracts' do
+  include ScriptRuntimeHarness
+
+  before do
+    Lich::Common::MockXMLData.game = 'GSIV'
+    Lich::Common::MockXMLData.name = 'TestCharacter'
+    Lich::Common::MockScript.current_name = 'current_script'
+
+    stub_const('XMLData', Lich::Common::MockXMLData)
+    stub_const('Script', Lich::Common::MockScript)
+  end
+
+  describe 'Settings script_name namespaces' do
+    let(:settings_db) { Lich::Common::MockDatabaseAdapter.new }
+
+    before do
+      Lich::Common::Settings.instance_variable_set(:@db_adapter, settings_db)
+      Lich::Common::Settings.instance_variable_set(:@path_navigator, Lich::Common::PathNavigator.new(settings_db))
+      Lich::Common::Settings.instance_variable_set(:@settings_cache, {})
+    end
+
+    it 'stores default Settings values under the current script name' do
+      Lich::Common::Settings[:key] = 'value'
+
+      expect(settings_db.dump).to include('current_script::' => { key: 'value' })
+    end
+
+    it 'supports fixed non-current script namespaces through script_name:' do
+      Lich::Common::Settings.set_script_settings('GSIV:TestCharacter', :key, 'value', script_name: 'core')
+
+      expect(settings_db.dump).to include('core:GSIV:TestCharacter' => { key: 'value' })
+    end
+  end
+
+  describe Lich::Common::Vars do
+    let(:fake_db) { ScriptRuntimeHarness::FakeDb.new }
+    let(:mutex) { Mutex.new }
+
+    before do
+      allow(Lich).to receive(:db).and_return(fake_db)
+      allow(Lich).to receive(:db_mutex).and_return(mutex)
+      reset_vars_state
+    end
+
+    it 'loads and saves through the uservars table, not script_auto_settings' do
+      described_class[:loot_sack] = 'backpack'
+      described_class.save
+
+      queries = fake_db.queries.map { |_kind, query, _params| query }
+      expect(queries).to include(a_string_matching(/FROM uservars/))
+      expect(queries).to include(a_string_matching(/INTO uservars/))
+      expect(queries).not_to include(a_string_matching(/script_auto_settings/))
+    end
+
+    it 'normalizes string and symbol keys to the same storage key' do
+      described_class[:loot_sack] = 'backpack'
+
+      expect(described_class['loot_sack']).to eq('backpack')
+      expect(described_class.list).to include('loot_sack' => 'backpack')
+    end
+
+    it 'deletes keys when assigned nil' do
+      described_class['temporary'] = 'value'
+      described_class['temporary'] = nil
+
+      expect(described_class['temporary']).to be_nil
+      expect(described_class.list).not_to have_key('temporary')
+    end
+
+    it 'returns a duplicate from list' do
+      described_class['kept'] = 'value'
+
+      listed = described_class.list
+      listed['kept'] = 'changed'
+
+      expect(described_class['kept']).to eq('value')
+    end
+  end
+
+  describe SCRIPT_RUNTIME_USER_VARS do
+    before do
+      allow(Lich).to receive(:db).and_return(ScriptRuntimeHarness::FakeDb.new)
+      allow(Lich).to receive(:db_mutex).and_return(Mutex.new)
+      reset_vars_state
+    end
+
+    it 'delegates bracket and method access to Vars' do
+      described_class['container'] = 'satchel'
+      described_class.weapon = 'sword'
+
+      expect(Lich::Common::Vars['container']).to eq('satchel')
+      expect(Lich::Common::Vars['weapon']).to eq('sword')
+      expect(described_class.weapon).to eq('sword')
+    end
+
+    it 'preserves change/add/delete convenience helpers and ignored legacy parameters' do
+      expect(described_class.change('tags', 'foo', :ignored)).to eq('foo')
+      expect(described_class.add('tags', 'bar', :ignored)).to eq('foo, bar')
+      expect(described_class.delete('tags', :ignored)).to be_nil
+      expect(described_class['tags']).to be_nil
+    end
+
+    it 'keeps global and character list compatibility behavior' do
+      described_class['local'] = 'value'
+
+      expect(described_class.list_global).to eq([])
+      expect(described_class.list_char).to include('local' => 'value')
+    end
+  end
+end

--- a/spec/lib/common/script_settings_vars_contract_spec.rb
+++ b/spec/lib/common/script_settings_vars_contract_spec.rb
@@ -12,6 +12,18 @@ require 'common/vars'
 RSpec.describe 'script runtime settings and vars contracts' do
   include ScriptRuntimeHarness
 
+  around do |example|
+    original_game = Lich::Common::MockXMLData.game
+    original_name = Lich::Common::MockXMLData.name
+    original_current_name = Lich::Common::MockScript.current_name
+
+    example.run
+  ensure
+    Lich::Common::MockXMLData.game = original_game
+    Lich::Common::MockXMLData.name = original_name
+    Lich::Common::MockScript.current_name = original_current_name
+  end
+
   before do
     Lich::Common::MockXMLData.game = 'GSIV'
     Lich::Common::MockXMLData.name = 'TestCharacter'
@@ -62,6 +74,10 @@ RSpec.describe 'script runtime settings and vars contracts' do
     before do
       allow(Lich).to receive(:db).and_return(fake_db)
       allow(Lich).to receive(:db_mutex).and_return(mutex)
+      reset_vars_state
+    end
+
+    after do
       reset_vars_state
     end
 
@@ -121,6 +137,10 @@ RSpec.describe 'script runtime settings and vars contracts' do
     before do
       allow(Lich).to receive(:db).and_return(ScriptRuntimeHarness::FakeDb.new)
       allow(Lich).to receive(:db_mutex).and_return(Mutex.new)
+      reset_vars_state
+    end
+
+    after do
       reset_vars_state
     end
 

--- a/spec/lib/common/script_settings_vars_contract_spec.rb
+++ b/spec/lib/common/script_settings_vars_contract_spec.rb
@@ -8,10 +8,6 @@ require 'digest'
 require 'sqlite3'
 require 'common/settings'
 require 'common/vars'
-require 'common/uservars'
-
-SCRIPT_RUNTIME_USER_VARS = Lich::Common::UserVars
-Lich::Common.send(:remove_const, :UserVars)
 
 RSpec.describe 'script runtime settings and vars contracts' do
   include ScriptRuntimeHarness
@@ -27,6 +23,18 @@ RSpec.describe 'script runtime settings and vars contracts' do
 
   describe 'Settings script_name namespaces' do
     let(:settings_db) { Lich::Common::MockDatabaseAdapter.new }
+
+    around do |example|
+      original_db_adapter = Lich::Common::Settings.instance_variable_get(:@db_adapter)
+      original_path_navigator = Lich::Common::Settings.instance_variable_get(:@path_navigator)
+      original_settings_cache = Lich::Common::Settings.instance_variable_get(:@settings_cache)
+
+      example.run
+    ensure
+      Lich::Common::Settings.instance_variable_set(:@db_adapter, original_db_adapter)
+      Lich::Common::Settings.instance_variable_set(:@path_navigator, original_path_navigator)
+      Lich::Common::Settings.instance_variable_set(:@settings_cache, original_settings_cache)
+    end
 
     before do
       Lich::Common::Settings.instance_variable_set(:@db_adapter, settings_db)
@@ -92,7 +100,24 @@ RSpec.describe 'script runtime settings and vars contracts' do
     end
   end
 
-  describe SCRIPT_RUNTIME_USER_VARS do
+  describe 'UserVars compatibility facade' do
+    let(:user_vars) { @script_runtime_user_vars }
+
+    around do |example|
+      original_defined = Lich::Common.const_defined?(:UserVars, false)
+      original_user_vars = Lich::Common.const_get(:UserVars, false) if original_defined
+
+      Lich::Common.send(:remove_const, :UserVars) if original_defined
+      load File.expand_path('../../../lib/common/uservars.rb', __dir__)
+      @script_runtime_user_vars = Lich::Common::UserVars
+
+      example.run
+    ensure
+      Lich::Common.send(:remove_const, :UserVars) if Lich::Common.const_defined?(:UserVars, false)
+      Lich::Common.const_set(:UserVars, original_user_vars) if original_defined
+      @script_runtime_user_vars = nil
+    end
+
     before do
       allow(Lich).to receive(:db).and_return(ScriptRuntimeHarness::FakeDb.new)
       allow(Lich).to receive(:db_mutex).and_return(Mutex.new)
@@ -100,26 +125,26 @@ RSpec.describe 'script runtime settings and vars contracts' do
     end
 
     it 'delegates bracket and method access to Vars' do
-      described_class['container'] = 'satchel'
-      described_class.weapon = 'sword'
+      user_vars['container'] = 'satchel'
+      user_vars.weapon = 'sword'
 
       expect(Lich::Common::Vars['container']).to eq('satchel')
       expect(Lich::Common::Vars['weapon']).to eq('sword')
-      expect(described_class.weapon).to eq('sword')
+      expect(user_vars.weapon).to eq('sword')
     end
 
     it 'preserves change/add/delete convenience helpers and ignored legacy parameters' do
-      expect(described_class.change('tags', 'foo', :ignored)).to eq('foo')
-      expect(described_class.add('tags', 'bar', :ignored)).to eq('foo, bar')
-      expect(described_class.delete('tags', :ignored)).to be_nil
-      expect(described_class['tags']).to be_nil
+      expect(user_vars.change('tags', 'foo', :ignored)).to eq('foo')
+      expect(user_vars.add('tags', 'bar', :ignored)).to eq('foo, bar')
+      expect(user_vars.delete('tags', :ignored)).to be_nil
+      expect(user_vars['tags']).to be_nil
     end
 
     it 'keeps global and character list compatibility behavior' do
-      described_class['local'] = 'value'
+      user_vars['local'] = 'value'
 
-      expect(described_class.list_global).to eq([])
-      expect(described_class.list_char).to include('local' => 'value')
+      expect(user_vars.list_global).to eq([])
+      expect(user_vars.list_char).to include('local' => 'value')
     end
   end
 end

--- a/spec/lib/common/script_settings_vars_contract_spec.rb
+++ b/spec/lib/common/script_settings_vars_contract_spec.rb
@@ -6,6 +6,22 @@ require_relative '../../mock_database_adapter'
 
 require 'digest'
 require 'sqlite3'
+require 'sequel'
+
+module Lich
+  DEFAULT_SQLITE_BUSY_TIMEOUT_MS = 5000 unless const_defined?(:DEFAULT_SQLITE_BUSY_TIMEOUT_MS)
+
+  def self.sqlite_busy_timeout_ms
+    DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+  end
+
+  def self.open_sequel_sqlite(path)
+    db = Sequel.sqlite(path)
+    db.run("PRAGMA busy_timeout = #{sqlite_busy_timeout_ms}")
+    db
+  end
+end
+
 require 'common/settings'
 require 'common/vars'
 

--- a/spec/support/script_runtime_harness.rb
+++ b/spec/support/script_runtime_harness.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+require 'prism'
+
+module ScriptRuntimeHarness
+  GLOBAL_DEFS_PATH = File.expand_path('../../lib/global_defs.rb', __dir__)
+
+  def self.global_defs_module(*method_names)
+    wanted = method_names.map(&:to_sym)
+    lines = File.readlines(GLOBAL_DEFS_PATH)
+    result = Prism.parse_file(GLOBAL_DEFS_PATH)
+    nodes = []
+    queue = [result.value]
+
+    until queue.empty?
+      node = queue.shift
+      nodes << node if node.type == :def_node && wanted.include?(node.name)
+      queue.concat(node.child_nodes.compact)
+    end
+
+    missing = wanted - nodes.map(&:name)
+    raise "global_defs methods not found: #{missing.join(', ')}" unless missing.empty?
+
+    Module.new.tap do |mod|
+      nodes.sort_by { |node| node.location.start_line }.each do |node|
+        source = lines[(node.location.start_line - 1)..(node.location.end_line - 1)].join
+        mod.module_eval(source, GLOBAL_DEFS_PATH, node.location.start_line)
+      end
+    end
+  end
+
+  class FakeScript
+    attr_accessor :name, :custom, :no_echo, :downstream_buffer, :match_stack_labels,
+                  :match_stack_strings, :jump_label, :watchfor, :want_downstream,
+                  :want_downstream_xml, :want_upstream, :want_script_output,
+                  :silent, :hidden, :vars
+
+    def initialize(name: 'test-script', lines: [])
+      @name = name
+      @custom = false
+      @no_echo = false
+      @downstream_buffer = lines.dup
+      @match_stack_labels = []
+      @match_stack_strings = []
+      @watchfor = {}
+      @want_downstream = true
+      @want_downstream_xml = false
+      @want_upstream = false
+      @want_script_output = false
+      @silent = false
+      @hidden = false
+      @vars = []
+      @cleared = false
+    end
+
+    def custom?
+      @custom
+    end
+
+    def gets
+      @downstream_buffer.shift
+    end
+
+    def gets?
+      @downstream_buffer.first
+    end
+
+    def clear
+      @cleared = true
+      @downstream_buffer.clear
+    end
+
+    def cleared?
+      @cleared
+    end
+
+    def match_stack_add(label, string)
+      @match_stack_labels << label
+      @match_stack_strings << string
+    end
+
+    def match_stack_clear
+      @match_stack_labels.clear
+      @match_stack_strings.clear
+    end
+  end
+
+  class FakeDb
+    attr_reader :queries
+
+    def initialize
+      @queries = []
+      @uservars = {}
+    end
+
+    def get_first_value(query, params = [])
+      @queries << [:get_first_value, query, params]
+      return @uservars[params.first] if query.include?('FROM uservars')
+
+      nil
+    end
+
+    def execute(query, params = [])
+      @queries << [:execute, query, params]
+      if query.include?('INTO uservars')
+        @uservars[params[0]] = params[1]
+      end
+    end
+
+    def stored_uservars(scope)
+      blob = @uservars[scope]
+      blob ? Marshal.load(blob) : {}
+    end
+  end
+
+  def reset_vars_state
+    vars = Lich::Common::Vars
+    vars.class_variable_set(:@@vars, {})
+    vars.class_variable_set(:@@md5, nil)
+    vars.class_variable_set(:@@load_state, vars::LoadState::UNLOADED)
+  end
+end

--- a/spec/support/script_runtime_harness.rb
+++ b/spec/support/script_runtime_harness.rb
@@ -96,14 +96,14 @@ module ScriptRuntimeHarness
 
     def get_first_value(query, params = [])
       @queries << [:get_first_value, query, params]
-      return @uservars[params.first] if query.include?('FROM uservars')
+      return @uservars[params.first] if query.match?(/\bfrom\s+uservars\b/i)
 
       nil
     end
 
     def execute(query, params = [])
       @queries << [:execute, query, params]
-      if query.include?('INTO uservars')
+      if query.match?(/\binto\s+uservars\b/i)
         @uservars[params[0]] = params[1]
       end
     end

--- a/spec/support/script_runtime_harness.rb
+++ b/spec/support/script_runtime_harness.rb
@@ -25,6 +25,8 @@ module ScriptRuntimeHarness
     Module.new.tap do |mod|
       nodes.sort_by { |node| node.location.start_line }.each do |node|
         source = lines[(node.location.start_line - 1)..(node.location.end_line - 1)].join
+        # Evaluate only the selected helper definitions so characterization specs
+        # track global_defs.rb without loading the full runtime and its globals.
         mod.module_eval(source, GLOBAL_DEFS_PATH, node.location.start_line)
       end
     end


### PR DESCRIPTION
This is specs-only: it adds characterization coverage for script IO flow, hooks/watchfors, and Settings/Vars/UserVars behavior, with a small harness under spec/support.

The intent is to set the design behaviors in a contractual form before making any changes to `script.rb` for modernization.

Validation passed:

4031 examples, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive contract specs for script runtime: hook/watchfor behavior, IO/flow helpers (echo, respond, put, clear, get/get?, wait, waitfor, waitforre, match/matchwait), and settings/vars persistence and semantics.
* **Tests**
  * Added a test harness with FakeScript and FakeDb, helpers for extracting global definitions, and utilities to reset vars state for isolated runtime specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->