### PR TITLE
feat(gs): parse <crtrStatus> XML into Creature via GameObj#creature

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -230,6 +230,24 @@ module Lich
       end
 
       # ---------------------------------------------------------------------------
+      # Creature (Gemstone crtrStatus) linkage
+      # ---------------------------------------------------------------------------
+
+      # Returns the +Lich::Gemstone::CreatureInstance+ that tracks this exist
+      # id, creating one lazily if it does not exist yet so callers can always
+      # do +obj.creature.crtr_status.hostile?+ without a nil check.
+      #
+      # Returns +nil+ in DragonRealms since Simu never emits <crtrStatus> there
+      # and the Creature module is Gemstone-scoped.
+      #
+      # @return [Lich::Gemstone::CreatureInstance, nil]
+      def creature
+        return nil unless defined?(Lich::Gemstone::Creature)
+        return nil if defined?(XMLData) && XMLData.respond_to?(:game) && XMLData.game !~ /^GS/
+        Lich::Gemstone::Creature.track(@id, @name, @noun)
+      end
+
+      # ---------------------------------------------------------------------------
       # Class-level factory methods
       # ---------------------------------------------------------------------------
 

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -422,6 +422,17 @@ module Lich
             @room_climate = attributes['climate'].to_i if attributes['climate']
             @room_terrain = attributes['terrain'].to_i if attributes['terrain']
           end
+          # <crtrStatus exist="..." hostile="1" prone="1" .../> is Gemstone-only;
+          # Simu never emits this tag in DragonRealms. Only currently-active
+          # flags are enumerated on each update, so CrtrStatus#update is
+          # responsible for resetting previously seen flags to false before
+          # applying the incoming attributes.
+          if name == 'crtrStatus' && attributes['exist'] && XMLData.game =~ /^GS/
+            id  = attributes['exist']
+            obj = GameObj[id.to_s]
+            instance = Lich::Gemstone::Creature.track(id, obj&.name, obj&.noun)
+            instance&.crtr_status&.update(attributes)
+          end
           if name == 'pushStream'
             @in_stream = true
             @current_stream = attributes['id'].to_s

--- a/lib/gemstone/creature.rb
+++ b/lib/gemstone/creature.rb
@@ -166,6 +166,80 @@ module Lich
       end
     end
 
+    # Boolean flag snapshot parsed from the Gemstone <crtrStatus .../> XML tag.
+    #
+    # The Gemstone server only enumerates *currently active* status flags
+    # (value "1") on each <crtrStatus> emission. Flags that are no longer
+    # active are simply omitted from the tag, so on every #update we MUST
+    # clear all previously seen flags to false before applying the incoming
+    # attributes, otherwise we would leave stale flags stuck at true.
+    #
+    # The set of possible flags is intentionally NOT enumerated in code:
+    # Simu may add new ones at any time, and we should not have to patch
+    # this class every time that happens. Any XML attribute other than the
+    # ones listed in NON_FLAG_ATTRIBUTES is treated as a status flag, and
+    # the flag is considered active iff its value is exactly "1".
+    #
+    # This is a plain value object owned by a CreatureInstance and reached
+    # via CreatureInstance#crtr_status (or GameObj#creature.crtr_status).
+    # It intentionally does not use the existing @status array/has_status?
+    # machinery so the crtrStatus flag semantics stay independent of the
+    # message-based (breeze/web/stunned/...) status tracking, which has its
+    # own timing/expiry rules.
+    class CrtrStatus
+      # Attributes on <crtrStatus> that are metadata, not boolean flags.
+      # Everything else on the tag is treated as a status flag.
+      NON_FLAG_ATTRIBUTES = %w[exist].freeze
+
+      attr_reader :flags, :updated_at
+
+      def initialize
+        @flags      = {}
+        @updated_at = nil
+      end
+
+      # Apply an incoming <crtrStatus> attributes hash. All previously seen
+      # flags are reset to false before the incoming attributes are applied,
+      # so a subsequent tag that omits a flag correctly transitions it back
+      # to false.
+      def update(attributes)
+        @flags.each_key { |k| @flags[k] = false }
+        attributes.each do |key, value|
+          next if NON_FLAG_ATTRIBUTES.include?(key.to_s)
+          @flags[key.to_s] = (value.to_s == '1')
+        end
+        @updated_at = Time.now
+        self
+      end
+
+      # Generic lookup: crtr_status.flag?("hostile") or .flag?(:MiniBoss).
+      # Accepts a String or Symbol. Returns false for any flag we have never
+      # observed, which is the correct "not active" answer.
+      def flag?(name)
+        !!@flags[name.to_s]
+      end
+      alias is? flag?
+
+      # All flags currently set to true, as an array of the original XML
+      # attribute names (Strings).
+      def active_flags
+        @flags.select { |_k, v| v }.keys
+      end
+
+      # True if we have never received a <crtrStatus> for this creature.
+      def stale?
+        @updated_at.nil?
+      end
+
+      def to_h
+        { 'updated_at' => @updated_at }.merge(@flags)
+      end
+
+      def inspect
+        "#<Lich::Gemstone::CrtrStatus flags=#{active_flags.inspect} updated_at=#{@updated_at.inspect}>"
+      end
+    end
+
     # Individual creature instance (runtime tracking with ID)
     class CreatureInstance
       @@instances = {}
