### PR TITLE
fix(all): keep Gemfile.lock in sync on self-update and tolerate stale locks at boot

### DIFF
--- a/lib/common/update/release_installer.rb
+++ b/lib/common/update/release_installer.rb
@@ -12,9 +12,23 @@ module Lich
   module Util
     module Update
       class ReleaseInstaller
-        # Top-level files (besides lib/ and lich.rbw) to copy from release archive.
-        # lich.rbw is handled separately due to its dynamic target name.
-        TOP_LEVEL_FILES = %w[Gemfile LICENSE].freeze
+        # Top-level files (besides lib/ and lich.rbw) copied verbatim from the
+        # release/branch archive into LICH_DIR during a self-update. lich.rbw is
+        # handled separately due to its dynamic target name.
+        #
+        # Gemfile.lock travels alongside Gemfile so the resolved dependency set
+        # stays consistent with the Gemfile after an update. When only Gemfile is
+        # replaced, the leftover lock is stale relative to the new Gemfile, which
+        # forces Bundler to re-resolve at boot; against a multi-platform lock that
+        # re-resolution can fail even though every required gem is installed.
+        # Entries absent from the archive are skipped (see #copy_top_level_files).
+        TOP_LEVEL_FILES = %w[Gemfile Gemfile.lock LICENSE].freeze
+
+        # Archive entries that must exist for an extracted download to count as a
+        # structurally valid Lich installation. Deliberately distinct from
+        # TOP_LEVEL_FILES so that optional payload (e.g. Gemfile.lock, which older
+        # release tarballs may omit) never gates an update.
+        REQUIRED_ARCHIVE_ITEMS = %w[lib lich.rbw Gemfile LICENSE].freeze
 
         # @param client [GitHubClient] GitHub API client instance
         # @param resolver [ChannelResolver] channel resolver instance
@@ -255,14 +269,7 @@ module Lich
           respond "All Lich lib files have been updated."
           respond
 
-          # Copy top-level release files to LICH_DIR
-          TOP_LEVEL_FILES.each do |filename|
-            src = File.join(source_dir, filename)
-            if File.exist?(src)
-              FileUtils.cp(src, File.join(LICH_DIR, filename))
-              respond "Updated #{filename}."
-            end
-          end
+          copy_top_level_files(source_dir)
 
           file_updater = FileUpdater.new(@client, @resolver)
           file_updater.update_core_data_and_scripts(version)
@@ -273,13 +280,30 @@ module Lich
           true
         end
 
-        # Validates extracted directory contains required Lich files.
+        # Copies each top-level file present in the extracted archive into
+        # LICH_DIR. Files missing from the archive are skipped rather than
+        # treated as errors, so a partial archive (e.g. one without Gemfile.lock)
+        # updates cleanly instead of aborting.
+        #
+        # @param source_dir [String] extracted tarball directory
+        # @return [void]
+        def copy_top_level_files(source_dir)
+          TOP_LEVEL_FILES.each do |filename|
+            src = File.join(source_dir, filename)
+            next unless File.exist?(src)
+
+            FileUtils.cp(src, File.join(LICH_DIR, filename))
+            respond "Updated #{filename}."
+          end
+        end
+
+        # Validates the extracted directory contains every archive entry Lich
+        # requires to install safely.
         #
         # @param dir [String] directory to check
-        # @return [Boolean] true if valid
+        # @return [Boolean] true if all required entries are present
         def validate_lich_structure(dir)
-          required_items = ['lib', 'lich.rbw'] + TOP_LEVEL_FILES
-          required_items.all? { |item| File.exist?(File.join(dir, item)) }
+          REQUIRED_ARCHIVE_ITEMS.all? { |item| File.exist?(File.join(dir, item)) }
         end
 
         # Checks if current Ruby meets minimum version requirement.

