### PR TITLE
fix(all): monkeypatch gi for memoryreleaser / asyncprocessor until patched upstream

### DIFF
--- a/lib/gemstone/combat/async_processor.rb
+++ b/lib/gemstone/combat/async_processor.rb
@@ -5,6 +5,7 @@
 #
 
 require 'concurrent'
+require_relative '../../util/gtk_compaction'
 
 module Lich
   module Gemstone
@@ -62,9 +63,11 @@ module Lich
           @thread_pool.each(&:join)
           @thread_pool.clear
 
-          # Force GC after shutdown to help with memory fragmentation
+          # Force GC after shutdown to help with memory fragmentation.
+          # Compaction is routed through Lich::Util::GtkCompaction, which
+          # keeps it safe to use alongside gtk3.
           GC.start
-          GC.compact if GC.respond_to?(:compact) # Ruby 2.7+
+          Lich::Util::GtkCompaction.safe_compact!
         end
 
         def stats
@@ -100,7 +103,7 @@ module Lich
           # Periodic heap compaction to reduce fragmentation (every hour)
           if GC.respond_to?(:compact) && (Time.now - @last_compact) > 3600
             GC.start
-            GC.compact
+            Lich::Util::GtkCompaction.safe_compact!
             @last_compact = Time.now
             respond "[Combat] Triggered hourly GC compaction" if Tracker.debug?
           end

--- a/lib/util/gtk_compaction.rb
+++ b/lib/util/gtk_compaction.rb
@@ -1,0 +1,191 @@
+require 'fiddle'
+
+module Lich
+  module Util
+    # Keeps Lich's periodic GC.compact calls (MemoryReleaser,
+    # Combat::AsyncProcessor) safe to use alongside gtk3/glib2/gdk3/pango --
+    # on a stock, unpatched ruby-gnome install, with GC.compact still
+    # actually running.
+    #
+    # ruby-gnome's native gems cache a Ruby Proc for each "boxed"/"object"
+    # GType conversion (Gdk::Event, Pango::Attribute, ...) inside a plain C
+    # struct that Ruby's GC can't see or update (BoxedInstance2RObjData /
+    # ObjectInstance2RObjData in gobject-introspection's rb-gi-loader.c).
+    # GC.compact can relocate that Proc without anything updating this one
+    # untracked reference to it, so the next GTK signal marshaled through it
+    # dereferences a dangling pointer and crashes with SIGBUS/SIGSEGV.
+    #
+    # The clean fix is a one-line C patch: pin each converter Proc as a
+    # permanent GC root (rb_gc_register_mark_object) instead of caching a
+    # raw, GC-invisible reference to it. That function is a public,
+    # documented libruby API -- exported from an already-loaded shared
+    # library -- which means we can call it ourselves, from pure Ruby, via
+    # Fiddle, without patching or recompiling anything:
+    #
+    #   1. GObjectIntrospection::Loader.register_boxed_class_converter and
+    #      .register_object_class_converter are the same *public* methods
+    #      gdk3/pango/etc. call to install these converters in the first
+    #      place. We wrap them so our wrapper captures the block as `&block`
+    #      (a real, addressable Proc -- Ruby always reifies `&block`
+    #      params, and identity is preserved when forwarding it on), pins
+    #      *that* object via rb_gc_register_mark_object, then calls the
+    #      original method with the same block. Whatever the C
+    #      implementation's own rb_block_proc() resolves to is that exact,
+    #      now-pinned Proc -- confirmed empirically (forced compaction via
+    #      GC.verify_compaction_references against a stock gem, before and
+    #      after this wrapper: crashes without it, survives with it).
+    #   2. This has to happen on the *original* registration -- there is no
+    #      re-registration involved, ever. (Re-registering an
+    #      already-registered GType is a separate, deterministic crash on
+    #      stock gems: the free callback on the replaced entry dereferences
+    #      a field g_new never initializes. We never trigger that path.)
+    #
+    # Timing is everything here: this only works if our wrapper is defined
+    # before gdk3/pango/etc. ever call register_boxed_class_converter for
+    # the first time -- i.e. before gobject-introspection is first
+    # required, transitively or otherwise. `gtk_compaction.rb` is required
+    # at the top of lich.rbw specifically so this file loads (and installs
+    # its wrapper) before lib/init.rb's `require 'gtk3'` runs. If something
+    # still manages to load gtk3 before we get a chance to install the
+    # wrapper (a custom boot path, a script requiring it unusually early),
+    # we can't retroactively pin what's already registered -- in that edge
+    # case we fall back to checking whether the *installed gem itself*
+    # happens to carry the equivalent native patch (see
+    # native_gem_patched?), and only disable compaction outright if neither
+    # applies.
+    #
+    # RETIREMENT: this whole module is a stopgap, not permanent
+    # architecture. It exists because most users run a stock
+    # gobject-introspection gem that doesn't carry the native fix. Once
+    # Lich's enforced minimum gobject-introspection version is one that
+    # includes rb_gc_register_mark_object in rb-gi-loader.c upstream (i.e.
+    # GemCheck can assert gobject-introspection >= that version the same
+    # way it already asserts other minimums), every installed gem
+    # satisfies native_gem_patched? by construction and this module's
+    # Fiddle-based pinning wrapper (install!, and everything it sets up)
+    # is provably redundant -- delete it, and have MemoryReleaser /
+    # Combat::AsyncProcessor call GC.compact directly again. Don't let
+    # "it works" be the reason it's still here a year from now; the
+    # removal condition is a version-floor check, not a feeling.
+    module GtkCompaction
+      NATIVE_PATCH_MARKER = 'rb_gc_register_mark_object(data->rb_converter)'.freeze
+
+      class << self
+        # @return [Boolean] whether gtk3 (or glib2/gdk3/pango directly) has
+        #   been loaded into this process. Once true, it stays true for the
+        #   life of the process -- Ruby never unloads C extensions, and
+        #   Lich runs every script in one shared VM.
+        def gtk_loaded?
+          !!(defined?(GLib) || defined?(Gtk) || defined?(Gdk))
+        end
+
+        # Installs the pinning wrapper around
+        # GObjectIntrospection::Loader's converter-registration methods.
+        # Safe to call more than once (no-ops after the first successful
+        # install). Called eagerly at the bottom of this file -- not
+        # lazily from safe_compact! -- because by the time MemoryReleaser
+        # or AsyncProcessor first calls safe_compact!, gtk3 has almost
+        # always already been loaded and it would be too late.
+        #
+        # @return [void]
+        def install!
+          return if defined?(@installed)
+          @installed = true
+
+          if gtk_loaded?
+            # Something already required gtk3/gdk3/pango/glib2 before we
+            # got here -- the original converter registrations already
+            # happened, unpinned, and there's no way to retroactively find
+            # and pin them. native_gem_patched? is the fallback for this.
+            @pinning_active = false
+            return
+          end
+
+          begin
+            require 'gobject-introspection'
+          rescue LoadError
+            # gtk3 isn't installed at all for this Lich install (headless
+            # / --no-gtk). Nothing to protect -- gtk_loaded? will always
+            # be false, so safe_compact! never touches any of this.
+            @pinning_active = false
+            return
+          end
+
+          begin
+            register_mark_object = Fiddle::Function.new(
+              Fiddle::Handle::DEFAULT['rb_gc_register_mark_object'],
+              [Fiddle::TYPE_UINTPTR_T],
+              Fiddle::TYPE_VOID
+            )
+
+            loader_singleton = GObjectIntrospection::Loader.singleton_class
+            loader_singleton.send(:alias_method, :__gtk_compaction_unpinned_register_boxed_class_converter, :register_boxed_class_converter)
+            loader_singleton.send(:alias_method, :__gtk_compaction_unpinned_register_object_class_converter, :register_object_class_converter)
+
+            loader_singleton.send(:define_method, :register_boxed_class_converter) do |gtype, &block|
+              register_mark_object.call(Fiddle.dlwrap(block))
+              __gtk_compaction_unpinned_register_boxed_class_converter(gtype, &block)
+            end
+
+            loader_singleton.send(:define_method, :register_object_class_converter) do |gtype, &block|
+              register_mark_object.call(Fiddle.dlwrap(block))
+              __gtk_compaction_unpinned_register_object_class_converter(gtype, &block)
+            end
+
+            @pinning_active = true
+          rescue StandardError, ::Fiddle::DLError
+            # Anything going wrong here -- a Ruby implementation that
+            # doesn't export this libruby symbol the same way (JRuby,
+            # TruffleRuby), a future gobject-introspection release renaming
+            # these methods, whatever -- must not take the rest of Lich
+            # down with it. install! runs unconditionally, eagerly, at
+            # file-require time for every boot; a raised exception here
+            # propagates straight out of that require and crashes startup
+            # entirely, which is a strictly worse failure mode than the
+            # thing this module exists to prevent. Fail into the same
+            # conservative fallback as any other "can't pin" case.
+            @pinning_active = false
+          end
+        end
+
+        # @return [Boolean] whether the currently-loaded
+        #   gobject-introspection gem carries the GC.compact safety patch
+        #   natively (i.e. someone applied the native gem patch directly).
+        #   Fallback for the case where install! ran too late to install
+        #   our own pinning wrapper. Memoized: a loaded C extension can't
+        #   be swapped out mid-process, so this can't change once computed.
+        def native_gem_patched?
+          return @native_gem_patched if defined?(@native_gem_patched)
+
+          @native_gem_patched = begin
+            loaded = $LOADED_FEATURES.find { |f| f =~ /gobject_introspection\.(bundle|so)\z/ }
+            gem_dir = loaded && File.expand_path(File.join(File.dirname(loaded), '..'))
+            src = gem_dir && File.join(gem_dir, 'ext', 'gobject-introspection', 'rb-gi-loader.c')
+            !!(src && File.exist?(src) && File.read(src).include?(NATIVE_PATCH_MARKER))
+          rescue StandardError
+            false
+          end
+        end
+
+        # Runs GC.compact safely.
+        #
+        # If gtk3 hasn't been loaded, compacts immediately -- nothing in
+        # this module applies. If it has, compacts whenever we know it's
+        # safe: either our own pinning wrapper caught the original
+        # converter registrations (the common case), or the installed gem
+        # carries the native patch directly. Only gives up on compaction
+        # -- for the rest of the process -- if neither applies.
+        #
+        # @return [void]
+        def safe_compact!
+          return unless GC.respond_to?(:compact)
+          return GC.compact unless gtk_loaded?
+          return GC.compact if @pinning_active
+          return GC.compact if native_gem_patched?
+        end
+      end
+    end
+  end
+end
+
+Lich::Util::GtkCompaction.install!

