### PR TITLE
fix(all): pin lich directory for gemfile check

### DIFF
--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -25,6 +25,7 @@ module Lich
     # @return [void]
     def verify!(*groups)
       groups = [:default] if groups.empty?
+      configure_gemfile!
 
       missing = missing_gems(groups)
       unless missing.empty?
@@ -49,6 +50,17 @@ module Lich
           exit 1
         end
       end
+    end
+
+    # Ensures Bundler resolves Lich's Gemfile even when the app is launched
+    # from another working directory, such as macOS app launch from /.
+    # @return [void]
+    def configure_gemfile!
+      return if ENV['BUNDLE_GEMFILE'] && !ENV['BUNDLE_GEMFILE'].empty?
+      return unless defined?(LICH_DIR)
+
+      gemfile = File.join(LICH_DIR, 'Gemfile')
+      ENV['BUNDLE_GEMFILE'] = gemfile if File.file?(gemfile)
     end
 
     # Names of gems declared in the Gemfile that are not installed at any

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -147,6 +147,64 @@ RSpec.describe Lich::GemCheck do
     end
   end
 
+  describe '.configure_gemfile!' do
+    around do |example|
+      original = ENV.fetch('BUNDLE_GEMFILE', nil)
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete('BUNDLE_GEMFILE')
+      else
+        ENV['BUNDLE_GEMFILE'] = original
+      end
+    end
+
+    it 'points Bundler at the Lich Gemfile when launched from another directory' do
+      Dir.mktmpdir('lich-gemcheck-home') do |dir|
+        gemfile = File.join(dir, 'Gemfile')
+        File.write(gemfile, "source 'https://rubygems.org'\n")
+        stub_const('LICH_DIR', dir)
+        ENV.delete('BUNDLE_GEMFILE')
+
+        described_class.configure_gemfile!
+
+        expect(ENV.fetch('BUNDLE_GEMFILE')).to eq(gemfile)
+      end
+    end
+
+    it 'preserves an existing BUNDLE_GEMFILE override' do
+      Dir.mktmpdir('lich-gemcheck-home') do |dir|
+        File.write(File.join(dir, 'Gemfile'), "source 'https://rubygems.org'\n")
+        stub_const('LICH_DIR', dir)
+        ENV['BUNDLE_GEMFILE'] = '/custom/Gemfile'
+
+        described_class.configure_gemfile!
+
+        expect(ENV.fetch('BUNDLE_GEMFILE')).to eq('/custom/Gemfile')
+      end
+    end
+
+    it 'leaves BUNDLE_GEMFILE unset when LICH_DIR is undefined' do
+      hide_const('LICH_DIR')
+      ENV.delete('BUNDLE_GEMFILE')
+
+      described_class.configure_gemfile!
+
+      expect(ENV['BUNDLE_GEMFILE']).to be_nil
+    end
+
+    it 'leaves BUNDLE_GEMFILE unset when the Lich Gemfile does not exist' do
+      Dir.mktmpdir('lich-gemcheck-home') do |dir|
+        stub_const('LICH_DIR', dir)
+        ENV.delete('BUNDLE_GEMFILE')
+
+        described_class.configure_gemfile!
+
+        expect(ENV['BUNDLE_GEMFILE']).to be_nil
+      end
+    end
+  end
+
   describe '.missing_gems' do
     let(:default_present) do
       double('dep', name: 'sqlite3', requirement: Gem::Requirement.default, groups: [:default])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup to reliably use the correct Gemfile even when launched from a different working directory.
  * Preserves any existing Bundler Gemfile setting, avoiding unexpected environment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->