--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -14,13 +14,25 @@ module Lich
     TITLE           = 'Lich5: Missing Ruby Gems'
     RELEASE_URL     = 'https://github.com/elanthia-online/lich-5/releases/latest'
     LOG_FILENAME    = 'lich5-missing-gems.log'
+    STALE_LOCK_MESSAGE = 'Lich: Gemfile.lock could not be resolved, but every required gem ' \
+                         'is installed; continuing boot. Run \'bundle install\' from your ' \
+                         'Lich5 folder to refresh the lockfile.'
 
     module_function
 
     # Runs Bundler.setup for the given groups; on failure, alerts the
-    # user and exits. If Bundler complains about a gem outside the
-    # requested groups (which some Bundler versions do despite `without`
-    # settings), the complaint is silently ignored and boot continues.
+    # user and exits. Two classes of Bundler failure are tolerated instead of
+    # being fatal, because in both the gems Lich actually needs are present:
+    #
+    # 1. Bundler complains about a gem outside the requested groups (which some
+    #    Bundler versions do despite `without` settings).
+    # 2. Bundler cannot resolve the lockfile, yet our platform-aware detector
+    #    confirms every required gem is installed -- typically a stale,
+    #    multi-platform Gemfile.lock re-resolved offline after a self-update
+    #    replaced Gemfile but not Gemfile.lock. Boot proceeds on plain RubyGems
+    #    activation (how Lich loaded before GemCheck adopted Bundler.setup),
+    #    with a non-fatal notice pointing at `bundle install`.
+    #
     # @param groups [Array<Symbol>] Bundler groups to verify
     # @return [void]
     def verify!(*groups)
@@ -45,11 +57,27 @@ module Lich
           # Our detector already confirmed the requested groups are satisfied,
           # so this is a scope-semantics disagreement, not a real failure.
           # Continue boot silently.
+        elsif (still_missing = missing_gems(groups)).empty?
+          # Every required gem is installed, so the resolution failure is a
+          # lockfile artifact rather than a genuinely missing dependency.
+          # Warn and continue instead of blocking the user from logging in.
+          warn_stale_lock(e)
         else
-          alert(missing: missing_gems(groups), groups: groups, error: e)
+          alert(missing: still_missing, groups: groups, error: e)
           exit 1
         end
       end
+    end
+
+    # Records a tolerated lockfile-resolution failure and surfaces a non-fatal
+    # notice. The failure is logged for later inspection and echoed to stderr so
+    # it is visible in a terminal launch; boot is not interrupted.
+    #
+    # @param error [Bundler::BundlerError] the resolution failure being tolerated
+    # @return [void]
+    def warn_stale_lock(error)
+      write_log(missing: [], error: error)
+      warn STALE_LOCK_MESSAGE
     end
 
     # Ensures Bundler resolves Lich's Gemfile even when the app is launched

--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -61,7 +61,7 @@ module Lich
           # Every required gem is installed, so the resolution failure is a
           # lockfile artifact rather than a genuinely missing dependency.
           # Warn and continue instead of blocking the user from logging in.
-          warn_stale_lock(e)
+          warn_stale_lock(e, groups)
         else
           alert(missing: still_missing, groups: groups, error: e)
           exit 1
@@ -74,9 +74,11 @@ module Lich
     # it is visible in a terminal launch; boot is not interrupted.
     #
     # @param error [Bundler::BundlerError] the resolution failure being tolerated
+    # @param groups [Array<Symbol>] groups being verified, forwarded to the log
+    #   so its "Groups checked" diagnostic reflects the actual verify! call
     # @return [void]
-    def warn_stale_lock(error)
-      write_log(missing: [], error: error)
+    def warn_stale_lock(error, groups = [:default])
+      write_log(missing: [], groups: groups, error: error)
       warn STALE_LOCK_MESSAGE
     end
 