@@ -202,6 +276,12 @@ module Lich
         'poisoned'    => nil # Has removal messages
       }.freeze
 
+      # Boolean flag snapshot fed by the <crtrStatus .../> XML tag. Check
+      # flags via creature.crtr_status.is?('hostile') or .flag?(:prone).
+      # (Note: CreatureInstance#dead? is HP-based and unrelated to the
+      # crtrStatus "dead" flag which is exposed as crtr_status.is?('dead').)
+      attr_reader :crtr_status
+
       def initialize(id, noun, name)
         @id = id.to_i
         @noun = noun
@@ -217,6 +297,7 @@ module Lich
         @ucs_tierup = nil
         @ucs_smote = nil
         @ucs_updated = nil
+        @crtr_status = CrtrStatus.new
       end
 
       # Get the template for this creature
@@ -480,6 +561,34 @@ module Lich
           size >= @@max_size
         end
 
+        # Fetch-or-create a CreatureInstance by exist id, without going
+        # through the auto_register gate used by #register. Intended for the
+        # <crtrStatus> XML handler, which needs an instance for every id it
+        # sees regardless of whether the creature was ever a current target.
+        # Backfills name / noun on the existing instance if it was created
+        # earlier with nil values.
+        def track(id, name = nil, noun = nil)
+          int_id = id.to_i
+          if (existing = @@instances[int_id])
+            existing.name = name if existing.name.nil? && !name.nil?
+            existing.noun = noun if existing.noun.nil? && !noun.nil?
+            return existing
+          end
+
+          # Same age-based eviction ladder as #register.
+          if full?
+            [7200, 6300, 5400, 4500, 3600, 2700, 1800, 900].each do |age_threshold|
+              cleanup_old(age_threshold)
+              break unless full?
+            end
+            return nil if full?
+          end
+
+          instance = new(int_id, noun, name)
+          @@instances[int_id] = instance
+          instance
+        end
+
         # Register a new creature instance
         def register(name, id, noun = nil)
           return nil unless auto_register?
@@ -537,6 +646,13 @@ module Lich
       # Register a new creature
       def self.register(name, id, noun = nil)
         CreatureInstance.register(name, id, noun)
+      end
+
+      # Fetch-or-create the CreatureInstance for +id+ regardless of the
+      # auto_register setting. Used by the <crtrStatus> XML handler and by
+      # GameObj#creature so every known exist id has a place to hang state.
+      def self.track(id, name = nil, noun = nil)
+        CreatureInstance.track(id, name, noun)
       end
 
       # Configure the system

