### PR TITLE
fix(all): Refactor Lich exit - orderly user shutdown

### DIFF
--- a/lib/common/orderly_shutdown.rb
+++ b/lib/common/orderly_shutdown.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module Lich
+  module Common
+    # Runs the explicit user-requested shutdown sequence while game I/O is alive.
+    #
+    # This runner is separate from {ShutdownCoordinator}: the coordinator records
+    # intent and progress, while this module performs teardown steps and updates
+    # the stored result. Connection-loss cleanup can add its own runner without
+    # overloading the state object.
+    module OrderlyShutdown
+      # Result for one orderly-shutdown attempt.
+      Result = Struct.new(
+        :completed,
+        :failures,
+        :script_shutdown_result,
+        :scripts_drained,
+        :vars_saved,
+        :game_closed,
+        keyword_init: true
+      ) do
+        # @return [Boolean] whether every required orderly-shutdown step completed
+        def completed?
+          completed
+        end
+
+        # @return [Boolean] whether any step raised or script drain was incomplete
+        def failed?
+          !failures.empty?
+        end
+
+        # @return [Boolean] whether script shutdown ran and left no registered scripts
+        def scripts_drained?
+          scripts_drained
+        end
+
+        # @return [Boolean] whether local script settings were saved
+        def vars_saved?
+          vars_saved
+        end
+
+        # @return [Boolean] whether the game connection close step ran
+        def game_closed?
+          game_closed
+        end
+      end
+
+      class << self
+        # Executes orderly user shutdown once.
+        #
+        # The sequence intentionally runs script hooks and local state save before
+        # closing the game connection. If another frontend thread already started
+        # the same sequence, this method returns that existing result.
+        #
+        # @param coordinator [ShutdownCoordinator] state/intent coordinator
+        # @param initial_scripts [Array<#kill,#name>] scripts present at shutdown start
+        # @param remaining_scripts [#call] returns scripts still registered
+        # @param script_drain [#run] script drain service
+        # @param vars [#save] local script settings persistence
+        # @param game [#close] game connection facade
+        # @param active_sessions_lifecycle [#update_connected, nil] optional session registry
+        # @param slow_threshold [Float] seconds before script drain reports slow scripts
+        # @return [Result] stored orderly-shutdown result
+        # @raise [ArgumentError] when caller input is invalid or reason is not :user_exit
+        def run(coordinator:, initial_scripts:, remaining_scripts:, script_drain:, vars:, game:, active_sessions_lifecycle: nil, slow_threshold: 1.5)
+          validate!(coordinator: coordinator, remaining_scripts: remaining_scripts, script_drain: script_drain, vars: vars, game: game)
+          raise ArgumentError, "orderly user exit requires reason=:user_exit" unless coordinator.orderly_user_exit?
+
+          result = Result.new(
+            completed: false,
+            failures: [],
+            scripts_drained: false,
+            vars_saved: false,
+            game_closed: false
+          )
+
+          stored_result = coordinator.begin_orderly_shutdown(result)
+          return stored_result unless stored_result.equal?(result)
+
+          log("info: orderly user shutdown starting")
+          update_active_sessions(result, active_sessions_lifecycle)
+          drain_scripts(result, initial_scripts, remaining_scripts, script_drain, slow_threshold)
+          save_vars(result, vars)
+          close_game(result, game)
+          finish(result)
+        end
+
+        private
+
+        def validate!(coordinator:, remaining_scripts:, script_drain:, vars:, game:)
+          raise ArgumentError, "coordinator must respond to #orderly_user_exit?" unless coordinator.respond_to?(:orderly_user_exit?)
+          raise ArgumentError, "coordinator must respond to #begin_orderly_shutdown" unless coordinator.respond_to?(:begin_orderly_shutdown)
+          raise ArgumentError, "remaining_scripts must respond to #call" unless remaining_scripts.respond_to?(:call)
+          raise ArgumentError, "script_drain must respond to #run" unless script_drain.respond_to?(:run)
+          raise ArgumentError, "vars must respond to #save" unless vars.respond_to?(:save)
+          raise ArgumentError, "game must respond to #close" unless game.respond_to?(:close)
+        end
+
+        def update_active_sessions(result, active_sessions_lifecycle)
+          run_step(result, "ActiveSessions connection update") do
+            if active_sessions_lifecycle && active_sessions_lifecycle.respond_to?(:update_connected)
+              active_sessions_lifecycle.update_connected(false)
+            end
+          end
+        end
+
+        def drain_scripts(result, initial_scripts, remaining_scripts, script_drain, slow_threshold)
+          run_step(result, "script shutdown") do
+            log("info: stopping scripts before closing game connection...")
+            result.script_shutdown_result = script_drain.run(
+              initial_scripts: initial_scripts,
+              remaining_scripts: remaining_scripts,
+              slow_threshold: slow_threshold
+            )
+            result.scripts_drained = script_drain_complete?(result.script_shutdown_result)
+            log_script_drain_result(result.script_shutdown_result)
+          end
+        end
+
+        def save_vars(result, vars)
+          run_step(result, "Vars.save") do
+            log("info: saving script settings before closing game connection...")
+            vars.save
+            result.vars_saved = true
+          end
+        end
+
+        def close_game(result, game)
+          run_step(result, "Game.close") do
+            log("info: closing game connection after orderly user shutdown...")
+            game.close
+            result.game_closed = true
+          end
+        end
+
+        def finish(result)
+          result.completed = !result.failed? && result.scripts_drained? && result.vars_saved? && result.game_closed?
+          log("info: orderly user shutdown #{result.completed? ? 'finished' : 'finished with warnings'}")
+          result
+        end
+
+        def run_step(result, description)
+          yield
+        rescue StandardError => e
+          result.failures << "#{description}: #{e.class}: #{e.message}"
+          log("warning: #{description} failed during orderly user shutdown: #{e.class}: #{e.message}")
+        end
+
+        def script_drain_complete?(script_shutdown_result)
+          return true unless script_shutdown_result.respond_to?(:scripts_remaining)
+
+          script_shutdown_result.scripts_remaining.to_i.zero?
+        end
+
+        def log_script_drain_result(script_shutdown_result)
+          return unless script_shutdown_result
+
+          slow_scripts = script_shutdown_result.respond_to?(:slow_scripts) ? script_shutdown_result.slow_scripts : []
+          scripts_remaining = script_shutdown_result.respond_to?(:scripts_remaining) ? script_shutdown_result.scripts_remaining.to_i : 0
+          return if slow_scripts.empty? && scripts_remaining.zero?
+
+          details = script_shutdown_result.respond_to?(:details) ? script_shutdown_result.details : script_shutdown_result.inspect
+          level = scripts_remaining.positive? ? "warning" : "info"
+          log("#{level}: orderly user shutdown script drain #{details}")
+        end
+
+        def log(message)
+          return unless defined?(Lich) && Lich.respond_to?(:log)
+
+          Lich.log(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/common/orderly_shutdown.rb
+++ b/lib/common/orderly_shutdown.rb
@@ -24,7 +24,7 @@ module Lich
           completed
         end
 
-        # @return [Boolean] whether any step raised or script drain was incomplete
+        # @return [Boolean] whether any teardown step raised
         def failed?
           !failures.empty?
         end
@@ -52,7 +52,7 @@ module Lich
         # closing the game connection. If another frontend thread already started
         # the same sequence, this method returns that existing result.
         #
-        # @param coordinator [ShutdownCoordinator] state/intent coordinator
+        # @param coordinator [Lich::Common::ShutdownCoordinator] state/intent coordinator
         # @param initial_scripts [Array<#kill,#name>] scripts present at shutdown start
         # @param remaining_scripts [#call] returns scripts still registered
         # @param script_drain [#run] script drain service

--- a/lib/common/shutdown_coordinator.rb
+++ b/lib/common/shutdown_coordinator.rb
@@ -53,7 +53,10 @@ module Lich
               source: source.to_s,
               detail: detail,
               requested_at: Time.now
-            ).tap { |shutdown_request| log_request(shutdown_request) }
+            ).tap do |shutdown_request|
+              log_request(shutdown_request)
+              shutdown_request.freeze
+            end
           end
         end
 