--- a/spec/lib/common/update/release_installer_spec.rb
+++ b/spec/lib/common/update/release_installer_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative 'update_spec_helper'
+
+RSpec.describe Lich::Util::Update::ReleaseInstaller do
+  subject(:installer) { described_class.new(client, resolver, snapshot_manager) }
+
+  let(:client) { double('GitHubClient') }
+  let(:resolver) { double('ChannelResolver') }
+  let(:snapshot_manager) { double('SnapshotManager') }
+
+  # A freshly extracted archive directory populated with the given entries.
+  # Directories are created for names ending in '/', regular files otherwise.
+  #
+  # @param entries [Array<String>] archive-relative names to materialize
+  # @return [String] path to the populated temporary directory
+  def build_archive(*entries)
+    dir = Dir.mktmpdir('lich-archive')
+    entries.each do |entry|
+      path = File.join(dir, entry)
+      if entry.end_with?('/')
+        FileUtils.mkdir_p(path)
+      else
+        File.write(path, "# #{entry}\n")
+      end
+    end
+    dir
+  end
+
+  describe 'TOP_LEVEL_FILES' do
+    it 'carries Gemfile.lock alongside Gemfile so the resolved set stays in sync' do
+      expect(described_class::TOP_LEVEL_FILES).to include('Gemfile', 'Gemfile.lock')
+    end
+  end
+
+  describe 'REQUIRED_ARCHIVE_ITEMS' do
+    it 'requires the core install entries' do
+      expect(described_class::REQUIRED_ARCHIVE_ITEMS).to include('lib', 'lich.rbw', 'Gemfile', 'LICENSE')
+    end
+
+    it 'does not require the optional Gemfile.lock' do
+      expect(described_class::REQUIRED_ARCHIVE_ITEMS).not_to include('Gemfile.lock')
+    end
+  end
+
+  describe '#copy_top_level_files' do
+    let(:target_dir) { Dir.mktmpdir('lich-target') }
+
+    before { stub_const('LICH_DIR', target_dir) }
+
+    after { FileUtils.remove_entry(target_dir) if Dir.exist?(target_dir) }
+
+    it 'copies the Gemfile.lock into LICH_DIR alongside the Gemfile' do
+      source_dir = build_archive('Gemfile', 'Gemfile.lock', 'LICENSE')
+
+      installer.copy_top_level_files(source_dir)
+
+      expect(File).to exist(File.join(target_dir, 'Gemfile'))
+      expect(File).to exist(File.join(target_dir, 'Gemfile.lock'))
+      expect(File).to exist(File.join(target_dir, 'LICENSE'))
+    ensure
+      FileUtils.remove_entry(source_dir)
+    end
+
+    it 'skips top-level files absent from the archive without raising' do
+      source_dir = build_archive('Gemfile') # no Gemfile.lock, no LICENSE
+
+      expect { installer.copy_top_level_files(source_dir) }.not_to raise_error
+
+      expect(File).to exist(File.join(target_dir, 'Gemfile'))
+      expect(File).not_to exist(File.join(target_dir, 'Gemfile.lock'))
+      expect(File).not_to exist(File.join(target_dir, 'LICENSE'))
+    ensure
+      FileUtils.remove_entry(source_dir)
+    end
+  end
+
+  describe '#validate_lich_structure' do
+    it 'accepts an archive containing every required entry' do
+      source_dir = build_archive('lib/', 'lich.rbw', 'Gemfile', 'Gemfile.lock', 'LICENSE')
+
+      expect(installer.validate_lich_structure(source_dir)).to be(true)
+    ensure
+      FileUtils.remove_entry(source_dir)
+    end
+
+    it 'accepts an archive that omits the optional Gemfile.lock' do
+      source_dir = build_archive('lib/', 'lich.rbw', 'Gemfile', 'LICENSE')
+
+      expect(installer.validate_lich_structure(source_dir)).to be(true)
+    ensure
+      FileUtils.remove_entry(source_dir)
+    end
+
+    it 'rejects an archive missing a required entry' do
+      source_dir = build_archive('lib/', 'Gemfile', 'LICENSE') # no lich.rbw
+
+      expect(installer.validate_lich_structure(source_dir)).to be(false)
+    ensure
+      FileUtils.remove_entry(source_dir)
+    end
+  end
+end

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -122,17 +122,17 @@ RSpec.describe Lich::GemCheck do
         expect { described_class.verify! }.not_to raise_error
       end
 
