### PR TITLE
ci(all): Implementing repository level config for CodeRabbitAI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+inheritance: true
+
+reviews:
+  auto_review:
+    enabled: false
+    auto_incremental_review: false
+    drafts: false
+    base_branches: []
+
+  pre_merge_checks:
+    docstrings:
+      mode: warning
+      threshold: 60
+
+  path_instructions:
+    - path: "spec/**/*.rb"
+      instructions: >
+        These are RSpec spec files. Do not evaluate or report missing YARD
+        docstrings. RSpec describe, context, and it text is the documentation
+        for spec behavior. Exclude these files from the docstring coverage
+        percentage entirely.
+
+code_generation:
+  docstrings:
+    path_instructions:
+      - path: "spec/**/*.rb"
+        instructions: >
+          Do not generate YARD docstrings for RSpec spec files.
+
+chat:
+  art: false
+  allow_non_org_members: false


### PR DESCRIPTION
## Summary

Adds a repository-level CodeRabbit configuration for Lich 5.

## Changes

- Disables automatic/incremental CodeRabbit reviews so reviews are manually triggered.
- Keeps docstring coverage as a warning at 60%.
- Excludes RSpec files from docstring coverage and docstring generation guidance.
- Restricts CodeRabbit chat to organization members.
- Disables CodeRabbit chat art.

## Notes on usage

This configuration keeps CodeRabbit reviews manual. Because this repository does not use PR templates, PR authors who want a CodeRabbit-generated summary should add `@coderabbitai` summary to the PR body explicitly.  This will not cost a 'review'.  

To manually execute the review, simply create a comment `@coderabbitai review`.  This should also add a summary to the PR description, but needs testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration settings, including review behavior, validation thresholds, and chat features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->