--- a/lib/util/gtk_compaction.rb
+++ b/lib/util/gtk_compaction.rb
@@ -8,9 +8,16 @@ module Lich
     # actually running.
     #
     # ruby-gnome's native gems cache a Ruby Proc for each "boxed"/"object"
-    # GType conversion (Gdk::Event, Pango::Attribute, ...) inside a plain C
-    # struct that Ruby's GC can't see or update (BoxedInstance2RObjData /
-    # ObjectInstance2RObjData in gobject-introspection's rb-gi-loader.c).
+    # GType conversion inside a plain C struct that Ruby's GC can't see or
+    # update (BoxedInstance2RObjData / ObjectInstance2RObjData in
+    # gobject-introspection's rb-gi-loader.c). In the current stack this is
+    # only ever exercised through the *boxed* half in practice -- gdk3's
+    # Gdk::Event/Gdk::Rectangle and pango's Pango::Attribute are the real
+    # examples, and they're all boxed. Nothing calls
+    # register_object_class_converter today; that half is wrapped
+    # defensively, on the same reasoning, but has no real-gem example and
+    # is not independently exercised the way the boxed path has been
+    # (empirically, via forced compaction against Pango::Attribute).
     # GC.compact can relocate that Proc without anything updating this one
     # untracked reference to it, so the next GTK signal marshaled through it
     # dereferences a dangling pointer and crashes with SIGBUS/SIGSEGV.
@@ -43,11 +50,12 @@ module Lich
     # Timing is everything here: this only works if our wrapper is defined
     # before gdk3/pango/etc. ever call register_boxed_class_converter for
     # the first time -- i.e. before gobject-introspection is first
-    # required, transitively or otherwise. `gtk_compaction.rb` is required
-    # at the top of lich.rbw specifically so this file loads (and installs
-    # its wrapper) before lib/init.rb's `require 'gtk3'` runs. If something
-    # still manages to load gtk3 before we get a chance to install the
-    # wrapper (a custom boot path, a script requiring it unusually early),
+    # required, transitively or otherwise. lich.rbw requires this file and
+    # then explicitly calls install! immediately after, before lib/init.rb's
+    # `require 'gtk3'` runs. Requiring this file by itself does *not*
+    # install anything -- see install!'s own doc for why that's deliberate.
+    # If something still manages to load gtk3 before install! gets a chance
+    # to run (a custom boot path, a script requiring it unusually early),
     # we can't retroactively pin what's already registered -- in that edge
     # case we fall back to checking whether the *installed gem itself*
     # happens to carry the equivalent native patch (see
@@ -82,10 +90,20 @@ module Lich
         # Installs the pinning wrapper around
         # GObjectIntrospection::Loader's converter-registration methods.
         # Safe to call more than once (no-ops after the first successful
