### PR TITLE
fix(all): increase read timeout on idle socket to 300 seconds

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -238,7 +238,7 @@ module Lich
     # Base Game class with common functionality
     class Game
       # Seconds to wait for readable game socket data before one read timeout.
-      READ_TIMEOUT_SECONDS = 30
+      READ_TIMEOUT_SECONDS = 100
 
       # Consecutive read timeouts allowed before treating the game link as dead.
       MAX_CONSECUTIVE_READ_TIMEOUTS = 3

--- a/spec/lib/games_spec.rb
+++ b/spec/lib/games_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe Lich::GameBase do
     end
 
     it 'reports total elapsed no-data time for consecutive read timeouts' do
-      expect(described_class.total_read_timeout_seconds).to eq(90)
-      expect(described_class.total_read_timeout_seconds(2)).to eq(60)
+      expect(described_class.total_read_timeout_seconds).to eq(300)
+      expect(described_class.total_read_timeout_seconds(2)).to eq(200)
     end
 
     it 'keeps stream desync disruption logging to one line in the thread handler' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket read waiting behavior so game connections are less likely to time out too quickly.
  * Updated related timeout expectations to match the new, longer wait period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->