### PR TITLE
fix(all): Script#kill remove GC.start and add optional instrumentation

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -300,9 +300,29 @@ module Lich
         end
       }
       @@running = Array.new
+      @@kill_metrics_mutex = Mutex.new
+      @@kill_metrics = {
+        :minute            => nil,
+        :runtime_stops     => 0,
+        :duration_total_ms => 0.0,
+        :duration_max_ms   => 0.0,
+        :failures          => 0
+      }
 
       attr_reader :name, :vars, :safe, :file_name, :label_order, :at_exit_procs
       attr_accessor :quiet, :no_echo, :jump_label, :current_label, :want_downstream, :want_downstream_xml, :want_upstream, :want_script_output, :hidden, :paused, :silent, :no_pause_all, :no_kill_all, :downstream_buffer, :upstream_buffer, :unique_buffer, :die_with, :match_stack_labels, :match_stack_strings, :watchfor, :command_line, :ignore_pause, :killed_externally, :kill_source
+
+      KILL_METRICS_FEATURE_FLAG = :script_kill_metrics
+      KILL_METRICS_FEATURE_FLAG_RECORD = {
+        :name            => KILL_METRICS_FEATURE_FLAG.to_s,
+        :owner           => 'script_runtime',
+        :intent          => 'Opt-in aggregate diagnostics for non-shutdown Script#kill activity.',
+        :introduced_in   => '5.17.3',
+        :default_state   => false,
+        :default_flip_in => nil,
+        :remove_in       => nil,
+        :status          => :ops_debug
+      }.freeze
 
       class JumpError < StandardError; end
       JUMP = JumpError.exception('JUMP')
@@ -586,6 +606,90 @@ module Lich
         end
       end
 
+      class << self
+        private
+
+        # Returns whether script-kill aggregate metrics should be collected.
+        #
+        # The feature flag defaults off. Keeping the check behind this helper
+        # gives later runtime-facade work one narrow place to replace the flag
+        # lookup with a cached runtime mode or diagnostics service.
+        #
+        # @return [Boolean]
+        def __script_kill_metrics_enabled?
+          return false unless defined?(Lich::Common::FeatureFlags)
+
+          Lich::Common::FeatureFlags.enabled?(KILL_METRICS_FEATURE_FLAG)
+        rescue StandardError => e
+          Lich.log("warning: script kill metrics flag check failed: #{e.class}: #{e.message}") if defined?(Lich) && Lich.respond_to?(:log)
+          false
+        end
+
+        # Records one non-shutdown script kill and logs the completed previous
+        # minute when the current event rolls into a new minute bucket.
+        #
+        # This intentionally stores process-local, aggregate-only telemetry.
+        # It does not persist script names, emit per-kill logs, or count process
+        # shutdown stops. The goal is low-noise lifecycle diagnostics for
+        # release validation, not user-visible runtime reporting.
+        #
+        # @param duration_ms [Float] elapsed kill processing time in milliseconds
+        # @param failed [Boolean] whether the kill cleanup path raised
+        # @return [void]
+        # @api private
+        def __record_kill_metric(duration_ms:, failed:)
+          current_minute = Time.now.to_i / 60
+          summary = nil
+
+          @@kill_metrics_mutex.synchronize {
+            if @@kill_metrics[:minute] && @@kill_metrics[:minute] != current_minute
+              summary = @@kill_metrics.dup
+              __reset_kill_metrics_bucket
+            end
+
+            @@kill_metrics[:minute] = current_minute
+            @@kill_metrics[:runtime_stops] += 1
+            @@kill_metrics[:duration_total_ms] += duration_ms
+            @@kill_metrics[:duration_max_ms] = [@@kill_metrics[:duration_max_ms], duration_ms].max
+            @@kill_metrics[:failures] += 1 if failed
+          }
+
+          __log_kill_metric_summary(summary) if summary
+        end
+
+        # Clears the current script-kill metric bucket while preserving the
+        # mutex and hash identity used by tests and future runtime adapters.
+        #
+        # @return [void]
+        # @api private
+        def __reset_kill_metrics_bucket
+          @@kill_metrics[:runtime_stops] = 0
+          @@kill_metrics[:duration_total_ms] = 0.0
+          @@kill_metrics[:duration_max_ms] = 0.0
+          @@kill_metrics[:failures] = 0
+        end
+
+        # Emits a compact aggregate summary for a completed minute bucket.
+        #
+        # Callers only reach this method when the kill metrics feature flag is
+        # enabled and a minute rollover has occurred. The message is deliberately
+        # aggregate-only to avoid noisy per-script diagnostics in normal play.
+        #
+        # @param summary [Hash] completed metric bucket
+        # @return [void]
+        # @api private
+        def __log_kill_metric_summary(summary)
+          return unless summary[:runtime_stops].positive?
+
+          avg_ms = summary[:duration_total_ms] / summary[:runtime_stops]
+          Lich.log(
+            "debug: script kill metrics runtime_stops_last_minute=#{summary[:runtime_stops]} " \
+            "avg_ms=#{format('%.2f', avg_ms)} max_ms=#{format('%.2f', summary[:duration_max_ms])} " \
+            "failures=#{summary[:failures]}"
+          )
+        end
+      end
+
       def initialize(args)
         @file_name = args[:file]
         @name = /.*[\/\\]+([^\.]+)\./.match(@file_name).captures.first