-      it 'routes the tolerated error through warn_stale_lock' do
+      it 'routes the tolerated error and requested groups through warn_stale_lock' do
         error = Bundler::GemNotFound.new('unresolvable lockfile')
         allow(Bundler).to receive(:setup).and_raise(error)
-        expect(described_class).to receive(:warn_stale_lock).with(error)
+        expect(described_class).to receive(:warn_stale_lock).with(error, [:default])
         described_class.verify!
       end
 
       it 'tolerates other BundlerError subclasses the same way' do
         error = Bundler::PathError.new('bundler path error')
         allow(Bundler).to receive(:setup).and_raise(error)
-        expect(described_class).to receive(:warn_stale_lock).with(error)
+        expect(described_class).to receive(:warn_stale_lock).with(error, [:default])
         expect { described_class.verify! }.not_to raise_error
       end
     end
@@ -169,9 +169,14 @@ RSpec.describe Lich::GemCheck do
       allow(described_class).to receive(:warn)
     end
 
-    it 'logs the tolerated error with an empty missing list' do
-      expect(described_class).to receive(:write_log).with(missing: [], error: error)
+    it 'logs the tolerated error with an empty missing list and default groups' do
+      expect(described_class).to receive(:write_log).with(missing: [], groups: [:default], error: error)
       described_class.warn_stale_lock(error)
+    end
+
+    it 'forwards the requested groups to the log for accurate diagnostics' do
+      expect(described_class).to receive(:write_log).with(missing: [], groups: [:default, :gtk], error: error)
+      described_class.warn_stale_lock(error, [:default, :gtk])
     end
 
     it 'echoes the remediation notice to stderr' do

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -104,22 +104,36 @@ RSpec.describe Lich::GemCheck do
       end
     end
 
-    context 'when Bundler.setup raises another BundlerError subclass' do
+    context 'when Bundler.setup fails but every required gem is installed' do
       before do
         allow(described_class).to receive(:missing_gems)
           .with([:default]).and_return([])
         allow(described_class).to receive(:bundler_error_out_of_scope?)
           .and_return(false)
+        allow(described_class).to receive(:warn_stale_lock)
       end
 
-      it 'alerts and exits 1 (rescue covers all Bundler setup failures)' do
+      it 'tolerates a stale-lock GemNotFound without alerting or exiting' do
+        error = Bundler::GemNotFound.new(
+          "Could not find gems matching 'ffi' valid for all resolution platforms"
+        )
+        allow(Bundler).to receive(:setup).and_raise(error)
+        expect(described_class).not_to receive(:alert)
+        expect { described_class.verify! }.not_to raise_error
+      end
+
+      it 'routes the tolerated error through warn_stale_lock' do
+        error = Bundler::GemNotFound.new('unresolvable lockfile')
+        allow(Bundler).to receive(:setup).and_raise(error)
+        expect(described_class).to receive(:warn_stale_lock).with(error)
+        described_class.verify!
+      end
+
+      it 'tolerates other BundlerError subclasses the same way' do
         error = Bundler::PathError.new('bundler path error')
         allow(Bundler).to receive(:setup).and_raise(error)
-        expect(described_class).to receive(:alert)
-          .with(missing: [], groups: [:default], error: error)
-        expect { described_class.verify! }.to raise_error(SystemExit) do |e|
-          expect(e.status).to eq(1)
-        end
+        expect(described_class).to receive(:warn_stale_lock).with(error)
+        expect { described_class.verify! }.not_to raise_error
       end
     end
 
