### PR TITLE
fix(all): Refactor Lich exit - Add shutdown reason plumbing

### DIFF
--- a/lib/common/shutdown_coordinator.rb
+++ b/lib/common/shutdown_coordinator.rb
@@ -42,7 +42,10 @@ module Lich
               source: source.to_s,
               detail: detail,
               requested_at: Time.now
-            ).tap { |shutdown_request| log_request(shutdown_request) }
+            ).tap do |shutdown_request|
+              log_request(shutdown_request)
+              shutdown_request.freeze
+            end
           end
         end
 

--- a/lib/common/shutdown_coordinator.rb
+++ b/lib/common/shutdown_coordinator.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Lich
+  module Common
+    # Records why the process began shutting down.
+    #
+    # This is intentionally small: PR #1 only captures first-wins shutdown
+    # attribution. Later shutdown work can make decisions from this state without
+    # threading more globals through main.rb.
+    module ShutdownCoordinator
+      ALLOWED_REASONS = [
+        :user_exit,
+        :client_disconnect,
+        :game_eof,
+        :game_timeout,
+        :connection_reset,
+        :connection_pipe,
+        :connection_aborted,
+        :unrecoverable_game_thread_error,
+      ].freeze
+
+      CONNECTION_LOSS_REASONS = [
+        :client_disconnect,
+        :game_eof,
+        :game_timeout,
+        :connection_reset,
+        :connection_pipe,
+        :connection_aborted,
+        :unrecoverable_game_thread_error,
+      ].freeze
+
+      Request = Struct.new(:reason, :source, :detail, :requested_at, keyword_init: true)
+
+      class << self
+        def request(reason:, source:, detail: nil)
+          validate_reason!(reason)
+          validate_source!(source)
+
+          mutex.synchronize do
+            @request ||= Request.new(
+              reason: reason,
+              source: source.to_s,
+              detail: detail,
+              requested_at: Time.now
+            ).tap { |shutdown_request| log_request(shutdown_request) }
+          end
+        end
+
+        def requested?
+          !current.nil?
+        end
+
+        def current
+          mutex.synchronize { @request }
+        end
+
+        def reason
+          current&.reason
+        end
+
+        def orderly_user_exit?
+          reason == :user_exit
+        end
+
+        def connection_loss?
+          CONNECTION_LOSS_REASONS.include?(reason)
+        end
+
+        def reset!
+          mutex.synchronize { @request = nil }
+        end
+
+        private
+
+        def mutex
+          @mutex ||= Mutex.new
+        end
+
+        def validate_reason!(reason)
+          unless reason.is_a?(Symbol) && ALLOWED_REASONS.include?(reason)
+            raise ArgumentError, "invalid shutdown reason: #{reason.inspect}"
+          end
+        end
+
+        def validate_source!(source)
+          if source.nil? || source.to_s.empty?
+            raise ArgumentError, "shutdown source must be present"
+          end
+        end
+
+        def log_request(shutdown_request)
+          return unless defined?(Lich) && Lich.respond_to?(:log)
+
+          detail = shutdown_request.detail
+          detail_text = detail.nil? || detail.to_s.empty? ? "" : " detail=#{detail}"
+          Lich.log("info: shutdown requested reason=#{shutdown_request.reason} source=#{shutdown_request.source}#{detail_text}")
+        end
+      end
+    end
+  end
+end

--- a/lib/common/shutdown_intent.rb
+++ b/lib/common/shutdown_intent.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Lich
+  module Common
+    # Detects explicit frontend shutdown commands.
+    module ShutdownIntent
+      USER_EXIT_COMMAND = /\A\s*(?:<c>)?\s*(?:exit|quit)\s*\z/i
+
+      def self.user_exit_command?(client_string)
+        return false if client_string.nil?
+
+        USER_EXIT_COMMAND.match?(client_string.to_s)
+      end
+    end
+  end
+end

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -355,7 +355,10 @@ module Lich
                   consecutive_timeouts = 0
 
                   # Break if socket closed (gets returns nil)
-                  break if server_string.nil?
+                  if server_string.nil?
+                    record_shutdown_reason(:game_eof, source: :game_reader)
+                    break
+                  end
 
                   @last_recv = Time.now
                   @_buffer.update(server_string) if defined?(TESTING) && TESTING
@@ -402,6 +405,7 @@ module Lich
                 sleep 1 # Brief pause before retry
                 retry
               else
+                record_shutdown_reason(shutdown_reason_for_thread_exit(e), source: :game_reader, detail: e.class)
                 Lich.log "Server thread exiting due to unrecoverable error"
               end
             end
@@ -657,6 +661,29 @@ module Lich
               return true
             end
           end
