### PR TITLE
fix(all): stop locking the load path at boot; keep Gemfile.lock in sync on self-update

### DIFF
--- a/lib/common/update/release_installer.rb
+++ b/lib/common/update/release_installer.rb
@@ -12,9 +12,22 @@ module Lich
   module Util
     module Update
       class ReleaseInstaller
-        # Top-level files (besides lib/ and lich.rbw) to copy from release archive.
-        # lich.rbw is handled separately due to its dynamic target name.
-        TOP_LEVEL_FILES = %w[Gemfile LICENSE].freeze
+        # Top-level files (besides lib/ and lich.rbw) copied verbatim from the
+        # release/branch archive into LICH_DIR during a self-update. lich.rbw is
+        # handled separately due to its dynamic target name.
+        #
+        # Gemfile.lock travels alongside Gemfile so the resolved dependency set
+        # on disk stays consistent with the Gemfile after an update. Shipping a
+        # new Gemfile without its lock would leave a stale lock that a later
+        # `bundle install` (or any Bundler invocation) has to re-resolve.
+        # Entries absent from the archive are skipped (see #copy_top_level_files).
+        TOP_LEVEL_FILES = %w[Gemfile Gemfile.lock LICENSE].freeze
+
+        # Archive entries that must exist for an extracted download to count as a
+        # structurally valid Lich installation. Deliberately distinct from
+        # TOP_LEVEL_FILES so that optional payload (e.g. Gemfile.lock, which older
+        # release tarballs may omit) never gates an update.
+        REQUIRED_ARCHIVE_ITEMS = %w[lib lich.rbw Gemfile LICENSE].freeze
 
         # @param client [GitHubClient] GitHub API client instance
         # @param resolver [ChannelResolver] channel resolver instance
@@ -255,14 +268,7 @@ module Lich
           respond "All Lich lib files have been updated."
           respond
 
-          # Copy top-level release files to LICH_DIR
-          TOP_LEVEL_FILES.each do |filename|
-            src = File.join(source_dir, filename)
-            if File.exist?(src)
-              FileUtils.cp(src, File.join(LICH_DIR, filename))
-              respond "Updated #{filename}."
-            end
-          end
+          copy_top_level_files(source_dir)
 
           file_updater = FileUpdater.new(@client, @resolver)
           file_updater.update_core_data_and_scripts(version)
@@ -273,13 +279,30 @@ module Lich
           true
         end
 
-        # Validates extracted directory contains required Lich files.
+        # Copies each top-level file present in the extracted archive into
+        # LICH_DIR. Files missing from the archive are skipped rather than
+        # treated as errors, so a partial archive (e.g. one without Gemfile.lock)
+        # updates cleanly instead of aborting.
+        #
+        # @param source_dir [String] extracted tarball directory
+        # @return [void]
+        def copy_top_level_files(source_dir)
+          TOP_LEVEL_FILES.each do |filename|
+            src = File.join(source_dir, filename)
+            next unless File.exist?(src)
+
+            FileUtils.cp(src, File.join(LICH_DIR, filename))
+            respond "Updated #{filename}."
+          end
+        end
+
+        # Validates the extracted directory contains every archive entry Lich
+        # requires to install safely.
         #
         # @param dir [String] directory to check
-        # @return [Boolean] true if valid
+        # @return [Boolean] true if all required entries are present
         def validate_lich_structure(dir)
-          required_items = ['lib', 'lich.rbw'] + TOP_LEVEL_FILES
-          required_items.all? { |item| File.exist?(File.join(dir, item)) }
+          REQUIRED_ARCHIVE_ITEMS.all? { |item| File.exist?(File.join(dir, item)) }
         end
 
         # Checks if current Ruby meets minimum version requirement.

--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -17,10 +17,13 @@ module Lich
 
     module_function
 
-    # Runs Bundler.setup for the given groups; on failure, alerts the
-    # user and exits. If Bundler complains about a gem outside the
-    # requested groups (which some Bundler versions do despite `without`
-    # settings), the complaint is silently ignored and boot continues.
+    # Verifies every gem required by the requested Bundler groups is installed,
+    # alerting the user (native OS dialog, with a log-file fallback) and exiting
+    # when any are missing. This is a presence check only -- it does not call
+    # Bundler.setup, so it never locks the load path. Boot then proceeds on
+    # plain RubyGems activation, which leaves scripts free to require gems they
+    # install at runtime (gems outside Lich's Gemfile, e.g. discordrb).
+    #
     # @param groups [Array<Symbol>] Bundler groups to verify
     # @return [void]
     def verify!(*groups)
