### PR TITLE
feat(all): setup_files: support scripts/data/custom for user data overrides

### DIFF
--- a/lib/common/setup_files.rb
+++ b/lib/common/setup_files.rb
@@ -133,6 +133,13 @@ module Lich
         @scripts_data_path ||= File.join(SCRIPT_DIR, 'data')
       end
 
+      # Lazy memoized path -- user-supplied data files that take precedence
+      # over the shipped base data files, mirroring how scripts/custom takes
+      # precedence over scripts/ when loading scripts.
+      def scripts_data_custom_path
+        @scripts_data_custom_path ||= File.join(scripts_data_path, 'custom')
+      end
+
       # Returns the character name for filename construction.
       # Prefers Account.character (available from authentication, before XML stream)
       # with fallback to checkname (XMLData.name, available after XML stream starts).
@@ -172,7 +179,10 @@ module Lich
       end
 
       def get_data_glob_patterns(filenames = [])
-        get_glob_patterns(scripts_data_path, filenames)
+        # Scan scripts/data/custom before scripts/data so a user's custom data
+        # file wins by basename in load_files (first match wins via ||=).
+        get_glob_patterns(scripts_data_custom_path, filenames) +
+          get_glob_patterns(scripts_data_path, filenames)
       end
 
       def get_glob_patterns(basepath = '.', filenames = [])

--- a/spec/lib/common/setup_files_spec.rb
+++ b/spec/lib/common/setup_files_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Lich::Common::SetupFiles do
   let(:tmpdir) { Dir.mktmpdir('setup-files-test') }
   let(:profiles_dir) { File.join(tmpdir, 'profiles') }
   let(:data_dir) { File.join(tmpdir, 'data') }
+  let(:custom_data_dir) { File.join(data_dir, 'custom') }
   let(:setup_files) { described_class.new }
 
   before do
@@ -87,6 +88,37 @@ RSpec.describe Lich::Common::SetupFiles do
     it 'loads data from the correct file' do
       result = setup_files.get_data('spells')
       expect(result.spell_data).to eq({ 'Shield' => { 'mana' => 3 } })
+    end
+
+    context 'with a custom data file' do
+      before { FileUtils.mkdir_p(custom_data_dir) }
+
+      it 'prefers scripts/data/custom over scripts/data' do
+        File.write(File.join(custom_data_dir, 'base-spells.yaml'), { spell_data: { 'Shield' => { 'mana' => 99 } } }.to_yaml)
+        result = setup_files.get_data('spells')
+        expect(result.spell_data).to eq({ 'Shield' => { 'mana' => 99 } })
+      end
+
+      it 'loads a custom-only data file with no base equivalent' do
+        File.write(File.join(custom_data_dir, 'base-custom.yaml'), { my_setting: 'mine' }.to_yaml)
+        result = setup_files.get_data('custom')
+        expect(result.my_setting).to eq('mine')
+      end
+
+      it 'falls back to scripts/data when no custom file exists' do
+        result = setup_files.get_data('spells')
+        expect(result.spell_data).to eq({ 'Shield' => { 'mana' => 3 } })
+      end
+
+      it 'falls back to scripts/data after a custom file is removed' do
+        custom_file = File.join(custom_data_dir, 'base-spells.yaml')
+        File.write(custom_file, { spell_data: { 'Shield' => { 'mana' => 99 } } }.to_yaml)
+        expect(setup_files.get_data('spells').spell_data).to eq({ 'Shield' => { 'mana' => 99 } })
+
+        File.delete(custom_file)
+        setup_files.reload
+        expect(setup_files.get_data('spells').spell_data).to eq({ 'Shield' => { 'mana' => 3 } })
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Lets users drop their own data files in `scripts/data/custom/` that take precedence over the shipped `scripts/data/` files, mirroring how `scripts/custom/` already takes precedence over `scripts/` when loading scripts.

Today, a user who wants to tweak a shipped `base-{type}.yaml` (e.g. `base-items.yaml`) has to edit it in place, which conflicts on every update. With this change they can place `scripts/data/custom/base-items.yaml` and it wins without touching the tracked file.

## How it works

`SetupFiles#get_data_glob_patterns` now scans `scripts/data/custom` before `scripts/data`. Because `load_files` keys its cache by basename with first-match-wins (`||=`), the custom file overrides the base one. Custom-only data files with no base equivalent are also picked up.

The custom directory is entirely optional: `Dir.glob` on a missing path returns nothing, so behavior is unchanged when no custom data exists. The cache also self-heals back to the base file if a custom file is later removed and `reload` runs.

## Tests

Added specs to `setup_files_spec.rb` covering:
- custom file overrides base
- custom-only file with no base equivalent
- fallback to base when no custom file exists
- fallback to base after a custom file is deleted

All existing specs still pass; rubocop clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-added data files now take priority over bundled data when both exist.
  * The app now correctly falls back to bundled data if no custom file is present.
  * Reloading data updates the active file selection after custom files are removed.

* **Tests**
  * Added coverage for data loading with a custom data directory and priority-based file selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->