### PR TITLE
ci(all): Make RuboCop check required-safe

### DIFF
--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -1,3 +1,18 @@
+# ------------------------------------------------------------------------------
+# RuboCop CI: required-check-safe preflight
+#
+# Purpose
+# - Keep the RuboCop check present and green for branch protection on every
+#   push/PR, while skipping the expensive Ruby setup and lint run when a change
+#   only touches files RuboCop cannot inspect.
+#
+# How preflight decides
+# - For pull_request: lists changed files via pulls.listFiles.
+# - For push: compares commits between before and the new SHA.
+# - If any changed file is Ruby-lintable, should_lint = true.
+# - If it cannot determine the file list, it defaults to should_lint = true for
+#   safety.
+# ------------------------------------------------------------------------------
 name: Rubocop
 on: 
   push:
@@ -5,15 +20,7 @@ on:
       - master
       - staging
       - main
-    paths:
-      - "**/*.lic"
-      - "**/*.rb"
-      - "lich.rbw"
   pull_request:
-    paths:
-      - "**/*.lic"
-      - "**/*.rb"
-      - "lich.rbw"
 
 jobs:
   rubocop:
@@ -22,14 +29,63 @@ jobs:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
     name: Run Rubocop on Ruby
     steps:
+      - name: Classify changed files (preflight)
+        id: preflight
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const ev    = context.eventName;
+            function isRubyLintable(path) {
+              return path.endsWith('.rb') ||
+                path.endsWith('.lic') ||
+                path === 'lich.rbw';
+            }
+            async function changedFilesForPR(number) {
+              const files = await github.paginate(
+                github.rest.pulls.listFiles,
+                { owner, repo, pull_number: number, per_page: 100 }
+              );
+              return files.map(f => f.filename);
+            }
+            async function changedFilesForPush() {
+              const before = (context.payload.before || '').trim();
+              const head   = context.sha;
+              if (!before) return null;
+              const cmp = await github.rest.repos.compareCommits({ owner, repo, base: before, head });
+              return (cmp.data.files || []).map(f => f.filename);
+            }
+            let files = null;
+            if (ev === 'pull_request') {
+              const num = context.payload.pull_request && context.payload.pull_request.number;
+              files = num ? await changedFilesForPR(num) : null;
+            } else if (ev === 'push') {
+              files = await changedFilesForPush();
+            }
+            if (!files || files.length === 0) {
+              core.notice('Preflight: could not determine changed files; defaulting to run RuboCop.');
+              core.setOutput('should_lint', 'true');
+            } else {
+              const lintable = files.filter(isRubyLintable);
+              const should = lintable.length > 0;
+              core.notice(`Preflight: changed files = ${files.length}, lintable = ${lintable.length}; should_lint=${should}`);
+              core.setOutput('should_lint', should ? 'true' : 'false');
+            }
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.preflight.outputs.should_lint == 'true'
         with:
           fetch-depth: 0
       
       - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+        if: steps.preflight.outputs.should_lint == 'true'
         with:
           bundler-cache: true
 
       - name: Rubocop
+        if: steps.preflight.outputs.should_lint == 'true'
         run: |
           bundle exec rubocop
+      - name: RuboCop skipped (no Ruby-lintable files changed)
+        if: steps.preflight.outputs.should_lint != 'true'
+        run: echo "Preflight determined no Ruby-lintable files changed; skipping RuboCop."

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -56,21 +56,26 @@ jobs:
               const cmp = await github.rest.repos.compareCommits({ owner, repo, base: before, head });
               return (cmp.data.files || []).map(f => f.filename);
             }
-            let files = null;
-            if (ev === 'pull_request') {
-              const num = context.payload.pull_request && context.payload.pull_request.number;
-              files = num ? await changedFilesForPR(num) : null;
-            } else if (ev === 'push') {
-              files = await changedFilesForPush();
-            }
-            if (!files || files.length === 0) {
-              core.notice('Preflight: could not determine changed files; defaulting to run RuboCop.');
+            try {
+              let files = null;
+              if (ev === 'pull_request') {
+                const num = context.payload.pull_request && context.payload.pull_request.number;
+                files = num ? await changedFilesForPR(num) : null;
+              } else if (ev === 'push') {
+                files = await changedFilesForPush();
+              }
+              if (!files || files.length === 0) {
+                core.notice('Preflight: could not determine changed files; defaulting to run RuboCop.');
+                core.setOutput('should_lint', 'true');
+              } else {
+                const lintable = files.filter(isRubyLintable);
+                const should = lintable.length > 0;
+                core.notice(`Preflight: changed files = ${files.length}, lintable = ${lintable.length}; should_lint=${should}`);
+                core.setOutput('should_lint', should ? 'true' : 'false');
+              }
+            } catch (error) {
+              core.error(`Preflight failed: ${error.message || error}`);
               core.setOutput('should_lint', 'true');
-            } else {
-              const lintable = files.filter(isRubyLintable);
-              const should = lintable.length > 0;
-              core.notice(`Preflight: changed files = ${files.length}, lintable = ${lintable.length}; should_lint=${should}`);
-              core.setOutput('should_lint', should ? 'true' : 'false');
             }
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.preflight.outputs.should_lint == 'true'


### PR DESCRIPTION
## Summary

Updates the RuboCop workflow so it always creates the `Run Rubocop on Ruby` check on pull requests and main-branch pushes.

The workflow now performs a lightweight changed-file preflight:

- runs RuboCop when changed files include Ruby-lintable paths: `.rb`, `.lic`, or `lich.rbw`
- emits a successful skip message when no Ruby-lintable files changed
- defaults to running RuboCop if changed-file detection fails

## Why

This makes the RuboCop workflow safe to use as a required branch-protection check. Today the workflow is path-filtered away for docs-only PRs, so requiring it can leave those PRs permanently waiting on a check that will never be created.

This mirrors the required-check-safe pattern already used by the RSpec workflow.

## Validation

- Parsed `.github/workflows/rubocop.yaml` with Ruby YAML loader
- Proved the same change on Lich5/lich-5: https://github.com/Lich5/lich-5/pull/5

## Notes

This PR is intentionally proposed upstream for `elanthia-online/lich-5` adoption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD Improvements**
  * Lint workflow now runs on pushes to master, staging, and main and on all pull requests.
  * Preflight detects changed Ruby files and runs RuboCop only when needed, reducing unnecessary CI runs.
  * Workflow emits clear skip notices when linting is skipped and defaults to running lint if preflight cannot determine changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/lich-5/pull/1350)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->