### PR TITLE
fix(all): Script module replace MemoryReleaser with GC.start for cleanup

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -706,9 +706,9 @@ module Lich
                 end
                 unless context == :shutdown
                   if defined?(Gtk)
-                    Gtk.queue { Lich::Util::MemoryReleaser.release }
+                    Gtk.queue { GC.start }
                   else
-                    Lich::Util::MemoryReleaser.release
+                    GC.start
                   end
                 end
               rescue


### PR DESCRIPTION
When multiple scripts exited around same time, caused a backup/queue of MemoryReleaser processing causing a slight lag/delay. Move this garbage collection back to previous `GC.start` instead of the more comprehensive MemoryReleaser module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized memory cleanup behavior during application shutdown in GTK environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/lich-5/pull/1364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->