@@ -672,10 +776,10 @@ module Lich
 
       # Stops this script and runs its before_dying/at_exit handlers.
       #
-      # Normal runtime kills release reclaimed Ruby/GObject memory back toward
-      # the operating system because the Lich process continues running. During
-      # process shutdown, callers may pass `context: :shutdown` to skip that
-      # expensive release; the OS is about to reclaim the process anyway.
+      # Runtime kills can optionally feed aggregate lifecycle metrics. Shutdown
+      # kills still run normal script cleanup, but are ignored by those metrics
+      # because process exit can stop many scripts for reasons unrelated to
+      # ordinary script churn.
       #
       # @param context [Symbol] :runtime for ordinary script stops, :shutdown
       #   when the owning Lich process is closing
@@ -685,6 +789,9 @@ module Lich
         Thread.new {
           @killer_mutex.synchronize {
             if @@running.include?(self)
+              instrument_kill = (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
+              started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
+              failed = false
               begin
                 @thread_group.list.dup.each { |t|
                   unless t == Thread.current
@@ -704,16 +811,19 @@ module Lich
                     respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.")
                   end
                 end
-                unless context == :shutdown
-                  if defined?(Gtk)
-                    Gtk.queue { GC.start }
-                  else
-                    GC.start
-                  end
-                end
               rescue
+                failed = true
                 respond "--- Lich: error: #{$!}"
                 Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+              ensure
+                if instrument_kill
+                  finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                  Script.__send__(
+                    :__record_kill_metric,
+                    :duration_ms => (finished_at - started_at) * 1000.0,
+                    :failed      => failed
+                  )
+                end
               end
             end
           }

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -776,50 +776,84 @@ module Lich
       # @return [String] script name
       def kill(context: :runtime)
         source = @kill_source || caller[0..2]
-        Thread.new {
-          @killer_mutex.synchronize {
-            if @@running.include?(self)
-              instrument_kill = (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
-              started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
-              failed = false
-              begin
-                @thread_group.list.dup.each { |t|
-                  unless t == Thread.current
-                    t.kill rescue nil
-                  end
-                }
-                @thread_group.add(Thread.current)
-                @die_with.each { |script_name| Script.kill(script_name) }
-                @paused = false
-                @at_exit_procs.each { |p| report_errors { p.call } }
-                @die_with = @at_exit_procs = @downstream_buffer = @upstream_buffer = @match_stack_labels = @match_stack_strings = nil
-                @@running.delete(self)
-                unless @quiet
-                  if @killed_externally
-                    respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
-                  else
-                    respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.")
-                  end
-                end
-              rescue
-                failed = true
-                respond "--- Lich: error: #{$!}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              ensure
-                if instrument_kill
-                  finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-                  Script.__send__(
-                    :__record_kill_metric,
-                    :duration_ms => (finished_at - started_at) * 1000.0,
-                    :failed      => failed
-                  )
-                end
-              end
-            end
-          }
-        }
+
+        begin
+          Thread.new { __run_kill_cleanup(source: source, context: context) }
+        rescue ThreadError => e
+          __log_kill_thread_fallback(e)
+          __run_kill_cleanup(source: source, context: context)
+        end
+
         @name
       end
+
+      # Runs the script cleanup body used by {#kill}.
+      #
+      # The normal lifecycle path runs this body in a separate cleanup thread,
+      # preserving existing return/timing behavior. If Ruby cannot allocate that
+      # thread, {#kill} calls this method inline as a degraded fallback so the
+      # script is still removed from the registry and at-exit handlers still get
+      # a chance to run.
+      #
+      # @param source [Array<String>] caller lines used for external-kill logging
+      # @param context [Symbol] kill context, such as :runtime or :shutdown
+      # @return [void]
+      # @api private
+      def __run_kill_cleanup(source:, context:)
+        @killer_mutex.synchronize {
+          if @@running.include?(self)
+            instrument_kill = (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
+            started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
+            failed = false
+            begin
+              @thread_group.list.dup.each { |t|
+                unless t == Thread.current
+                  t.kill rescue nil
+                end
+              }
+              @thread_group.add(Thread.current)
+              @die_with.each { |script_name| Script.kill(script_name) }
+              @paused = false
+              @at_exit_procs.each { |p| report_errors { p.call } }
+              @die_with = @at_exit_procs = @downstream_buffer = @upstream_buffer = @match_stack_labels = @match_stack_strings = nil
+              @@running.delete(self)
+              unless @quiet
+                if @killed_externally
+                  respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
+                else
+                  respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.")
+                end
+              end
+            rescue
+              failed = true
+              respond "--- Lich: error: #{$!}"
+              Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+            ensure
+              if instrument_kill
+                finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                Script.__send__(
+                  :__record_kill_metric,
+                  :duration_ms => (finished_at - started_at) * 1000.0,
+                  :failed      => failed
+                )
+              end
+            end
+          end
+        }
+      end
+      private :__run_kill_cleanup
+
+      # Logs when {#kill} cannot allocate its normal cleanup thread.
+      #
+      # @param error [ThreadError] allocation failure from `Thread.new`
+      # @return [void]
+      # @api private
+      def __log_kill_thread_fallback(error)
+        return unless defined?(Lich) && Lich.respond_to?(:log)
+
+        Lich.log("warning: Script#kill cleanup thread unavailable for #{@name}: #{error.class}: #{error.message}; running cleanup inline")
+      end
+      private :__log_kill_thread_fallback
 
       def at_exit(&block)
         if block

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -313,16 +313,6 @@ module Lich
       attr_accessor :quiet, :no_echo, :jump_label, :current_label, :want_downstream, :want_downstream_xml, :want_upstream, :want_script_output, :hidden, :paused, :silent, :no_pause_all, :no_kill_all, :downstream_buffer, :upstream_buffer, :unique_buffer, :die_with, :match_stack_labels, :match_stack_strings, :watchfor, :command_line, :ignore_pause, :killed_externally, :kill_source
 
       KILL_METRICS_FEATURE_FLAG = :script_kill_metrics
-      KILL_METRICS_FEATURE_FLAG_RECORD = {
-        :name            => KILL_METRICS_FEATURE_FLAG.to_s,
-        :owner           => 'script_runtime',
-        :intent          => 'Opt-in aggregate diagnostics for non-shutdown Script#kill activity.',
-        :introduced_in   => '5.17.3',
-        :default_state   => false,
-        :default_flip_in => nil,
-        :remove_in       => nil,
-        :status          => :ops_debug
-      }.freeze
 
       class JumpError < StandardError; end
       JUMP = JumpError.exception('JUMP')

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -778,10 +778,10 @@ module Lich
         source = @kill_source || caller[0..2]
 
         begin
-          Thread.new { __run_kill_cleanup(source: source, context: context) }
+          Thread.new { __run_kill_cleanup(source: source, context: context, record_metrics: true) }
         rescue ThreadError => e
           __log_kill_thread_fallback(e)
-          __run_kill_cleanup(source: source, context: context)
+          __run_kill_cleanup(source: source, context: context, record_metrics: false)
         end
 
         @name
@@ -795,14 +795,19 @@ module Lich
       # script is still removed from the registry and at-exit handlers still get
       # a chance to run.
       #
+      # Inline fallback cleanup does not record runtime metrics. Thread
+      # allocation failure is usually exit pressure or resource exhaustion, not
+      # ordinary script churn, and should not pollute the runtime stop bucket.
+      #
       # @param source [Array<String>] caller lines used for external-kill logging
       # @param context [Symbol] kill context, such as :runtime or :shutdown
+      # @param record_metrics [Boolean] whether this cleanup can feed runtime metrics
       # @return [void]
       # @api private
-      def __run_kill_cleanup(source:, context:)
+      def __run_kill_cleanup(source:, context:, record_metrics:)
         @killer_mutex.synchronize {
           if @@running.include?(self)
-            instrument_kill = (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
+            instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
             started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
             failed = false
             begin

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -72,9 +72,41 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
         'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=25.00 max_ms=25.00 failures=0'
       )
     end
+
+    it 'records a failed metric when an at_exit proc raises during runtime kill' do
+      first = build_script(name: 'first')
+      second = build_script(name: 'second')
+      first.at_exit { raise 'cleanup failed' }
+      script_class.class_variable_set(:@@running, [first, second])
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
+      allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
+
+      first.kill
+      second.kill
+
+      expect(Lich).to have_received(:log).with(
+        'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=25.00 max_ms=25.00 failures=1'
+      )
+    end
   end
 
   describe 'internal kill metric helpers' do
+    it 'returns false when feature flags are unavailable' do
+      feature_flags = Lich::Common.send(:remove_const, :FeatureFlags)
+
+      expect(script_class.__send__(:__script_kill_metrics_enabled?)).to be(false)
+    ensure
+      Lich::Common.const_set(:FeatureFlags, feature_flags) if feature_flags
+    end
+
+    it 'returns false and logs when feature flag lookup raises' do
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_raise(StandardError, 'flag read failed')
+
+      expect(script_class.__send__(:__script_kill_metrics_enabled?)).to be(false)
+      expect(Lich).to have_received(:log).with('warning: script kill metrics flag check failed: StandardError: flag read failed')
+    end
+
     it 'counts failed runtime kills in the next aggregate summary' do
       allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
       allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/feature_flags'
+
+RSpec.describe 'Lich::Common::Script kill metrics' do
+  let(:thread_group) { instance_double(ThreadGroup, list: [], add: true) }
+  let(:script_class) { Lich::Common::Script }
+
+  before(:context) do
+    require_relative '../../../lib/common/script'
+  end
+
+  after(:context) do
+    %i[Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+      Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
+    end
+    $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }
+  end
+
+  before do
+    script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@kill_metrics, {
+      :minute            => nil,
+      :runtime_stops     => 0,
+      :duration_total_ms => 0.0,
+      :duration_max_ms   => 0.0,
+      :failures          => 0
+    })
+    allow(Lich).to receive(:log)
+    allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
+    allow(Thread).to receive(:new) { |&block| block.call; instance_double(Thread) }
+    allow(GC).to receive(:start)
+  end
+
+  after do
+    script_class.class_variable_set(:@@running, [])
+  end
+
+  describe '#kill' do
+    it 'removes the script without forcing garbage collection' do
+      script = build_script
+      script_class.class_variable_set(:@@running, [script])
+
+      expect(script.kill).to eq('metric-target')
+
+      expect(script_class.list).to be_empty
+      expect(GC).not_to have_received(:start)
+    end
+
+    it 'uses shutdown context to skip runtime kill metrics' do
+      script = build_script
+      script_class.class_variable_set(:@@running, [script])
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
+      expect(script_class).not_to receive(:__record_kill_metric)
+
+      script.kill(context: :shutdown)
+    end
+
+    it 'logs only an aggregate runtime-kill summary when the feature flag is enabled and the minute rolls over' do
+      first = build_script(name: 'first')
+      second = build_script(name: 'second')
+      script_class.class_variable_set(:@@running, [first, second])
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
+      allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
+
+      first.kill
+      second.kill
+
+      expect(Lich).to have_received(:log).with(
+        'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=25.00 max_ms=25.00 failures=0'
+      )
+    end
+  end
+
+  describe 'internal kill metric helpers' do
+    it 'counts failed runtime kills in the next aggregate summary' do
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
+      allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))
+
+      script_class.__send__(:__record_kill_metric, :duration_ms => 12.5, :failed => true)
+      script_class.__send__(:__record_kill_metric, :duration_ms => 1.0, :failed => false)
+
+      expect(Lich).to have_received(:log).with(
+        'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=12.50 max_ms=12.50 failures=1'
+      )
+    end
+  end
+
+  def build_script(name: 'metric-target')
+    script_class.allocate.tap do |script|
+      script.instance_variable_set(:@name, name)
+      script.instance_variable_set(:@custom, false)
+      script.instance_variable_set(:@quiet, true)
+      script.instance_variable_set(:@thread_group, thread_group)
+      script.instance_variable_set(:@die_with, [])
+      script.instance_variable_set(:@paused, false)
+      script.instance_variable_set(:@at_exit_procs, [])
+      script.instance_variable_set(:@downstream_buffer, [])
+      script.instance_variable_set(:@upstream_buffer, [])
+      script.instance_variable_set(:@match_stack_labels, [])
+      script.instance_variable_set(:@match_stack_strings, [])
+      script.instance_variable_set(:@killer_mutex, Mutex.new)
+      script.instance_variable_set(:@killed_externally, false)
+      script.instance_variable_set(:@kill_source, nil)
+    end
+  end
+end

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
   end
 
   after(:context) do
-    %i[Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+    %i[ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
       Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
     end
     $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }
@@ -46,6 +46,19 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
 
       expect(script_class.list).to be_empty
       expect(GC).not_to have_received(:start)
+    end
+
+    it 'falls back to inline cleanup when Ruby cannot allocate a cleanup thread' do
+      script = build_script
+      script_class.class_variable_set(:@@running, [script])
+      allow(Thread).to receive(:new).and_raise(ThreadError, "can't alloc thread")
+
+      expect(script.kill).to eq('metric-target')
+
+      expect(script_class.list).to be_empty
+      expect(Lich).to have_received(:log).with(
+        "warning: Script#kill cleanup thread unavailable for metric-target: ThreadError: can't alloc thread; running cleanup inline"
+      )
     end
 
     it 'uses shutdown context to skip runtime kill metrics' do

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script = build_script
       script_class.class_variable_set(:@@running, [script])
       allow(Thread).to receive(:new).and_raise(ThreadError, "can't alloc thread")
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
+      expect(script_class).not_to receive(:__record_kill_metric)
 
       expect(script.kill).to eq('metric-target')
 


### PR DESCRIPTION
`Script#kill` has explicitly triggered `GC.start` throughout Lich 5. Recent runtime and lifecycle work made this path more timing-sensitive, and that exposed problems around script teardown and shutdown behavior.

We tried moving cleanup into the GTK queue and briefly routed it through `MemoryReleaser`, but that proved too heavy for rapid script exits. We then returned to a direct `GC.start` call while the immediate blocker was addressed separately with SQLite busy timeouts.

After revisiting the inherited design, we agreed that script teardown should not be responsible for forcing process-wide garbage collection. The cost of a major GC scales with the whole Ruby heap, not just the script being stopped, so doing that work inside `Script#kill` couples script lifecycle to global memory policy.

This PR removes the forced GC from `Script#kill` and adds opt-in aggregate instrumentation for non-shutdown script stops. The instrumentation is disabled by default, but gives us a way to measure script-stop volume and teardown duration if this area becomes suspicious again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in, per-minute aggregated runtime diagnostics for non-shutdown script kills (avg/max duration and failure counts).
* **Bug Fixes**
  * Consolidated cleanup into a single path, always run cleanup and log errors; fall back to inline cleanup with a warning if background thread creation fails.
* **Tests**
  * Added deterministic tests for metric aggregation, minute-rollover logging, failure reporting, and feature-flag behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/lich-5/pull/1368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->