--- a/lib/common/shutdown_coordinator.rb
+++ b/lib/common/shutdown_coordinator.rb
@@ -8,6 +8,8 @@ module Lich
     # intent and stores the result of any higher-level shutdown runner, but it
     # does not perform teardown work itself.
     module ShutdownCoordinator
+      @mutex = Mutex.new
+
       ALLOWED_REASONS = [
         :user_exit,
         :client_disconnect,
@@ -131,7 +133,7 @@ module Lich
         private
 
         def mutex
-          @mutex ||= Mutex.new
+          @mutex
         end
 
         def validate_reason!(reason)

--- a/lib/common/shutdown_coordinator.rb
+++ b/lib/common/shutdown_coordinator.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Lich
+  module Common
+    # Records why the process began shutting down.
+    #
+    # This is intentionally small: PR #1 only captures first-wins shutdown
+    # attribution. Later shutdown work can make decisions from this state without
+    # threading more globals through main.rb.
+    module ShutdownCoordinator
+      ALLOWED_REASONS = [
+        :user_exit,
+        :client_disconnect,
+        :game_eof,
+        :game_timeout,
+        :connection_reset,
+        :connection_pipe,
+        :connection_aborted,
+        :unrecoverable_game_thread_error,
+      ].freeze
+
+      CONNECTION_LOSS_REASONS = [
+        :client_disconnect,
+        :game_eof,
+        :game_timeout,
+        :connection_reset,
+        :connection_pipe,
+        :connection_aborted,
+        :unrecoverable_game_thread_error,
+      ].freeze
+
+      Request = Struct.new(:reason, :source, :detail, :requested_at, keyword_init: true)
+
+      class << self
+        def request(reason:, source:, detail: nil)
+          validate_reason!(reason)
+          validate_source!(source)
+
+          mutex.synchronize do
+            @request ||= Request.new(
+              reason: reason,
+              source: source.to_s,
+              detail: detail,
+              requested_at: Time.now
+            ).tap { |shutdown_request| log_request(shutdown_request) }
+          end
+        end
+
+        def requested?
+          !current.nil?
+        end
+
+        def current
+          mutex.synchronize { @request }
+        end
+
+        def reason
+          current&.reason
+        end
+
+        def orderly_user_exit?
+          reason == :user_exit
+        end
+
+        def connection_loss?
+          CONNECTION_LOSS_REASONS.include?(reason)
+        end
+
+        def reset!
+          mutex.synchronize { @request = nil }
+        end
+
+        private
+
+        def mutex
+          @mutex ||= Mutex.new
+        end
+
+        def validate_reason!(reason)
+          unless reason.is_a?(Symbol) && ALLOWED_REASONS.include?(reason)
+            raise ArgumentError, "invalid shutdown reason: #{reason.inspect}"
+          end
+        end
+
+        def validate_source!(source)
+          if source.nil? || source.to_s.empty?
+            raise ArgumentError, "shutdown source must be present"
+          end
+        end
+
+        def log_request(shutdown_request)
+          return unless defined?(Lich) && Lich.respond_to?(:log)
+
+          detail = shutdown_request.detail
+          detail_text = detail.nil? || detail.to_s.empty? ? "" : " detail=#{detail}"
+          Lich.log("info: shutdown requested reason=#{shutdown_request.reason} source=#{shutdown_request.source}#{detail_text}")
+        end
+      end
+    end
+  end
+end

--- a/lib/common/shutdown_coordinator.rb
+++ b/lib/common/shutdown_coordinator.rb
@@ -2,11 +2,11 @@
 
 module Lich
   module Common
-    # Records why the process began shutting down.
+    # Records process shutdown attribution and coarse shutdown progress.
     #
-    # This is intentionally small: PR #1 only captures first-wins shutdown
-    # attribution. Later shutdown work can make decisions from this state without
-    # threading more globals through main.rb.
+    # The coordinator is deliberately state-only. It records first-wins shutdown
+    # intent and stores the result of any higher-level shutdown runner, but it
+    # does not perform teardown work itself.
     module ShutdownCoordinator
       ALLOWED_REASONS = [
         :user_exit,
@@ -29,9 +29,20 @@ module Lich
         :unrecoverable_game_thread_error,
       ].freeze
 
+      # First shutdown request observed by the process.
       Request = Struct.new(:reason, :source, :detail, :requested_at, keyword_init: true)
 
       class << self
+        # Records shutdown intent once.
+        #
+        # First request wins so later fallout, such as Game.close unblocking the
+        # reader thread, does not overwrite the initiating reason.
+        #
+        # @param reason [Symbol] one of {ALLOWED_REASONS}
+        # @param source [#to_s] subsystem that observed the request
+        # @param detail [Object, nil] optional compact diagnostic detail
+        # @return [Request] the stored first request
+        # @raise [ArgumentError] when reason/source is invalid
         def request(reason:, source:, detail: nil)
           validate_reason!(reason)
           validate_source!(source)
@@ -46,28 +57,72 @@ module Lich
           end
         end
 
+        # @return [Boolean] whether any shutdown request has been recorded
         def requested?
           !current.nil?
         end
 
+        # @return [Request, nil] stored first shutdown request
         def current
           mutex.synchronize { @request }
         end
 
+        # @return [Symbol, nil] stored shutdown reason
         def reason
           current&.reason
         end
 
+        # @return [Boolean] whether shutdown was explicitly requested by user input
         def orderly_user_exit?
           reason == :user_exit
         end
 
+        # @return [Boolean] whether shutdown began from local or remote connection loss
         def connection_loss?
           CONNECTION_LOSS_REASONS.include?(reason)
         end
 
+        # Stores the in-progress or completed orderly-shutdown result once.
+        #
+        # @param result [#completed?] result object produced by the orderly runner
+        # @return [Object] stored result; may be a previously stored result
+        # @raise [ArgumentError] when result is nil or missing expected predicates
+        def begin_orderly_shutdown(result)
+          validate_orderly_shutdown_result!(result)
+
+          mutex.synchronize do
+            @orderly_shutdown_result ||= result
+          end
+        end
+
+        # @return [Object, nil] orderly-shutdown result if a user-exit runner started
+        def orderly_shutdown_result
+          mutex.synchronize { @orderly_shutdown_result }
+        end
+
+        # @return [Boolean] whether the orderly-shutdown runner completed all steps
+        def orderly_shutdown_completed?
+          orderly_shutdown_result&.completed?
+        end
+
+        # @return [Boolean] whether orderly shutdown fully drained scripts
+        def orderly_scripts_drained?
+          orderly_shutdown_result&.scripts_drained?
+        end
+
+        # @return [Boolean] whether orderly shutdown saved script settings
+        def orderly_vars_saved?
+          orderly_shutdown_result&.vars_saved?
+        end
+
+        # Clears coordinator state for tests and process reinitialization.
+        #
+        # @return [nil]
         def reset!
-          mutex.synchronize { @request = nil }
+          mutex.synchronize do
+            @request = nil
+            @orderly_shutdown_result = nil
+          end
         end
 
         private
@@ -88,12 +143,23 @@ module Lich
           end
         end
 
-        def log_request(shutdown_request)
-          return unless defined?(Lich) && Lich.respond_to?(:log)
+        def validate_orderly_shutdown_result!(result)
+          raise ArgumentError, "orderly shutdown result must be present" if result.nil?
+          raise ArgumentError, "orderly shutdown result must respond to #completed?" unless result.respond_to?(:completed?)
+          raise ArgumentError, "orderly shutdown result must respond to #scripts_drained?" unless result.respond_to?(:scripts_drained?)
+          raise ArgumentError, "orderly shutdown result must respond to #vars_saved?" unless result.respond_to?(:vars_saved?)
+        end
 
+        def log_request(shutdown_request)
           detail = shutdown_request.detail
           detail_text = detail.nil? || detail.to_s.empty? ? "" : " detail=#{detail}"
-          Lich.log("info: shutdown requested reason=#{shutdown_request.reason} source=#{shutdown_request.source}#{detail_text}")
+          log("info: shutdown requested reason=#{shutdown_request.reason} source=#{shutdown_request.source}#{detail_text}")
+        end
+
+        def log(message)
+          return unless defined?(Lich) && Lich.respond_to?(:log)
+
+          Lich.log(message)
         end
       end
     end

--- a/lib/common/shutdown_coordinator.rb
+++ b/lib/common/shutdown_coordinator.rb
@@ -10,6 +10,7 @@ module Lich
     module ShutdownCoordinator
       @mutex = Mutex.new
 
+      # Shutdown reasons accepted by {request}.
       ALLOWED_REASONS = [
         :user_exit,
         :client_disconnect,
@@ -21,6 +22,7 @@ module Lich
         :unrecoverable_game_thread_error,
       ].freeze
 
+      # Reasons that indicate local frontend loss or remote game connection loss.
       CONNECTION_LOSS_REASONS = [
         :client_disconnect,
         :game_eof,

--- a/lib/common/shutdown_intent.rb
+++ b/lib/common/shutdown_intent.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Lich
+  module Common
+    # Detects explicit frontend shutdown commands.
+    module ShutdownIntent
+      USER_EXIT_COMMAND = /\A\s*(?:<c>)?\s*(?:exit|quit)\s*\z/i
+
+      def self.user_exit_command?(client_string)
+        return false if client_string.nil?
+
+        USER_EXIT_COMMAND.match?(client_string.to_s)
+      end
+    end
+  end
+end

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -395,9 +395,13 @@ module Lich
                 end
               end
             rescue StandardError => e
+              if intentional_shutdown_close_error?(e)
+                Lich.log "info: server thread exiting after orderly user shutdown"
+                next
+              end
+
               # Handle any other errors
               should_continue = handle_thread_error(e)
-
               # Only retry if handle_thread_error says it's safe and socket is still open
               if should_continue && !@socket.closed? && $_CLIENT_.alive?
                 Lich.log "Retrying server thread after error..."
@@ -684,6 +688,14 @@ module Lich
           Lich::Common::ShutdownCoordinator.request(reason: reason, source: source, detail: detail)
         rescue StandardError => e
           Lich.log "warning: failed to record shutdown reason #{reason.inspect}: #{e.class}: #{e.message}"
+        end
+
+        def intentional_shutdown_close_error?(error)
+          return false unless defined?(Lich::Common::ShutdownCoordinator)
+          return false unless Lich::Common::ShutdownCoordinator.orderly_user_exit?
+          return false unless @socket&.closed?
+
+          error.to_s =~ /stream closed in another thread|closed stream/i
         end
 
         protected

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -355,7 +355,10 @@ module Lich
                   consecutive_timeouts = 0
 
                   # Break if socket closed (gets returns nil)
-                  break if server_string.nil?
+                  if server_string.nil?
+                    record_shutdown_reason(:game_eof, source: :game_reader)
+                    break
+                  end
 
                   @last_recv = Time.now
                   @_buffer.update(server_string) if defined?(TESTING) && TESTING
@@ -402,6 +405,7 @@ module Lich
                 sleep 1 # Brief pause before retry
                 retry
               else
+                record_shutdown_reason(shutdown_reason_for_thread_exit(e), source: :game_reader, detail: e.class)
                 Lich.log "Server thread exiting due to unrecoverable error"
               end
             end
@@ -657,6 +661,29 @@ module Lich
               return true
             end
           end
+        end
+
+        def shutdown_reason_for_thread_exit(error)
+          case error
+          when Errno::ETIMEDOUT, Errno::EWOULDBLOCK, IO::TimeoutError
+            :game_timeout
+          when Errno::ECONNRESET
+            :connection_reset
+          when Errno::EPIPE
+            :connection_pipe
+          when Errno::ECONNABORTED
+            :connection_aborted
+          else
+            :unrecoverable_game_thread_error
+          end
+        end
+
+        def record_shutdown_reason(reason, source:, detail: nil)
+          return unless defined?(Lich::Common::ShutdownCoordinator)
+
+          Lich::Common::ShutdownCoordinator.request(reason: reason, source: source, detail: detail)
+        rescue StandardError => e
+          Lich.log "warning: failed to record shutdown reason #{reason.inspect}: #{e.class}: #{e.message}"
         end
 
         protected

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -2,7 +2,10 @@
 # this needs work to break up and improve 2024-06-13
 
 reconnect_if_wanted = proc {
-  if ARGV.include?('--reconnect') and ARGV.include?('--login') and not $_CLIENTBUFFER_.any? { |cmd| cmd =~ /^(?:\[.*?\])?(?:<c>)?(?:quit|exit)/i }
+  explicit_shutdown = Lich::Common::ShutdownCoordinator.orderly_user_exit?
+  explicit_exit_buffered = $_CLIENTBUFFER_.any? { |cmd| cmd =~ /^(?:\[.*?\])?(?:<c>)?(?:quit|exit)/i }
+
+  if ARGV.include?('--reconnect') and ARGV.include?('--login') and not explicit_shutdown and not explicit_exit_buffered
     if (reconnect_arg = ARGV.find { |arg| arg =~ /^\-\-reconnect\-delay=[0-9]+(?:\+[0-9]+)?$/ })
       reconnect_arg =~ /^\-\-reconnect\-delay=([0-9]+)(\+[0-9]+)?/
       reconnect_delay = $1.to_i
@@ -49,6 +52,8 @@ reconnect_if_wanted = proc {
   # Lifecycle tracker is loaded here because startup context (argv/account)
   # and shutdown sequencing both live in main runtime orchestration.
   require File.join(LIB_DIR, 'common', 'session_lifecycle.rb')
+  require File.join(LIB_DIR, 'common', 'shutdown_coordinator.rb')
+  require File.join(LIB_DIR, 'common', 'shutdown_intent.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_script_drain.rb')
 
   if ARGV.include?('--login')
@@ -588,6 +593,9 @@ reconnect_if_wanted = proc {
           elsif Frontend.client.eql?('frostbite')
             client_string = fb_to_sf(client_string)
           end
+          if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
+            Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :primary_frontend)
+          end
           # Lich.log(client_string)
           begin
             $_IDLETIMESTAMP_ = Time.now
@@ -606,6 +614,7 @@ reconnect_if_wanted = proc {
       ensure
         Frontend.cleanup_session_file
       end
+      Lich::Common::ShutdownCoordinator.request(reason: :client_disconnect, source: :primary_frontend)
       Game.close
     }
   end
@@ -734,6 +743,9 @@ reconnect_if_wanted = proc {
                 next # swallow the control line; don't pass it to do_client
               end
               client_string = "#{$cmd_prefix}#{client_string}" # if $frontend =~ /^(?:wizard|avalon)$/
+              if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
+                Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :detachable_frontend)
+              end
               begin
                 $_IDLETIMESTAMP_ = Time.now
                 do_client(client_string)

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -52,9 +52,22 @@ reconnect_if_wanted = proc {
   # Lifecycle tracker is loaded here because startup context (argv/account)
   # and shutdown sequencing both live in main runtime orchestration.
   require File.join(LIB_DIR, 'common', 'session_lifecycle.rb')
+  require File.join(LIB_DIR, 'common', 'orderly_shutdown.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_coordinator.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_intent.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_script_drain.rb')
+
+  run_orderly_user_shutdown = proc {
+    Lich::Common::OrderlyShutdown.run(
+      coordinator: Lich::Common::ShutdownCoordinator,
+      initial_scripts: (Script.running + Script.hidden),
+      remaining_scripts: proc { Script.running + Script.hidden },
+      script_drain: Lich::Common::ShutdownScriptDrain,
+      vars: Vars,
+      game: Game,
+      active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))
+    )
+  }
 
   if ARGV.include?('--login')
     # CLI login flow: character authentication via saved entries
@@ -595,6 +608,8 @@ reconnect_if_wanted = proc {
           end
           if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
             Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :primary_frontend)
+            run_orderly_user_shutdown.call
+            break
           end
           # Lich.log(client_string)
           begin
@@ -745,6 +760,8 @@ reconnect_if_wanted = proc {
               client_string = "#{$cmd_prefix}#{client_string}" # if $frontend =~ /^(?:wizard|avalon)$/
               if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
                 Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :detachable_frontend)
+                run_orderly_user_shutdown.call
+                break
               end
               begin
                 $_IDLETIMESTAMP_ = Time.now
@@ -772,6 +789,8 @@ reconnect_if_wanted = proc {
             Lich.log "info: detachable client cleaned up, ready for new connection"
           end
         end
+        break if Lich::Common::ShutdownCoordinator.orderly_user_exit?
+
         sleep 0.1
       }
     }
@@ -878,22 +897,30 @@ reconnect_if_wanted = proc {
       Lich::InternalAPI::ActiveSessions::Lifecycle.update_connected(false) if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle)
     end
 
-    script_shutdown_result = nil
-    shutdown_step.call('script shutdown', details: proc { script_shutdown_result&.details }) do
-      Lich.log 'info: stopping scripts...'
-      # Shutdown context preserves before_dying/at_exit handlers while skipping
-      # MemoryReleaser work; process exit will reclaim memory.
-      # Individual script names are reported at 2x the step threshold so normal
-      # teardown stays quiet while slow exits remain visible.
-      script_shutdown_slow_threshold = shutdown_step_trace_thresholds.fetch('script shutdown', 0.75) * 2
-      script_shutdown_result = Lich::Common::ShutdownScriptDrain.run(
-        initial_scripts: (Script.running + Script.hidden),
-        remaining_scripts: proc { Script.running + Script.hidden },
-        slow_threshold: script_shutdown_slow_threshold
-      )
+    if Lich::Common::ShutdownCoordinator.orderly_scripts_drained?
+      Lich.log 'info: script shutdown already completed before closing game connection...'
+    else
+      script_shutdown_result = nil
+      shutdown_step.call('script shutdown', details: proc { script_shutdown_result&.details }) do
+        Lich.log 'info: stopping scripts...'
+        # Shutdown context preserves before_dying/at_exit handlers while skipping
+        # MemoryReleaser work; process exit will reclaim memory.
+        # Individual script names are reported at 2x the step threshold so normal
+        # teardown stays quiet while slow exits remain visible.
+        script_shutdown_slow_threshold = shutdown_step_trace_thresholds.fetch('script shutdown', 0.75) * 2
+        script_shutdown_result = Lich::Common::ShutdownScriptDrain.run(
+          initial_scripts: (Script.running + Script.hidden),
+          remaining_scripts: proc { Script.running + Script.hidden },
+          slow_threshold: script_shutdown_slow_threshold
+        )
+      end
     end
-    Lich.log 'info: saving script settings...'
-    shutdown_step.call('Vars.save') { Vars.save }
+    if Lich::Common::ShutdownCoordinator.orderly_vars_saved?
+      Lich.log 'info: script settings already saved before closing game connection...'
+    else
+      Lich.log 'info: saving script settings...'
+      shutdown_step.call('Vars.save') { Vars.save }
+    end
     Lich.log 'info: closing connections...'
     shutdown_step.call('Game.close') { Game.close }
     shutdown_step.call('client_thread.kill') { client_thread.kill }

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -3,7 +3,7 @@
 
 reconnect_if_wanted = proc {
   explicit_shutdown = Lich::Common::ShutdownCoordinator.orderly_user_exit?
-  explicit_exit_buffered = $_CLIENTBUFFER_.any? { |cmd| cmd =~ /^(?:\[.*?\])?(?:<c>)?(?:quit|exit)/i }
+  explicit_exit_buffered = $_CLIENTBUFFER_.any? { |cmd| Lich::Common::ShutdownIntent.user_exit_command?(cmd) }
 
   if ARGV.include?('--reconnect') and ARGV.include?('--login') and not explicit_shutdown and not explicit_exit_buffered
     if (reconnect_arg = ARGV.find { |arg| arg =~ /^\-\-reconnect\-delay=[0-9]+(?:\+[0-9]+)?$/ })

--- a/spec/lib/common/orderly_shutdown_spec.rb
+++ b/spec/lib/common/orderly_shutdown_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/shutdown_coordinator'
+require_relative '../../../lib/common/orderly_shutdown'
+
+RSpec.describe Lich::Common::OrderlyShutdown do
+  def run_orderly_shutdown(**overrides)
+    scripts = overrides.fetch(:initial_scripts, [])
+    described_class.run(
+      coordinator: overrides.fetch(:coordinator, coordinator),
+      initial_scripts: scripts,
+      remaining_scripts: overrides.fetch(:remaining_scripts, proc { [] }),
+      script_drain: overrides.fetch(:script_drain, script_drain),
+      vars: overrides.fetch(:vars, vars),
+      game: overrides.fetch(:game, game),
+      active_sessions_lifecycle: overrides.fetch(:active_sessions_lifecycle, active_sessions_lifecycle)
+    )
+  end
+
+  let(:coordinator) { Lich::Common::ShutdownCoordinator }
+
+  let(:script_drain_result) do
+    Struct.new(:scripts_remaining, :slow_scripts, :details, keyword_init: true).new(
+      scripts_remaining: 0,
+      slow_scripts: [],
+      details: 'scripts_started=2 slow_scripts=[] scripts_remaining=0'
+    )
+  end
+
+  let(:script_drain) do
+    result = script_drain_result
+    Struct.new(:calls, :result) do
+      def run(initial_scripts:, remaining_scripts:, slow_threshold:)
+        calls << {
+          initial_scripts: initial_scripts,
+          remaining_scripts: remaining_scripts,
+          slow_threshold: slow_threshold,
+        }
+        result
+      end
+    end.new([], result)
+  end
+
+  let(:vars) do
+    Struct.new(:calls) do
+      def save
+        calls << :save
+      end
+    end.new([])
+  end
+
+  let(:game) do
+    Struct.new(:calls) do
+      def close
+        calls << :close
+      end
+    end.new([])
+  end
+
+  let(:active_sessions_lifecycle) do
+    Struct.new(:calls) do
+      def update_connected(value)
+        calls << value
+      end
+    end.new([])
+  end
+
+  before do
+    coordinator.reset!
+    coordinator.request(reason: :user_exit, source: :primary_frontend)
+    allow(Lich).to receive(:log)
+  end
+
+  after do
+    coordinator.reset!
+  end
+
+  it 'runs local shutdown work before closing the game connection' do
+    result = run_orderly_shutdown(initial_scripts: %w[alpha beta])
+
+    expect(active_sessions_lifecycle.calls).to eq([false])
+    expect(script_drain.calls.first[:initial_scripts]).to eq(%w[alpha beta])
+    expect(script_drain.calls.first[:slow_threshold]).to eq(1.5)
+    expect(vars.calls).to eq([:save])
+    expect(game.calls).to eq([:close])
+    expect(result).to be_completed
+    expect(result).to be_scripts_drained
+    expect(result).to be_vars_saved
+    expect(result).to be_game_closed
+    expect(result.script_shutdown_result).to equal(script_drain_result)
+    expect(coordinator.orderly_shutdown_result).to equal(result)
+  end
+
+  it 'only runs the orderly shutdown sequence once' do
+    first = run_orderly_shutdown
+    second = run_orderly_shutdown
+
+    expect(second).to equal(first)
+    expect(script_drain.calls.length).to eq(1)
+    expect(vars.calls).to eq([:save])
+    expect(game.calls).to eq([:close])
+  end
+
+  it 'continues later cleanup steps when one step fails' do
+    failing_vars = Struct.new(:calls) do
+      def save
+        calls << :save
+        raise StandardError, 'cannot save'
+      end
+    end.new([])
+
+    result = run_orderly_shutdown(vars: failing_vars)
+
+    expect(result).not_to be_completed
+    expect(result).to be_scripts_drained
+    expect(result).not_to be_vars_saved
+    expect(result.failures).to eq(['Vars.save: StandardError: cannot save'])
+    expect(game.calls).to eq([:close])
+    expect(Lich).to have_received(:log).with(
+      'warning: Vars.save failed during orderly user shutdown: StandardError: cannot save'
+    )
+  end
+
+  it 'does not mark scripts drained when the drain leaves scripts registered' do
+    script_drain_result.scripts_remaining = 1
+    script_drain_result.details = 'scripts_started=2 slow_scripts=[] scripts_remaining=1 remaining_scripts=["slow"]'
+
+    result = run_orderly_shutdown
+
+    expect(result).not_to be_completed
+    expect(result).not_to be_scripts_drained
+    expect(Lich).to have_received(:log).with(
+      'warning: orderly user shutdown script drain scripts_started=2 slow_scripts=[] scripts_remaining=1 remaining_scripts=["slow"]'
+    )
+  end
+
+  it 'logs slow script drain detail without marking shutdown failed' do
+    script_drain_result.slow_scripts = ['slow=1.500s']
+    script_drain_result.details = 'scripts_started=1 slow_scripts=["slow=1.500s"] scripts_remaining=0'
+
+    result = run_orderly_shutdown
+
+    expect(result).to be_completed
+    expect(Lich).to have_received(:log).with(
+      'info: orderly user shutdown script drain scripts_started=1 slow_scripts=["slow=1.500s"] scripts_remaining=0'
+    )
+  end
+
+  it 'requires a user-exit shutdown reason' do
+    coordinator.reset!
+    coordinator.request(reason: :game_eof, source: :game_reader)
+
+    expect {
+      run_orderly_shutdown
+    }.to raise_error(ArgumentError, 'orderly user exit requires reason=:user_exit')
+  end
+
+  it 'rejects invalid orderly shutdown dependencies' do
+    expect {
+      run_orderly_shutdown(vars: Object.new)
+    }.to raise_error(ArgumentError, 'vars must respond to #save')
+  end
+end

--- a/spec/lib/common/shutdown_coordinator_spec.rb
+++ b/spec/lib/common/shutdown_coordinator_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Lich::Common::ShutdownCoordinator do
 
     expect(request.reason).to eq(:user_exit)
     expect(request.source).to eq('primary_frontend')
+    expect(request).to be_frozen
+    expect(described_class.current).to be_frozen
     expect(described_class.reason).to eq(:user_exit)
     expect(described_class).to be_requested
   end

--- a/spec/lib/common/shutdown_coordinator_spec.rb
+++ b/spec/lib/common/shutdown_coordinator_spec.rb
@@ -64,4 +64,45 @@ RSpec.describe Lich::Common::ShutdownCoordinator do
       described_class.request(reason: :game_eof, source: '')
     }.to raise_error(ArgumentError, 'shutdown source must be present')
   end
+
+  describe '.begin_orderly_shutdown' do
+    def result(scripts_drained: true, vars_saved: true, completed: true)
+      Struct.new(:completed, :scripts_drained, :vars_saved, keyword_init: true) do
+        def completed?
+          completed
+        end
+
+        def scripts_drained?
+          scripts_drained
+        end
+
+        def vars_saved?
+          vars_saved
+        end
+      end.new(completed: completed, scripts_drained: scripts_drained, vars_saved: vars_saved)
+    end
+
+    it 'stores the first orderly shutdown result and exposes progress predicates' do
+      stored = described_class.begin_orderly_shutdown(result(scripts_drained: true, vars_saved: false, completed: false))
+
+      expect(described_class.orderly_shutdown_result).to equal(stored)
+      expect(described_class).not_to be_orderly_shutdown_completed
+      expect(described_class).to be_orderly_scripts_drained
+      expect(described_class).not_to be_orderly_vars_saved
+    end
+
+    it 'keeps the first orderly shutdown result' do
+      first = described_class.begin_orderly_shutdown(result)
+      second = described_class.begin_orderly_shutdown(result(completed: false))
+
+      expect(second).to equal(first)
+      expect(described_class.orderly_shutdown_result).to equal(first)
+    end
+
+    it 'rejects invalid orderly shutdown results' do
+      expect {
+        described_class.begin_orderly_shutdown(Object.new)
+      }.to raise_error(ArgumentError, 'orderly shutdown result must respond to #completed?')
+    end
+  end
 end

--- a/spec/lib/common/shutdown_coordinator_spec.rb
+++ b/spec/lib/common/shutdown_coordinator_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/shutdown_coordinator'
+
+RSpec.describe Lich::Common::ShutdownCoordinator do
+  before do
+    described_class.reset!
+    allow(Lich).to receive(:log)
+  end
+
+  after do
+    described_class.reset!
+  end
+
+  it 'records the first shutdown request' do
+    request = described_class.request(reason: :user_exit, source: :primary_frontend)
+
+    expect(request.reason).to eq(:user_exit)
+    expect(request.source).to eq('primary_frontend')
+    expect(described_class.reason).to eq(:user_exit)
+    expect(described_class).to be_requested
+  end
+
+  it 'keeps the first reason when a later request arrives' do
+    first = described_class.request(reason: :user_exit, source: :primary_frontend)
+    second = described_class.request(reason: :game_eof, source: :game_reader)
+
+    expect(second).to equal(first)
+    expect(described_class.reason).to eq(:user_exit)
+    expect(described_class.current.source).to eq('primary_frontend')
+  end
+
+  it 'classifies explicit user exit as orderly' do
+    described_class.request(reason: :user_exit, source: :primary_frontend)
+
+    expect(described_class).to be_orderly_user_exit
+    expect(described_class).not_to be_connection_loss
+  end
+
+  it 'classifies connection loss reasons' do
+    described_class.request(reason: :connection_reset, source: :game_reader)
+
+    expect(described_class).to be_connection_loss
+    expect(described_class).not_to be_orderly_user_exit
+  end
+
+  it 'logs the first shutdown request with reason and source' do
+    described_class.request(reason: :game_timeout, source: :game_reader, detail: Errno::ETIMEDOUT)
+
+    expect(Lich).to have_received(:log).with(
+      'info: shutdown requested reason=game_timeout source=game_reader detail=Errno::ETIMEDOUT'
+    )
+  end
+
+  it 'rejects invalid reasons' do
+    expect {
+      described_class.request(reason: :unknown, source: :game_reader)
+    }.to raise_error(ArgumentError, 'invalid shutdown reason: :unknown')
+  end
+
+  it 'rejects missing sources' do
+    expect {
+      described_class.request(reason: :game_eof, source: '')
+    }.to raise_error(ArgumentError, 'shutdown source must be present')
+  end
+end

--- a/spec/lib/common/shutdown_intent_spec.rb
+++ b/spec/lib/common/shutdown_intent_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/shutdown_intent'
+
+RSpec.describe Lich::Common::ShutdownIntent do
+  describe '.user_exit_command?' do
+    it 'accepts explicit frontend exit commands' do
+      expect(described_class.user_exit_command?('exit')).to be true
+      expect(described_class.user_exit_command?('quit')).to be true
+      expect(described_class.user_exit_command?('<c>exit')).to be true
+      expect(described_class.user_exit_command?("  <c>QUIT  \r\n")).to be true
+    end
+
+    it 'rejects lich commands and non-exit input' do
+      expect(described_class.user_exit_command?(';exit')).to be false
+      expect(described_class.user_exit_command?('exit now')).to be false
+      expect(described_class.user_exit_command?('[script]><c>exit')).to be false
+      expect(described_class.user_exit_command?(nil)).to be false
+    end
+  end
+end

--- a/spec/lib/games_spec.rb
+++ b/spec/lib/games_spec.rb
@@ -6,6 +6,7 @@ require 'timeout'
 # Load production code
 require "common/class_exts/synchronizedsocket"
 require "common/sharedbuffer"
+require "common/shutdown_coordinator"
 require "games"
 require "gemstone/wounds"
 require "gemstone/scars"
@@ -376,6 +377,55 @@ end
 # from instance variables (@) to class variables (@@). This is testing the
 # implementation detail by design, not testing through public API.
 RSpec.describe Lich::GameBase::Game do
+  describe '.intentional_shutdown_close_error?' do
+    let(:closed_socket) { double('socket', closed?: true) }
+    let(:open_socket) { double('socket', closed?: false) }
+
+    before do
+      Lich::Common::ShutdownCoordinator.reset!
+      described_class.instance_variable_set(:@socket, closed_socket)
+    end
+
+    after do
+      Lich::Common::ShutdownCoordinator.reset!
+      described_class.instance_variable_set(:@socket, nil)
+    end
+
+    it 'recognizes reader-thread close errors during orderly user shutdown' do
+      Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :primary_frontend)
+
+      result = described_class.send(
+        :intentional_shutdown_close_error?,
+        IOError.new('stream closed in another thread')
+      )
+
+      expect(result).to be_truthy
+    end
+
+    it 'does not recognize close errors outside orderly user shutdown' do
+      Lich::Common::ShutdownCoordinator.request(reason: :game_eof, source: :game_reader)
+
+      result = described_class.send(
+        :intentional_shutdown_close_error?,
+        IOError.new('stream closed in another thread')
+      )
+
+      expect(result).to be false
+    end
+
+    it 'does not recognize orderly shutdown errors while the socket is open' do
+      Lich::Common::ShutdownCoordinator.request(reason: :user_exit, source: :primary_frontend)
+      described_class.instance_variable_set(:@socket, open_socket)
+
+      result = described_class.send(
+        :intentional_shutdown_close_error?,
+        IOError.new('stream closed in another thread')
+      )
+
+      expect(result).to be false
+    end
+  end
+
   describe '.autostarted?' do
     before do
       # Reset the class variable for test isolation


### PR DESCRIPTION
## Shutdown Modernization Train

This is PR 2 of 4 in the Lich 5 shutdown modernization sequence.

Train overview:

1. Add shutdown reason plumbing
2. Handle explicit orderly user shutdown
3. Add best-effort cleanup for connection disruption
4. Centralize shutdown logging and diagnostic gating

## Current PR

Handles explicit user-requested `exit` / `quit` as an orderly shutdown while game I/O is still alive.

This moves user-requested shutdown work ahead of closing the game socket, allowing scripts and local settings to drain/save before the reader is intentionally unblocked.

## Notes for Reviewers

Expected behavior added here:

- explicit `exit` / `quit` triggers orderly shutdown
- scripts are killed with `context: :shutdown`
- script settings are saved before closing the game connection
- post-join cleanup recognizes completed script/settings work and avoids duplicate cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an orderly shutdown flow that drains scripts, saves variables, updates session state, and disconnects reliably.
  * Enhanced detection of user-exit commands and explicit recording of shutdown intent to guide behavior.

* **Bug Fixes**
  * Shutdown is idempotent: repeated requests reuse the same result and avoid re-running steps.
  * Step failures are captured and logged without aborting the overall sequence.

* **Tests**
  * Comprehensive specs covering shutdown coordination, intent detection, step ordering, idempotency, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->