### PR TITLE
ci(all): Update action workflows to use latest action workflow pinning

### DIFF
--- a/.github/workflows/curate-pre-branch.yaml
+++ b/.github/workflows/curate-pre-branch.yaml
@@ -89,7 +89,7 @@ jobs:
         run: sudo apt-get update -y
 
       - name: Install jq
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/curate-pre-branch.yaml
+++ b/.github/workflows/curate-pre-branch.yaml
@@ -76,12 +76,12 @@ jobs:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/format-pr-body-prerelease.yaml
+++ b/.github/workflows/format-pr-body-prerelease.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (read optional sections.md if present)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Format body (prerelease)
         uses: ./.github/actions/format-body

--- a/.github/workflows/format-pr-body-stable.yaml
+++ b/.github/workflows/format-pr-body-stable.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (read optional sections.md if present)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Format body (stable, idempotent)
         uses: ./.github/actions/format-body
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (read optional sections.md if present)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Find open Release Please PR (stable)
       # Criteria:

--- a/.github/workflows/pin-audit.yaml
+++ b/.github/workflows/pin-audit.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Steps: checkout (read-only) + scanner (summary output)
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Scan refs & check currency
         id: scan

--- a/.github/workflows/pin-audit.yaml
+++ b/.github/workflows/pin-audit.yaml
@@ -64,7 +64,7 @@ jobs:
               [[ "$refname" != refs/tags/* ]] && continue
               tag="${refname#refs/tags/}"
               if [[ "$tag" =~ \^\{\}$ ]]; then
-                base="${tag%^{}}"
+                base="${tag%'^{}'}"
                 tag_commit["$base"]="$sha"
               elif [[ -z "${tag_commit[$tag]:-}" ]]; then
                 tag_commit["$tag"]="$sha"

--- a/.github/workflows/prepare-prerelease.yaml
+++ b/.github/workflows/prepare-prerelease.yaml
@@ -89,7 +89,7 @@ jobs:
             printf 'base_safe=%s\n'   "$BASE"   >> "$GITHUB_OUTPUT"
 
       - name: Checkout base branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.guard_validate.outputs.base_safe }}
           fetch-depth: 0
@@ -327,7 +327,7 @@ jobs:
           fi
 
       - name: Release Please (prerelease)
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
           config-file: release-please-config.prerelease.json

--- a/.github/workflows/prepare-stable-release.yaml
+++ b/.github/workflows/prepare-stable-release.yaml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.target_branch || github.ref_name || 'main' }}
           fetch-depth: 0
@@ -163,7 +163,7 @@ jobs:
       - name: Release Please (open/update Release PR)
         if: ${{ steps.classify.outputs.skip != 'true' && steps.guard.outputs.has_releasables == 'true' }}
         # Pinned to SHA for supply-chain safety (release-please-action v4.4.1)
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/prepare-stable-release.yaml
+++ b/.github/workflows/prepare-stable-release.yaml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Release Please (open/update Release PR)
         if: ${{ steps.classify.outputs.skip != 'true' && steps.guard.outputs.has_releasables == 'true' }}
-        # Pinned to SHA for supply-chain safety (release-please-action v4.4.1)
+        # Pinned to SHA for supply-chain safety
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json

--- a/.github/workflows/rebuild-release-assets.yaml
+++ b/.github/workflows/rebuild-release-assets.yaml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.release_guard.outputs.tag }}
           fetch-depth: 0
@@ -119,7 +119,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout target tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.release_guard.outputs.tag }}
           fetch-depth: 0
@@ -136,7 +136,7 @@ jobs:
           unzip -q lich-5.zip
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         with:
           bundler-cache: false
 

--- a/.github/workflows/release-on-push-prerelease.yaml
+++ b/.github/workflows/release-on-push-prerelease.yaml
@@ -375,6 +375,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Pin Ruby explicitly on windows-latest
       - name: Set up Ruby

--- a/.github/workflows/release-on-push-prerelease.yaml
+++ b/.github/workflows/release-on-push-prerelease.yaml
@@ -58,7 +58,7 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       # 1) Release Please for prerelease branches
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
           config-file: release-please-config.prerelease.json
@@ -219,7 +219,7 @@ jobs:
 
       - name: Checkout repository
         if: ${{ steps.rp.outputs.release_created == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -374,11 +374,11 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Pin Ruby explicitly on windows-latest
       - name: Set up Ruby
-        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         with:
           bundler-cache: false
 

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -61,7 +61,7 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       # 1) Release Please for stable branch (creates public release, we convert to draft immediately)
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
           skip-github-release: false
@@ -302,7 +302,7 @@ jobs:
       # 3) Only build/upload when a new GitHub Release was created
       - name: Checkout repository
         if: ${{ steps.rp.outputs.release_created == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -414,11 +414,11 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Pin Ruby explicitly on windows-latest
       - name: Set up Ruby
-        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         with:
           bundler-cache: false
 

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -415,6 +415,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Pin Ruby explicitly on windows-latest
       - name: Set up Ruby

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -124,9 +124,9 @@ jobs:
               core.notice(`Preflight: changed files = ${files.length}, non-ignored = ${nonIgnored.length}; should_test=${should}`);
               core.setOutput('should_test', should ? 'true' : 'false');
             }
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: steps.preflight.outputs.should_test == 'true'
-      - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+      - uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         if: steps.preflight.outputs.should_test == 'true'
         with:
           bundler-cache: true

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -77,12 +77,12 @@ jobs:
               core.error(`Preflight failed: ${error.message || error}`);
               core.setOutput('should_lint', 'true');
             }
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: steps.preflight.outputs.should_lint == 'true'
         with:
           fetch-depth: 0
       
-      - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+      - uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         if: steps.preflight.outputs.should_lint == 'true'
         with:
           bundler-cache: true

--- a/.github/workflows/ruby_syntax.yaml
+++ b/.github/workflows/ruby_syntax.yaml
@@ -22,7 +22,7 @@ jobs:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
     name: Run tests on Ruby
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           
@@ -35,7 +35,7 @@ jobs:
             **/*.rb
             lich.rbw
             
-      - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
+      - uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         with:
           bundler-cache: true
           


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple automated workflows to use newer pinned versions of key GitHub Actions.
  * Refreshed versions used across release preparation, stable/prerelease publishing, formatting, linting, syntax checks, and tests to keep automation consistent.
  * Kept existing workflow behavior and job logic unchanged while modernizing the underlying tooling.
* **Bug Fixes**
  * Improved tag recognition in the audit process by refining how dereferenced annotated tags are mapped back to their base version tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->