### PR TITLE
fix(gs): psms Warcry.available? correction

### DIFF
--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -135,10 +135,13 @@ module Lich
       # blocked by overexertion
       # @example
       #   Warcry.available?("holler") => true # if known, affordable, not on cooldown, and not overexerted
+      #   and not silenced or cutthroat
       def Warcry.available?(name, min_rank: 1, forcert_count: 0)
         Warcry.known?(name, min_rank: min_rank) &&
           Warcry.affordable?(name, forcert_count: forcert_count) &&
-          PSMS.available?(name)
+          PSMS.available?(name) &&
+          !Status.cutthroat? &&
+          !Status.silenced?
       end
 
       # DEPRECATED: Use {#buff_active?} instead.


### PR DESCRIPTION
You are unable to use warcries while cutthroat or silenced.  

"Somebody" gestures at you.                                                                                   
  CS: +438 - TD: +330 + CvA: -27 + d100: +70 == +151                                                                                                                                    
  Warding failed!                                                                                                                                                                           
A pall of silence settles over you.                                                                                                                                                                                                                                                                                                             
>;e echo Status.silenced?                                                                                                                                                                   
--- Lich: exec1 active.                                                                                                                                                                      
[exec1: true]                                                                                                                                                                                
--- Lich: exec1 has exited.                                                                                                                                                                                                                                                                                                                            
>warcry shout                                                                                                                                                                                  
The pall of silence settles more heavily over you.

Warcry.available? already checks for:
  is it known?
  is it affordable?
  are you over-exerted?

I think the intent of the .available? method was to be a single check to say whether or not you can actually do something right now.  If that's the case, then I think checks for cutthroat and silenced should be included.