### PR TITLE
feat(all): Add character generator support via EAccess protocol

### DIFF
--- a/docs/eaccess-protocol-analysis.md
+++ b/docs/eaccess-protocol-analysis.md
@@ -1,0 +1,340 @@
+# EAccess Protocol Analysis
+
+## Overview
+
+This document captures findings from systematic probing of the Simutronics EAccess authentication protocol at `eaccess.play.net:7910`. The protocol uses SSL/TLS over TCP with tab-delimited text commands. Each command is a single uppercase letter optionally followed by tab-separated arguments, terminated by a newline.
+
+The server responds with `?` for unrecognized commands or malformed argument counts.
+
+---
+
+## Connection
+
+- Host: `eaccess.play.net`
+- Port: `7910`
+- Transport: TLS over TCP
+- Certificate: Self-signed, stored locally as `simu.pem` in the data directory
+- Packet size: Up to 8192 bytes per read
+
+---
+
+## Protocol Command Reference
+
+### Known Commands (used by Lich)
+
+#### K -- Hash Key Exchange
+
+Request: `K`
+Response: 32-byte random hash key string
+
+Used to XOR-encrypt the password before transmission. The encryption algorithm:
+
+```
+for each byte i in password:
+  encrypted[i] = ((password[i] - 32) ^ hashkey[i]) + 32
+```
+
+This is obfuscation, not real encryption -- the key is transmitted in the clear on the same connection.
+
+---
+
+#### A -- Authenticate
+
+Request: `A\t{ACCOUNT}\t{HASHED_PASSWORD}`
+Response (success): `A\t{ACCOUNT}\tKEY\t{SESSION_KEY}\t{ACCOUNT_HOLDER_NAME}`
+Response (failure): Error code (e.g., `REJECT`, `NORECORD`, `INVALID`, `PASSWORD`)
+
+The session key is a 32-character hex string reused later in the `L` command response. The account holder's real name is returned in the success response.
+
+---
+
+#### M -- List Available Games
+
+Request: `M`
+Response: `M\t{CODE1}\t{NAME1}\t{CODE2}\t{NAME2}\t...`
+
+Returns all game instances visible to the authenticated account. Observed game codes:
+
+| Code | Name | Notes |
+|------|------|-------|
+| DR | DragonRealms | Production |
+| DRD | DragonRealms Development | Staff-only |
+| DRF | DragonRealms The Fallen | Separate subscription |
+| DRT | DragonRealms Prime Test | Open to subscribers |
+| DRX | DragonRealms Platinum | Separate subscription |
+| GS3 | GemStone IV | Production |
+| GS4D | GemStone IV Development | Staff-only |
+| GSF | GemStone IV Shattered | Separate subscription |
+| GST | GemStone IV Prime Test | Open (FREE tier) |
+| GSX | GemStone IV Platinum | Separate subscription |
+
+All codes are returned regardless of whether the account has access. The `F` command determines actual access.
+
+---
+
+#### F -- Check Subscription / Access Tier
+
+Request: `F\t{GAME_CODE}`
+Response: `F\t{TIER}`
+
+Possible tier values:
+
+| Tier | Meaning |
+|------|---------|
+| `PREMIUM` | Full paid subscription |
+| `NORMAL` | Standard subscription |
+| `FREE` | Free-to-play access |
+| `TRIAL` | Trial period |
+| `INTERNAL` | Staff/GM access (not observed, but handled in code) |
+| `NEW_TO_GAME` | No subscription for this game instance |
+
+`NEW_TO_GAME` is returned for game instances the account has never subscribed to. This is distinct from an error -- it indicates the game is recognized but the account lacks entitlement.
+
+**`NEW_TO_GAME` is the normal response for every unsubscribed instance, not a failure.** Probing a test account (subscribed only to DR/DRT) returned `NEW_TO_GAME` uniformly for `GS3`, `DRX`, `GSX`, `DRF`, and `GSF`. This matters for the character generator: a guard that treats only `NORMAL|PREMIUM|TRIAL|INTERNAL|FREE` as valid will abort on `F` before reaching `L`, blocking generator entry on every instance the account does not already hold -- which is precisely the case the generator exists to serve. `NEW_TO_GAME` must be tolerated on the generator path. Whether creation is actually permitted is decided later, by the `G` tier and the `L` response (see below), not by `F`.
+
+---
+
+#### N -- Check Game Frontend Availability
+
+Request: `N\t{GAME_CODE}`
+Response: Contains `STORM` if the game supports the Storm/Wrayth frontend
+
+Used in the legacy login path to filter which games support the current frontend protocol.
+
+---
+
+#### G -- Select Game (Detailed Info)
+
+Request: `G\t{GAME_CODE}`
+Response: `G\t{GAME_NAME}\t{TIER}\t{FLAG}\t\t{KEY1=VAL1}\t{KEY2=VAL2}\t...`
+
+The second field is the **effective access tier for this account on this instance**, and it is the real entitlement signal -- more informative than `F`, which collapses every unsubscribed state to `NEW_TO_GAME`. Observed values while `F` returned `NEW_TO_GAME`:
+
+| Instance | `G` tier | Generator (`L\t0`) outcome |
+|----------|----------|----------------------------|
+| GS3 | `TRIAL` (31) | accepted -- server grants a temporary trial entitlement |
+| DRX | `TRIAL` (31) | accepted |
+| GSX | `TRIAL` (31) | accepted |
+| DRF | `UNKNOWN` | refused (`L\tPROBLEM\t1`) -- no trial offered, paid subscription required |
+| GSF | `UNKNOWN` | refused (`L\tPROBLEM\t1`) -- paid subscription required |
+| DR (subscribed) | `PREMIUM` | accepted |
+
+A `TRIAL` or paid tier (`NORMAL`/`PREMIUM`) permits generator entry; `UNKNOWN` means the account has no path to create on that instance without first purchasing a subscription. Nothing here is inherently non-creatable -- a Fallen/Shattered account with a paid subscription would see `F` return `NORMAL`/`PREMIUM` and behave like DR. The outcome is per-account entitlement state, decided by the server, so the client must not crash on any of it.
+
+Returns game metadata including URL templates for various services. The URLs contain `{KEY}` placeholder for session key substitution. Observed keys:
+
+- `ROOT` -- Base path (e.g., `sgc/dr`)
+- `BILLINGINFO` -- Account info URL with session key injection point
+- `LTSIGNUP` -- Long-term signup URL
+- `SIGNUP`, `SIGNUPA` -- Signup redirect URLs
+- `FEEDBACK`, `MAILFAIL`, `MAILSUCC` -- Feedback system paths
+- Various content paths: `MAIN`, `MKTG`, `GAMEINFO`, `PLAYINFO`, `MSGBRD`, `CHAT`, `FILES`
+
+---
+
+#### P -- Platform / Pricing Info
+
+Request: `P\t{GAME_CODE}`
+Response: `P\t{CODE}\t{PRICE1}\t{CODE.EC}\t{PRICE2}\t{CODE.P}\t{PRICE3}`
+
+Returns pricing tiers for the game instance. Observed values:
+
+| Game | Base Price | EC Price | Platinum Price |
+|------|-----------|----------|----------------|
+| DR | 1495 | 250 | 2500 |
+| DRT | 1495 | 250 | 2500 |
+| GST | 1000 | -1 | 2500 |
+
+The `.EC` suffix likely means "Extra Characters" (additional character slot pricing). A value of `-1` indicates the feature is unavailable. Prices are presumably in cents.
+
+---
+
+#### C -- Character List
+
+Request: `C`
+Response: `C\t{N1}\t{N2}\t{N3}\t{N4}\t{CODE1}\t{NAME1}\t{CODE2}\t{NAME2}\t...`
+
+Returns the account's characters for the currently selected game. The four header numbers:
+
+| Position | Observed Values | Likely Meaning |
+|----------|----------------|----------------|
+| N1 | 0, 2 | Active character count |
+| N2 | 16, 100 | Maximum character slots |
+| N3 | 0, 1 | Unknown (possibly deleted count or status flag) |
+| N4 | 1 | Unknown (possibly account status flag) |
+
+Premium DR accounts get 16 slots. GST (free) accounts get 100 slots.
+
+Character codes follow the format `W_{ACCOUNT}_{SLOT}` where SLOT is a zero-padded 3-digit number (e.g., `W002`, `W003`). Slot numbers are not necessarily sequential -- gaps indicate previously deleted characters.
+
+When an account has no characters on an instance, only the header is returned (e.g., `C\t0\t100\t0\t1`).
+
+**Characters are shared across test and production instances.** The same character codes and names appear on both DR and DRT for the same account.
+
+---
+
+#### L -- Launch / Select Character
+
+Request: `L\t{CHAR_CODE}\tSTORM`
+Response (success): `L\tOK\t{KEY1=VAL1}\t{KEY2=VAL2}\t...`
+
+Selects a character and returns game server connection details. Observed response keys:
+
+| Key | Example Value | Purpose |
+|-----|---------------|---------|
+| UPPORT | 5535 | Support port (note: may be `SUPPORT` with leading S consumed) |
+| GAME | STORM | Frontend protocol |
+| GAMECODE | DR | Game instance |
+| FULLGAMENAME | Wrayth | Frontend application name |
+| GAMEFILE | WRAYTH.EXE | Frontend executable |
+| GAMEHOST | dr.simutronics.net | Game server hostname |
+| GAMEPORT | 11024 | Game server port |
+| KEY | (session key) | Authentication key for game server |
+
+**Character code `0` enters the character generator.** Sending `L\t0\tSTORM` bypasses character selection entirely and returns valid connection details that lead to the character creation flow on the game server. This works even when the account has no characters on the selected instance, and even when `F` returned `NEW_TO_GAME`, provided the account has a creation entitlement (a paid tier or a `TRIAL` grant; see the `G` command).
+
+**Generator entry can be refused: `L\tPROBLEM\t1`.** When the account has no entitlement to create on the instance (the `G` tier is `UNKNOWN`, e.g. unsubscribed Fallen/Shattered), `L\t0\tSTORM` returns `L\tPROBLEM\t1` instead of `L\tOK\t...`. Note this still begins with `L\t`, so a guard of the form `response =~ /^L\t/` accepts it and then parses a garbage launch payload (`{"l"=>nil, "problem"=>nil, "1"=>nil}`). The success guard must require `^L\tOK\t`, and `L\tPROBLEM` should be surfaced as a clear "account not entitled to create a character on this instance" error rather than crashing or launching with broken data.
+
+---
+
+### Discovered Commands (not used by Lich)
+
+#### B -- Billing Status
+
+Request: `B`
+Response: `B\t{TIER}`
+
+Returns the account's current billing/subscription tier without requiring a game code argument. Appears to return the account-level subscription rather than a game-specific one. With arguments, returns `?`.
+
+---
+
+#### D -- Delete Character (or Character Info)
+
+Request: `D\t{CHAR_CODE}`
+Response (not found): `D\t{CHAR_CODE}\tERROR: Character not found`
+
+Takes a single argument: the character code (e.g., `W_ACCT_W002`). Two-argument forms return `?`. The command validates the character code against the account's character list and returns a structured error when the code doesn't match.
+
+The response format for a valid character code was not tested to avoid data loss. The error response structure suggests the success response would be `D\t{CHAR_CODE}\t{STATUS}`.
+
+---
+
+#### E -- Email Address
+
+Request: `E`
+Response: `S\t{EMAIL_ADDRESS}`
+
+Returns the email address associated with the authenticated account. Note the response prefix is `S` (not `E`), possibly indicating a "Settings" response category.
+
+This is a read-only information disclosure endpoint. It accepts no arguments -- `E\t{value}` returns `?`, so it cannot be used to modify the email.
+
+---
+
+#### S -- Subscription Management
+
+Request: `S`
+Response: `S\tPROBLEM\tProblem processing subscription. Please try again later or contact customer service.`
+
+Appears to be a subscription purchase or modification endpoint. The bare command reaches a real server-side handler that returns a structured error message, but every argument variation returns `?`:
+
+Tested and rejected argument patterns:
+- `S\t{GAME_CODE}` (e.g., `S\tDR`, `S\tDRD`)
+- `S\t{TIER}` (e.g., `S\tINTERNAL`, `S\tPREMIUM`)
+- `S\t{GAME_CODE}\t{TIER}`
+- `S\t{GAME_CODE}\t{NUMBER}`
+- `S\t{GAME_CODE}\t{TIER}\t{NUMBER}`
+- `S\tSUBSCRIBE\t{GAME_CODE}`
+
+The handler likely requires a payment token or transaction reference from the web billing portal (`account.play.net`). The protocol alone cannot modify subscriptions. After all probe attempts, `F` responses remained unchanged -- no subscription state was altered.
+
+---
+
+#### V -- Protocol Version
+
+Request: `V`
+Response: `V\t1`
+
+Returns the EAccess protocol version number. Currently version 1. Accepts no arguments.
+
+---
+
+#### Z -- Logout / Session Close
+
+Request: `Z`
+Response: `OK`
+
+Cleanly terminates the authenticated session. The connection remains open but the session state is cleared.
+
+---
+
+### Unused Command Letters
+
+The following letters return `?` in all tested forms (bare and with arguments) and appear to be unimplemented:
+
+`H`, `I` (returns `I\tPROBLEM` with game code arg), `J`, `O`, `Q`, `R`, `T`, `U`, `W`, `X`, `Y`
+
+The `I` command with a game code argument returns `I\tPROBLEM`, suggesting a partially implemented or disabled endpoint -- possibly an "Info" or "Inquiry" command.
+
+---
+
+## Access Control Observations
+
+### Development Server Access
+
+The development instances (DRD, GS4D) are visible in the game list but return `NEW_TO_GAME` for standard accounts. Access is gated by subscription tier, not by game visibility. The `INTERNAL` tier (handled in code but never observed) is presumably the staff subscription that grants access.
+
+There is no protocol-level mechanism to elevate subscription tier. The `S` command's server-side handler appears to require external input (likely from the web billing system) and cannot be used standalone.
+
+### Test Server Access
+
+Test instances (DRT, GST) are freely accessible:
+- DRT inherits the account's DR subscription tier (PREMIUM)
+- GST is available as FREE tier to all accounts
+- GST provides 100 character slots (vs. 16 for premium DR)
+- Characters and character codes are shared between production and test instances
+
+### Character Slot Allocation
+
+| Tier | Observed Max Slots |
+|------|--------------------|
+| PREMIUM (DR) | 16 |
+| FREE (GST) | 100 |
+
+The generous GST slot allocation (100) combined with the character code `0` entry point makes it a useful target for character generator testing.
+
+---
+
+## Security Observations
+
+1. **Password obfuscation is weak.** The XOR scheme with a cleartext key provides no meaningful security beyond the TLS transport layer.
+
+2. **Email disclosure.** The `E` command returns the account holder's email with no additional authentication beyond the initial login.
+
+3. **Account holder name disclosure.** The `A` command success response includes the account holder's full name.
+
+4. **Subscription tier disclosure.** The `B`, `F`, and `G` commands expose subscription information.
+
+5. **No rate limiting observed.** The protocol accepted rapid sequential probing without throttling or lockout.
+
+6. **Self-signed certificate.** The server uses a self-signed certificate with no chain of trust. The client must manually verify the certificate against a stored copy.
+
+---
+
+## Protocol State Machine
+
+The protocol follows a strict state progression:
+
+```
+K (hash key)
+  -> A (authenticate)
+    -> M (list games)
+      -> F (check subscription for game)
+        -> G (select game)
+          -> P (platform info)
+            -> C (character list)
+              -> L (launch character)
+```
+
+Auxiliary commands (B, D, E, S, V, Z) can be issued at various points after authentication. The `D` command requires a game to be selected (via G) so the server knows which character list to validate against.
+
+Commands issued out of order may produce unexpected results or error responses. The `F` command resets the game selection context, requiring G/P/C to be re-issued for a different game.