-        # install). Called eagerly at the bottom of this file -- not
-        # lazily from safe_compact! -- because by the time MemoryReleaser
-        # or AsyncProcessor first calls safe_compact!, gtk3 has almost
-        # always already been loaded and it would be too late.
+        # install). Called explicitly from lich.rbw, immediately after
+        # requiring this file -- not automatically as a side effect of the
+        # require itself, and not lazily from safe_compact! either.
+        #
+        # Deliberately *not* auto-called at the bottom of this file: this
+        # module needs to be `require`-able (in specs, tools, a script) as
+        # a plain library, without side-loading gobject-introspection just
+        # because someone loaded the file. Requiring gtk_compaction.rb must
+        # stay inert; install! is the only thing that acts.
+        #
+        # This has to run before lib/init.rb's `require 'gtk3'` -- by the
+        # time MemoryReleaser or AsyncProcessor first calls safe_compact!,
+        # gtk3 has almost always already been loaded and it would be too
+        # late.
         #
         # @return [void]
         def install!
@@ -118,18 +136,23 @@ module Lich
               Fiddle::TYPE_VOID
             )
 
+            # Both converter kinds get the identical treatment. In the
+            # current ruby-gnome stack only the boxed variant is actually
+            # exercised by real gems (gdk3's Gdk::Event/Gdk::Rectangle,
+            # pango's Pango::Attribute are all boxed); nothing calls
+            # register_object_class_converter today. It's wrapped anyway,
+            # on the same reasoning, but that half is defensive -- it has
+            # not been independently exercised against a real converter the
+            # way the boxed path has (empirically, via forced compaction
+            # against Pango::Attribute).
             loader_singleton = GObjectIntrospection::Loader.singleton_class
-            loader_singleton.send(:alias_method, :__gtk_compaction_unpinned_register_boxed_class_converter, :register_boxed_class_converter)
-            loader_singleton.send(:alias_method, :__gtk_compaction_unpinned_register_object_class_converter, :register_object_class_converter)
-
-            loader_singleton.send(:define_method, :register_boxed_class_converter) do |gtype, &block|
-              register_mark_object.call(Fiddle.dlwrap(block))
-              __gtk_compaction_unpinned_register_boxed_class_converter(gtype, &block)
-            end
-
-            loader_singleton.send(:define_method, :register_object_class_converter) do |gtype, &block|
-              register_mark_object.call(Fiddle.dlwrap(block))
-              __gtk_compaction_unpinned_register_object_class_converter(gtype, &block)
+            %i[register_boxed_class_converter register_object_class_converter].each do |method_name|
+              unpinned_name = :"__gtk_compaction_unpinned_#{method_name}"
+              loader_singleton.send(:alias_method, unpinned_name, method_name)
+              loader_singleton.send(:define_method, method_name) do |gtype, &block|
+                register_mark_object.call(Fiddle.dlwrap(block))
+                send(unpinned_name, gtype, &block)
+              end
             end
 
             @pinning_active = true
@@ -138,9 +161,9 @@ module Lich
             # doesn't export this libruby symbol the same way (JRuby,
             # TruffleRuby), a future gobject-introspection release renaming
             # these methods, whatever -- must not take the rest of Lich
-            # down with it. install! runs unconditionally, eagerly, at
-            # file-require time for every boot; a raised exception here
-            # propagates straight out of that require and crashes startup
+            # down with it. install! runs unconditionally near the very
+            # start of lich.rbw's boot sequence; a raised exception here
+            # propagates straight out of that call and crashes startup
             # entirely, which is a strictly worse failure mode than the
             # thing this module exists to prevent. Fail into the same
             # conservative fallback as any other "can't pin" case.
@@ -158,6 +181,14 @@ module Lich
           return @native_gem_patched if defined?(@native_gem_patched)
 
           @native_gem_patched = begin
+            # Reads the .c source on disk, not the already-loaded compiled
+            # bundle/so -- a last-resort heuristic, not a certainty. Source
+            # and binary can disagree (source patched after the extension
+            # was already compiled and loaded this process; or vice versa,
+            # a stale checked-out source tree next to a binary built from a
+            # different version). Good enough for "does this install look
+            # like someone ran the patch script," not a guarantee about
+            # what's actually running in memory right now.
             loaded = $LOADED_FEATURES.find { |f| f =~ /gobject_introspection\.(bundle|so)\z/ }
             gem_dir = loaded && File.expand_path(File.join(File.dirname(loaded), '..'))
             src = gem_dir && File.join(gem_dir, 'ext', 'gobject-introspection', 'rb-gi-loader.c')
@@ -182,10 +213,27 @@ module Lich
           return GC.compact unless gtk_loaded?
           return GC.compact if @pinning_active
           return GC.compact if native_gem_patched?
+
+          warn_compaction_disabled_once!
+          nil
+        end
+
+        private
+
+        # Contrast the hourly path in Combat::AsyncProcessor, which logs its
+        # happy case -- this is the one branch where GC.compact silently
+        # stops running for the rest of the process, with nothing in the
+        # logs pointing back at why. One line, once, so a future "why did
+        # memory usage climb all session" investigation has somewhere to
+        # start.
+        def warn_compaction_disabled_once!
+          return if defined?(@compaction_disabled_warned)
+          @compaction_disabled_warned = true
+          warn '[Lich::Util::GtkCompaction] GC.compact disabled for the rest of this process: ' \
+               'gtk3 loaded before install! could pin its converters, and the installed ' \
+               'gobject-introspection gem is not natively patched. See lib/util/gtk_compaction.rb.'
         end
       end
     end
   end
 end
-
-Lich::Util::GtkCompaction.install!

--- a/lib/util/memoryreleaser.rb
+++ b/lib/util/memoryreleaser.rb
@@ -1,5 +1,6 @@
 require 'fiddle'
 require 'rbconfig'
+require_relative 'gtk_compaction'
 
 module Lich
   module Util
@@ -439,13 +440,16 @@ module Lich
         # Run Ruby's garbage collector
         #
         # Performs a full mark and immediate sweep, and attempts to compact
-        # the heap if the Ruby version supports it.
+        # the heap if the Ruby version supports it. Compaction is routed
+        # through Lich::Util::GtkCompaction, which keeps it safe to use
+        # alongside gtk3 -- see that module for why a plain GC.compact call
+        # isn't safe once gtk3 is loaded.
         #
         # @return [void]
         # @api private
         def run_gc
           GC.start(full_mark: true, immediate_sweep: true)
-          GC.compact if GC.respond_to?(:compact)
+          Lich::Util::GtkCompaction.safe_compact!
         end
 
         # Release memory back to the operating system

