### PR TITLE
feat(all): Refactor Util::issue_command to better handle possible single/multi-line matches

### DIFF
--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -102,10 +102,10 @@ module Lich
         Timeout::timeout(timeout, Interrupt) {
           DownstreamHook.add(name, proc { |line|
             if filter
-              if ignore_end || line =~ end_pattern
+              if line =~ end_pattern
                 DownstreamHook.remove(name)
                 filter = false
-                if quiet && !ignore_end
+                if quiet
                   next(nil)
                 else
                   line

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -87,7 +87,8 @@ module Lich
       result = []
       name = self.anon_hook
       filter = false
-      ignore_end = end_pattern.eql?(:ignore)
+      end_pattern = start_pattern if end_pattern.eql?(:ignore)
+      matched_start_and_end = false
 
       save_script_silent = Script.current.silent
       save_want_downstream = Script.current.want_downstream
@@ -116,6 +117,14 @@ module Lich
                   line
                 end
               end
+            elsif line =~ start_pattern && line =~ end_pattern
+              matched_start_and_end = true
+              DownstreamHook.remove(name)
+              if quiet
+                next(nil)
+              else
+                line
+              end
             elsif line =~ start_pattern
               filter = true
               if quiet
@@ -131,16 +140,10 @@ module Lich
 
           until (line = get) =~ start_pattern; end
           result << line.rstrip
-          unless ignore_end
-            until (line = get) =~ end_pattern
-              result << line.rstrip
-            end
+          until matched_start_and_end || (line = get) =~ end_pattern
+            result << line.rstrip
           end
-          unless ignore_end
-            if include_end
-              result << line.rstrip
-            end
-          end
+          result << line.rstrip if include_end && !matched_start_and_end 
         }
       rescue Interrupt
         nil

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -143,7 +143,7 @@ module Lich
           until matched_start_and_end || (line = get) =~ end_pattern
             result << line.rstrip
           end
-          result << line.rstrip if include_end && !matched_start_and_end 
+          result << line.rstrip if include_end && !matched_start_and_end
         }
       rescue Interrupt
         nil


### PR DESCRIPTION
Support known single line and known multiple line matches AND where you don't know if the output will be single OR multiple line match before you issue the command. Preserves the end_pattern = `:ignore` symbol behavior by then setting end_pattern = start_pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved command output capture behavior for edge cases involving start/end pattern matching.
  * More reliably stops capturing and decides whether to include or suppress the matching boundary line, including when the start and end occur on the same line.
  * Enhances consistency with the existing capture options, reducing unexpected omissions or extra lines in captured output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->