### PR TITLE
fix(all): Set 5-second busy_timeout on SQLite database handle

### DIFF
--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -169,7 +169,11 @@ module Lich
   end
 
   def Lich.db
-    @@lich_db ||= SQLite3::Database.new("#{DATA_DIR}/lich.db3")
+    @@lich_db ||= begin
+      db = SQLite3::Database.new("#{DATA_DIR}/lich.db3")
+      db.busy_timeout = 5000
+      db
+    end
   end
 
   def Lich.init_db

--- a/spec/lib/lich_spec.rb
+++ b/spec/lib/lich_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'sqlite3'
+
+# Minimal DATA_DIR for database creation
+DATA_DIR = Dir.tmpdir unless defined?(DATA_DIR)
+
+require_relative '../../lib/lich'
+
+RSpec.describe 'Lich.db' do
+  before do
+    # Reset the cached handle so each example creates a fresh connection
+    Lich.class_variable_set(:@@lich_db, nil)
+  end
+
+  after do
+    db = Lich.class_variable_get(:@@lich_db)
+    db&.close unless db.nil? || db.closed?
+    Lich.class_variable_set(:@@lich_db, nil)
+    db_path = File.join(DATA_DIR, 'lich.db3')
+    File.delete(db_path) if File.exist?(db_path)
+  end
+
+  it 'returns a SQLite3::Database instance' do
+    expect(Lich.db).to be_a(SQLite3::Database)
+  end
+
+  it 'sets a busy_timeout on the database handle' do
+    db = Lich.db
+    timeout = db.get_first_value('PRAGMA busy_timeout;')
+    expect(timeout).to eq(5000)
+  end
+
+  it 'reuses the same handle on subsequent calls' do
+    first = Lich.db
+    second = Lich.db
+    expect(first).to be(second)
+  end
+
+  it 'only sets busy_timeout once during initialization' do
+    db = Lich.db
+    original_timeout = db.get_first_value('PRAGMA busy_timeout;')
+    expect(original_timeout).to eq(5000)
+
+    db.busy_timeout = 1000
+    expect(db.get_first_value('PRAGMA busy_timeout;')).to eq(1000)
+
+    second = Lich.db
+    expect(second.get_first_value('PRAGMA busy_timeout;')).to eq(1000)
+  end
+end


### PR DESCRIPTION
## Summary
- Sets `busy_timeout = 5000` on the SQLite database handle during initialization in `Lich.db`
- Reads were failing with `SQLite3::BusyException` when a concurrent write held an exclusive lock, because the default SQLite behavior is to fail immediately rather than wait
- The 5-second timeout lets readers wait for brief write locks to release instead of raising

## Test plan
- [x] New spec file `spec/lib/lich_spec.rb` verifies:
  - Database handle is a `SQLite3::Database`
  - `busy_timeout` PRAGMA is set to 5000
  - Handle is reused on subsequent calls
  - Timeout is only set once during initialization (not on every access)
- [x] Existing `feature_flags_spec.rb` passes (20 examples, 0 failures)
- [x] Rubocop clean on both touched files
- [ ] Manual testing: deploy to local instance and monitor logs for `BusyException` reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * SQLite database connection now includes enhanced timeout configuration to better handle concurrent access, ensuring more reliable database operations under load and reducing potential timeout issues.

* **Tests**
  * Added comprehensive test coverage for database connection initialization, including verification of proper connection reuse, timeout configuration, and consistent initialization behavior across multiple calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/lich-5/pull/1366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->