@@ -28,28 +31,10 @@ module Lich
       configure_gemfile!
 
       missing = missing_gems(groups)
-      unless missing.empty?
-        alert(missing: missing, groups: groups)
-        exit 1
-      end
+      return if missing.empty?
 
-      excluded = (all_groups - groups).map(&:to_s)
-      begin
-        Bundler.settings.temporary(without: excluded) do
-          Bundler.definition(true)
-          Bundler.setup(*groups)
-        end
-      rescue Bundler::BundlerError => e
-        if bundler_error_out_of_scope?(e, groups)
-          # Bundler is complaining about a gem outside the requested groups.
-          # Our detector already confirmed the requested groups are satisfied,
-          # so this is a scope-semantics disagreement, not a real failure.
-          # Continue boot silently.
-        else
-          alert(missing: missing_gems(groups), groups: groups, error: e)
-          exit 1
-        end
-      end
+      alert(missing: missing, groups: groups)
+      exit 1
     end
 
     # Ensures Bundler resolves Lich's Gemfile even when the app is launched
@@ -84,29 +69,6 @@ module Lich
       Bundler.definition.groups
     rescue StandardError
       [:default]
-    end
-
-    # @param error [Exception]
-    # @param groups [Array<Symbol>]
-    # @return [Boolean] true if the error concerns a gem outside the requested groups
-    def bundler_error_out_of_scope?(error, groups)
-      name = extract_gem_name(error.message)
-      return false unless name
-
-      dep = safe_call { Bundler.definition.current_dependencies.find { |d| d.name == name } }
-      return false unless dep.respond_to?(:groups)
-
-      (dep.groups & groups).empty?
-    end
-
-    # Extracts a gem name from a Bundler error message. Matches:
-    #   "Could not find gem 'foo' in ..."
-    #   "Could not find 'foo' in ..."
-    # @param msg [String]
-    # @return [String, nil]
-    def extract_gem_name(msg)
-      match = msg.match(/Could not find (?:gem )?['"]([^'"]+)['"]/)
-      match && match[1]
     end
 
     # @param missing [Array<String>] gem names identified by our detector

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -16,133 +16,58 @@ require_relative '../../lib/gemcheck'
 
 RSpec.describe Lich::GemCheck do
   describe '.verify!' do
-    let(:settings) { double('settings') }
+    before { allow(described_class).to receive(:configure_gemfile!) }
 
-    before do
-      allow(Bundler).to receive(:settings).and_return(settings)
-      allow(settings).to receive(:temporary).and_yield
-      allow(Bundler).to receive(:definition).with(true)
-      allow(described_class).to receive(:all_groups)
-        .and_return([:default, :development, :gtk])
-    end
-
-    context 'when nothing is missing and Bundler.setup succeeds' do
-      before do
-        allow(described_class).to receive(:missing_gems).and_return([])
-        allow(Bundler).to receive(:setup)
-      end
+    context 'when nothing is missing' do
+      before { allow(described_class).to receive(:missing_gems).and_return([]) }
 
       it 'does not alert' do
         expect(described_class).not_to receive(:alert)
         described_class.verify!
       end
 