--- a/lich.rbw
+++ b/lich.rbw
@@ -36,6 +36,12 @@ require File.join(LIB_DIR, 'version.rb')
 require File.join(LIB_DIR, 'gemcheck.rb')
 Lich::GemCheck.verify!
 
+# Must load before lib/init.rb's `require 'gtk3'` -- it installs a wrapper
+# around gobject-introspection's converter registration that has to be in
+# place before gdk3/pango's own loaders run, or it can't do its job. See
+# lib/util/gtk_compaction.rb for why.
+require File.join(LIB_DIR, 'util', 'gtk_compaction.rb')
+
 # TODO: Move all local requires to top of file
 require 'base64'
 require 'digest/md5'

--- a/lich.rbw
+++ b/lich.rbw
@@ -36,11 +36,13 @@ require File.join(LIB_DIR, 'version.rb')
 require File.join(LIB_DIR, 'gemcheck.rb')
 Lich::GemCheck.verify!
 
-# Must load before lib/init.rb's `require 'gtk3'` -- it installs a wrapper
-# around gobject-introspection's converter registration that has to be in
-# place before gdk3/pango's own loaders run, or it can't do its job. See
-# lib/util/gtk_compaction.rb for why.
+# Must run before lib/init.rb's `require 'gtk3'` -- install! sets up a
+# wrapper around gobject-introspection's converter registration that has to
+# be in place before gdk3/pango's own loaders run, or it can't do its job.
+# Requiring the file alone does not install anything (deliberately -- see
+# lib/util/gtk_compaction.rb); install! has to be called explicitly.
 require File.join(LIB_DIR, 'util', 'gtk_compaction.rb')
+Lich::Util::GtkCompaction.install!
 
 # TODO: Move all local requires to top of file
 require 'base64'

--- a/spec/lib/gemstone/combat/async_processor_spec.rb
+++ b/spec/lib/gemstone/combat/async_processor_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require 'gemstone/combat/async_processor'
+
+# Narrow, isolated coverage for AsyncProcessor's two GC.compact call sites
+# (#shutdown, and the hourly path inside the private #cleanup_dead_threads),
+# both of which moved from a raw GC.compact to
+# Lich::Util::GtkCompaction.safe_compact! in this branch. Deliberately does
+# not exercise real chunk processing / Processor.process / thread spawning
+# -- that's full combat integration, out of scope here. The only thing
+# being locked down is: does this class still call GC.compact directly
+# anywhere (it must not), and does it delegate to safe_compact! at the
+# right times.
+RSpec.describe Lich::Gemstone::Combat::AsyncProcessor do
+  before do
+    stub_const('Lich::Gemstone::Combat::Tracker', Module.new)
+    allow(Lich::Gemstone::Combat::Tracker).to receive(:debug?).and_return(false)
+  end
+
+  describe '#shutdown' do
+    it 'joins and clears the thread pool' do
+      processor = described_class.new
+      thread = instance_double(Thread, alive?: false, join: true)
+      processor.instance_variable_set(:@thread_pool, [thread])
+      allow(GC).to receive(:start)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.shutdown
+
+      expect(thread).to have_received(:join)
+      expect(processor.instance_variable_get(:@thread_pool)).to be_empty
+    end
+
+    it 'calls GC.start with no arguments' do
+      processor = described_class.new
+      allow(GC).to receive(:start)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.shutdown
+
+      expect(GC).to have_received(:start).with(no_args)
+    end
+
+    it 'delegates compaction to Lich::Util::GtkCompaction.safe_compact!' do
+      processor = described_class.new
+      allow(GC).to receive(:start)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.shutdown
+
+      expect(Lich::Util::GtkCompaction).to have_received(:safe_compact!)
+    end
+
+    it 'never calls GC.compact directly' do
+      # This is the exact regression this file exists to catch: a future
+      # edit that reverts (or "simplifies") this back to a raw GC.compact
+      # call bypasses GtkCompaction's safety logic entirely.
+      processor = described_class.new
+      allow(GC).to receive(:start)
+      allow(GC).to receive(:compact)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.shutdown
+
+      expect(GC).not_to have_received(:compact)
+    end
+
+    it 'still compacts correctly when Tracker.debug? is true (debug logging does not interfere)' do
+      # Every other example in this file stubs Tracker.debug? to false, so
+      # the "Waiting for N threads..." respond call is otherwise dead code
+      # as far as this spec is concerned.
+      allow(Lich::Gemstone::Combat::Tracker).to receive(:debug?).and_return(true)
+      processor = described_class.new
+      thread = instance_double(Thread, alive?: false, join: true)
+      processor.instance_variable_set(:@thread_pool, [thread])
+      allow(GC).to receive(:start)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      expect { processor.shutdown }.not_to raise_error
+      expect(Lich::Util::GtkCompaction).to have_received(:safe_compact!)
+    end
+  end
+
+  describe '#cleanup_dead_threads (private -- hourly compaction path)' do
+    def stub_compact_supported(supported)
+      allow(GC).to receive(:respond_to?).and_call_original
+      allow(GC).to receive(:respond_to?).with(:compact).and_return(supported)
+    end
+
+    it 'does not compact exactly at the 3600s boundary (strictly greater-than, not >=)' do
+      # Real Time.now drifts forward between instance_variable_set and the
+      # actual check inside cleanup_dead_threads -- a few microseconds of
+      # test overhead is enough to push "exactly 3600" past the boundary
+      # and defeat the point of a boundary test. Freeze time so both sides
+      # of the comparison see the exact same instant.
+      frozen_now = Time.now
+      allow(Time).to receive(:now).and_return(frozen_now)
+      processor = described_class.new
+      processor.instance_variable_set(:@last_compact, frozen_now - 3600)
+      stub_compact_supported(true)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.send(:cleanup_dead_threads)
+
+      expect(Lich::Util::GtkCompaction).not_to have_received(:safe_compact!)
+    end
+
+    it 'does not compact when @last_compact is in the future (clock skew), and does not raise' do
+      processor = described_class.new
+      processor.instance_variable_set(:@last_compact, Time.now + 60)
+      stub_compact_supported(true)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      expect { processor.send(:cleanup_dead_threads) }.not_to raise_error
+      expect(Lich::Util::GtkCompaction).not_to have_received(:safe_compact!)
+    end
+
+    it 'does not compact when the hourly interval has not elapsed' do
+      processor = described_class.new
+      processor.instance_variable_set(:@last_compact, Time.now)
+      stub_compact_supported(true)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.send(:cleanup_dead_threads)
+
+      expect(Lich::Util::GtkCompaction).not_to have_received(:safe_compact!)
+    end
+
+    it 'delegates to Lich::Util::GtkCompaction.safe_compact! once the hourly interval has elapsed' do
+      processor = described_class.new
+      processor.instance_variable_set(:@last_compact, Time.now - 3601)
+      stub_compact_supported(true)
+      allow(GC).to receive(:start)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.send(:cleanup_dead_threads)
+
+      expect(Lich::Util::GtkCompaction).to have_received(:safe_compact!)
+    end
+
+    it 'updates @last_compact after compacting, so it does not fire again immediately' do
+      processor = described_class.new
+      stale_time = Time.now - 3601
+      processor.instance_variable_set(:@last_compact, stale_time)
+      stub_compact_supported(true)
+      allow(GC).to receive(:start)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.send(:cleanup_dead_threads)
+
+      expect(processor.instance_variable_get(:@last_compact)).to be > stale_time
+    end
+
+    it 'does not compact when GC does not respond_to?(:compact), even past the hourly interval' do
+      processor = described_class.new
+      processor.instance_variable_set(:@last_compact, Time.now - 3601)
+      stub_compact_supported(false)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.send(:cleanup_dead_threads)
+
+      expect(Lich::Util::GtkCompaction).not_to have_received(:safe_compact!)
+    end
+
+    it 'never calls GC.compact directly' do
+      processor = described_class.new
+      processor.instance_variable_set(:@last_compact, Time.now - 3601)
+      stub_compact_supported(true)
+      allow(GC).to receive(:start)
+      allow(GC).to receive(:compact)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.send(:cleanup_dead_threads)
+
+      expect(GC).not_to have_received(:compact)
+    end
+
+    it 'does not trigger safe_compact! merely from dead-thread cleanup when the hourly interval has not elapsed' do
+      # Adversarial: this method has two independent GC-triggering
+      # branches (dead-thread count > 10 -> plain GC.start; hourly elapsed
+      # -> safe_compact!). Confirms they stay decoupled -- a busy pool with
+      # many dead threads must not accidentally also trigger compaction.
+      processor = described_class.new
+      processor.instance_variable_set(:@last_compact, Time.now)
+      processor.instance_variable_set(:@thread_pool, Array.new(15) { instance_double(Thread, alive?: false) })
+      stub_compact_supported(true)
+      allow(GC).to receive(:start)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
+
+      processor.send(:cleanup_dead_threads)
+
+      expect(GC).to have_received(:start)
+      expect(Lich::Util::GtkCompaction).not_to have_received(:safe_compact!)
+    end
+  end
+end

