### PR TITLE
fix(all): Mapdb sort tags by downcase and original case

### DIFF
--- a/lib/common/map/map_base.rb
+++ b/lib/common/map/map_base.rb
@@ -311,7 +311,7 @@ module Lich
             timeto: @timeto&.sort_by { |k, _v| k.to_i }&.to_h,
             image: @image,
             image_coords: @image_coords,
-            tags: @tags&.sort_by(&:downcase),
+            tags: @tags&.sort_by { |tag| [tag.downcase, tag] },
             check_location: @check_location,
             unique_loot: @unique_loot,
             uid: @uid


### PR DESCRIPTION
Resolves issue where two tags that are identical letters (ex: Pawnshop, pawnshop) could end up being swapped back and forth when saving, causing issues with DIFF showing changes for just array placement of tags.