--- a/spec/lib/gemstone/creature_crtr_status_spec.rb
+++ b/spec/lib/gemstone/creature_crtr_status_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require 'gemstone/creature'
+
+# Specs for the Gemstone <crtrStatus .../> XML tag parsing that hangs off of
+# the existing Lich::Gemstone::Creature module.
+#
+# CrtrStatus is intentionally flag-agnostic -- it does not enumerate the
+# set of possible flag names, because Simu may add new ones at any time.
+# Anything on the tag other than metadata (see NON_FLAG_ATTRIBUTES) is
+# treated as a boolean flag, active iff its value is exactly "1".
+describe Lich::Gemstone::CrtrStatus do
+  subject(:status) { described_class.new }
+
+  it 'starts with no flags and no updated_at' do
+    expect(status.flags).to eq({})
+    expect(status.active_flags).to eq([])
+    expect(status.stale?).to eq(true)
+    expect(status.updated_at).to be_nil
+  end
+
+  it "sets flags whose value is '1'" do
+    status.update({ 'exist' => '166660193', 'hostile' => '1', 'inferior' => '1' })
+    expect(status.flag?('hostile')).to eq(true)
+    expect(status.flag?('inferior')).to eq(true)
+    expect(status.flag?('dead')).to eq(false)
+    expect(status.active_flags).to match_array(%w[hostile inferior])
+    expect(status.updated_at).to be_a(Time)
+    expect(status.stale?).to eq(false)
+  end
+
+  it 'clears previously-set flags that are omitted on a subsequent update' do
+    status.update({ 'exist' => '1', 'hostile' => '1', 'prone' => '1' })
+    expect(status.active_flags).to match_array(%w[hostile prone])
+
+    # Sparse follow-up: Simu only enumerates active statuses, so a creature
+    # that stood up and stopped being hostile arrives with those flags absent
+    # entirely. Both must revert to false.
+    status.update({ 'exist' => '1' })
+    expect(status.flag?('hostile')).to eq(false)
+    expect(status.flag?('prone')).to eq(false)
+    expect(status.active_flags).to eq([])
+  end
+
+  it 'keeps flags true across updates when they are resent' do
+    status.update({ 'exist' => '1', 'hostile' => '1' })
+    status.update({ 'exist' => '1', 'hostile' => '1', 'stunned' => '1' })
+    expect(status.flag?('hostile')).to eq(true)
+    expect(status.flag?('stunned')).to eq(true)
+  end
+
+  it 'ignores non-flag metadata attributes like exist' do
+    status.update({ 'exist' => '166660193' })
+    expect(status.flags).not_to include('exist')
+    expect(status.active_flags).to eq([])
+  end
+
+  it 'treats an unrecognized non-"1" value as an inactive flag' do
+    status.update({ 'hostile' => '0', 'prone' => 'true', 'dead' => '' })
+    expect(status.flag?('hostile')).to eq(false)
+    expect(status.flag?('prone')).to eq(false)
+    expect(status.flag?('dead')).to eq(false)
+    expect(status.active_flags).to eq([])
+  end
+
+  it 'accepts arbitrary future flag names without any code change' do
+    # Simu could add flags we have never heard of; they should just work.
+    status.update({ 'brand_new_flag_2027' => '1', 'AnotherWeirdOne' => '1' })
+    expect(status.flag?('brand_new_flag_2027')).to eq(true)
+    expect(status.flag?('AnotherWeirdOne')).to eq(true)
+    expect(status.active_flags).to match_array(%w[brand_new_flag_2027 AnotherWeirdOne])
+  end
+
+  describe '#flag? / #is?' do
+    before do
+      status.update({ 'hostile' => '1', 'AscensionBoss' => '1' })
+    end
+
+    it 'accepts String and Symbol equivalently' do
+      expect(status.flag?('hostile')).to eq(true)
+      expect(status.flag?(:hostile)).to eq(true)
+      expect(status.flag?('AscensionBoss')).to eq(true)
+      expect(status.flag?(:AscensionBoss)).to eq(true)
+    end
+
+    it 'returns false for flags that have never been observed' do
+      expect(status.flag?('never_seen')).to eq(false)
+      expect(status.flag?(:also_never_seen)).to eq(false)
+    end
+
+    it 'is? is a straightforward alias for flag?' do
+      expect(status.is?('hostile')).to eq(true)
+      expect(status.is?(:hostile)).to eq(true)
+      expect(status.is?('AscensionBoss')).to eq(true)
+      expect(status.is?(:AscensionBoss)).to eq(true)
+      expect(status.is?('prone')).to eq(false)
+      expect(status.is?(:prone)).to eq(false)
+    end
+
+    it 'is case-sensitive to match the raw XML attribute names' do
+      # Simu emits camelCase flag names for some flags; we preserve them as-is
+      # and do not fold case.
+      expect(status.is?('ascensionboss')).to eq(false)
+      expect(status.is?('AscensionBoss')).to eq(true)
+    end
+  end
+end
+
+describe Lich::Gemstone::Creature, 'crtrStatus integration' do
+  before(:each) { Lich::Gemstone::Creature.clear }
+
+  describe '.track' do
+    it 'creates a CreatureInstance the first time an id is seen' do
+      inst = described_class.track('166660193', 'a snarling goblin', 'goblin')
+      expect(inst).to be_a(Lich::Gemstone::CreatureInstance)
+      expect(inst.id).to eq(166660193)
+      expect(inst.name).to eq('a snarling goblin')
+      expect(inst.noun).to eq('goblin')
+    end
+
+    it 'returns the same instance on subsequent calls for the same id' do
+      a = described_class.track(1, 'thing', 'thing')
+      b = described_class.track(1)
+      expect(a).to be(b)
+    end
+
+    it 'backfills name / noun when they were previously nil, without overwriting' do
+      described_class.track(1)                          # created with nil name / noun
+      described_class.track(1, 'a goblin', 'goblin')    # backfilled
+      inst = described_class[1]
+      expect(inst.name).to eq('a goblin')
+      expect(inst.noun).to eq('goblin')
+
+      described_class.track(1, 'something else', 'else')
+      expect(inst.name).to eq('a goblin') # existing non-nil values preserved
+      expect(inst.noun).to eq('goblin')
+    end
+
+    it 'ignores the auto_register setting (unlike .register)' do
+      Lich::Gemstone::CreatureInstance.configure(auto_register: false)
+      begin
+        expect(described_class.register('x', 42, 'x')).to be_nil
+        expect(described_class.track(42, 'x', 'x')).to be_a(Lich::Gemstone::CreatureInstance)
+      ensure
+        Lich::Gemstone::CreatureInstance.configure(auto_register: true)
+      end
+    end
+  end
+
+  describe 'CreatureInstance#crtr_status' do
+    it 'is initialized empty on a fresh instance' do
+      inst = described_class.track(1)
+      expect(inst.crtr_status).to be_a(Lich::Gemstone::CrtrStatus)
+      expect(inst.crtr_status.stale?).to eq(true)
+      expect(inst.crtr_status.active_flags).to eq([])
+    end
+
+    it 'reads back the flags of a raw <crtrStatus> attributes hash' do
+      inst = described_class.track(1)
+      inst.crtr_status.update({
+        'exist' => '1', 'hostile' => '1', 'prone' => '1', 'inferior' => '1'
+      })
+      expect(inst.crtr_status.is?('hostile')).to eq(true)
+      expect(inst.crtr_status.is?(:prone)).to eq(true)
+      expect(inst.crtr_status.is?('inferior')).to eq(true)
+    end
+
+    it 'does not interfere with the HP-based CreatureInstance#dead?' do
+      inst = described_class.track(1)
+      inst.crtr_status.update({ 'exist' => '1', 'dead' => '1' })
+      # HP-based dead? on the instance -- damage_taken is 0 so current_hp > 0
+      expect(inst.dead?).to eq(false)
+      # crtrStatus "dead" flag on the value object -- reflects the XML tag
+      expect(inst.crtr_status.is?('dead')).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Adds parsing for the new crtrStatus tags. Support any arbitrary value to be extensible (vs freezing on the known list we've seen so far). Information is saved in the new creature module in `Creature.crtr_status` but also adds shortcut methods in GameObj as `GameObj.creature` (for the entire creature object) and `GameObj.crtr_status` for this new model.

can get the entire key w/ `crtr_status.flags` or check for a specific flag w/ `crtr_status.is?(:prone)`


```
>;e echo GameObj.target.creature.crtr_status.is?(:prone)
--- Lich: exec1 active.
[exec1: false]
--- Lich: exec1 has exited.

[exec1]>incant 1207
You take a deep breath and focus inward, raising a hand and quietly murmuring the words of the Force Projection spell...
Your spell is ready.
You gesture at a behemothic gorefrost golem.
[SMR result: 114 (Open d100: -25)]
A translucent force moves outward from you and toward a behemothic gorefrost golem.
A behemothic gorefrost golem is buffeted by the force and is knocked to the ground.
Cast Roundtime 2 Seconds.

>;e echo GameObj.target.creature.crtr_status.is?(:prone)
--- Lich: exec1 active.
[exec1: true]
--- Lich: exec1 has exited
```