### PR TITLE
feat(all): Modify running? method to support optional exact matching of script names

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -131,8 +131,11 @@ def stop_script(*target_names)
   end
 end
 
-def running?(*snames)
-  snames.each { |checking| (return false) unless (Script.running.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.running.find { |lscr| lscr.name =~ /^#{checking}/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}/i }) }
+def running?(*snames, exact_match: false)
+  if exact_match
+    snames.each { |checking| (return false) unless (Script.running.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}$/i }) }
+  else
+    snames.each { |checking| (return false) unless (Script.running.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.running.find { |lscr| lscr.name =~ /^#{checking}/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}/i }) }
   true
 end
 

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -136,6 +136,7 @@ def running?(*snames, exact_match: false)
     snames.each { |checking| (return false) unless (Script.running.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}$/i }) }
   else
     snames.each { |checking| (return false) unless (Script.running.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.running.find { |lscr| lscr.name =~ /^#{checking}/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}$/i } || Script.hidden.find { |lscr| lscr.name =~ /^#{checking}/i }) }
+  end
   true
 end
 


### PR DESCRIPTION
Updated running? method to include exact_match parameter for stricter matching of script names.
Preserves default behavior of partial (starts with) matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option for more precise script-name checks, allowing exact matching when needed.
  * Existing matching behavior remains unchanged by default, continuing to support partial name matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->