--- a/lib/common/account.rb
+++ b/lib/common/account.rb
@@ -53,7 +53,7 @@ module Lich
 
       def self.members=(value)
         potential_members = {}
-        for code_name in value.sub(/^C\t[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+[\t\n]/, '').scan(/[^\t]+\t[^\t^\n]+/)
+        for code_name in value.sub(/^C\t[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+[\t\n]/, '').scan(/[^\t]+\t[^\t\n]+/)
           char_code, char_name = code_name.split("\t")
           potential_members[char_code] = char_name
         end

--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -29,16 +29,18 @@ module Lich
       # @param character [String, nil] Character name (optional)
       # @param game_code [String, nil] Game code (optional)
       # @param legacy [Boolean] Whether to use legacy authentication
+      # @param generator [Boolean] Whether to enter the character generator instead of selecting a character
       # @return [Hash, Array] Authentication data containing connection information
       # @raise [StandardError] Re-raises the last error after all retries exhausted
-      def self.authenticate(account:, password:, character: nil, game_code: nil, legacy: false)
+      def self.authenticate(account:, password:, character: nil, game_code: nil, legacy: false, generator: false)
         with_retry do
           if character && game_code
             EAccess.auth(
               account: account,
               password: password,
               character: character,
-              game_code: game_code
+              game_code: game_code,
+              generator: generator
             )
           elsif legacy
             EAccess.auth(

--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -35,7 +35,7 @@ module Lich
       # @raise [StandardError] Re-raises the last error after all retries exhausted
       def self.authenticate(account:, password:, character: nil, game_code: nil, legacy: false, generator: false)
         with_retry do
-          if character && game_code
+          if game_code && (character || generator)
             EAccess.auth(
               account: account,
               password: password,

--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -19,7 +19,8 @@ module Lich
       # Known fatal error codes that should not be retried
       # REJECT = bad credentials, NORECORD = account not found, INVALID = invalid request
       # PASSWORD = wrong password, CHARACTER_NOT_FOUND = character not in account
-      FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND].freeze
+      # GENERATOR_NOT_AVAILABLE = account not entitled to create a character on the instance
+      FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND GENERATOR_NOT_AVAILABLE].freeze
 
       # Authenticates a user with the game server
       # Includes automatic retry with exponential backoff for transient errors

--- a/lib/common/authentication/cli.rb
+++ b/lib/common/authentication/cli.rb
@@ -77,12 +77,16 @@ module Lich
         #
         # @param account_name [String] account name as stored in entry.yaml
         # @param game_code [String, nil] game instance code (e.g. "DR", "GS3")
+        # @param frontend [String, Symbol, nil] requested frontend for the launched session
+        #   (nil or the :__unset sentinel default to 'profanity')
+        # @param custom_launch [String, Symbol, nil] custom launch command (the :__unset sentinel is treated as none)
+        # @param custom_launch_dir [String, Symbol, nil] custom launch directory (the :__unset sentinel is treated as none)
         # @param data_dir [String, nil] directory containing saved login entries
         # @return [Array<String>, nil] launch data strings if successful, nil on failure
         #
         # @example
         #   launch_data = CLI.execute_new_character('MYACCOUNT', game_code: 'DR', data_dir: '/path/to/data')
-        def self.execute_new_character(account_name, game_code: nil, data_dir: nil)
+        def self.execute_new_character(account_name, game_code: nil, frontend: nil, custom_launch: nil, custom_launch_dir: nil, data_dir: nil)
           data_dir ||= DATA_DIR
 
           unless account_name && !account_name.empty?
@@ -106,11 +110,22 @@ module Lich
             password: account_data[:password],
             char_name: 'NEW',
             game_code: game_code,
-            frontend: 'profanity',
+            frontend: unset_login_value?(frontend) ? 'profanity' : frontend,
+            custom_launch: unset_login_value?(custom_launch) ? nil : custom_launch,
+            custom_launch_dir: unset_login_value?(custom_launch_dir) ? nil : custom_launch_dir,
             generator: true,
           }
 
           decrypt_and_authenticate(char_entry, entry_data)
+        end
+
+        # Treats nil and the :__unset CLI sentinel as "value not provided".
+        #
+        # @param value [Object] a parsed CLI login value
+        # @return [Boolean] true when the value should be treated as absent
+        # @api private
+        def self.unset_login_value?(value)
+          value.nil? || value == :__unset
         end
 
         # Loads and parses entry.yaml from the given data directory.

--- a/lib/common/authentication/cli.rb
+++ b/lib/common/authentication/cli.rb
@@ -134,7 +134,7 @@ module Lich
         # @return [Hash, nil] symbolized entry data, or nil on failure
         # @api private
         def self.load_entry_data(data_dir)
-          unless CLIPassword.validate_master_password_available
+          unless CLIPassword.validate_master_password_available(data_dir: data_dir)
             Lich.log "error: Master password validation failed during CLI login"
             return nil
           end
@@ -163,8 +163,15 @@ module Lich
         # @return [Array(String, Hash), nil] [canonical account name, account data], or nil if not found
         # @api private
         def self.find_account(entry_data, account_name)
+          # New character creation requires the accounts-based YAML format. Legacy
+          # array-format entries have no account container to look up by name.
+          unless entry_data.is_a?(Hash)
+            Lich.log "error: New character creation requires the accounts-based entry format"
+            return nil
+          end
+
           accounts = entry_data[:accounts]
-          unless accounts
+          unless accounts.is_a?(Hash)
             Lich.log "error: No accounts found in saved entries"
             return nil
           end

--- a/lib/common/authentication/cli.rb
+++ b/lib/common/authentication/cli.rb
@@ -107,6 +107,7 @@ module Lich
             char_name: 'NEW',
             game_code: game_code,
             frontend: 'profanity',
+            generator: true,
           }
 
           decrypt_and_authenticate(char_entry, entry_data)
