### PR TITLE
feat(all): enumerate script subdirs with file glob

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -67,10 +67,10 @@ module Lich
         custom_dirs = []
         if File.directory?(custom_base)
           custom_dirs << custom_base
-          Dir.children(custom_base).sort.each do |child|
-            child_path = File.join(custom_base, child)
-            custom_dirs << child_path if File.directory?(child_path)
-          end
+          # Dir.glob with trailing '/' matches directories only via libc readdir d_type,
+          # avoiding a File.directory? stat() per file. Critical on slower filesystems
+          # where each stat() costs ~5-10ms.
+          custom_dirs.concat(Dir.glob(File.join(custom_base, "*/")).map { |p| p.chomp("/") }.sort)
         end
         file_list = custom_dirs.flat_map { |dir|
           prefix = dir.sub(SCRIPT_DIR, '')


### PR DESCRIPTION
After updating and hitting this code path i noticed *extreme* slowdown in script instantiation. Running the following:
```
;e t = Time.now;Script.start('test');echo Time.now - t
```

where test is just "echo test", to get start time from the function (note it is non-blocking script.start, not script.run, so only measuring time to bring up the new Script object) I was seeing 1.5 - 2.5 second script startup times.

Most likely do not notice this as they probably have a combination of fewer custom scripts + are playing on local SSD drives. I am currently playing from a spinning disk network share, and while i expect some performance loss this was obvious enough to warrant investigation.

The numerous File.directory? calls stacked up to i in testing ~1500 MS. Post change to .glob i'm seeing the startup time from the exec above at more like 0.04 seconds instead of 1.5, which is what i would expect. Formatting of the return from the glob call is mutated to match the output from the Dir.children call so everything else works as expected.

This is likely all just a good reminder i should delete a bunch of random things i never run out of my custom directory :D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Performance
* Improved script loading speed on slower filesystems by optimizing directory detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->