-      it 'passes :default when no groups are given' do
-        expect(Bundler).to receive(:setup).with(:default)
-        described_class.verify!
-      end
-
-      it 'forwards custom groups to Bundler.setup' do
-        expect(Bundler).to receive(:setup).with(:default, :gtk)
-        described_class.verify!(:default, :gtk)
-      end
-
-      it 'excludes non-requested groups via Bundler.settings.temporary' do
-        expect(settings).to receive(:temporary)
-          .with(without: %w[development gtk]).and_yield
-        described_class.verify!(:default)
-      end
-
-      it 'forces definition rebuild under the temporary settings' do
-        expect(Bundler).to receive(:definition).with(true)
-        described_class.verify!(:default)
-      end
-    end
-
-    context 'when our detector finds missing gems in scope' do
-      before do
-        allow(described_class).to receive(:missing_gems)
-          .with([:default]).and_return(['ox'])
-      end
-
-      it 'alerts with the detected list and exits 1 before calling Bundler.setup' do
-        expect(described_class).to receive(:alert)
-          .with(missing: ['ox'], groups: [:default])
-        expect(Bundler).not_to receive(:setup)
-        expect { described_class.verify! }.to raise_error(SystemExit) do |e|
-          expect(e.status).to eq(1)
-        end
-      end
-    end
-
-    context 'when Bundler.setup raises for an in-scope gem' do
-      before do
-        allow(described_class).to receive(:missing_gems)
-          .with([:default]).and_return([], ['transitive-gem'])
-        allow(described_class).to receive(:bundler_error_out_of_scope?)
-          .and_return(false)
-      end
-
-      it 'alerts and exits 1 on GemNotFound' do
-        error = Bundler::GemNotFound.new("Could not find gem 'transitive-gem'")
-        allow(Bundler).to receive(:setup).and_raise(error)
-        expect(described_class).to receive(:alert)
-          .with(missing: ['transitive-gem'], groups: [:default], error: error)
-        expect { described_class.verify! }.to raise_error(SystemExit) do |e|
-          expect(e.status).to eq(1)
-        end
-      end
-
-      it 'alerts and exits 1 on GitError' do
-        error = Bundler::GitError.new('git clone failed')
-        allow(Bundler).to receive(:setup).and_raise(error)
-        expect(described_class).to receive(:alert)
-          .with(missing: ['transitive-gem'], groups: [:default], error: error)
-        expect { described_class.verify! }.to raise_error(SystemExit) do |e|
-          expect(e.status).to eq(1)
-        end
-      end
-    end
-
-    context 'when Bundler.setup raises another BundlerError subclass' do
-      before do
-        allow(described_class).to receive(:missing_gems)
-          .with([:default]).and_return([])
-        allow(described_class).to receive(:bundler_error_out_of_scope?)
-          .and_return(false)
-      end
-
-      it 'alerts and exits 1 (rescue covers all Bundler setup failures)' do
-        error = Bundler::PathError.new('bundler path error')
-        allow(Bundler).to receive(:setup).and_raise(error)
-        expect(described_class).to receive(:alert)
-          .with(missing: [], groups: [:default], error: error)
-        expect { described_class.verify! }.to raise_error(SystemExit) do |e|
-          expect(e.status).to eq(1)
-        end
-      end
-    end
-
-    context 'when Bundler.setup raises for an out-of-scope gem' do
-      before do
-        allow(described_class).to receive(:missing_gems)
-          .with([:default]).and_return([])
-        allow(described_class).to receive(:bundler_error_out_of_scope?)
-          .and_return(true)
-      end
-
-      it 'silently continues without alerting or exiting' do
-        allow(Bundler).to receive(:setup)
-          .and_raise(Bundler::GemNotFound.new("Could not find gem 'rspec'"))
-        expect(described_class).not_to receive(:alert)
+      it 'returns without exiting' do
         expect { described_class.verify! }.not_to raise_error
       end
 
-      it 'does not write to the log' do
-        allow(Bundler).to receive(:setup)
-          .and_raise(Bundler::GemNotFound.new("Could not find gem 'rspec'"))
-        expect(described_class).not_to receive(:write_log)
+      it 'never locks the load path via Bundler.setup' do
+        expect(Bundler).not_to receive(:setup)
         described_class.verify!
+      end
+
+      it 'configures the Gemfile path before checking' do
+        expect(described_class).to receive(:configure_gemfile!)
+        described_class.verify!
+      end
+
+      it 'defaults to the :default group when none is given' do
+        expect(described_class).to receive(:missing_gems).with([:default]).and_return([])
+        described_class.verify!
+      end
+
+      it 'forwards custom groups to the detector' do
+        expect(described_class).to receive(:missing_gems).with([:default, :gtk]).and_return([])
+        described_class.verify!(:default, :gtk)
+      end
+    end
+
+    context 'when required gems are missing' do
+      before do
+        allow(described_class).to receive(:missing_gems).with([:default]).and_return(['ox'])
+      end
+
+      it 'alerts with the detected list and exits 1' do
+        expect(described_class).to receive(:alert)
+          .with(missing: ['ox'], groups: [:default])
+        expect { described_class.verify! }.to raise_error(SystemExit) do |e|
+          expect(e.status).to eq(1)
+        end
+      end
+
+      it 'does not lock the load path via Bundler.setup' do
+        allow(described_class).to receive(:alert)
+        expect(Bundler).not_to receive(:setup)
+        expect { described_class.verify! }.to raise_error(SystemExit)
       end
     end
   end