+        end
+
+        def shutdown_reason_for_thread_exit(error)
+          case error
+          when Errno::ETIMEDOUT, Errno::EWOULDBLOCK, IO::TimeoutError
+            :game_timeout
+          when Errno::ECONNRESET
+            :connection_reset
+          when Errno::EPIPE
+            :connection_pipe
+          when Errno::ECONNABORTED
+            :connection_aborted
+          else
+            :unrecoverable_game_thread_error
+          end
+        end
+
+        def record_shutdown_reason(reason, source:, detail: nil)
+          return unless defined?(Lich::Common::ShutdownCoordinator)
+
+          Lich::Common::ShutdownCoordinator.request(reason: reason, source: source, detail: detail)
+        rescue StandardError => e
+          Lich.log "warning: failed to record shutdown reason #{reason.inspect}: #{e.class}: #{e.message}"
         end
 
         protected

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -2,7 +2,10 @@
 # this needs work to break up and improve 2024-06-13
 
 reconnect_if_wanted = proc {
-  if ARGV.include?('--reconnect') and ARGV.include?('--login') and not $_CLIENTBUFFER_.any? { |cmd| cmd =~ /^(?:\[.*?\])?(?:<c>)?(?:quit|exit)/i }
+  explicit_shutdown = Lich::Common::ShutdownCoordinator.orderly_user_exit?
+  explicit_exit_buffered = $_CLIENTBUFFER_.any? { |cmd| cmd =~ /^(?:\[.*?\])?(?:<c>)?(?:quit|exit)/i }
+
+  if ARGV.include?('--reconnect') and ARGV.include?('--login') and not explicit_shutdown and not explicit_exit_buffered
     if (reconnect_arg = ARGV.find { |arg| arg =~ /^\-\-reconnect\-delay=[0-9]+(?:\+[0-9]+)?$/ })
       reconnect_arg =~ /^\-\-reconnect\-delay=([0-9]+)(\+[0-9]+)?/
       reconnect_delay = $1.to_i
@@ -49,6 +52,8 @@ reconnect_if_wanted = proc {
   # Lifecycle tracker is loaded here because startup context (argv/account)
   # and shutdown sequencing both live in main runtime orchestration.
   require File.join(LIB_DIR, 'common', 'session_lifecycle.rb')
+  require File.join(LIB_DIR, 'common', 'shutdown_coordinator.rb')
+  require File.join(LIB_DIR, 'common', 'shutdown_intent.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_script_drain.rb')
 
   if ARGV.include?('--login')
@@ -588,6 +593,9 @@ reconnect_if_wanted = proc {
           elsif Frontend.client.eql?('frostbite')
             client_string = fb_to_sf(client_string)
           end
+          if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
+            Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :primary_frontend)
+          end
           # Lich.log(client_string)
           begin
             $_IDLETIMESTAMP_ = Time.now
@@ -606,6 +614,7 @@ reconnect_if_wanted = proc {
       ensure
         Frontend.cleanup_session_file
       end
+      Lich::Common::ShutdownCoordinator.request(reason: :client_disconnect, source: :primary_frontend)
       Game.close
     }
   end
@@ -734,6 +743,9 @@ reconnect_if_wanted = proc {
                 next # swallow the control line; don't pass it to do_client
               end
               client_string = "#{$cmd_prefix}#{client_string}" # if $frontend =~ /^(?:wizard|avalon)$/
+              if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
+                Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :detachable_frontend)
+              end
               begin
                 $_IDLETIMESTAMP_ = Time.now
                 do_client(client_string)

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -3,7 +3,7 @@
 
 reconnect_if_wanted = proc {
   explicit_shutdown = Lich::Common::ShutdownCoordinator.orderly_user_exit?
-  explicit_exit_buffered = $_CLIENTBUFFER_.any? { |cmd| cmd =~ /^(?:\[.*?\])?(?:<c>)?(?:quit|exit)/i }
+  explicit_exit_buffered = $_CLIENTBUFFER_.any? { |cmd| Lich::Common::ShutdownIntent.user_exit_command?(cmd) }
 
   if ARGV.include?('--reconnect') and ARGV.include?('--login') and not explicit_shutdown and not explicit_exit_buffered
     if (reconnect_arg = ARGV.find { |arg| arg =~ /^\-\-reconnect\-delay=[0-9]+(?:\+[0-9]+)?$/ })

--- a/spec/lib/common/shutdown_coordinator_spec.rb
+++ b/spec/lib/common/shutdown_coordinator_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Lich::Common::ShutdownCoordinator do
 
     expect(request.reason).to eq(:user_exit)
     expect(request.source).to eq('primary_frontend')
+    expect(request).to be_frozen
+    expect(described_class.current).to be_frozen
     expect(described_class.reason).to eq(:user_exit)
     expect(described_class).to be_requested
   end

--- a/spec/lib/common/shutdown_coordinator_spec.rb
+++ b/spec/lib/common/shutdown_coordinator_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/shutdown_coordinator'
+
+RSpec.describe Lich::Common::ShutdownCoordinator do
+  before do
+    described_class.reset!
+    allow(Lich).to receive(:log)
+  end
+
+  after do
+    described_class.reset!
+  end
+
+  it 'records the first shutdown request' do
+    request = described_class.request(reason: :user_exit, source: :primary_frontend)
+
+    expect(request.reason).to eq(:user_exit)
+    expect(request.source).to eq('primary_frontend')
+    expect(described_class.reason).to eq(:user_exit)
+    expect(described_class).to be_requested
+  end
+
+  it 'keeps the first reason when a later request arrives' do
+    first = described_class.request(reason: :user_exit, source: :primary_frontend)
+    second = described_class.request(reason: :game_eof, source: :game_reader)
+
+    expect(second).to equal(first)
+    expect(described_class.reason).to eq(:user_exit)
+    expect(described_class.current.source).to eq('primary_frontend')
+  end
+
+  it 'classifies explicit user exit as orderly' do
+    described_class.request(reason: :user_exit, source: :primary_frontend)
+
+    expect(described_class).to be_orderly_user_exit
+    expect(described_class).not_to be_connection_loss
+  end
+
+  it 'classifies connection loss reasons' do
+    described_class.request(reason: :connection_reset, source: :game_reader)
+
+    expect(described_class).to be_connection_loss
+    expect(described_class).not_to be_orderly_user_exit
+  end
+
+  it 'logs the first shutdown request with reason and source' do
+    described_class.request(reason: :game_timeout, source: :game_reader, detail: Errno::ETIMEDOUT)
+
+    expect(Lich).to have_received(:log).with(
+      'info: shutdown requested reason=game_timeout source=game_reader detail=Errno::ETIMEDOUT'
+    )
+  end
+
+  it 'rejects invalid reasons' do
+    expect {
+      described_class.request(reason: :unknown, source: :game_reader)
+    }.to raise_error(ArgumentError, 'invalid shutdown reason: :unknown')
+  end
+
+  it 'rejects missing sources' do
+    expect {
+      described_class.request(reason: :game_eof, source: '')
+    }.to raise_error(ArgumentError, 'shutdown source must be present')
+  end
+end

--- a/spec/lib/common/shutdown_intent_spec.rb
+++ b/spec/lib/common/shutdown_intent_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/shutdown_intent'
+
+RSpec.describe Lich::Common::ShutdownIntent do
+  describe '.user_exit_command?' do
+    it 'accepts explicit frontend exit commands' do
+      expect(described_class.user_exit_command?('exit')).to be true
+      expect(described_class.user_exit_command?('quit')).to be true
+      expect(described_class.user_exit_command?('<c>exit')).to be true
+      expect(described_class.user_exit_command?("  <c>QUIT  \r\n")).to be true
+    end
+
+    it 'rejects lich commands and non-exit input' do
+      expect(described_class.user_exit_command?(';exit')).to be false
+      expect(described_class.user_exit_command?('exit now')).to be false
+      expect(described_class.user_exit_command?('[script]><c>exit')).to be false
+      expect(described_class.user_exit_command?(nil)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Shutdown Modernization Train

This is PR 1 of 4 in the Lich 5 shutdown modernization sequence.

Train overview:

1. Add shutdown reason plumbing
2. Handle explicit orderly user shutdown
3. Add best-effort cleanup for connection disruption
4. Centralize shutdown logging and diagnostic gating

## Current PR

Adds a small shutdown coordinator and frontend intent detection so shutdown paths can record why shutdown began before later cleanup runs.

This PR does not change teardown ordering. It only introduces attribution/state plumbing used by later PRs.

## Notes for Reviewers

Expected behavior added here:

- explicit frontend `exit` / `quit` records `reason=:user_exit`
- frontend disconnect and game-reader exits can record distinct reasons
- first shutdown reason wins, so later fallout does not overwrite the initiating cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved shutdown handling: the app distinguishes explicit user exit commands from connection losses and records the first shutdown reason.
  * Reconnection behavior refined: the client will not auto-reconnect after an explicit `exit`/`quit`, and reconnects only when appropriate options are present.
  * Shutdown events are logged with reason, source, and details.

* **Tests**
  * Added comprehensive tests covering shutdown coordination and exit-command detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->