--- a/spec/lib/util/gtk_compaction_spec.rb
+++ b/spec/lib/util/gtk_compaction_spec.rb
@@ -5,20 +5,24 @@ require_relative '../../../lib/util/gtk_compaction'
 require 'tmpdir'
 require 'fileutils'
 
-# This module runs eagerly, once, at real Lich boot (lich.rbw requires it
-# before lib/init.rb's `require 'gtk3'`), and its correctness is the entire
+# Requiring this file is inert -- it does not call install! (deliberately;
+# see install!'s own doc). Only lich.rbw calling install! explicitly, right
+# after requiring this file and before lib/init.rb's `require 'gtk3'`, ever
+# activates the pinning wrapper for real. That correctness is the entire
 # difference between "GC.compact runs safely" and "GC.compact occasionally
 # crashes the process." Its state (@installed, @pinning_active,
-# @native_gem_patched) is process-global and was already set for real by
-# the time this spec file loads (either at real Lich boot, or -- in a plain
-# rspec run -- whenever some other spec first required gtk3/gdk3/glib2).
-# Every example below explicitly resets that state before exercising the
-# method under test and restores whatever was there before, via the `around`
-# hook, so this file can neither depend on nor pollute ambient process state
-# or the rest of the 4473-example suite.
+# @native_gem_patched, @compaction_disabled_warned) is process-global,
+# though, so a plain rspec run can still have it set by the time this file
+# loads -- if some other spec earlier in the run called install! itself, or
+# (before this file's own fixes) merely required gtk3/gdk3/glib2 in a way
+# that used to trigger it as a side effect. Every example below explicitly
+# resets that state before exercising the method under test and restores
+# whatever was there before, via the `around` hook, so this file can
+# neither depend on nor pollute ambient process state or the rest of the
+# suite.
 RSpec.describe Lich::Util::GtkCompaction do
   def memoized_ivars
-    %i[@installed @pinning_active @native_gem_patched]
+    %i[@installed @pinning_active @native_gem_patched @compaction_disabled_warned]
   end
 
   def clear_memoized_state!
@@ -78,6 +82,18 @@ RSpec.describe Lich::Util::GtkCompaction do
   describe '.native_gem_patched?' do
     around do |example|
       original_loaded_features = $LOADED_FEATURES.dup
+      # Strip any real gobject_introspection entry before each example, not
+      # just whatever the fake-path tests happen to append. native_gem_patched?
+      # does $LOADED_FEATURES.find { ... } -- first match wins -- so on any
+      # machine that actually has the real gem installed and loaded (which
+      # is most dev boxes, just not CI, which runs with BUNDLE_WITHOUT: gtk),
+      # a real, stock, unpatched entry earlier in the array would win over
+      # the fake one these tests append, silently testing the wrong thing.
+      # This is a defense-in-depth guarantee -- install! no longer runs as a
+      # require-time side effect (see install!'s own doc), so in practice
+      # nothing should inject a real entry here anymore, but this describe
+      # block shouldn't depend on that alone to stay correct.
+      $LOADED_FEATURES.reject! { |f| f =~ /gobject_introspection\.(bundle|so)\z/ }
       example.run
       $LOADED_FEATURES.replace(original_loaded_features)
     end
@@ -415,6 +431,35 @@ RSpec.describe Lich::Util::GtkCompaction do
       described_class.safe_compact!
 
       expect(GC).not_to have_received(:compact)
+    end
+
+    it 'warns once when compaction is disabled for the rest of the process' do
+      clear_memoized_state!
+      stub_compact_supported(true)
+      allow(described_class).to receive(:gtk_loaded?).and_return(true)
+      allow(described_class).to receive(:native_gem_patched?).and_return(false)
+      allow(described_class).to receive(:warn)
+
+      described_class.safe_compact!
+      described_class.safe_compact!
+      described_class.safe_compact!
+
+      expect(described_class).to have_received(:warn).once
+    end
+
+    it 'does not warn on any branch that actually compacts' do
+      clear_memoized_state!
+      stub_compact_supported(true)
+      allow(described_class).to receive(:warn)
+
+      allow(described_class).to receive(:gtk_loaded?).and_return(false)
+      described_class.safe_compact!
+
+      described_class.instance_variable_set(:@pinning_active, true)
+      allow(described_class).to receive(:gtk_loaded?).and_return(true)
+      described_class.safe_compact!
+
+      expect(described_class).not_to have_received(:warn)
     end
 
     it 'treats pinning_active as false when never set (fresh/uninstalled state), not as an error' do

