### PR TITLE
fix(dr): match (prone)/(sitting) posture detection under HidePostStrings (#4529)

### DIFF
--- a/lib/dragonrealms/drinfomon/drdefs.rb
+++ b/lib/dragonrealms/drinfomon/drdefs.rb
@@ -12,10 +12,15 @@ module Lich
       PARENTHETICAL = / \(.+\)/.freeze
       # Pattern to extract player name (word characters at end)
       PLAYER_NAME = /\w+$/.freeze
-      # Pattern for lying down players
-      LYING_DOWN = /who is lying down/i.freeze
-      # Pattern for sitting players
-      SITTING = /who is sitting/i.freeze
+      # Pattern for lying down / prone players. Matches the default
+      # "who is lying down" long form and the "(prone)" short form shown when
+      # the HidePostStrings option is on (issue #4529). PARENTHETICAL still
+      # strips the "(prone)" suffix before the name is extracted.
+      LYING_DOWN = /who is lying down|\(prone\)/i.freeze
+      # Pattern for sitting players. Matches the default "who is sitting" long
+      # form and the "(sitting)" short form shown when the HidePostStrings
+      # option is on (issue #4529).
+      SITTING = /who is sitting|\(sitting\)/i.freeze
       # Pattern for "You also see" prefix
       YOU_ALSO_SEE = /You also see/.freeze
       # Pattern for mount descriptions

--- a/spec/lib/dragonrealms/drinfomon/drdefs_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drdefs_spec.rb
@@ -119,6 +119,24 @@ RSpec.describe Lich::DragonRealms do
       it 'is case insensitive' do
         expect('Mahtra WHO IS LYING DOWN').to match(pattern)
       end
+
+      # Issue #4529: HidePostStrings renders posture as "(prone)"
+      it 'matches the "(prone)" HidePostStrings short form' do
+        expect('Mahtra (prone)').to match(pattern)
+      end
+
+      it 'matches "(prone)" case insensitively' do
+        expect('Mahtra (PRONE)').to match(pattern)
+      end
+
+      it 'does not match a sitting player in either form' do
+        expect('Mahtra who is sitting').not_to match(pattern)
+        expect('Mahtra (sitting)').not_to match(pattern)
+      end
+
+      it 'does not match a player with no posture' do
+        expect('Mahtra').not_to match(pattern)
+      end
     end
 
     describe 'SITTING' do
@@ -130,6 +148,24 @@ RSpec.describe Lich::DragonRealms do
 
       it 'is case insensitive' do
         expect('Mahtra WHO IS SITTING').to match(pattern)
+      end
+
+      # Issue #4529: HidePostStrings renders posture as "(sitting)"
+      it 'matches the "(sitting)" HidePostStrings short form' do
+        expect('Mahtra (sitting)').to match(pattern)
+      end
+
+      it 'matches "(sitting)" case insensitively' do
+        expect('Mahtra (SITTING)').to match(pattern)
+      end
+
+      it 'does not match a prone player in either form' do
+        expect('Mahtra who is lying down').not_to match(pattern)
+        expect('Mahtra (prone)').not_to match(pattern)
+      end
+
+      it 'does not match a mount described as "sitting astride its back"' do
+        expect('a warhorse with a saddle sitting astride its back').not_to match(pattern)
       end
     end
 
@@ -440,6 +476,23 @@ RSpec.describe Lich::DragonRealms do
       end
     end
 
+    context 'with the "(prone)" HidePostStrings short form (issue #4529)' do
+      it 'extracts the name from a "(prone)" player' do
+        result = helper.find_pcs_prone('Mahtra (prone)')
+        expect(result).to eq(['Mahtra'])
+      end
+
+      it 'handles a mix of long-form and short-form prone players' do
+        result = helper.find_pcs_prone('Mahtra who is lying down and Quilsilgas (prone)')
+        expect(result).to contain_exactly('Mahtra', 'Quilsilgas')
+      end
+
+      it 'does not treat a "(sitting)" player as prone' do
+        result = helper.find_pcs_prone('Mahtra (sitting)')
+        expect(result).to eq([])
+      end
+    end
+
     context 'with no prone players' do
       it 'returns empty array' do
         result = helper.find_pcs_prone('Mahtra and Quilsilgas')
@@ -478,6 +531,23 @@ RSpec.describe Lich::DragonRealms do
       it 'returns multiple sitting players' do
         result = helper.find_pcs_sitting('Mahtra who is sitting and Quilsilgas who is sitting')
         expect(result).to contain_exactly('Mahtra', 'Quilsilgas')
+      end
+    end
+
+    context 'with the "(sitting)" HidePostStrings short form (issue #4529)' do
+      it 'extracts the name from a "(sitting)" player' do
+        result = helper.find_pcs_sitting('Mahtra (sitting)')
+        expect(result).to eq(['Mahtra'])
+      end
+
+      it 'handles a mix of long-form and short-form sitting players' do
+        result = helper.find_pcs_sitting('Mahtra who is sitting and Quilsilgas (sitting)')
+        expect(result).to contain_exactly('Mahtra', 'Quilsilgas')
+      end
+
+      it 'does not treat a "(prone)" player as sitting' do
+        result = helper.find_pcs_sitting('Mahtra (prone)')
+        expect(result).to eq([])
       end
     end
 


### PR DESCRIPTION
Resolves elanthia-online/dr-scripts#4529

Closed as "not planned" but still valid.

`DRDefsPattern::LYING_DOWN` / `SITTING` only matched the "who is lying down" / "who is sitting" long forms. With the HidePostStrings option on, posture shows as "(prone)" / "(sitting)", so `DRRoom.pcs_prone` / `pcs_sitting` came back empty and safe-room's wait-for-others logic walked away early. Broadened both patterns to also match the short forms; `PARENTHETICAL` already strips the "(prone)" suffix before the name is extracted.

Testing: extended `drdefs_spec.rb` -- (prone)/(sitting) constant matching (case-insensitive, plus cross-posture negatives such as a mount "sitting astride" not matching), and `find_pcs_prone`/`find_pcs_sitting` extraction including mixed long/short forms.

Note: `drdefs_spec.rb`'s pre-existing `add_ordinals_to_duplicates with more than 20 duplicates` example fails on current main as well (unrelated to this change).

Generated with [Claude Code](https://claude.com/claude-code)