@@ -272,55 +197,6 @@ RSpec.describe Lich::GemCheck do
     it 'returns [:default] when Bundler.definition raises' do
       allow(Bundler).to receive(:definition).and_raise(StandardError)
       expect(described_class.all_groups).to eq([:default])
-    end
-  end
-
-  describe '.bundler_error_out_of_scope?' do
-    let(:dev_dep) { double('dep', name: 'rspec', groups: [:development]) }
-    let(:default_dep) { double('dep', name: 'ox', groups: [:default]) }
-    let(:definition) { double('definition', current_dependencies: [dev_dep, default_dep]) }
-
-    before { allow(Bundler).to receive(:definition).and_return(definition) }
-
-    it 'returns true when the errored gem is in a non-requested group' do
-      error = double('error', message: "Could not find gem 'rspec' in locally installed gems.")
-      expect(described_class.bundler_error_out_of_scope?(error, [:default])).to be(true)
-    end
-
-    it 'returns false when the errored gem is in a requested group' do
-      error = double('error', message: "Could not find gem 'ox' in locally installed gems.")
-      expect(described_class.bundler_error_out_of_scope?(error, [:default])).to be(false)
-    end
-
-    it 'returns false when the errored gem is unknown to the Gemfile' do
-      error = double('error', message: "Could not find gem 'not-in-gemfile' in locally installed gems.")
-      expect(described_class.bundler_error_out_of_scope?(error, [:default])).to be(false)
-    end
-
-    it 'returns false when the gem name cannot be extracted' do
-      error = double('error', message: 'some unexpected error format')
-      expect(described_class.bundler_error_out_of_scope?(error, [:default])).to be(false)
-    end
-  end
-
-  describe '.extract_gem_name' do
-    it 'extracts from the standard "Could not find gem" message' do
-      msg = "Could not find gem 'rspec' in locally installed gems."
-      expect(described_class.extract_gem_name(msg)).to eq('rspec')
-    end
-
-    it 'extracts from the variant without the word "gem"' do
-      msg = "Could not find 'rspec' in any of the sources"
-      expect(described_class.extract_gem_name(msg)).to eq('rspec')
-    end
-
-    it 'extracts from double-quoted variants' do
-      msg = 'Could not find gem "rspec" in locally installed gems.'
-      expect(described_class.extract_gem_name(msg)).to eq('rspec')
-    end
-
-    it 'returns nil when no gem name is present' do
-      expect(described_class.extract_gem_name('some other error')).to be_nil
     end
   end
 


### PR DESCRIPTION
Supersedes #1432. This keeps that PR's `Gemfile.lock`-in-sync fix but replaces its
"tolerate a failed `Bundler.setup`" approach with removing the boot-time `Bundler.setup`
altogether. GemCheck goes back to being a presence check, and boot no longer locks the
load path. Recommend closing #1432 in favor of this.

## Problem

Two failures, one root cause.

Since #1420, `GemCheck.verify!` runs `Bundler.setup(:default)` at boot. `Bundler.setup`
does not merely confirm gems are present -- it **locks the process to the bundle**: it
prunes `$LOAD_PATH` (and the in-memory `Gem::Specification` set) down to the gems declared
in Lich's `Gemfile`. Any installed gem that is not in the `Gemfile` becomes unrequireable.

**1. Runtime-gem scripts break.** Community scripts install and `require` their own gems at
runtime (e.g. `zdiscord` / `discordhook` -> `discordrb`). `discordrb` is not in Lich's
`Gemfile`, so once boot clears GemCheck the `require` fails even though the gem is installed:

    --- Lich: error: cannot load such file -- discordrb
            .../ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
            .../ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
    --- Lich: zdiscord has exited.

`gem list` shows the gem, and the scripts' own installed-gem guard
(`Gem::Specification.map(&:name)`) sees it too -- both ignore Bundler -- so the scripts skip
reinstalling and go straight to the failing `require`. The `bundled_gems.rb` frames are just
Ruby 4.0's `require` wrapper; the actual cause is the pruned load path.

