### PR TITLE
fix(all): rubocop custom cop ascii only cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,14 +80,3 @@ Style/AsciiComments:
 
 Custom/AsciiOnlySource:
   Enabled: true
-  Exclude:
-    - 'lib/common/cli/cli_encryption_mode_change.rb'
-    - 'lib/common/gui/account_manager_ui.rb'
-    - 'lib/common/gui/manual_login_tab.rb'
-    - 'lib/common/gui/master_password_prompt_ui.rb'
-    - 'lib/common/gui/saved_login_tab.rb'
-    - 'lib/games.rb'
-    - 'spec/lib/common/authentication/entry_store_spec.rb'
-    - 'spec/lib/common/gui/master_password_prompt_spec.rb'
-    - 'spec/lib/common/gui/password_cipher_spec.rb'
-    - 'spec/lib/common/gui/windows_credential_manager_spec.rb'

--- a/lib/common/cli/cli_encryption_mode_change.rb
+++ b/lib/common/cli/cli_encryption_mode_change.rb
@@ -80,7 +80,7 @@ module Lich
               return 1
             end
 
-            puts "✓ Master password validated"
+            puts "ok: Master password validated"
             puts ""
           end
 
@@ -98,13 +98,13 @@ module Lich
               return 4
             end
 
-            puts "✓ Master password accepted"
+            puts "ok: Master password accepted"
             puts ""
           end
 
           # Warn about plaintext mode
           if new_mode == :plaintext
-            puts "⚠️  WARNING: Plaintext mode disables encryption"
+            puts "warning: Plaintext mode disables encryption"
             puts "Passwords will be stored unencrypted and visible in the file."
             puts ""
             print "Continue? (yes/no): "
@@ -130,8 +130,8 @@ module Lich
             return 1
           end
 
-          puts "✓ Encryption mode changed: #{current_mode} -> #{new_mode}"
-          puts "✓ #{account_count} accounts re-encrypted" if account_count > 0
+          puts "ok: Encryption mode changed: #{current_mode} -> #{new_mode}"
+          puts "ok: #{account_count} accounts re-encrypted" if account_count > 0
 
           Lich.log "info: CLI encryption mode change successful: #{current_mode} -> #{new_mode}"
           0

--- a/lib/common/gui/account_manager_ui.rb
+++ b/lib/common/gui/account_manager_ui.rb
@@ -902,7 +902,9 @@ module Lich
 
                   # Toggle favorite status with frontend precision
                   new_status = FavoritesManager.toggle_favorite(data_dir, account, character, game_code, frontend)
+                  # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
                   iter[5] = new_status ? '★' : '☆'
