### PR TITLE
fix(all): Add sqlite busy timeout policy to core

### DIFF
--- a/docs/sqlite-busy-timeout.md
+++ b/docs/sqlite-busy-timeout.md
@@ -1,0 +1,16 @@
+# SQLite Busy Timeout
+
+Lich configures SQLite connections opened through the core database helpers with
+a 5000 ms busy timeout.
+
+The timeout is connection-local SQLite behavior. It is applied when Lich opens a
+connection; it is not persisted in `lich.db3` and does not affect independently
+opened SQLite handles.
+
+Covered core open paths:
+
+- `Lich.db`
+- `Lich.open_sqlite_db(path)`
+- `Lich.open_sequel_sqlite(path)`
+- Settings' `lich.db3` Sequel adapter
+- Session summary adapter fallback connections

--- a/lib/common/settings/database_adapter.rb
+++ b/lib/common/settings/database_adapter.rb
@@ -4,7 +4,7 @@ module Lich
     class DatabaseAdapter
       def initialize(data_dir, table_name)
         @file = File.join(data_dir, "lich.db3")
-        @db = Sequel.sqlite(@file)
+        @db = Lich.open_sequel_sqlite(@file)
         @table_name = table_name
         setup!
       end

--- a/lib/common/settings/session_database_adapter.rb
+++ b/lib/common/settings/session_database_adapter.rb
@@ -15,7 +15,7 @@ module Lich
       # @param data_dir [String] directory containing lich.db3 when db is not injected
       # @param table_name [String] session summary table name
       def initialize(db: nil, data_dir: DATA_DIR, table_name: DEFAULT_TABLE_NAME)
-        @db = db || SQLite3::Database.new(File.join(data_dir, 'lich.db3'))
+        @db = db || open_database(File.join(data_dir, 'lich.db3'))
         @table_name = table_name
       end
 
@@ -112,6 +112,12 @@ module Lich
       end
 
       private
+
+      def open_database(path)
+        return Lich.open_sqlite_db(path) if defined?(Lich) && Lich.respond_to?(:open_sqlite_db)
+
+        SQLite3::Database.new(path)
+      end
 
       # Binds payload values in stable column order for upsert SQL.
       #

--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -1,5 +1,27 @@
 require 'time'
 module Lich
+  DEFAULT_SQLITE_BUSY_TIMEOUT_MS = 5000 unless const_defined?(:DEFAULT_SQLITE_BUSY_TIMEOUT_MS)
+
+  def Lich.sqlite_busy_timeout_ms
+    DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+  end
+
+  def Lich.configure_sqlite_connection(db)
+    db.busy_timeout(sqlite_busy_timeout_ms) if db.respond_to?(:busy_timeout)
+    db
+  end
+
+  def Lich.open_sqlite_db(path)
+    configure_sqlite_connection(SQLite3::Database.new(path))
+  end
+
+  def Lich.open_sequel_sqlite(path)
+    db = Sequel.sqlite(path)
+    # Sequel does not expose sqlite3's busy_timeout API on its database wrapper.
+    db.run("PRAGMA busy_timeout = #{sqlite_busy_timeout_ms.to_i}")
+    db
+  end
+
   # --- Minimal DB maintenance helpers (simple + safe) ---
   # Stores last maintenance timestamp and summary in lich_settings.
   # Uses an advisory OS file lock so only one Lich instance attempts VACUUM.
@@ -169,7 +191,7 @@ module Lich
   end
 
   def Lich.db
-    @@lich_db ||= SQLite3::Database.new("#{DATA_DIR}/lich.db3")
+    @@lich_db ||= open_sqlite_db("#{DATA_DIR}/lich.db3")
   end
 
   def Lich.init_db

--- a/spec/lib/common/settings/database_adapter_spec.rb
+++ b/spec/lib/common/settings/database_adapter_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+require 'sqlite3'
+require 'sequel'
+
+module Lich
+  DEFAULT_SQLITE_BUSY_TIMEOUT_MS = 5000 unless const_defined?(:DEFAULT_SQLITE_BUSY_TIMEOUT_MS)
+
+  def self.sqlite_busy_timeout_ms
+    DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+  end
+
+  def self.open_sequel_sqlite(path)
+    db = Sequel.sqlite(path)
+    db.run("PRAGMA busy_timeout = #{sqlite_busy_timeout_ms}")
+    db
+  end
+end
+
+require_relative '../../../../lib/common/settings/database_adapter'
+
+RSpec.describe Lich::Common::DatabaseAdapter do
+  let(:tmp_dir) { Dir.mktmpdir('settings-db-adapter-spec') }
+
+  after do
+    db = @adapter&.instance_variable_get(:@db)
+    db&.disconnect
+    FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir)
+  end
+
+  it 'opens settings storage with the core sqlite busy timeout' do
+    @adapter = described_class.new(tmp_dir, :script_auto_settings)
+    db = @adapter.instance_variable_get(:@db)
+
+    expect(db.fetch('PRAGMA busy_timeout;').first[:timeout]).to eq(Lich.sqlite_busy_timeout_ms)
+  end
+end

--- a/spec/lib/common/settings/session_database_adapter_spec.rb
+++ b/spec/lib/common/settings/session_database_adapter_spec.rb
@@ -6,6 +6,20 @@ require 'tmpdir'
 
 # Contract spec for the row-oriented session summary adapter.
 # This verifies DB-level behavior independently from higher-level Settings proxies.
+module Lich
+  DEFAULT_SQLITE_BUSY_TIMEOUT_MS = 5000 unless const_defined?(:DEFAULT_SQLITE_BUSY_TIMEOUT_MS)
+
+  def self.sqlite_busy_timeout_ms
+    DEFAULT_SQLITE_BUSY_TIMEOUT_MS
+  end
+
+  def self.open_sqlite_db(path)
+    db = SQLite3::Database.new(path)
+    db.busy_timeout(sqlite_busy_timeout_ms)
+    db
+  end
+end
+
 require_relative '../../../../lib/common/settings/session_database_adapter'
 
 RSpec.describe Lich::Common::SessionDatabaseAdapter do
@@ -20,6 +34,7 @@ RSpec.describe Lich::Common::SessionDatabaseAdapter do
   end
 
   after(:each) do
+    @fallback_db&.close
     sqlite_db.close if sqlite_db
     File.delete(db_path) if File.exist?(db_path)
     Dir.rmdir(tmp_dir) if Dir.exist?(tmp_dir)
@@ -54,6 +69,13 @@ RSpec.describe Lich::Common::SessionDatabaseAdapter do
       expect { described_class.new(db: sqlite_db) }.not_to raise_error
       row = sqlite_db.get_first_row("SELECT name FROM sqlite_master WHERE type='table' AND name='session_summary_state';")
       expect(row['name']).to eq('session_summary_state')
+    end
+
+    it 'opens fallback storage with the core sqlite busy timeout when available' do
+      adapter = described_class.new(data_dir: tmp_dir)
+      @fallback_db = adapter.instance_variable_get(:@db)
+
+      expect(@fallback_db.get_first_value('PRAGMA busy_timeout;')).to eq(Lich.sqlite_busy_timeout_ms)
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQLite connections now automatically configure a 5-second busy timeout, improving resilience during concurrent database access scenarios.

* **Documentation**
  * Added guide documenting SQLite busy timeout configuration and covered connection initialization paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/lich-5/pull/1365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->