@@ -166,6 +167,7 @@ module Lich
         # Decrypts the password from a character entry and authenticates with the game server.
         #
         # @param char_entry [Hash] character entry with :username, :password, :char_name, :game_code, :frontend keys
+        #   and an optional :generator flag for character-generator entry
         # @param entry_data [Hash] full entry data (needed for encryption mode)
         # @return [Array<String>, nil] launch data strings if successful, nil on failure
         def self.decrypt_and_authenticate(char_entry, entry_data)
@@ -195,7 +197,8 @@ module Lich
               account: char_entry[:username],
               password: plaintext_password,
               character: char_entry[:char_name],
-              game_code: char_entry[:game_code]
+              game_code: char_entry[:game_code],
+              generator: char_entry[:generator] || false
             )
 
             # Format and return launch data

--- a/lib/common/authentication/cli.rb
+++ b/lib/common/authentication/cli.rb
@@ -102,11 +102,11 @@ module Lich
           entry_data = load_entry_data(data_dir)
           return nil unless entry_data
 
-          account_data = find_account(entry_data, account_name)
+          canonical_name, account_data = find_account(entry_data, account_name)
           return nil unless account_data
 
           char_entry = {
-            username: account_name,
+            username: canonical_name,
             password: account_data[:password],
             char_name: 'NEW',
             game_code: game_code,
@@ -154,9 +154,13 @@ module Lich
 
         # Finds an account by name in the entry data (case-insensitive).
         #
+        # Returns the stored canonical account key alongside the account data so
+        # callers authenticate with the canonical identifier rather than the
+        # caller-supplied casing.
+        #
         # @param entry_data [Hash] symbolized entry data with :accounts key
         # @param account_name [String] account name to search for
-        # @return [Hash, nil] account data hash, or nil if not found
+        # @return [Array(String, Hash), nil] [canonical account name, account data], or nil if not found
         # @api private
         def self.find_account(entry_data, account_name)
           accounts = entry_data[:accounts]
@@ -165,7 +169,7 @@ module Lich
             return nil
           end
 
-          _name, account_data = accounts.find { |key, _v| key.to_s.casecmp?(account_name) }
+          canonical_name, account_data = accounts.find { |key, _v| key.to_s.casecmp?(account_name) }
           unless account_data
             Lich.log "error: Account not found: #{account_name}"
             return nil
@@ -176,7 +180,7 @@ module Lich
             return nil
           end
 
-          account_data
+          [canonical_name.to_s, account_data]
         end
 
         # Decrypts the password from a character entry and authenticates with the game server.

--- a/lib/common/authentication/cli.rb
+++ b/lib/common/authentication/cli.rb
@@ -35,26 +35,8 @@ module Lich
             return nil
           end
 
-          # Validate master password availability before attempting login (required for Enhanced encryption mode)
-          unless CLIPassword.validate_master_password_available
-            Lich.log "error: Master password validation failed during CLI login"
-            return nil
-          end
-
-          # Load raw YAML data (not decrypted yet)
-          yaml_file = EntryStore.yaml_file_path(data_dir)
-          unless File.exist?(yaml_file)
-            Lich.log "error: No saved entries YAML file found"
-            return nil
-          end
-
-          begin
-            yaml_data = YAML.safe_load_file(yaml_file, permitted_classes: [Symbol])
-            entry_data = LoginHelpers.symbolize_keys(yaml_data)
-          rescue StandardError => e
-            Lich.log "error: Failed to load YAML data: #{e.message}"
-            return nil
-          end
+          entry_data = load_entry_data(data_dir)
+          return nil unless entry_data
 
           # Find matching character(s) using login_helpers
           matching_entries = LoginHelpers.find_character_by_name_game_and_frontend(
@@ -87,6 +69,105 @@ module Lich
           decrypt_and_authenticate(char_entry, entry_data)
         end
 
+        # Executes CLI login flow to enter the character generator on an existing account.
+        #
+        # Looks up the account by name in saved entries, decrypts its password,
+        # and authenticates with character name "NEW" to reach the character
+        # creation flow on the game server.
+        #
+        # @param account_name [String] account name as stored in entry.yaml
+        # @param game_code [String, nil] game instance code (e.g. "DR", "GS3")
+        # @param data_dir [String, nil] directory containing saved login entries
+        # @return [Array<String>, nil] launch data strings if successful, nil on failure
+        #
+        # @example
+        #   launch_data = CLI.execute_new_character('MYACCOUNT', game_code: 'DR', data_dir: '/path/to/data')
+        def self.execute_new_character(account_name, game_code: nil, data_dir: nil)
+          data_dir ||= DATA_DIR
+
+          unless account_name && !account_name.empty?
+            Lich.log "error: Account name is required for new character creation"
+            return nil
+          end
+
+          unless game_code
+            Lich.log "error: Game code is required for new character creation (e.g. --dr, --gemstone)"
+            return nil
+          end
+
+          entry_data = load_entry_data(data_dir)
+          return nil unless entry_data
+
+          account_data = find_account(entry_data, account_name)
+          return nil unless account_data
+
+          char_entry = {
+            username: account_name,
+            password: account_data[:password],
+            char_name: 'NEW',
+            game_code: game_code,
+            frontend: 'profanity',
+          }
+
+          decrypt_and_authenticate(char_entry, entry_data)
+        end
+
+        # Loads and parses entry.yaml from the given data directory.
+        #
+        # @param data_dir [String] directory containing entry.yaml
+        # @return [Hash, nil] symbolized entry data, or nil on failure
+        # @api private
+        def self.load_entry_data(data_dir)
+          unless CLIPassword.validate_master_password_available
+            Lich.log "error: Master password validation failed during CLI login"
+            return nil
+          end
+
+          yaml_file = EntryStore.yaml_file_path(data_dir)
+          unless File.exist?(yaml_file)
+            Lich.log "error: No saved entries YAML file found"
+            return nil
+          end
+
+          yaml_data = YAML.safe_load_file(yaml_file, permitted_classes: [Symbol])
+          LoginHelpers.symbolize_keys(yaml_data)
+        rescue StandardError => e
+          Lich.log "error: Failed to load YAML data: #{e.message}"
+          nil
+        end
+
+        # Finds an account by name in the entry data (case-insensitive).
+        #
+        # @param entry_data [Hash] symbolized entry data with :accounts key
+        # @param account_name [String] account name to search for
+        # @return [Hash, nil] account data hash, or nil if not found
+        # @api private
+        def self.find_account(entry_data, account_name)
+          accounts = entry_data[:accounts]
+          unless accounts
+            Lich.log "error: No accounts found in saved entries"
+            return nil
+          end
+
+          _name, account_data = accounts.find { |key, _v| key.to_s.casecmp?(account_name) }
+          unless account_data
+            Lich.log "error: Account not found: #{account_name}"
+            return nil
+          end
+
+          unless account_data[:password]
+            Lich.log "error: No password saved for account: #{account_name}"
+            return nil
+          end
+
+          account_data
+        end
+
+        # Decrypts the password from a character entry and authenticates with the game server.
+        #
+        # @param char_entry [Hash] character entry with :username, :password, :char_name, :game_code, :frontend keys
+        # @param entry_data [Hash] full entry data (needed for encryption mode)
+        # @return [Array<String>, nil] launch data strings if successful, nil on failure
         def self.decrypt_and_authenticate(char_entry, entry_data)
           # Get encryption mode from YAML
           encryption_mode = (entry_data[:encryption_mode] || 'plaintext').to_sym

--- a/lib/common/authentication/cli.rb
+++ b/lib/common/authentication/cli.rb
@@ -90,8 +90,8 @@ module Lich
             return nil
           end
 
-          unless game_code
-            Lich.log "error: Game code is required for new character creation (e.g. --dr, --gemstone)"
+          unless game_code && LoginHelpers::VALID_GAME_CODES.include?(game_code.to_s)
+            Lich.log "error: A valid game code is required for new character creation (e.g. --dr, --gemstone). Got: #{game_code.inspect}"
             return nil
           end
 

--- a/lib/common/authentication/cli_password.rb
+++ b/lib/common/authentication/cli_password.rb
@@ -374,9 +374,9 @@ module Lich
         # Validates if master password is available in keychain for enhanced mode
         # Checks: YAML exists, validation test present, keychain available with password
         #
+        # @param data_dir [String] directory containing entry.yaml (defaults to DATA_DIR)
         # @return [Boolean] true if ready for operations, false if issues found
-        def self.validate_master_password_available
-          data_dir = DATA_DIR
+        def self.validate_master_password_available(data_dir: DATA_DIR)
           yaml_file = Lich::Common::Authentication::EntryStore.yaml_file_path(data_dir)
 
           unless File.exist?(yaml_file)

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -125,7 +125,15 @@ module Lich
             unless legacy
               conn.puts "F\t#{game_code}\n"
               response = EAccess.read(conn)
-              raise StandardError, response unless response =~ /NORMAL|PREMIUM|TRIAL|INTERNAL|FREE/
+              # F reports the account's tier for this instance. NEW_TO_GAME is the
+              # normal response for any instance the account is not subscribed to --
+              # not an error. The generator path tolerates it because character
+              # creation is exactly the flow that targets instances the account does
+              # not already hold; whether creation is permitted is decided later by
+              # the L response, not here.
+              unless response =~ /NORMAL|PREMIUM|TRIAL|INTERNAL|FREE/ || (generator && response =~ /NEW_TO_GAME/)
+                raise StandardError, response
+              end
               if defined?(Lich::Common::Account)
                 Lich::Common::Account.subscription = response
               end
@@ -145,7 +153,18 @@ module Lich
               char_code = generator ? NEW_CHARACTER_CODE : resolve_char_code(response, character)
               conn.puts "L\t#{char_code}\tSTORM\n"
               response = EAccess.read(conn)
-              raise StandardError, response unless response =~ /^L\t/
+              # Both success and failure are prefixed with "L\t" (e.g. the server
+              # returns "L\tPROBLEM\t1" when the account is not entitled to create on
+              # this instance), so require the explicit OK before parsing the launch
+              # payload -- otherwise a PROBLEM line is parsed into a garbage hash.
+              unless response =~ /^L\tOK\t/
+                # On the generator path a PROBLEM here means the account has no
+                # entitlement to create a character on this instance (e.g. an
+                # unsubscribed Fallen/Shattered). Fail fast with a clear code rather
+                # than crash or launch broken data.
+                raise AuthenticationError, "GENERATOR_NOT_AVAILABLE" if generator
+                raise StandardError, response
+              end
               # pp "L:response=%s" % response
               login_info = response.sub(/^L\tOK\t/, '')
                                    .split("\t")

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -21,6 +21,14 @@ module Lich
 
         PACKET_SIZE = 8192
 
+        # Character code that enters the character generator instead of selecting an existing character.
+        # When sent via the L command, the game server starts the character creation flow.
+        NEW_CHARACTER_CODE = "0"
+
+        # Pattern for detecting the special "NEW" character name (case-insensitive).
+        # @api private
+        NEW_CHARACTER_PATTERN = /\Anew\z/i
+
         # @api private
         def self.pem
           @pem ||= File.join(DATA_DIR, "simu.pem")
@@ -72,6 +80,19 @@ module Lich
           return ssl_socket
         end
 
+        # Authenticates with the EAccess server and launches a character session.
+        #
+        # When +character+ matches "NEW" (case-insensitive), the character lookup
+        # is skipped and the server enters the character generator instead of
+        # selecting an existing character.
+        #
+        # @param password [String] account password (plaintext, will be hashed)
+        # @param account [String] account name
+        # @param character [String, nil] character name to select, or "NEW" for character generator
+        # @param game_code [String, nil] game instance code (e.g. "DR", "GS3")
+        # @param legacy [Boolean] use legacy multi-game enumeration flow
+        # @return [Hash, Array] login info hash (normal) or array of character hashes (legacy)
+        # @raise [AuthenticationError] on auth failure or character not found
         def self.auth(password:, account:, character: nil, game_code: nil, legacy: false)
           # Set Account module state
           if defined?(Lich::Common::Account)
@@ -124,13 +145,7 @@ module Lich
               if defined?(Lich::Common::Account)
                 Lich::Common::Account.members = response
               end
-              char_entry = response.sub(/^C\t[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+[\t\n]/, '')
-                                   .scan(/[^\t]+\t[^\t^\n]+/)
-                                   .find { |c| c.split("\t")[1] == character }
-              unless char_entry
-                raise AuthenticationError, "CHARACTER_NOT_FOUND"
-              end
-              char_code = char_entry.split("\t")[0]
+              char_code = resolve_char_code(response, character)
               conn.puts "L\t#{char_code}\tSTORM\n"
               response = EAccess.read(conn)
               raise StandardError, response unless response =~ /^L\t/
@@ -178,6 +193,26 @@ module Lich
           ensure
             conn&.close unless conn&.closed?
           end
+        end
+
+        # Resolves the character code from the C response, or returns the
+        # character generator code when the character name is "NEW".
+        #
+        # @param c_response [String] raw C command response from the server
+        # @param character [String] character name to look up, or "NEW" for generator
+        # @return [String] character code for the L command
+        # @raise [AuthenticationError] when the character is not found in the response
+        # @api private
+        def self.resolve_char_code(c_response, character)
+          return NEW_CHARACTER_CODE if character&.match?(NEW_CHARACTER_PATTERN)
+
+          char_entry = c_response.sub(/^C\t[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+[\t\n]/, '')
+                                 .scan(/[^\t]+\t[^\t^\n]+/)
+                                 .find { |c| c.split("\t")[1] == character }
+
+          raise AuthenticationError, "CHARACTER_NOT_FOUND" unless char_entry
+
+          char_entry.split("\t")[0]
         end
 
         # @api private

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -25,10 +25,6 @@ module Lich
         # When sent via the L command, the game server starts the character creation flow.
         NEW_CHARACTER_CODE = "0"
 
-        # Pattern for detecting the special "NEW" character name (case-insensitive).
-        # @api private
-        NEW_CHARACTER_PATTERN = /\Anew\z/i
-
         # @api private
         def self.pem
           @pem ||= File.join(DATA_DIR, "simu.pem")
@@ -82,18 +78,19 @@ module Lich
 
         # Authenticates with the EAccess server and launches a character session.
         #
-        # When +character+ matches "NEW" (case-insensitive), the character lookup
-        # is skipped and the server enters the character generator instead of
-        # selecting an existing character.
+        # When +generator+ is true, the character lookup is skipped and the server
+        # enters the character generator (character code "0") instead of selecting
+        # an existing character.
         #
         # @param password [String] account password (plaintext, will be hashed)
         # @param account [String] account name
-        # @param character [String, nil] character name to select, or "NEW" for character generator
+        # @param character [String, nil] character name to select
         # @param game_code [String, nil] game instance code (e.g. "DR", "GS3")
         # @param legacy [Boolean] use legacy multi-game enumeration flow
+        # @param generator [Boolean] enter the character generator instead of selecting a character
         # @return [Hash, Array] login info hash (normal) or array of character hashes (legacy)
         # @raise [AuthenticationError] on auth failure or character not found
-        def self.auth(password:, account:, character: nil, game_code: nil, legacy: false)
+        def self.auth(password:, account:, character: nil, game_code: nil, legacy: false, generator: false)
           # Set Account module state
           if defined?(Lich::Common::Account)
             Lich::Common::Account.name = account
@@ -145,7 +142,7 @@ module Lich
               if defined?(Lich::Common::Account)
                 Lich::Common::Account.members = response
               end
-              char_code = resolve_char_code(response, character)
+              char_code = generator ? NEW_CHARACTER_CODE : resolve_char_code(response, character)
               conn.puts "L\t#{char_code}\tSTORM\n"
               response = EAccess.read(conn)
               raise StandardError, response unless response =~ /^L\t/
@@ -195,19 +192,16 @@ module Lich
           end
         end
 
-        # Resolves the character code from the C response, or returns the
-        # character generator code when the character name is "NEW".
+        # Resolves the character code for the requested character from the C response.
         #
         # @param c_response [String] raw C command response from the server
-        # @param character [String] character name to look up, or "NEW" for generator
+        # @param character [String] character name to look up
         # @return [String] character code for the L command
         # @raise [AuthenticationError] when the character is not found in the response
         # @api private
         def self.resolve_char_code(c_response, character)
-          return NEW_CHARACTER_CODE if character&.match?(NEW_CHARACTER_PATTERN)
-
           char_entry = c_response.sub(/^C\t[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+[\t\n]/, '')
-                                 .scan(/[^\t]+\t[^\t^\n]+/)
+                                 .scan(/[^\t]+\t[^\t\n]+/)
                                  .find { |c| c.split("\t")[1] == character }
 
           raise AuthenticationError, "CHARACTER_NOT_FOUND" unless char_entry

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -155,7 +155,7 @@ module Lich
                                    }.to_h
             else
               login_info = Array.new
-              for game in response.sub(/^M\t/, '').scan(/[^\t]+\t[^\t^\n]+/)
+              for game in response.sub(/^M\t/, '').scan(/[^\t]+\t[^\t\n]+/)
                 game_code, game_name = game.split("\t")
                 # pp "M:response = %s" % response
                 conn.puts "N\t#{game_code}\n"
@@ -176,7 +176,7 @@ module Lich
                     if defined?(Lich::Common::Account)
                       Lich::Common::Account.members = response
                     end
-                    for code_name in response.sub(/^C\t[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+[\t\n]/, '').scan(/[^\t]+\t[^\t^\n]+/)
+                    for code_name in response.sub(/^C\t[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+[\t\n]/, '').scan(/[^\t]+\t[^\t\n]+/)
                       char_code, char_name = code_name.split("\t")
                       hash = { :game_code => "#{game_code}", :game_name => "#{game_name}",
                               :char_code => "#{char_code}", :char_name => "#{char_name}" }

--- a/lib/common/authentication/login_helpers.rb
+++ b/lib/common/authentication/login_helpers.rb
@@ -13,6 +13,12 @@ module Lich
         # Valid game codes
         VALID_GAME_CODES = %w[GS3 GS4 GSX GSF GST DR DRX DRF DRT].freeze
 
+        # CLI login name that requests the character generator instead of
+        # selecting an existing character (e.g. `--login NEW`). This is a
+        # user-facing CLI convention; the generator decision is carried to the
+        # lower layers as explicit intent, not as a magic character name.
+        NEW_CHARACTER_LOGIN = /\Anew\z/i
+
         # Valid frontend flags accepted by CLI login argument parsing.
         # Note: only wizard/stormfront/avalon affect protocol path selection;
         # other values are treated as frontend launch selectors/modifiers.

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -70,6 +70,8 @@ reconnect_if_wanted = proc {
                           Lich::Common::Authentication::CLI.execute_new_character(
                             @argv_options[:account],
                             game_code: requested_instance,
+                            frontend: requested_fe,
+                            custom_launch: requested_custom_launch,
                             data_dir: DATA_DIR
                           )
                         else

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -66,7 +66,7 @@ reconnect_if_wanted = proc {
     lookup_frontend = Lich::Common::Authentication::LoginHelpers.resolve_lookup_frontend(requested_fe, ARGV)
 
     # Execute CLI login flow and get launch data
-    launch_data_array = if requested_character.match?(/\Anew\z/i) && @argv_options[:account]
+    launch_data_array = if requested_character.match?(Lich::Common::Authentication::LoginHelpers::NEW_CHARACTER_LOGIN) && @argv_options[:account]
                           Lich::Common::Authentication::CLI.execute_new_character(
                             @argv_options[:account],
                             game_code: requested_instance,

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -66,13 +66,21 @@ reconnect_if_wanted = proc {
     lookup_frontend = Lich::Common::Authentication::LoginHelpers.resolve_lookup_frontend(requested_fe, ARGV)
 
     # Execute CLI login flow and get launch data
-    launch_data_array = Lich::Common::Authentication::CLI.execute(
-      requested_character,
-      game_code: requested_instance,
-      frontend: lookup_frontend,
-      custom_launch: requested_custom_launch,
-      data_dir: DATA_DIR
-    )
+    launch_data_array = if requested_character.match?(/\Anew\z/i) && @argv_options[:account]
+                          Lich::Common::Authentication::CLI.execute_new_character(
+                            @argv_options[:account],
+                            game_code: requested_instance,
+                            data_dir: DATA_DIR
+                          )
+                        else
+                          Lich::Common::Authentication::CLI.execute(
+                            requested_character,
+                            game_code: requested_instance,
+                            frontend: lookup_frontend,
+                            custom_launch: requested_custom_launch,
+                            data_dir: DATA_DIR
+                          )
+                        end
 
     if launch_data_array
       Lich.log "info: CLI login successful for #{requested_character}"

--- a/spec/lib/common/authentication/authenticator_spec.rb
+++ b/spec/lib/common/authentication/authenticator_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe Lich::Common::Authentication do
         account: 'testuser',
         password: 'testpass',
         character: 'TestChar',
-        game_code: 'GS3'
+        game_code: 'GS3',
+        generator: false
       ).and_return(auth_result)
 
       result = described_class.authenticate(
@@ -67,6 +68,24 @@ RSpec.describe Lich::Common::Authentication do
       )
 
       expect(result).to eq(auth_result)
+    end
+
+    it 'forwards the generator flag to EAccess.auth' do
+      expect(Lich::Common::Authentication::EAccess).to receive(:auth).with(
+        account: 'testuser',
+        password: 'testpass',
+        character: 'NEW',
+        game_code: 'GS3',
+        generator: true
+      ).and_return(auth_result)
+
+      described_class.authenticate(
+        account: 'testuser',
+        password: 'testpass',
+        character: 'NEW',
+        game_code: 'GS3',
+        generator: true
+      )
     end
 
     it 'calls EAccess.auth with legacy flag when specified' do

--- a/spec/lib/common/authentication/authenticator_spec.rb
+++ b/spec/lib/common/authentication/authenticator_spec.rb
@@ -88,6 +88,23 @@ RSpec.describe Lich::Common::Authentication do
       )
     end
 
+    it 'routes to EAccess.auth on generator intent without a character' do
+      expect(Lich::Common::Authentication::EAccess).to receive(:auth).with(
+        account: 'testuser',
+        password: 'testpass',
+        character: nil,
+        game_code: 'GS3',
+        generator: true
+      ).and_return(auth_result)
+
+      described_class.authenticate(
+        account: 'testuser',
+        password: 'testpass',
+        game_code: 'GS3',
+        generator: true
+      )
+    end
+
     it 'calls EAccess.auth with legacy flag when specified' do
       expect(Lich::Common::Authentication::EAccess).to receive(:auth).with(
         account: 'testuser',

--- a/spec/lib/common/authentication/cli_spec.rb
+++ b/spec/lib/common/authentication/cli_spec.rb
@@ -77,12 +77,26 @@ RSpec.describe Lich::Common::Authentication::CLI do
       end
     end
 
-    context 'with missing game code' do
+    context 'with missing or invalid game code' do
       it 'returns nil when game_code is nil' do
         result = described_class.execute_new_character('TESTUSER', game_code: nil, data_dir: data_dir)
 
         expect(result).to be_nil
-        expect(Lich).to have_received(:log).with(/Game code is required/)
+        expect(Lich).to have_received(:log).with(/valid game code is required/i)
+      end
+
+      it 'returns nil when game_code is the :__unset sentinel' do
+        result = described_class.execute_new_character('TESTUSER', game_code: :__unset, data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/valid game code is required/i)
+      end
+
+      it 'returns nil when game_code is not a known game code' do
+        result = described_class.execute_new_character('TESTUSER', game_code: 'BOGUS', data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/valid game code is required/i)
       end
     end
 

--- a/spec/lib/common/authentication/cli_spec.rb
+++ b/spec/lib/common/authentication/cli_spec.rb
@@ -135,10 +135,19 @@ RSpec.describe Lich::Common::Authentication::CLI do
         expect(Lich).to have_received(:log).with(/Account not found/)
       end
 
-      it 'finds account case-insensitively' do
+      it 'finds account case-insensitively and authenticates with the canonical account key' do
         allow(Lich::Common::Authentication::EntryStore).to receive(:decrypt_password).and_return('testpass')
-        allow(Lich::Common::Authentication).to receive(:authenticate).and_return({ 'key' => 'abc' })
         allow(Lich::Common::Authentication::LaunchData).to receive(:prepare).and_return(['GAME=DR'])
+
+        # Looked up with lower-case 'testuser' but the stored key is 'TESTUSER';
+        # authentication must use the canonical 'TESTUSER'.
+        expect(Lich::Common::Authentication).to receive(:authenticate).with(
+          account: 'TESTUSER',
+          password: 'testpass',
+          character: 'NEW',
+          game_code: 'DR',
+          generator: true
+        ).and_return({ 'key' => 'abc' })
 
         result = described_class.execute_new_character('testuser', game_code: 'DR', data_dir: data_dir)
 

--- a/spec/lib/common/authentication/cli_spec.rb
+++ b/spec/lib/common/authentication/cli_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Lich::Common::Authentication::CLI do
         expect(result).to eq(['GAME=DR'])
       end
 
-      it 'authenticates with character name NEW' do
+      it 'authenticates with explicit generator intent' do
         allow(Lich::Common::Authentication::EntryStore).to receive(:decrypt_password).and_return('testpass')
         allow(Lich::Common::Authentication::LaunchData).to receive(:prepare).and_return(['GAME=DR'])
 
@@ -139,7 +139,8 @@ RSpec.describe Lich::Common::Authentication::CLI do
           account: 'TESTUSER',
           password: 'testpass',
           character: 'NEW',
-          game_code: 'DR'
+          game_code: 'DR',
+          generator: true
         ).and_return({ 'key' => 'abc' })
 
         described_class.execute_new_character('TESTUSER', game_code: 'DR', data_dir: data_dir)

--- a/spec/lib/common/authentication/cli_spec.rb
+++ b/spec/lib/common/authentication/cli_spec.rb
@@ -55,6 +55,118 @@ RSpec.describe Lich::Common::Authentication::CLI do
     FileUtils.rm_rf(data_dir) if File.exist?(data_dir)
   end
 
+  describe '.execute_new_character' do
+    before do
+      allow(Lich).to receive(:log)
+      allow(Lich::Common::Authentication::CLIPassword).to receive(:validate_master_password_available).and_return(true)
+    end
+
+    context 'with missing account name' do
+      it 'returns nil when account_name is nil' do
+        result = described_class.execute_new_character(nil, game_code: 'DR', data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/Account name is required/)
+      end
+
+      it 'returns nil when account_name is empty' do
+        result = described_class.execute_new_character('', game_code: 'DR', data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/Account name is required/)
+      end
+    end
+
+    context 'with missing game code' do
+      it 'returns nil when game_code is nil' do
+        result = described_class.execute_new_character('TESTUSER', game_code: nil, data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/Game code is required/)
+      end
+    end
+
+    context 'with missing YAML file' do
+      it 'returns nil when entry.yaml does not exist' do
+        result = described_class.execute_new_character('TESTUSER', game_code: 'DR', data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/No saved entries YAML file found/)
+      end
+    end
+
+    context 'with valid YAML file' do
+      let(:yaml_data) do
+        {
+          'accounts'        => {
+            'TESTUSER' => {
+              'password'   => 'testpass',
+              'characters' => [
+                { 'char_name' => 'ExistingChar', 'game_code' => 'DR', 'frontend' => 'profanity' }
+              ]
+            }
+          },
+          'encryption_mode' => 'plaintext'
+        }
+      end
+
+      before do
+        File.write(yaml_file, yaml_data.to_yaml)
+      end
+
+      it 'returns nil when account is not found' do
+        result = described_class.execute_new_character('NONEXISTENT', game_code: 'DR', data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/Account not found/)
+      end
+
+      it 'finds account case-insensitively' do
+        allow(Lich::Common::Authentication::EntryStore).to receive(:decrypt_password).and_return('testpass')
+        allow(Lich::Common::Authentication).to receive(:authenticate).and_return({ 'key' => 'abc' })
+        allow(Lich::Common::Authentication::LaunchData).to receive(:prepare).and_return(['GAME=DR'])
+
+        result = described_class.execute_new_character('testuser', game_code: 'DR', data_dir: data_dir)
+
+        expect(result).to eq(['GAME=DR'])
+      end
+
+      it 'authenticates with character name NEW' do
+        allow(Lich::Common::Authentication::EntryStore).to receive(:decrypt_password).and_return('testpass')
+        allow(Lich::Common::Authentication::LaunchData).to receive(:prepare).and_return(['GAME=DR'])
+
+        expect(Lich::Common::Authentication).to receive(:authenticate).with(
+          account: 'TESTUSER',
+          password: 'testpass',
+          character: 'NEW',
+          game_code: 'DR'
+        ).and_return({ 'key' => 'abc' })
+
+        described_class.execute_new_character('TESTUSER', game_code: 'DR', data_dir: data_dir)
+      end
+    end
+
+    context 'with account missing password' do
+      before do
+        yaml_data = {
+          'accounts' => {
+            'NOPASS' => {
+              'characters' => []
+            }
+          }
+        }
+        File.write(yaml_file, yaml_data.to_yaml)
+      end
+
+      it 'returns nil and logs error' do
+        result = described_class.execute_new_character('NOPASS', game_code: 'DR', data_dir: data_dir)
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/No password saved/)
+      end
+    end
+  end
+
   describe '.execute' do
     context 'with missing character name' do
       it 'returns nil when character_name is nil' do

--- a/spec/lib/common/authentication/cli_spec.rb
+++ b/spec/lib/common/authentication/cli_spec.rb
@@ -17,7 +17,7 @@ module Lich
   module Common
     module Authentication
       module CLIPassword
-        def self.validate_master_password_available
+        def self.validate_master_password_available(**)
           true
         end
       end unless defined?(Lich::Common::Authentication::CLIPassword)
@@ -215,6 +215,26 @@ RSpec.describe Lich::Common::Authentication::CLI do
 
         expect(result).to be_nil
         expect(Lich).to have_received(:log).with(/No password saved/)
+      end
+    end
+
+    context 'with legacy array-format entry.yaml' do
+      before do
+        # Legacy installs store a top-level array of character entries rather
+        # than the accounts-based Hash; generator entry has no account to look up.
+        legacy_data = [
+          { 'char_name' => 'ExistingChar', 'game_code' => 'DR', 'frontend' => 'profanity' }
+        ]
+        File.write(yaml_file, legacy_data.to_yaml)
+      end
+
+      it 'fails gracefully instead of raising on the non-Hash entry data' do
+        result = nil
+        expect { result = described_class.execute_new_character('TESTUSER', game_code: 'DR', data_dir: data_dir) }
+          .not_to raise_error
+
+        expect(result).to be_nil
+        expect(Lich).to have_received(:log).with(/accounts-based entry format/)
       end
     end
   end

--- a/spec/lib/common/authentication/cli_spec.rb
+++ b/spec/lib/common/authentication/cli_spec.rb
@@ -159,6 +159,34 @@ RSpec.describe Lich::Common::Authentication::CLI do
 
         described_class.execute_new_character('TESTUSER', game_code: 'DR', data_dir: data_dir)
       end
+
+      it 'forwards the requested frontend and custom launch to LaunchData' do
+        allow(Lich::Common::Authentication::EntryStore).to receive(:decrypt_password).and_return('testpass')
+        allow(Lich::Common::Authentication).to receive(:authenticate).and_return({ 'key' => 'abc' })
+
+        expect(Lich::Common::Authentication::LaunchData).to receive(:prepare).with(
+          { 'key' => 'abc' }, 'wizard', 'warlock', nil
+        ).and_return(['GAME=WIZ'])
+
+        result = described_class.execute_new_character(
+          'TESTUSER', game_code: 'DR', frontend: 'wizard', custom_launch: 'warlock', data_dir: data_dir
+        )
+
+        expect(result).to eq(['GAME=WIZ'])
+      end
+
+      it 'defaults frontend to profanity and drops unset custom launch' do
+        allow(Lich::Common::Authentication::EntryStore).to receive(:decrypt_password).and_return('testpass')
+        allow(Lich::Common::Authentication).to receive(:authenticate).and_return({ 'key' => 'abc' })
+
+        expect(Lich::Common::Authentication::LaunchData).to receive(:prepare).with(
+          { 'key' => 'abc' }, 'profanity', nil, nil
+        ).and_return(['GAME=DR'])
+
+        described_class.execute_new_character(
+          'TESTUSER', game_code: 'DR', frontend: :__unset, custom_launch: :__unset, data_dir: data_dir
+        )
+      end
     end
 
     context 'with account missing password' do

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -32,6 +32,15 @@ end unless defined?(Lich::Common::Account)
 require_relative '../../../../lib/common/authentication/eaccess'
 
 RSpec.describe Lich::Common::Authentication::EAccess do
+  ACCOUNT_STATE_ACCESSORS = %i[name game_code character subscription members].freeze
+
+  around do |example|
+    account_state = ACCOUNT_STATE_ACCESSORS.to_h { |accessor| [accessor, Lich::Common::Account.public_send(accessor)] }
+    example.run
+  ensure
+    account_state.each { |accessor, value| Lich::Common::Account.public_send("#{accessor}=", value) }
+  end
+
   describe 'AuthenticationError' do
     it 'stores the error code' do
       error = described_class::AuthenticationError.new('REJECT')

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe Lich::Common::Authentication::EAccess do
       params = described_class.method(:auth).parameters
       expect(params).to include([:key, :legacy])
     end
+
+    it 'has optional generator parameter' do
+      params = described_class.method(:auth).parameters
+      expect(params).to include([:key, :generator])
+    end
   end
 
   describe 'NEW_CHARACTER_CODE' do
@@ -115,46 +120,29 @@ RSpec.describe Lich::Common::Authentication::EAccess do
     end
   end
 
-  describe 'NEW_CHARACTER_PATTERN' do
-    it 'matches "new" case-insensitively' do
-      pattern = described_class::NEW_CHARACTER_PATTERN
-      expect('new').to match(pattern)
-      expect('NEW').to match(pattern)
-      expect('New').to match(pattern)
-      expect('nEw').to match(pattern)
-    end
-
-    it 'does not match substrings containing "new"' do
-      pattern = described_class::NEW_CHARACTER_PATTERN
-      expect('newchar').not_to match(pattern)
-      expect('anew').not_to match(pattern)
-      expect('renew').not_to match(pattern)
-    end
-  end
-
   describe '.resolve_char_code' do
     let(:c_response) { "C\t2\t16\t1\t1\tW_ACCT_W002\tGrimaldo\tW_ACCT_W003\tIdavoll" }
 
-    context 'when character is "NEW" (case-insensitive)' do
-      it 'returns NEW_CHARACTER_CODE for "NEW"' do
-        result = described_class.resolve_char_code(c_response, 'NEW')
-        expect(result).to eq('0')
-      end
+    context 'when a character is literally named "New"' do
+      # Regression guard: "New" must resolve to its real character code, not the
+      # generator code. Generator entry is now driven by explicit intent, not by
+      # the character name, so an existing character named "New" is never hijacked.
+      let(:c_response_with_new) { "C\t2\t16\t1\t1\tW_ACCT_W002\tGrimaldo\tW_ACCT_W004\tNew" }
 
-      it 'returns NEW_CHARACTER_CODE for "new"' do
-        result = described_class.resolve_char_code(c_response, 'new')
-        expect(result).to eq('0')
+      it 'returns the real character code, not the generator code' do
+        result = described_class.resolve_char_code(c_response_with_new, 'New')
+        expect(result).to eq('W_ACCT_W004')
       end
+    end
 
-      it 'returns NEW_CHARACTER_CODE for "New"' do
-        result = described_class.resolve_char_code(c_response, 'New')
-        expect(result).to eq('0')
-      end
+    context 'when the character name contains a caret' do
+      # Negated-class regression: the second field must be captured in full even
+      # when it contains a caret. The class is [^\t\n], not [^\t^\n].
+      let(:c_response_with_caret) { "C\t1\t16\t1\t1\tW_ACCT_W005\tFoo^Bar" }
 
-      it 'skips character lookup entirely' do
-        empty_response = "C\t0\t16\t0\t1"
-        result = described_class.resolve_char_code(empty_response, 'NEW')
-        expect(result).to eq('0')
+      it 'captures the full name and resolves the code' do
+        result = described_class.resolve_char_code(c_response_with_caret, 'Foo^Bar')
+        expect(result).to eq('W_ACCT_W005')
       end
     end
 

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -32,13 +32,12 @@ end unless defined?(Lich::Common::Account)
 require_relative '../../../../lib/common/authentication/eaccess'
 
 RSpec.describe Lich::Common::Authentication::EAccess do
-  ACCOUNT_STATE_ACCESSORS = %i[name game_code character subscription members].freeze
-
   around do |example|
-    account_state = ACCOUNT_STATE_ACCESSORS.to_h { |accessor| [accessor, Lich::Common::Account.public_send(accessor)] }
+    account_state_accessors = %i[name game_code character subscription members]
+    account_state = account_state_accessors.to_h { |accessor| [accessor, Lich::Common::Account.public_send(accessor)] }
     example.run
   ensure
-    account_state.each { |accessor, value| Lich::Common::Account.public_send("#{accessor}=", value) }
+    account_state&.each { |accessor, value| Lich::Common::Account.public_send("#{accessor}=", value) }
   end
 
   describe 'AuthenticationError' do

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -174,4 +174,92 @@ RSpec.describe Lich::Common::Authentication::EAccess do
       end
     end
   end
+
+  describe '.auth protocol guards' do
+    # These exercise the full protocol exchange with the socket and read steps
+    # stubbed, to cover the entitlement-tolerance behavior of the generator path.
+    let(:conn) { instance_double('SSLSocket') }
+    let(:hashkey) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' }
+
+    before do
+      allow(described_class).to receive(:socket).and_return(conn)
+      allow(described_class).to receive(:verify_pem)
+      allow(conn).to receive(:puts)
+      allow(conn).to receive(:close)
+      allow(conn).to receive(:closed?).and_return(false)
+    end
+
+    # Scripts the read responses for one full A -> M -> F -> G -> P -> C -> L pass.
+    def stub_protocol(f_response:, l_response:, c_response: "C\t0\t0\t0\t0\n", g_tier: 'TRIAL')
+      allow(described_class).to receive(:read).and_return(
+        hashkey,                                # K
+        "A\tACCT\tKEY\tSESSIONKEY\tHolder\n",   # A
+        "M\tDR\tDragonRealms\n",                # M
+        f_response,                             # F
+        "G\tDragonRealms\t#{g_tier}\t31\t\n",   # G
+        "P\tDR\t1495\n",                        # P
+        c_response,                             # C
+        l_response                              # L
+      )
+    end
+
+    context 'on the generator path when F returns NEW_TO_GAME' do
+      it 'tolerates NEW_TO_GAME and returns launch info when the server grants entry' do
+        stub_protocol(
+          f_response: "F\tNEW_TO_GAME\n",
+          l_response: "L\tOK\tGAMEHOST=dr.simutronics.net\tGAMEPORT=11124\tKEY=abc\n"
+        )
+
+        result = described_class.auth(account: 'ACCT', password: 'pass', game_code: 'DRX', generator: true)
+
+        expect(result['gamehost']).to eq('dr.simutronics.net')
+        expect(result['gameport']).to eq('11124')
+      end
+
+      it 'sends the generator character code 0 on the L command' do
+        stub_protocol(f_response: "F\tNEW_TO_GAME\n", l_response: "L\tOK\tKEY=abc\n")
+
+        expect(conn).to receive(:puts).with("L\t0\tSTORM\n")
+
+        described_class.auth(account: 'ACCT', password: 'pass', game_code: 'DRX', generator: true)
+      end
+    end
+
+    context 'on the normal (non-generator) path when F returns NEW_TO_GAME' do
+      it 'still raises (entitlement tolerance is generator-only)' do
+        stub_protocol(f_response: "F\tNEW_TO_GAME\n", l_response: "L\tOK\tKEY=abc\n")
+
+        expect {
+          described_class.auth(account: 'ACCT', password: 'pass', character: 'X', game_code: 'DRX')
+        }.to raise_error(StandardError, /NEW_TO_GAME/)
+      end
+    end
+
+    context 'when the server refuses generator entry with L PROBLEM' do
+      # Unsubscribed Fallen/Shattered: F is NEW_TO_GAME and the server returns
+      # "L\tPROBLEM\t1" because the account is not entitled to create there.
+      it 'raises GENERATOR_NOT_AVAILABLE instead of parsing a garbage launch payload' do
+        stub_protocol(f_response: "F\tNEW_TO_GAME\n", l_response: "L\tPROBLEM\t1\n", g_tier: 'UNKNOWN')
+
+        expect {
+          described_class.auth(account: 'ACCT', password: 'pass', game_code: 'GSF', generator: true)
+        }.to raise_error(described_class::AuthenticationError, /GENERATOR_NOT_AVAILABLE/)
+      end
+    end
+
+    context 'on the normal path when L returns PROBLEM' do
+      it 'raises instead of accepting the PROBLEM line as success' do
+        stub_protocol(
+          f_response: "F\tPREMIUM\n",
+          c_response: "C\t1\t16\t1\t1\tW_ACCT_W002\tGrimaldo\n",
+          l_response: "L\tPROBLEM\t1\n",
+          g_tier: 'PREMIUM'
+        )
+
+        expect {
+          described_class.auth(account: 'ACCT', password: 'pass', character: 'Grimaldo', game_code: 'DR')
+        }.to raise_error(StandardError, /PROBLEM/)
+      end
+    end
+  end
 end

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -5,6 +5,7 @@
 # the SGE protocol handling works standalone without network dependencies.
 
 require 'rspec'
+require 'tmpdir'
 
 # Mock dependencies before requiring the code
 # Use Dir.tmpdir which always exists on all platforms
@@ -92,7 +93,6 @@ RSpec.describe Lich::Common::Authentication::EAccess do
     # - Account state setting happens at the start of auth before any network ops
 
     it 'requires password and account parameters' do
-      # The auth method signature requires these kwargs
       expect(described_class.method(:auth).parameters).to include([:keyreq, :password])
       expect(described_class.method(:auth).parameters).to include([:keyreq, :account])
     end
@@ -106,6 +106,84 @@ RSpec.describe Lich::Common::Authentication::EAccess do
     it 'has optional legacy parameter' do
       params = described_class.method(:auth).parameters
       expect(params).to include([:key, :legacy])
+    end
+  end
+
+  describe 'NEW_CHARACTER_CODE' do
+    it 'equals "0"' do
+      expect(described_class::NEW_CHARACTER_CODE).to eq('0')
+    end
+  end
+
+  describe 'NEW_CHARACTER_PATTERN' do
+    it 'matches "new" case-insensitively' do
+      pattern = described_class::NEW_CHARACTER_PATTERN
+      expect('new').to match(pattern)
+      expect('NEW').to match(pattern)
+      expect('New').to match(pattern)
+      expect('nEw').to match(pattern)
+    end
+
+    it 'does not match substrings containing "new"' do
+      pattern = described_class::NEW_CHARACTER_PATTERN
+      expect('newchar').not_to match(pattern)
+      expect('anew').not_to match(pattern)
+      expect('renew').not_to match(pattern)
+    end
+  end
+
+  describe '.resolve_char_code' do
+    let(:c_response) { "C\t2\t16\t1\t1\tW_ACCT_W002\tGrimaldo\tW_ACCT_W003\tIdavoll" }
+
+    context 'when character is "NEW" (case-insensitive)' do
+      it 'returns NEW_CHARACTER_CODE for "NEW"' do
+        result = described_class.resolve_char_code(c_response, 'NEW')
+        expect(result).to eq('0')
+      end
+
+      it 'returns NEW_CHARACTER_CODE for "new"' do
+        result = described_class.resolve_char_code(c_response, 'new')
+        expect(result).to eq('0')
+      end
+
+      it 'returns NEW_CHARACTER_CODE for "New"' do
+        result = described_class.resolve_char_code(c_response, 'New')
+        expect(result).to eq('0')
+      end
+
+      it 'skips character lookup entirely' do
+        empty_response = "C\t0\t16\t0\t1"
+        result = described_class.resolve_char_code(empty_response, 'NEW')
+        expect(result).to eq('0')
+      end
+    end
+
+    context 'when character is a normal name' do
+      it 'returns the matching character code' do
+        result = described_class.resolve_char_code(c_response, 'Grimaldo')
+        expect(result).to eq('W_ACCT_W002')
+      end
+
+      it 'returns the correct code for the second character' do
+        result = described_class.resolve_char_code(c_response, 'Idavoll')
+        expect(result).to eq('W_ACCT_W003')
+      end
+    end
+
+    context 'when character is not found' do
+      it 'raises AuthenticationError with CHARACTER_NOT_FOUND' do
+        expect {
+          described_class.resolve_char_code(c_response, 'NonExistent')
+        }.to raise_error(described_class::AuthenticationError, /CHARACTER_NOT_FOUND/)
+      end
+    end
+
+    context 'when character is nil' do
+      it 'raises AuthenticationError with CHARACTER_NOT_FOUND' do
+        expect {
+          described_class.resolve_char_code(c_response, nil)
+        }.to raise_error(described_class::AuthenticationError, /CHARACTER_NOT_FOUND/)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Add support for launching into the character generator from the CLI by passing
`--login NEW --account=MYACCOUNT`. The EAccess protocol accepts character code
`0` in the `L` command to enter character creation instead of selecting an
existing character.

Generator entry is carried as **explicit intent** (a `generator:` boolean)
rather than by overloading the character name. The `--login NEW` string is a
user-facing CLI convention only; the lower layers receive a clear request for
generator mode, so ordinary character authentication (CLI and GUI) is left
untouched.

## Usage

```
ruby lich.rbw --login NEW --account=MYACCOUNT --dr --without-frontend
```

This authenticates with the saved credentials for `MYACCOUNT` from `entry.yaml`,
then sends character code `0` to the game server to enter the character generator.

## Changes

- **`lib/common/authentication/eaccess.rb`**: `auth` gains a `generator:` keyword
  (default `false`); when `true` it sends `NEW_CHARACTER_CODE` ("0") without a
  character lookup. `resolve_char_code` is a pure name-to-code lookup again (no
  `NEW` special case). `NEW_CHARACTER_CODE` stays here as a protocol fact.
- **`lib/common/authentication/authenticator.rb`**: `authenticate` threads
  `generator:` through to `EAccess.auth`, and routes to `EAccess.auth` on
  generator intent (gated on `game_code`) whether or not a character is supplied,
  so generator mode no longer depends on a placeholder character name.
- **`lib/common/authentication/cli.rb`**: `execute_new_character` flags the entry
  with `generator: true`, validates the game code against `VALID_GAME_CODES`
  before any network activity, uses the stored canonical account key, and accepts
  `frontend` / `custom_launch` / `custom_launch_dir` (with `:__unset`/`nil`
  normalization). Extracts `load_entry_data` and `find_account` for reuse;
  `load_entry_data` threads `data_dir` into master-password validation, and
  `find_account` fails gracefully on legacy array-format `entry.yaml`.
- **`lib/common/authentication/cli_password.rb`**: `validate_master_password_available`
  accepts a `data_dir:` override (default `DATA_DIR`) so validation reads the same
  `entry.yaml` as the caller's load.
- **`lib/common/authentication/login_helpers.rb`**: add `NEW_CHARACTER_LOGIN`, the
  single source of truth for the `--login NEW` CLI convention.
- **`lib/main/main.rb`**: route `--login NEW --account=ACCT` to
  `execute_new_character`, forwarding the requested frontend and custom launch.
- **`lib/common/account.rb`**: correctness fix carried along (see below).

## Behavioral fixes addressed in review

- **Explicit generator intent.** Previously any login (CLI or GUI) of a character
  literally named `New`/`NEW`/`new` was hijacked into the generator, because the
  decision lived in `EAccess.resolve_char_code` on the shared auth path. Now the
  name is never special at the protocol layer; a real character named "New"
  authenticates normally (regression test added).
- **Valid game code required.** The previous `unless game_code` guard let the
  `:__unset` sentinel (a truthy Symbol returned when no game flag is given) pass,
  sending `F\t__unset\n` to the server after the password handshake. The path now
  validates against `VALID_GAME_CODES` and fails fast.
- **Frontend / custom launch preserved.** The generator path hardcoded
  `frontend: 'profanity'` and dropped custom launch; `--wizard`, `--avalon`, and
  `--custom-launch` are now forwarded (falling back to `profanity` when none is
  requested, matching the prior headless default).
- **Canonical account key.** Account lookup is case-insensitive, but the matched
  canonical key is now used for authentication instead of the caller-supplied
  casing.
- **Regex correctness.** The character-scan regex `[^\t^\n]` (stray caret in the
  negated class) is corrected to `[^\t\n]` in `eaccess.rb` and `account.rb`.
- **Generator routing independent of character (CodeRabbit).** `Authentication.authenticate`
  previously gated the `EAccess.auth` flow on `character && game_code`, so a
  `generator: true` call without a character silently fell through to the
  account-only path. It now routes on `game_code && (character || generator)`, so
  the explicit `generator:` boolean is honored on its own (regression test added).
- **Validation honors `data_dir` (CodeRabbit).** `load_entry_data` now passes
  `data_dir` into `validate_master_password_available`, so validation and the
  subsequent `File.exist?` check read the same `entry.yaml` under a non-default
  data directory.
- **Legacy entry format no longer crashes generator login (CodeRabbit).**
  `find_account` indexed `entry_data[:accounts]` directly, raising `TypeError` on
  legacy array-format `entry.yaml`. It now guards for the accounts-based Hash and
  fails gracefully with a logged error (regression test added).

## Test plan

- [x] `rspec spec/lib/common/authentication/ spec/lib/common/gui/` - 523 examples, 0 failures
- [x] `rubocop` on all changed files (incl. `Custom/AsciiOnlySource`) - 0 offenses
- [ ] Manual: `ruby lich.rbw --login NEW --account=TESTACCOUNT --dr --without-frontend` enters character generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to create new characters on existing accounts through CLI
  * Added support for `--login NEW` command-line convention to initiate character creation

* **Bug Fixes**
  * Fixed account entry parsing to correctly handle newline characters during data processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