+                  # rubocop:enable Custom/AsciiOnlySource
 
                   # Notify other tabs of data change
                   notify_data_changed(:favorite_toggled, {
@@ -1208,7 +1210,9 @@ module Lich
 
               # Add favorites information with frontend precision
               is_favorite = FavoritesManager.is_favorite?(@data_dir, account, character[:char_name], character[:game_code], character[:frontend])
+              # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
               char_iter[5] = is_favorite ? '★' : '☆'
+              # rubocop:enable Custom/AsciiOnlySource
             end
           end
         end

--- a/lib/common/gui/manual_login_tab.rb
+++ b/lib/common/gui/manual_login_tab.rb
@@ -171,7 +171,9 @@ module Lich
           @make_quick_option = Gtk::CheckButton.new('Save this info for quick game entry')
 
           # Create favorites option
+          # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
           @make_favorite_option = Gtk::CheckButton.new('★ Mark as favorite')
+          # rubocop:enable Custom/AsciiOnlySource
           @make_favorite_option.set_tooltip_text('Mark this character as a favorite for quick access')
 
           # Create play button

--- a/lib/common/gui/master_password_prompt_ui.rb
+++ b/lib/common/gui/master_password_prompt_ui.rb
@@ -210,6 +210,7 @@ module Lich
           category_box = Gtk::Box.new(:vertical, 5)
           category_box.border_width = 10
 
+          # rubocop:disable Custom/AsciiOnlySource -- GTK markup displays Unicode status glyphs correctly.
           uppercase_icon = Gtk::Label.new
           uppercase_icon.markup = "<span foreground='gray'>✗</span>"
           uppercase_label = Gtk::Label.new("Uppercase letters (A-Z)")
@@ -248,6 +249,7 @@ module Lich
           length_item = Gtk::Box.new(:horizontal, 5)
           length_item.pack_start(length_icon, expand: false)
           length_item.pack_start(length_label, expand: true)
+          # rubocop:enable Custom/AsciiOnlySource
           category_box.pack_start(length_item, expand: false)
 
           category_frame.add(category_box)
@@ -284,9 +286,13 @@ module Lich
             if password_entry.text.empty? && confirm_entry.text.empty?
               match_status.markup = ""
             elsif password_entry.text == confirm_entry.text && !password_entry.text.empty?
+              # rubocop:disable Custom/AsciiOnlySource -- GTK markup displays Unicode status glyphs correctly.
               match_status.markup = "<span foreground='#44ff44'>✓ Passwords match</span>"
+              # rubocop:enable Custom/AsciiOnlySource
             else
+              # rubocop:disable Custom/AsciiOnlySource -- GTK markup displays Unicode status glyphs correctly.
               match_status.markup = "<span foreground='#ff4444'>✗ Passwords do not match</span>"
+              # rubocop:enable Custom/AsciiOnlySource
             end
           end
 
@@ -477,9 +483,11 @@ module Lich
           # Success Message
           # ====================================================================
           success_message = Gtk::Label.new
+          # rubocop:disable Custom/AsciiOnlySource -- GTK markup displays Unicode status glyphs correctly.
           success_message.markup = "<b>✓ Password Successfully Saved</b>\n\n" +
                                    "Your master password has been restored to your system Keychain.\n" +
                                    "You can now access your encrypted credentials."
+          # rubocop:enable Custom/AsciiOnlySource
           success_message.wrap = true
           success_message.justify = :center
           content_box.pack_start(success_message, expand: false)
@@ -596,9 +604,13 @@ module Lich
 
         def update_category_icon(icon_label, has_category, color_code)
           if has_category
+            # rubocop:disable Custom/AsciiOnlySource -- GTK markup displays Unicode status glyphs correctly.
             icon_label.markup = "<span foreground='#{color_code}'>✓</span>"
+            # rubocop:enable Custom/AsciiOnlySource
           else
+            # rubocop:disable Custom/AsciiOnlySource -- GTK markup displays Unicode status glyphs correctly.
             icon_label.markup = "<span foreground='gray'>✗</span>"
+            # rubocop:enable Custom/AsciiOnlySource
           end
         end
 

--- a/lib/common/gui/saved_login_tab.rb
+++ b/lib/common/gui/saved_login_tab.rb
@@ -417,7 +417,9 @@ module Lich
           # Add favorites to the tab
           if favorite_entries.empty?
             # Show message when no favorites exist
+            # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
             no_favorites_label = Gtk::Label.new("No favorite characters yet.\n\nMark characters as favorites using the ★ button\nin the account tabs or saved entries list.")
+            # rubocop:enable Custom/AsciiOnlySource
             no_favorites_label.set_justify(:center)
             no_favorites_label.set_margin_top(50)
             no_favorites_label.set_margin_bottom(50)
@@ -434,7 +436,9 @@ module Lich
           scrolled_window.set_policy(:never, :automatic)
           scrolled_window.add(favorites_box)
 
+          # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
           @account_book.prepend_page(scrolled_window, Gtk::Label.new("★ FAVORITES"))
+          # rubocop:enable Custom/AsciiOnlySource
         end
 
         # Creates a list layout for accounts (non-tabbed)
@@ -526,7 +530,9 @@ module Lich
           @play_button = Gtk::Button.new()
 
           # Add favorite indicator to character name if it's a favorite
+          # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
           char_name_text = is_favorite ? "★ #{login_params.char_name}" : login_params.char_name
+          # rubocop:enable Custom/AsciiOnlySource
           char_label = Gtk::Label.new(char_name_text)
           char_label.set_width_chars(15)
 
@@ -569,7 +575,9 @@ module Lich
           @favorite_button = nil
           if @favorites_enabled
             @favorite_button = Gtk::Button.new()
+            # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
             favorite_text = is_favorite ? '★' : '☆'
+            # rubocop:enable Custom/AsciiOnlySource
             favorite_label = Gtk::Label.new(favorite_text)
             favorite_label.set_width_chars(3)
             @favorite_button.add(favorite_label)
@@ -619,12 +627,16 @@ module Lich
               new_status = FavoritesManager.toggle_favorite(@data_dir, login_params.user_id, login_params.char_name, login_params.game_code, login_params.frontend)
 
               # Update button appearance
+              # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
               favorite_text = new_status ? '★' : '☆'
+              # rubocop:enable Custom/AsciiOnlySource
               favorite_label.text = favorite_text
               favorite_button.tooltip_text = new_status ? 'Remove from favorites' : 'Add to favorites'
 
               # Update character name display
+              # rubocop:disable Custom/AsciiOnlySource -- GTK displays Unicode favorite markers correctly.
               char_name_text = new_status ? "★ #{login_params.char_name}" : login_params.char_name
+              # rubocop:enable Custom/AsciiOnlySource
               char_label.text = char_name_text
 
               # Update play button styling

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -122,6 +122,9 @@ module Lich
 
     # XML string cleaner module
     module XMLCleaner
+      POORLY_ENCODED_APOSTROPHE_BYTE = 0x92
+      ASCII_APOSTROPHE_BYTE = 0x27
+
       class << self
         def clean_nested_quotes(server_string)
           # Fix nested single quotes
@@ -161,9 +164,13 @@ module Lich
           end
 
           # Fix poorly encoded apostrophes
-          if server_string =~ /\\x92/
+          if server_string.bytes.include?(POORLY_ENCODED_APOSTROPHE_BYTE)
             Lich.log "Detected poorly encoded apostrophe: #{server_string.inspect}"
-            server_string.gsub!("\x92", "'")
+            original_encoding = server_string.encoding
+            repaired_bytes = server_string.bytes.map do |byte|
+              byte == POORLY_ENCODED_APOSTROPHE_BYTE ? ASCII_APOSTROPHE_BYTE : byte
+            end
+            server_string.replace(repaired_bytes.pack('C*').force_encoding(original_encoding))
             Lich.log "Changed poorly encoded apostrophe to: #{server_string.inspect}"
           end
 

--- a/spec/lib/common/authentication/entry_store_spec.rb
+++ b/spec/lib/common/authentication/entry_store_spec.rb
@@ -553,7 +553,9 @@ RSpec.describe Lich::Common::Authentication::EntryStore do
       end
 
       it 'handles unicode characters in password' do
+        # rubocop:disable Custom/AsciiOnlySource -- Intentional Unicode password fixture exercises encryption round-trip behavior.
         unicode_password = 'pässwörd123日本語'
+        # rubocop:enable Custom/AsciiOnlySource
 
         encrypted = described_class.encrypt_password(
           unicode_password,

--- a/spec/lib/common/gui/master_password_prompt_spec.rb
+++ b/spec/lib/common/gui/master_password_prompt_spec.rb
@@ -155,7 +155,9 @@ RSpec.describe Lich::Common::GUI::MasterPasswordPrompt do
       end
 
       it 'handles unicode characters' do
+        # rubocop:disable Custom/AsciiOnlySource -- Intentional Unicode password fixture exercises prompt pass-through.
         password = 'Пароль密码🔐12345'
+        # rubocop:enable Custom/AsciiOnlySource
         allow(Lich::Common::GUI::MasterPasswordPromptUI).to receive(:show_dialog)
           .and_return(password)
 

--- a/spec/lib/common/gui/password_cipher_spec.rb
+++ b/spec/lib/common/gui/password_cipher_spec.rb
@@ -114,7 +114,9 @@ RSpec.describe Lich::Common::GUI::PasswordCipher do
       end
 
       it 'handles password with unicode characters' do
+        # rubocop:disable Custom/AsciiOnlySource -- Intentional Unicode password fixture exercises cipher round-trip behavior.
         unicode_password = 'пароль密码🔐'
+        # rubocop:enable Custom/AsciiOnlySource
         encrypted = described_class.encrypt(unicode_password, mode: :standard, account_name: account_name)
         decrypted = described_class.decrypt(encrypted, mode: :standard, account_name: account_name)
         expect(decrypted).to eq(unicode_password)

--- a/spec/lib/common/gui/windows_credential_manager_spec.rb
+++ b/spec/lib/common/gui/windows_credential_manager_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Lich::Common::GUI::WindowsCredentialManager do
     end
 
     context 'with special characters in password' do
+      # rubocop:disable Custom/AsciiOnlySource -- Intentional Unicode password fixtures exercise credential encoding.
       special_passwords = [
         'p@ssw0rd!',
         'pässwörd',
@@ -99,6 +100,7 @@ RSpec.describe Lich::Common::GUI::WindowsCredentialManager do
         "p'ss\"w@rd",
         'p\nw\t\r'
       ]
+      # rubocop:enable Custom/AsciiOnlySource
 
       special_passwords.each do |special_pass|
         it "handles password with special characters: #{special_pass.inspect}" do
@@ -239,11 +241,13 @@ RSpec.describe Lich::Common::GUI::WindowsCredentialManager do
         allow(Lich).to receive(:log)
 
         # Store credential with UTF-8 string to test encoding
+        # rubocop:disable Custom/AsciiOnlySource -- Intentional Unicode strings exercise UTF-16LE boundary conversion.
         result = described_class.store_credential(
           'тест.service',
           'пользователь',
           'пароль'
         )
+        # rubocop:enable Custom/AsciiOnlySource
 
         expect([true, false]).to include(result)
       end

--- a/spec/lib/games_spec.rb
+++ b/spec/lib/games_spec.rb
@@ -41,12 +41,11 @@ RSpec.describe Lich::GameBase do
       expect(output).not_to include("\a")
     end
 
-    # Need to figure out how to send this bad character string - FIXME
-    # it 'fixes poorly encoded apostrophes' do
-    #  input = "Membrach\x92s Greed"
-    #  output = Lich::GameBase::XMLCleaner.fix_invalid_characters(input)
-    #  expect(output).to eq("Membrach's Greed")
-    # end
+    it 'fixes poorly encoded apostrophes' do
+      input = [*'Membrach'.bytes, 0x92, *'s Greed'.bytes].pack('C*')
+      output = Lich::GameBase::XMLCleaner.fix_invalid_characters(input)
+      expect(output).to eq("Membrach's Greed")
+    end
 
     it 'fixes open-ended XML tags' do
       # Use +@ to unfreeze string for in-place modification


### PR DESCRIPTION
## Summary
Classifies and resolves the current Custom/AsciiOnlySource baseline so the cop can run without exclusions.

This keeps intentional Unicode where it is purposeful and supported:

GTK display glyphs are retained with scoped cop disables.
Unicode password/credential fixtures are retained with scoped cop disables.
CLI status output is converted to plain ASCII text.
Also updates the 0x92 apostrophe cleanup in lib/games.rb to use byte-level detection/replacement and adds a focused spec for that repair path.

Validation:

rbenv exec bundle exec rubocop --cache false --only Custom/AsciiOnlySource
rbenv exec bundle exec rspec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of poorly encoded characters in data processing.

* **Chores**
  * Updated CLI message formatting for encryption mode transitions (replaced checkmarks with "ok:" prefix and standardized warning text format).
  * Enhanced code quality tooling to enforce ASCII-only source code with exceptions for UI elements and tests requiring Unicode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->