@@ -144,6 +158,25 @@ RSpec.describe Lich::GemCheck do
         expect(described_class).not_to receive(:write_log)
         described_class.verify!
       end
+    end
+  end
+
+  describe '.warn_stale_lock' do
+    let(:error) { Bundler::GemNotFound.new('unresolvable lockfile') }
+
+    before do
+      allow(described_class).to receive(:write_log)
+      allow(described_class).to receive(:warn)
+    end
+
+    it 'logs the tolerated error with an empty missing list' do
+      expect(described_class).to receive(:write_log).with(missing: [], error: error)
+      described_class.warn_stale_lock(error)
+    end
+
+    it 'echoes the remediation notice to stderr' do
+      expect(described_class).to receive(:warn).with(described_class::STALE_LOCK_MESSAGE)
+      described_class.warn_stale_lock(error)
     end
   end
 


### PR DESCRIPTION
## Problem

A self-update (`lich5-update --update` / `--branch=...`) copies `Gemfile` into the install but **not** `Gemfile.lock` (`TOP_LEVEL_FILES = %w[Gemfile LICENSE]`). Whenever the `Gemfile` changed, the leftover lock is now stale relative to it.

At boot, `GemCheck.verify!` forces a Bundler re-resolution (`Bundler.definition(true)`). Against a stale, multi-platform `Gemfile.lock`, that resolve runs **offline** (`Bundler.setup` only sees locally installed gems) and fails even though every required gem is installed for the current platform:

```
Bundler::GemNotFound
Could not find gems matching 'ffi' valid for all resolution platforms
(aarch64-linux, arm-linux, arm64-darwin, x64-mingw-ucrt, x86-linux,
 x86_64-darwin, x86_64-linux) in locally installed gems.
  The source contains the following gems matching 'ffi':
    * ffi-1.17.4-x86_64-linux-gnu
```

Because `ffi` is in the `:default` group, the error is treated as fatal and Lich `exit 1`s. The GemCheck log even shows `Missing gems (detected): none` and every dependency `OK` -- the gems are present; only the lockfile can't be re-resolved. The user is left unable to log in, with no in-app path to recover (the fix requires a shell `bundle install`).

## Fix (defense in depth)

**1. `ReleaseInstaller` keeps the lock in sync.** `Gemfile.lock` is copied alongside `Gemfile` so the resolved dependency set stays consistent after an update. Validation moves to its own `REQUIRED_ARCHIVE_ITEMS` constant so the optional lock never *gates* an update (older release tarballs may omit it), and the copy loop is extracted into a testable `copy_top_level_files`.

**2. `GemCheck.verify!` degrades gracefully.** When a Bundler resolution error occurs but the platform-aware `missing_gems` detector confirms every required gem is installed, GemCheck now logs the failure, warns the user to run `bundle install`, and **continues boot** on plain RubyGems activation (how Lich loaded before GemCheck adopted `Bundler.setup`) instead of exiting. Genuinely missing gems still alert and exit as before.

Either fix alone resolves the reported failure; together they also cover bundler-version skew and dead-platform locks from any source.

## Testing

- `rubocop -A` clean on all changed files (0 offenses).
- New `spec/lib/common/update/release_installer_spec.rb`: lock copy + structure validation (incl. optional-lock tolerance).
- Updated `spec/lib/gemcheck_spec.rb`: tolerate-and-continue behavior + `warn_stale_lock`.
- Full update suite + gemcheck: **100 + n examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updates now handle partial release archives more gracefully, copying available top-level files while continuing even if optional files are missing.
  * Bundler setup failures are now treated more leniently when dependencies are otherwise intact, allowing startup to continue with a warning.

* **Bug Fixes**
  * Prevents updates from failing when optional archive files like `Gemfile.lock` are absent.
  * Adds a clearer warning path for stale or mismatched lockfile situations instead of stopping the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->