--- a/spec/lib/util/gtk_compaction_spec.rb
+++ b/spec/lib/util/gtk_compaction_spec.rb
@@ -1,0 +1,435 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/util/gtk_compaction'
+require 'tmpdir'
+require 'fileutils'
+
+# This module runs eagerly, once, at real Lich boot (lich.rbw requires it
+# before lib/init.rb's `require 'gtk3'`), and its correctness is the entire
+# difference between "GC.compact runs safely" and "GC.compact occasionally
+# crashes the process." Its state (@installed, @pinning_active,
+# @native_gem_patched) is process-global and was already set for real by
+# the time this spec file loads (either at real Lich boot, or -- in a plain
+# rspec run -- whenever some other spec first required gtk3/gdk3/glib2).
+# Every example below explicitly resets that state before exercising the
+# method under test and restores whatever was there before, via the `around`
+# hook, so this file can neither depend on nor pollute ambient process state
+# or the rest of the 4473-example suite.
+RSpec.describe Lich::Util::GtkCompaction do
+  def memoized_ivars
+    %i[@installed @pinning_active @native_gem_patched]
+  end
+
+  def clear_memoized_state!
+    memoized_ivars.each do |ivar|
+      described_class.remove_instance_variable(ivar) if described_class.instance_variable_defined?(ivar)
+    end
+  end
+
+  around do |example|
+    saved = memoized_ivars.to_h do |ivar|
+      [ivar, described_class.instance_variable_defined?(ivar) ? described_class.instance_variable_get(ivar) : :__unset__]
+    end
+
+    example.run
+
+    saved.each do |ivar, value|
+      if value == :__unset__
+        described_class.remove_instance_variable(ivar) if described_class.instance_variable_defined?(ivar)
+      else
+        described_class.instance_variable_set(ivar, value)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # gtk_loaded?
+  # ---------------------------------------------------------------------
+  describe '.gtk_loaded?' do
+    it 'returns false when none of GLib, Gtk, or Gdk are defined' do
+      %w[GLib Gtk Gdk].each { |name| hide_const(name) if Object.const_defined?(name) }
+
+      expect(described_class.gtk_loaded?).to be(false)
+    end
+
+    it 'returns true when GLib is defined' do
+      stub_const('GLib', Module.new)
+
+      expect(described_class.gtk_loaded?).to be(true)
+    end
+
+    it 'returns true when Gtk is defined' do
+      stub_const('Gtk', Module.new)
+
+      expect(described_class.gtk_loaded?).to be(true)
+    end
+
+    it 'returns true when Gdk is defined' do
+      stub_const('Gdk', Module.new)
+
+      expect(described_class.gtk_loaded?).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # native_gem_patched?
+  # ---------------------------------------------------------------------
+  describe '.native_gem_patched?' do
+    around do |example|
+      original_loaded_features = $LOADED_FEATURES.dup
+      example.run
+      $LOADED_FEATURES.replace(original_loaded_features)
+    end
+
+    def write_fake_gem(dir, bundle_ext:, source_body:)
+      gem_dir = File.join(dir, 'gobject-introspection-4.3.6')
+      src_dir = File.join(gem_dir, 'ext', 'gobject-introspection')
+      lib_dir = File.join(gem_dir, 'lib')
+      FileUtils.mkdir_p(src_dir)
+      FileUtils.mkdir_p(lib_dir)
+      File.write(File.join(src_dir, 'rb-gi-loader.c'), source_body)
+      bundle_path = File.join(lib_dir, "gobject_introspection.#{bundle_ext}")
+      File.write(bundle_path, '')
+      bundle_path
+    end
+
+    it 'memoizes its result -- a second call does not recompute' do
+      clear_memoized_state!
+      $LOADED_FEATURES << '/fake/lib/gobject_introspection.bundle'
+      allow(File).to receive(:exist?).and_return(false)
+
+      first = described_class.native_gem_patched?
+
+      # If this were not memoized, flipping the underlying answer would
+      # change the second call's result.
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:read).and_return(described_class::NATIVE_PATCH_MARKER)
+      second = described_class.native_gem_patched?
+
+      expect(first).to be(false)
+      expect(second).to eq(first)
+    end
+
+    it 'returns false when no gobject_introspection bundle/so entry is in $LOADED_FEATURES' do
+      clear_memoized_state!
+      $LOADED_FEATURES.reject! { |f| f =~ /gobject_introspection/ }
+
+      expect(described_class.native_gem_patched?).to be(false)
+    end
+
+    it 'returns true when the loaded gem source carries the patch marker' do
+      clear_memoized_state!
+      Dir.mktmpdir do |dir|
+        bundle_path = write_fake_gem(dir, bundle_ext: 'bundle', source_body: "before\n#{described_class::NATIVE_PATCH_MARKER}\nafter")
+        $LOADED_FEATURES << bundle_path
+
+        expect(described_class.native_gem_patched?).to be(true)
+      end
+    end
+
+    it 'returns false when the loaded gem source does not carry the patch marker (stock gem)' do
+      clear_memoized_state!
+      Dir.mktmpdir do |dir|
+        bundle_path = write_fake_gem(dir, bundle_ext: 'bundle', source_body: 'nothing relevant here')
+        $LOADED_FEATURES << bundle_path
+
+        expect(described_class.native_gem_patched?).to be(false)
+      end
+    end
+
+    it 'matches a .so extension the same as .bundle (Linux, and Windows via RubyInstaller/mingw)' do
+      clear_memoized_state!
+      Dir.mktmpdir do |dir|
+        bundle_path = write_fake_gem(dir, bundle_ext: 'so', source_body: described_class::NATIVE_PATCH_MARKER)
+        $LOADED_FEATURES << bundle_path
+
+        expect(described_class.native_gem_patched?).to be(true)
+      end
+    end
+
+    it 'returns false, without raising, when the loaded path resolves outside any real gem (source missing)' do
+      clear_memoized_state!
+      $LOADED_FEATURES << '/definitely/does/not/exist/lib/gobject_introspection.bundle'
+
+      expect { described_class.native_gem_patched? }.not_to raise_error
+      expect(described_class.native_gem_patched?).to be(false)
+    end
+
+    it 'returns false, without raising, when reading the source file raises' do
+      clear_memoized_state!
+      $LOADED_FEATURES << '/fake/lib/gobject_introspection.bundle'
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:read).and_raise(Errno::EACCES, 'permission denied')
+
+      expect { described_class.native_gem_patched? }.not_to raise_error
+      expect(described_class.native_gem_patched?).to be(false)
+    end
+
+    it 'returns false, without raising, when the marker string is merely a substring elsewhere (adversarial near-miss)' do
+      clear_memoized_state!
+      Dir.mktmpdir do |dir|
+        # A near-miss should not match: a comment merely *mentioning* the
+        # function name, without the exact call-site marker, must not be
+        # read as "patched" -- that would be a false sense of safety.
+        bundle_path = write_fake_gem(dir, bundle_ext: 'bundle', source_body: '// see rb_gc_register_mark_object for background, not used here')
+        $LOADED_FEATURES << bundle_path
+
+        expect(described_class.native_gem_patched?).to be(false)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # install!
+  # ---------------------------------------------------------------------
+  describe '.install!' do
+    it 'is idempotent -- a second call does not re-run the installation logic' do
+      clear_memoized_state!
+      call_count = 0
+      allow(described_class).to receive(:gtk_loaded?) { call_count += 1; true }
+
+      described_class.install!
+      described_class.install!
+
+      expect(call_count).to eq(1)
+    end
+
+    it 'does not attempt to require gobject-introspection when gtk3 is already loaded' do
+      clear_memoized_state!
+      allow(described_class).to receive(:gtk_loaded?).and_return(true)
+      allow(described_class).to receive(:require)
+
+      described_class.install!
+
+      expect(described_class).not_to have_received(:require)
+      expect(described_class.instance_variable_get(:@pinning_active)).to be(false)
+    end
+
+    it 'sets pinning_active false, without raising, when gobject-introspection is not installed (headless/no-gtk)' do
+      clear_memoized_state!
+      allow(described_class).to receive(:gtk_loaded?).and_return(false)
+      allow(described_class).to receive(:require).with('gobject-introspection').and_raise(LoadError)
+
+      expect { described_class.install! }.not_to raise_error
+      expect(described_class.instance_variable_get(:@pinning_active)).to be(false)
+    end
+
+    it 'sets pinning_active false, without raising, when Fiddle symbol resolution fails' do
+      # Adversarial: this is the exact gap found and fixed in this session
+      # -- an unusual Ruby implementation (JRuby, TruffleRuby), or a future
+      # libruby that renames/removes this exported symbol, must degrade
+      # gracefully rather than crashing Lich's entire boot (install! runs
+      # eagerly, unconditionally, at file-require time).
+      clear_memoized_state!
+      allow(described_class).to receive(:gtk_loaded?).and_return(false)
+      allow(described_class).to receive(:require).with('gobject-introspection')
+      allow(Fiddle::Function).to receive(:new).and_raise(Fiddle::DLError, 'unknown symbol "rb_gc_register_mark_object"')
+
+      expect { described_class.install! }.not_to raise_error
+      expect(described_class.instance_variable_get(:@pinning_active)).to be(false)
+    end
+
+    it 'sets pinning_active false, without raising, when the loader does not define the expected methods' do
+      # Adversarial: a future gobject-introspection release renames or
+      # removes register_boxed_class_converter/register_object_class_converter.
+      clear_memoized_state!
+      allow(described_class).to receive(:gtk_loaded?).and_return(false)
+      allow(described_class).to receive(:require).with('gobject-introspection')
+      stub_const('GObjectIntrospection::Loader', Class.new)
+
+      expect { described_class.install! }.not_to raise_error
+      expect(described_class.instance_variable_get(:@pinning_active)).to be(false)
+    end
+
+    context 'successful installation' do
+      let(:fake_loader) do
+        Class.new do
+          class << self
+            def boxed_calls
+              @boxed_calls ||= []
+            end
+
+            def object_calls
+              @object_calls ||= []
+            end
+
+            def register_boxed_class_converter(gtype, &block)
+              boxed_calls << [gtype, block]
+              :boxed_original_return
+            end
+
+            def register_object_class_converter(gtype, &block)
+              object_calls << [gtype, block]
+              :object_original_return
+            end
+          end
+        end
+      end
+
+      before do
+        clear_memoized_state!
+        allow(described_class).to receive(:gtk_loaded?).and_return(false)
+        allow(described_class).to receive(:require).with('gobject-introspection')
+        stub_const('GObjectIntrospection::Loader', fake_loader)
+      end
+
+      it 'sets pinning_active true' do
+        described_class.install!
+
+        expect(described_class.instance_variable_get(:@pinning_active)).to be(true)
+      end
+
+      it 'pins the block via rb_gc_register_mark_object, called through Fiddle, before forwarding' do
+        pinned = []
+        fake_function = instance_double(Fiddle::Function)
+        allow(Fiddle::Function).to receive(:new)
+          .with(Fiddle::Handle::DEFAULT['rb_gc_register_mark_object'], [Fiddle::TYPE_UINTPTR_T], Fiddle::TYPE_VOID)
+          .and_return(fake_function)
+        allow(fake_function).to receive(:call) { |raw| pinned << raw }
+        allow(Fiddle).to receive(:dlwrap) { |obj| obj.object_id }
+
+        described_class.install!
+        my_block = proc { :converter_result }
+        fake_loader.register_boxed_class_converter(:some_gtype, &my_block)
+
+        expect(pinned).to eq([my_block.object_id])
+        expect(fake_loader.boxed_calls).to eq([[:some_gtype, my_block]])
+      end
+
+      it 'wraps register_object_class_converter the same way as register_boxed_class_converter' do
+        fake_function = instance_double(Fiddle::Function, call: nil)
+        allow(Fiddle::Function).to receive(:new).and_return(fake_function)
+
+        described_class.install!
+        my_block = proc { :whatever }
+        fake_loader.register_object_class_converter(:another_gtype, &my_block)
+
+        expect(fake_loader.object_calls).to eq([[:another_gtype, my_block]])
+      end
+
+      it "forwards the original method's return value, not the pin call's" do
+        fake_function = instance_double(Fiddle::Function, call: :pin_call_return_value_should_be_ignored)
+        allow(Fiddle::Function).to receive(:new).and_return(fake_function)
+
+        described_class.install!
+        result = fake_loader.register_boxed_class_converter(:x) {}
+
+        expect(result).to eq(:boxed_original_return)
+      end
+
+      it 'pins before forwarding to the original method, not after' do
+        # Adversarial: ordering matters here specifically because the
+        # original registration call can itself raise (e.g. re-registering
+        # an already-registered GType on a stock gem -- see the module
+        # doc). A "pin after forward" ordering would silently skip pinning
+        # whenever that happens, defeating the whole point.
+        order = []
+        fake_function = instance_double(Fiddle::Function)
+        allow(Fiddle::Function).to receive(:new).and_return(fake_function)
+        allow(fake_function).to receive(:call) { order << :pin }
+        allow(Fiddle).to receive(:dlwrap).and_return(0)
+
+        described_class.install!
+
+        fake_loader.singleton_class.send(:alias_method, :__real_original, :__gtk_compaction_unpinned_register_boxed_class_converter)
+        fake_loader.singleton_class.send(:define_method, :__gtk_compaction_unpinned_register_boxed_class_converter) do |gtype, &block|
+          order << :forward
+          __real_original(gtype, &block)
+        end
+
+        fake_loader.register_boxed_class_converter(:x) {}
+
+        expect(order).to eq(%i[pin forward])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # safe_compact!
+  # ---------------------------------------------------------------------
+  describe '.safe_compact!' do
+    def stub_compact_supported(supported)
+      allow(GC).to receive(:respond_to?).and_call_original
+      allow(GC).to receive(:respond_to?).with(:compact).and_return(supported)
+      allow(GC).to receive(:compact)
+    end
+
+    it 'does not call GC.compact when GC does not respond_to?(:compact)' do
+      stub_compact_supported(false)
+
+      described_class.safe_compact!
+
+      expect(GC).not_to have_received(:compact)
+    end
+
+    it 'does not evaluate gtk_loaded? at all when GC.compact is unsupported (short-circuits first)' do
+      stub_compact_supported(false)
+      allow(described_class).to receive(:gtk_loaded?)
+
+      described_class.safe_compact!
+
+      expect(described_class).not_to have_received(:gtk_loaded?)
+    end
+
+    it 'compacts unconditionally when gtk3 is not loaded' do
+      stub_compact_supported(true)
+      allow(described_class).to receive(:gtk_loaded?).and_return(false)
+
+      described_class.safe_compact!
+
+      expect(GC).to have_received(:compact)
+    end
+
+    it 'compacts when gtk3 is loaded and pinning is active, without consulting native_gem_patched?' do
+      stub_compact_supported(true)
+      allow(described_class).to receive(:gtk_loaded?).and_return(true)
+      described_class.instance_variable_set(:@pinning_active, true)
+      allow(described_class).to receive(:native_gem_patched?)
+
+      described_class.safe_compact!
+
+      expect(GC).to have_received(:compact)
+      expect(described_class).not_to have_received(:native_gem_patched?)
+    end
+
+    it 'compacts when gtk3 is loaded, pinning is not active, but the installed gem is natively patched' do
+      stub_compact_supported(true)
+      allow(described_class).to receive(:gtk_loaded?).and_return(true)
+      described_class.instance_variable_set(:@pinning_active, false)
+      allow(described_class).to receive(:native_gem_patched?).and_return(true)
+
+      described_class.safe_compact!
+
+      expect(GC).to have_received(:compact)
+    end
+
+    it 'does NOT compact when gtk3 is loaded, pinning is not active, and the gem is not natively patched' do
+      # This is the whole point of the module: the one combination where
+      # compacting would risk a dangling-Proc crash.
+      stub_compact_supported(true)
+      allow(described_class).to receive(:gtk_loaded?).and_return(true)
+      described_class.instance_variable_set(:@pinning_active, false)
+      allow(described_class).to receive(:native_gem_patched?).and_return(false)
+
+      described_class.safe_compact!
+
+      expect(GC).not_to have_received(:compact)
+    end
+
+    it 'treats pinning_active as false when never set (fresh/uninstalled state), not as an error' do
+      # Adversarial: @pinning_active is only ever set inside install!. If
+      # something calls safe_compact! before install! has run for this
+      # process (shouldn't happen given lich.rbw's ordering, but "shouldn't
+      # happen" is exactly what adversarial tests are for), an unset ivar
+      # must read as falsy, not raise or blow up truthiness checks.
+      clear_memoized_state!
+      stub_compact_supported(true)
+      allow(described_class).to receive(:gtk_loaded?).and_return(true)
+      allow(described_class).to receive(:native_gem_patched?).and_return(false)
+
+      expect { described_class.safe_compact! }.not_to raise_error
+      expect(GC).not_to have_received(:compact)
+    end
+  end
+end

