### PR TITLE
fix(all): Remove debug log IO from heartbeat tick loop

### DIFF
--- a/lib/common/session_lifecycle.rb
+++ b/lib/common/session_lifecycle.rb
@@ -121,11 +121,6 @@ module Lich
                   )
                 end
 
-                Lich.log(
-                  "debug: SessionLifecycle heartbeat tick " \
-                  "pid=#{Process.pid} session=#{session_name.inspect} role=#{role.inspect} " \
-                  "tick_epoch=#{Time.now.to_i}"
-                ) if Lich.respond_to?(:log)
                 SessionsSettings.send(:heartbeat_admitted,
                                       pid: Process.pid,
                                       state: 'running',

--- a/spec/lib/common/session_lifecycle_spec.rb
+++ b/spec/lib/common/session_lifecycle_spec.rb
@@ -190,6 +190,48 @@ RSpec.describe Lich::Common::SessionLifecycle do
       expect(described_class.stop).to be(true)
     end
 
+    it 'does not emit debug log on heartbeat ticks' do
+      heartbeat_thread = instance_double(Thread)
+      allow(heartbeat_thread).to receive(:join).with(0.5)
+      allow(heartbeat_thread).to receive(:alive?).and_return(false)
+      allow(heartbeat_thread).to receive(:kill)
+
+      captured_block = nil
+      allow(Thread).to receive(:new) do |&blk|
+        captured_block = blk
+        heartbeat_thread
+      end
+
+      allow(described_class).to receive(:resolve_frontend).and_return('stormfront')
+      allow(described_class).to receive(:resolve_game_code).and_return('DR')
+      allow(described_class).to receive(:attempt_register).and_return(true)
+
+      lich_mod = Module.new do
+        def self.log(_msg); end
+
+        def self.respond_to?(method, *args)
+          return true if method == :log
+
+          super
+        end
+      end
+      stub_const('Lich', lich_mod)
+      allow(lich_mod).to receive(:log).and_call_original
+
+      sleep_calls = 0
+      allow(described_class).to receive(:sleep) do |_seconds|
+        sleep_calls += 1
+        described_class.instance_variable_set(:@running, false) if sleep_calls >= 3
+      end
+
+      described_class.start(session_name: 'Tsetem', role: 'session', heartbeat_interval: 1, registration_delay: 0)
+      captured_block.call
+
+      expect(lich_mod).not_to have_received(:log).with(a_string_matching(/debug: SessionLifecycle heartbeat tick/))
+
+      described_class.stop
+    end
+
     it 'resets lifecycle state when thread creation raises' do
       allow(described_class).to receive(:resolve_frontend).and_return('stormfront')
       allow(Thread).to receive(:new).and_raise(StandardError, 'thread create failed')


### PR DESCRIPTION
## Summary
- Removes the `Lich.log` debug line that fired every 90 seconds per session in the heartbeat tick loop
- The log was pure observability noise with no programmatic consumers, adding unnecessary disk IO
- Heartbeat upsert and session tracking continue to function identically

## Test plan
- [x] Existing specs pass (24 examples, 0 failures)
- [x] New spec verifies no debug heartbeat log is emitted during tick execution
- [x] rubocop -A clean on both touched files
- [ ] Verify reduced log volume on a running session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced debug logging verbosity during session heartbeats to minimize log noise.

* **Tests**
  * Added test coverage to verify debug logging behavior during heartbeat operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/lich-5/pull/1363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->