### PR TITLE
fix(all): minimum Ruby 4.0 required & migrate Ruby version check

### DIFF
--- a/lib/init.rb
+++ b/lib/init.rb
@@ -9,27 +9,6 @@ if File.exist?("#{DATA_DIR}/lich.sav")
   exit
 end
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(REQUIRED_RUBY)
-  if (RUBY_PLATFORM =~ /mingw|win/) and (RUBY_PLATFORM !~ /darwin/i)
-    require 'win32ole'
-    shell = WIN32OLE.new('WScript.Shell')
-    message = "!!ALERT!!\nYour version #{RUBY_VERSION} of Ruby is too old!\nUpgrade Ruby to version #{REQUIRED_RUBY} or newer!\nClick OK to launch browser to go to documentation now!"
-    title = "Lich v#{LICH_VERSION}"
-    type = 1 + 64  # OK/Cancel buttons + Information icon
-    result = shell.Popup(message, 0, title, type)
-
-    if result == 1 # OK button clicked
-      shell.Run("https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich")
-    end
-  else
-    puts "!!ALERT!!"
-    puts "Your version #{RUBY_VERSION} of Ruby is too old!"
-    puts "Upgrade Ruby to version #{REQUIRED_RUBY} or newer!"
-    puts "Go to https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich for more info!"
-  end
-  exit
-end
-
 require_relative 'wine'
 
 begin

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,3 +3,24 @@
 LICH_VERSION = '5.18.0' # x-release-please-version
 REQUIRED_RUBY = '2.6'
 RECOMMENDED_RUBY = '3.2'
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(REQUIRED_RUBY)
+  if (RUBY_PLATFORM =~ /mingw|win/) and (RUBY_PLATFORM !~ /darwin/i)
+    require 'win32ole'
+    shell = WIN32OLE.new('WScript.Shell')
+    message = "!!ALERT!!\nYour version #{RUBY_VERSION} of Ruby is too old!\nUpgrade Ruby to version #{REQUIRED_RUBY} or newer!\nClick OK to launch browser to go to documentation now!"
+    title = "Lich v#{LICH_VERSION}"
+    type = 1 + 64  # OK/Cancel buttons + Information icon
+    result = shell.Popup(message, 0, title, type)
+
+    if result == 1 # OK button clicked
+      shell.Run("https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich")
+    end
+  else
+    puts "!!ALERT!!"
+    puts "Your version #{RUBY_VERSION} of Ruby is too old!"
+    puts "Upgrade Ruby to version #{REQUIRED_RUBY} or newer!"
+    puts "Go to https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich for more info!"
+  end
+  exit
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,8 +1,9 @@
 # Lich5 carveout to better manage semver
 
 LICH_VERSION = '5.18.0' # x-release-please-version
-REQUIRED_RUBY = '2.6'
-RECOMMENDED_RUBY = '3.2'
+
+REQUIRED_RUBY = '4.0'
+RECOMMENDED_RUBY = '4.0'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(REQUIRED_RUBY)
   if (RUBY_PLATFORM =~ /mingw|win/) and (RUBY_PLATFORM !~ /darwin/i)


### PR DESCRIPTION
* Updates minimum and recommended Ruby version to be 4.0
* Migrates version check from init.rb to version.rb so that version check can be done on immediate launch before doing anything else. (checking appropriate gems installed for example)