--- a/spec/lib/util/memoryreleaser_spec.rb
+++ b/spec/lib/util/memoryreleaser_spec.rb
@@ -186,17 +186,19 @@ RSpec.describe Lich::Util::MemoryReleaser do
       expect(manager).not_to have_received(:print_memory_stats)
     end
 
-    it 'run_gc calls full mark + immediate sweep and compacts when supported' do
+    it 'run_gc calls full mark + immediate sweep and delegates compaction to GtkCompaction' do
+      # Whether GC.compact actually runs is now Lich::Util::GtkCompaction's
+      # own conditional logic (gtk_loaded?, native_gem_patched?, etc, see
+      # lib/util/gtk_compaction.rb and its own spec) -- run_gc's job is
+      # just to delegate to it, not to decide when compaction is safe.
       manager = manager_class.new
       allow(GC).to receive(:start)
-      allow(GC).to receive(:compact)
-      allow(GC).to receive(:respond_to?).and_call_original
-      allow(GC).to receive(:respond_to?).with(:compact).and_return(true)
+      allow(Lich::Util::GtkCompaction).to receive(:safe_compact!)
 
       manager.send(:run_gc)
 
       expect(GC).to have_received(:start).with(full_mark: true, immediate_sweep: true)
-      expect(GC).to have_received(:compact)
+      expect(Lich::Util::GtkCompaction).to have_received(:safe_compact!)
     end
 
     it 'release_to_os dispatches linux path' do


### PR DESCRIPTION
Patches to mitigate real crash: GC.compact could relocate a Proc gobject-introspection caches outside Ruby's GC visibility for boxed/object type conversion (Gdk::Event, Pango::Attribute), leaving a dangling reference that SIGBUS/SIGSEGVs a live GTK session sometime after periodic compaction runs.

Lich::Util::GtkCompaction pins those converters via Fiddle (rb_gc_register_mark_object) before gtk3 loads, so GC.compact stays safe until a natively-patched gem is detected, or by disabling compaction, if pinning couldn't install in time (not preferred). MemoryReleaser and Combat::AsyncProcessor now route through it, with adversarial spec coverage for the safety branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GTK-safe heap compaction helper and routed compaction through it during shutdown and periodic cleanup.
  * Added early initialization to install the compaction safety behavior before GTK loads.

* **Bug Fixes**
  * Prevented direct heap compaction calls that could interfere with GTK/GObject introspection behavior.
  * Added safety gating and fallback behavior to skip compaction when conditions aren’t safe, with warn-once messaging.

* **Tests**
  * Added/updated RSpec coverage to verify delegation to the safe helper and correct cleanup timing and gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->