**2. Stale lockfiles false-fatal at boot** (the original #1432 report). A self-update replaced
`Gemfile` but not `Gemfile.lock`; `verify!`'s `Bundler.definition(true)` re-resolution then
failed offline against the multi-platform lock and `exit 1`ed, even though every required gem
was installed for the current platform:

    Bundler::GemNotFound
    Could not find gems matching 'ffi' valid for all resolution platforms
    (aarch64-linux, arm-linux, ...) in locally installed gems.

#1432 addressed (2) by catching the `Bundler.setup` failure and continuing on plain RubyGems.
But the deeper issue is that `Bundler.setup` -- locking the load path -- is fundamentally
incompatible with an engine that hosts scripts installing gems at runtime. It is the source of
both failures, and tolerating it one exception at a time (as #1432 did) leaves (1) unsolved.
No post-`setup` reactivation from a script fixes it either: `gem "discordrb"` raises
`not part of the bundle`, and `Gem::Specification.find_by_name(...).activate` raises
`MissingSpecError` even after `Gem::Specification.reset`, because Bundler has replaced the
registry.

## Fix

**1. `GemCheck.verify!` stops locking the load path.** It stays a presence check: read the
declared dependencies for the requested groups, confirm each is installed (via
`Gem::Specification`, platform-correct for the current machine), and alert + `exit 1` if any
are missing. It no longer calls `Bundler.setup`, `Bundler.definition(true)`, or
`Bundler.settings.temporary`. Boot then proceeds on plain RubyGems activation -- how Lich
loaded before #1420 -- so scripts can again `require` gems they install at runtime. Genuinely
missing gems still alert and exit exactly as before.

This also makes the #1432 failure **impossible** rather than merely tolerated: with no forced
re-resolution and no `setup`, a stale lock can no longer fail boot. The tolerance code that is
now dead is removed: `warn_stale_lock`, `STALE_LOCK_MESSAGE`, `bundler_error_out_of_scope?`,
and `extract_gem_name`.

**2. `ReleaseInstaller` keeps `Gemfile.lock` in sync on self-update** (retained from #1432).
`Gemfile.lock` is copied alongside `Gemfile` so the on-disk resolved set stays consistent for a
later `bundle install` / dev use. Structural validation lives in its own
`REQUIRED_ARCHIVE_ITEMS` constant so the optional lock never gates an update (older release
tarballs may omit it), and the copy loop is extracted into the testable `copy_top_level_files`.
Its comment is updated to drop the now-inaccurate "forces re-resolution at boot" rationale.

Detection itself is unaffected: `missing_gems` reads `Bundler.definition.current_dependencies`
(Gemfile as source of truth) and checks `Gem::Specification`, needing no `setup`; it fails open
if Bundler cannot parse the Gemfile, so a broken Gemfile never blocks login.

### Trade-off

Not locking means RubyGems auto-activates the newest installed version of each gem rather than
the exact lockfile pin. This only diverges when multiple versions of a gem coexist; on a normal
Ruby4Lich5 / `bundle install` machine there is one of each, and this is how Lich loaded for
years before #1420. Transitive-only breakage is no longer pre-flighted by GemCheck, but it still
surfaces as a clear `LoadError` at the offending `require`.

## Testing

- New/updated specs pass: **65 examples, 0 failures** across `spec/lib/gemcheck_spec.rb` and
  `spec/lib/common/update/release_installer_spec.rb`, verified on a clean `main` checkout with
  all changed files applied.
- `spec/lib/gemcheck_spec.rb` rewritten for the presence-check contract: missing -> alert +
  `exit 1`; nothing missing -> returns and never calls `Bundler.setup`; group forwarding;
  `configure_gemfile!` invoked.
- `spec/lib/common/update/release_installer_spec.rb` unchanged (lock copy + optional-lock
  tolerance).
- `ruby -c` clean; ASCII-only clean (`Custom/AsciiOnlySource`).
- `rubocop -A` clean on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update installs now copy `Gemfile.lock` along with other top-level files when available.

* **Bug Fixes**
  * Installation checks are less strict, allowing partial update archives to complete when optional files are missing.
  * Gem dependency verification now focuses on missing gems for the selected groups and exits cleanly when issues are found.

* **Tests**
  * Updated coverage to match the new update and gem-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->