### PR TITLE
debug(dr): log startup info lines reaching DRParser

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -388,9 +388,11 @@ module Lich
             DRStats.gender = match[:gender]
             DRStats.age = match[:age].to_i
             DRStats.circle = match[:circle].to_i
+            Lich.log("DEBUG drinfomon_startup: GenderAgeCircle matched - gender=#{match[:gender]} age=#{match[:age]} circle=#{match[:circle]}")
           elsif (match = line.match(Pattern::NameRaceGuild))
             DRStats.race = match[:race]
             DRStats.guild = match[:guild]
+            Lich.log("DEBUG drinfomon_startup: NameRaceGuild matched - race=#{match[:race]} guild=#{match[:guild]}")
           elsif (match = line.match(Pattern::EncumbranceValue))
             DRStats.encumbrance = match[:encumbrance]
           elsif (match = line.match(Pattern::LuckValue))

--- a/lib/dragonrealms/drinfomon/startup.rb
+++ b/lib/dragonrealms/drinfomon/startup.rb
@@ -82,6 +82,7 @@ module Lich
       end
 
       def self.startup_completed!
+        Lich.log("DEBUG drinfomon_startup: startup_completed! DRStats: race=#{DRStats.race.inspect} guild=#{DRStats.guild.inspect} gender=#{DRStats.gender.inspect} age=#{DRStats.age} circle=#{DRStats.circle}")
         @@startup_complete = true
         PostLoad.game_loaded! if defined?(PostLoad)
         post_startup_checks

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -927,6 +927,7 @@ module Lich
       def process_game_specific_data(server_string)
         # Parse directly to allow inline modifications (e.g., inline exp display)
         # The parser modifies server_string in place via line.replace()
+        Lich.log("DEBUG process_game_specific_data: #{server_string.inspect}") if server_string =~ /^Name:|^Gender:/
         DRParser.parse(server_string)
       end
 

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -428,7 +428,10 @@ module Lich
           # Clean server string based on game type
           if @game_instance
             server_string = @game_instance.clean_serverstring(server_string)
-            return if server_string.nil? # Buffering split component, wait for next line
+            if server_string.nil?
+              Lich.log("DEBUG drinfomon_startup: clean_serverstring returned nil, line dropped") if defined?(DRInfomon) && !DRInfomon.startup_complete?
+              return
+            end
           end
 
           # Debug output if needed
@@ -533,6 +536,7 @@ module Lich
                 retry
               else
                 handle_xml_error(server_string, e)
+                Lich.log("DEBUG drinfomon_startup: REXML unrecoverable nested quotes, line dropped: #{server_string.inspect}") if defined?(DRInfomon) && !DRInfomon.startup_complete? rescue nil
                 XMLData.reset
                 return
               end
@@ -544,6 +548,7 @@ module Lich
               retry
             else
               handle_xml_error(server_string, e)
+              Lich.log("DEBUG drinfomon_startup: REXML unhandled error, line dropped: #{server_string.inspect} error=#{e}") if defined?(DRInfomon) && !DRInfomon.startup_complete? rescue nil
               XMLData.reset
               return
             end
@@ -552,6 +557,8 @@ module Lich
           # Process game-specific data using instance
           if @game_instance && Module.const_defined?(:GameLoader)
             @game_instance.process_game_specific_data(server_string)
+          elsif server_string =~ /^Name:|^Gender:/
+            Lich.log("DEBUG drinfomon_startup: guard failed - game_instance=#{!@game_instance.nil?} GameLoader=#{Module.const_defined?(:GameLoader)} line=#{server_string.inspect}")
           end
 
           # Process downstream XML
@@ -927,7 +934,7 @@ module Lich
       def process_game_specific_data(server_string)
         # Parse directly to allow inline modifications (e.g., inline exp display)
         # The parser modifies server_string in place via line.replace()
-        Lich.log("DEBUG process_game_specific_data: #{server_string.inspect}") if server_string =~ /^Name:|^Gender:/
+        Lich.log("DEBUG drinfomon_startup: process_game_specific_data: #{server_string.inspect}") if server_string =~ /^Name:|^Gender:/
         DRParser.parse(server_string)
       end
 

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -143,6 +143,7 @@ module Lich
           end
         }
       rescue Interrupt
+        Lich.log("DEBUG drinfomon_startup: issue_command timed out after #{timeout}s for '#{command}'")
         nil
       ensure
         DownstreamHook.remove(name)


### PR DESCRIPTION
## Summary
- Adds a diagnostic log line in `process_game_specific_data` to confirm whether `Name:` and `Gender:` lines from the startup `info` command reach `DRParser.parse`
- Users report that the startup `info` fires but doesn't populate DRStats (guild, race, etc.), while manually running `info` later works
- This will identify whether the issue is the socket thread dropping lines before `DRParser.parse` (e.g., `@game_instance` guard, `buffer_room_objs` swallowing, or REXML failure)

## Test plan
- [ ] Login with the debug build and check `lich.log` for `DEBUG process_game_specific_data` entries
- [ ] If entries appear at startup, the socket pipeline is fine and the issue is in `DRParser.parse` pattern matching
- [ ] If entries only appear on manual `info`, the socket thread is dropping lines before `DRParser.parse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal improvements to game data processing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/lich-5/pull/1351)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->