### PR TITLE
fix(gs): Stash check result type before comparing regex for wear_to_inv

### DIFF
--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -65,7 +65,7 @@ module Lich
           return true if (![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id) && GameObj.inv.to_a.map(&:id).include?(item.id))
           return true if item.name =~ /^ethereal \w+$/ && ![GameObj.right_hand, GameObj.left_hand].map(&:id).compact.include?(item.id)
           sleep 0.1
-        } unless result =~ /You can only wear two items in that location\./
+        } unless result.is_a?(String) && result =~ /You can only wear two items in that location\./
 
         return @worn_items[item.name] = false
       end


### PR DESCRIPTION
Similar fix to the last commit to this file. fput doesn't always return a string so its type should be checked before comparing or else: --- Lich: error: undefined method '=~' for false
.../Lich5/lib/stash.rb:68:in 'block in Lich::Stash.wear_to_inv' .../Lich5/lib/stash.rb:38:in 'block in Lich::Stash.try_or_fail'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item-wearing behavior so the app no longer tries to apply text matching to non-text command results, reducing unexpected errors during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->