### PR TITLE
ci(all): Move from build to copy Ruby4Lich5 installer

### DIFF
--- a/.github/workflows/rebuild-release-assets.yaml
+++ b/.github/workflows/rebuild-release-assets.yaml
@@ -1,13 +1,13 @@
 # -----------------------------------------------------------------------------
 # PURPOSE
-#   Manually rebuild release assets for an existing GitHub release tag and
-#   upload them back to that draft release. This is a recovery workflow for
+#   Manually rebuild core release assets and attach the latest Ruby4Lich5
+#   installer to an existing GitHub release tag. This is a recovery workflow for
 #   situations where a draft release was deleted/recreated and its assets need
 #   to be restored without minting a new tag.
 #
 # NOTES
 # - Targets an existing release by tag (for example: v5.16.1).
-# - Rebuilds the same asset names used by the stable release workflow:
+# - Rebuilds the core archives and attaches the same installer asset used by the stable workflow:
 #     * lich-5.tar.gz
 #     * lich-5.zip
 #     * Ruby4Lich5.exe
@@ -23,18 +23,13 @@ on:
         required: true
         type: string
       build_installer:
-        description: "Also rebuild and upload the Windows installer"
+        description: "Also attach the latest Ruby4Lich5 Windows installer"
         required: true
         default: true
         type: boolean
 
 permissions:
   contents: write
-
-env:
-  EXP_PRUNE_PYTHON_MODE: files
-  EXP_PRUNE_BULK: 'true'
-  EXP_VALIDATE_RUBY_GTK: 'true'
 
 jobs:
   release_guard:
@@ -115,224 +110,17 @@ jobs:
   build_installer:
     needs: [release_guard, build_archives]
     if: ${{ inputs.build_installer }}
-    runs-on: windows-latest
-    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout target tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ needs.release_guard.outputs.tag }}
-          fetch-depth: 0
-
-      - name: Download core archive artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: rebuilt-release-archives
-
-      - name: Expand core payload
+      - name: Download latest Ruby4Lich5 installer
         shell: bash
         run: |
           set -euo pipefail
-          unzip -q lich-5.zip
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
-        with:
-          bundler-cache: false
-
-      - name: Install Inno Setup
-        shell: powershell
-        run: |
-          choco feature disable -n=showDownloadProgress
-          choco install -y --limit-output innosetup
-
-      - name: Install MSYS2 into app tree
-        shell: powershell
-        run: |
-          choco feature disable -n=showDownloadProgress
-          choco install -y --limit-output msys2 --params '"/InstallDir:C:\Ruby4Lich5\msys64 /NoUpdate"'
-
-      - name: Build sanitized PATH for vendored MSYS2
-        id: vendormsys
-        shell: powershell
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          if (!(Test-Path $msys)) { Write-Error "Expected $msys to exist at this point"; exit 1 }
-          $orig = $env:Path -split ';'
-          $filtered = $orig | Where-Object {
-            $_ -and
-            ($_ -notlike '*\Ruby\*\x64\msys64\*') -and
-            ($_ -ne 'C:\mingw64\bin') -and
-            ($_ -notmatch '^C:\\Strawberry(\\|$)')
-          }
-          $san = @("$msys\ucrt64\bin","$msys\usr\bin") + $filtered
-          $joined = ($san -join ';')
-          "PATH_VENDOR_MSYS=$joined" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "path=$joined" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "RI_DEVKIT=" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Initialize MSYS2 (minimal UCRT64; no meta toolchain)
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys   = 'C:\Ruby4Lich5\msys64'
-          $pacman = Join-Path $msys 'usr\bin\pacman.exe'
-          if (!(Test-Path $pacman)) { Write-Error "pacman not found at $pacman"; exit 1 }
-
-          $env:MSYSTEM = 'UCRT64'
-          & $pacman -Sy --noconfirm
-          & $pacman -S --needed --noconfirm `
-            mingw-w64-ucrt-x86_64-gcc `
-            mingw-w64-ucrt-x86_64-gcc-libs `
-            mingw-w64-ucrt-x86_64-make `
-            mingw-w64-ucrt-x86_64-pkgconf `
-            mingw-w64-ucrt-x86_64-gobject-introspection `
-            mingw-w64-ucrt-x86_64-sqlite3 `
-            mingw-w64-ucrt-x86_64-gtk3 `
-            make
-
-      - name: Dependency validation (toolchain & pkg-config)
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          $gcc  = Join-Path $msys 'ucrt64\bin\gcc.exe'
-          $pkgc = Join-Path $msys 'ucrt64\bin\pkg-config.exe'
-          $pac  = Join-Path $msys 'usr\bin\pacman.exe'
-
-          if (!(Test-Path $pac))  { Write-Error "pacman not found at $pac"; exit 1 }
-          if (!(Test-Path $gcc))  { Write-Error "vendored gcc not found at $gcc"; exit 1 }
-          if (!(Test-Path $pkgc)) { Write-Error "vendored pkg-config not found at $pkgc"; exit 1 }
-
-          & $gcc --version | Select-Object -First 1
-          if ($LASTEXITCODE -ne 0) { Write-Error "vendored gcc failed to execute"; exit 1 }
-          & $pkgc --version
-          if ($LASTEXITCODE -ne 0) { Write-Error "vendored pkg-config failed to execute"; exit 1 }
-
-          cmd /c `"$pkgc`" --print-errors --exists gtk+-3.0
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve gtk+-3.0"; exit 1 }
-          cmd /c `"$pkgc`" --print-errors --exists sqlite3
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve sqlite3"; exit 1 }
-
-          "CC=$gcc" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "PKG_CONFIG=$pkgc" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "PKG_CONFIG_PATH=$($msys)\ucrt64\lib\pkgconfig;$($msys)\lib\pkgconfig" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Install required gems
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-          MSYS2_ROOT: C:\Ruby4Lich5\msys64
-          CC: gcc
-          PKG_CONFIG: pkg-config
-        run: |
-          gem install sqlite3 --platform ruby -- --enable-system-libraries --with-sqlite3-include=${env:MSYS2_ROOT}/ucrt64/include --with-sqlite3-lib=${env:MSYS2_ROOT}/ucrt64/lib
-          gem install ascii_charts ffi gtk3 json kramdown logger os ostruct redis sequel terminal-table tzinfo tzinfo-data webrick --no-document
-
-      - name: Validate Ruby GTK/sqlite3 runtime
-        if: ${{ env.EXP_VALIDATE_RUBY_GTK == 'true' }}
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          $env:Path = "$msys\ucrt64\bin;$msys\usr\bin;$env:Path"
-
-          $rubyExe = (& "$env:SystemRoot\System32\where.exe" ruby 2>$null | Select-Object -First 1)
-          if (-not $rubyExe) { Write-Error "ruby.exe not found on PATH"; exit 1 }
-
-          $rbPath = Join-Path $PWD 'validate_gtk_runtime.rb'
-          @'
-          require "gtk3"
-          require "sqlite3"
-          puts "ruby=#{RUBY_VERSION}"
-          Gtk.init
-          puts "GTK.init OK"
-          '@ | Set-Content -Path $rbPath -Encoding UTF8
-
-          & $rubyExe $rbPath
-          if ($LASTEXITCODE -ne 0) { Write-Error "Ruby GTK3/sqlite3 load failed"; exit 1 }
-
-      - name: Prune Python from bundled MSYS2
-        if: ${{ env.EXP_PRUNE_PYTHON_MODE != 'off' }}
-        shell: powershell
-        env:
-          EXP_PRUNE_PYTHON_MODE: ${{ env.EXP_PRUNE_PYTHON_MODE }}
-        run: |
-          $msys   = 'C:\Ruby4Lich5\msys64'
-          if (!(Test-Path $msys)) { Write-Host "No MSYS2 at $msys; skipping."; exit 0 }
-
-          $mode   = "${env:EXP_PRUNE_PYTHON_MODE}"; if (-not $mode) { $mode = 'files' }
-          $pacman = Join-Path $msys 'usr\bin\pacman.exe'
-
-          if ($mode -eq 'pacman' -and (Test-Path $pacman)) {
-            $env:MSYSTEM = 'UCRT64'
-            $installed = & $pacman -Qq 2>$null; if ($LASTEXITCODE -ne 0) { $installed = @() }
-            $pattern   = '^(python($|[0-9]))|(mingw-w64-(ucrt-)?x86_64-python.*)$'
-            $py = @($installed | Where-Object { $_ -match $pattern })
-            if ($py.Count -gt 0) {
-              & $pacman -Rns --noconfirm @py 1>$null 2>$null
-              if ($LASTEXITCODE -ne 0) {
-                & $pacman -Rdd --noconfirm @py 1>$null 2>$null
-              }
-            }
-          }
-
-          $targets = @(
-            "$msys\ucrt64\bin\python*.exe",
-            "$msys\ucrt64\lib\python*",
-            "$msys\mingw64\bin\python*.exe",
-            "$msys\mingw64\lib\python*",
-            "$msys\usr\bin\python*.exe",
-            "$msys\usr\lib\python*"
-          )
-          foreach ($g in $targets) {
-            Get-ChildItem -Path $g -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object {
-              Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $_.FullName
-            }
-          }
-
-      - name: Bulk prune non-runtime trees
-        if: ${{ env.EXP_PRUNE_BULK == 'true' }}
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          $paths = @(
-            Join-Path $msys 'var\cache\pacman\pkg'
-            Join-Path $msys 'usr\share\man'
-            Join-Path $msys 'usr\share\doc'
-            Join-Path $msys 'usr\share\info'
-            Join-Path $msys 'usr\share\locale'
-            Join-Path $msys 'usr\lib\clang'
-          )
-          foreach ($p in $paths) {
-            if (Test-Path $p) {
-              Remove-Item $p -Recurse -Force -ErrorAction SilentlyContinue
-            }
-          }
-
-      - name: Build Windows installer with Inno Setup
-        shell: powershell
-        run: |
-          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
-          if (!(Test-Path $iscc)) { Write-Error "ISCC.exe not found at $iscc"; exit 1 }
-          & $iscc "R4LGTK3.iss"
-          $code = $LASTEXITCODE
-          if ($code -ne 0) {
-            Write-Error "ISCC exited with code $code."
-            exit $code
-          }
-          if (!(Test-Path .\Output\Ruby4Lich5.exe)) { Write-Error "Expected Output\Ruby4Lich5.exe not found"; exit 1 }
-          Move-Item -Path .\Output\Ruby4Lich5.exe -Destination .\Ruby4Lich5.exe -Force
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output Ruby4Lich5.exe \
+            https://github.com/Lich5/Ruby4Lich5/releases/latest/download/Ruby4Lich5.exe
+          test -s Ruby4Lich5.exe
 
       - name: Upload installer to release
         env:
@@ -342,7 +130,6 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "$TAG" Ruby4Lich5.exe --clobber --repo "$GITHUB_REPOSITORY"
-
   summary:
     needs: [release_guard, build_archives, build_installer]
     if: ${{ always() }}
@@ -362,9 +149,9 @@ jobs:
             echo "- Target tag: \`$TAG\`"
             echo "- Archive rebuild/upload: **$ARCHIVE_RESULT**"
             if [ "$WANT_INSTALLER" = "true" ]; then
-              echo "- Installer rebuild/upload: **$INSTALLER_RESULT**"
+              echo "- Installer attachment: **$INSTALLER_RESULT**"
             else
-              echo "- Installer rebuild/upload: **skipped by input**"
+              echo "- Installer attachment: **skipped by input**"
             fi
             echo ""
             echo "Expected assets:"

--- a/.github/workflows/release-on-push-prerelease.yaml
+++ b/.github/workflows/release-on-push-prerelease.yaml
@@ -1,13 +1,13 @@
 # -----------------------------------------------------------------------------
 # PURPOSE
-#   Create prerelease tags/releases on pushes to pre/*, then build and upload
-#   artifacts (core zips, optional Windows installer) with a corrected,
+#   Create prerelease tags/releases on pushes to pre/*, then package/upload
+#   core archives and attach the latest optional Ruby4Lich5 Windows installer.
 #   production-formatted release body/title as early as possible.
 #
 # INVARIANTS
 # - Release body/title must be finalized *before* packaging begins.
 # - No reliance on a local git checkout for GH release edits/uploads.
-# - PR labels 'skip-installer' or 'no-installer' gate the installer build (case-insensitive).
+# - PR labels 'skip-installer' or 'no-installer' gate installer attachment (case-insensitive).
 #
 # INPUTS (selected)
 # - Branch trigger: pre/beta or pre/beta/*
@@ -19,7 +19,6 @@
 # - installer_gate: steps.gate.outputs.installer (true|false)
 #
 # EXTENSION POINTS
-# - EXP_* env toggles at top of file
 # - "Transform body" step: header/footer/normalization rules only (no network)
 #
 # RERUNS / IDEMPOTENCE
@@ -40,15 +39,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-
-env:
-  # --- Experiments / toggles (live) ---
-  # python prune behavior: files | pacman | off
-  EXP_PRUNE_PYTHON_MODE: files
-  # prune the large non-runtime trees (man/doc/info/locale/cache/clang)
-  EXP_PRUNE_BULK: 'true'
-  # run ruby runtime validation via Gtk.init (not just requires)
-  EXP_VALIDATE_RUBY_GTK: 'true'
 
 jobs:
   release:
@@ -366,314 +356,26 @@ jobs:
           echo "release_created=${{ needs.release.outputs.release_created }}"
           echo "installer=${{ needs.installer_gate.outputs.installer }}"
 
-  # 4) Build Windows installer (Ruby4Lich5.exe)
+  # 4) Attach the latest Ruby4Lich5 installer (Ruby4Lich5.exe)
   build_installer:
     needs: [release, installer_gate]
     if: ${{ needs.release.outputs.release_created == 'true' && needs.installer_gate.outputs.installer == 'true' }}
-    runs-on: windows-latest
-    timeout-minutes: 120
-
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      # Pin Ruby explicitly on windows-latest
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
-        with:
-          bundler-cache: false
-
-      # Install Inno Setup
-      - name: Install Inno Setup
-        shell: powershell
+      - name: Download latest Ruby4Lich5 installer
+        shell: bash
         run: |
-          choco feature disable -n=showDownloadProgress
-          choco install -y --limit-output innosetup
+          set -euo pipefail
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output Ruby4Lich5.exe \
+            https://github.com/Lich5/Ruby4Lich5/releases/latest/download/Ruby4Lich5.exe
+          test -s Ruby4Lich5.exe
 
-      # Install MSYS2 directly into the app tree
-      - name: Install MSYS2 into app tree
-        shell: powershell
-        run: |
-          choco feature disable -n=showDownloadProgress
-          choco install -y --limit-output msys2 --params '"/InstallDir:C:\Ruby4Lich5\msys64 /NoUpdate"'
-
-      # Build sanitized PATH that prefers vendored MSYS2 (Option A) and cache it
-      # We prepend vendored MSYS2 so gcc/pkg-config resolves predictably.
-      # This prevents mixing runner DevKit/Strawberry toolchains (reproducibility).
-      - name: Build sanitized PATH for vendored MSYS2
-        id: vendormsys
-        shell: powershell
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          if (!(Test-Path $msys)) { Write-Error "Expected $msys to exist at this point"; exit 1 }
-          $orig = $env:Path -split ';'
-          $filtered = $orig | Where-Object {
-            $_ -and
-            ($_ -notlike '*\Ruby\*\x64\msys64\*') -and   # drop runner DevKit MSYS2
-            ($_ -ne 'C:\mingw64\bin') -and               # drop global mingw
-            ($_ -notmatch '^C:\\Strawberry(\\|$)')       # drop Strawberry toolchain
-          }
-          $san = @("$msys\ucrt64\bin","$msys\usr\bin") + $filtered
-          $joined = ($san -join ';')
-          "PATH_VENDOR_MSYS=$joined" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "RI_DEVKIT=" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "path=$joined" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Initialize MSYS2 (minimal UCRT64; no meta toolchain)
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys   = 'C:\Ruby4Lich5\msys64'
-          $pacman = Join-Path $msys 'usr\bin\pacman.exe'
-          if (!(Test-Path $pacman)) { Write-Error "pacman not found at $pacman"; exit 1 }
-
-          $env:MSYSTEM = 'UCRT64'
-          & $pacman -Sy --noconfirm
-          & $pacman -S --needed --noconfirm `
-            mingw-w64-ucrt-x86_64-gcc `
-            mingw-w64-ucrt-x86_64-gcc-libs `
-            mingw-w64-ucrt-x86_64-make `
-            mingw-w64-ucrt-x86_64-pkgconf `
-            mingw-w64-ucrt-x86_64-gobject-introspection `
-            mingw-w64-ucrt-x86_64-sqlite3 `
-            mingw-w64-ucrt-x86_64-gtk3 `
-            make
-
-      # Sanity checks: ensure vendored toolchain resolves first & libs are discoverable
-      - name: Dependency validation (toolchain & pkg-config)
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          $gcc  = Join-Path $msys 'ucrt64\bin\gcc.exe'
-          $pkgc = Join-Path $msys 'ucrt64\bin\pkg-config.exe'
-          $pac  = Join-Path $msys 'usr\bin\pacman.exe'
-
-          if (!(Test-Path $pac))  { Write-Error "pacman not found at $pac"; exit 1 }
-          if (!(Test-Path $gcc))  { Write-Error "vendored gcc not found at $gcc"; exit 1 }
-          if (!(Test-Path $pkgc)) { Write-Error "vendored pkg-config not found at $pkgc"; exit 1 }
-
-          # Prove the vendored tools run
-          & $gcc --version | Select-Object -First 1
-          if ($LASTEXITCODE -ne 0) { Write-Error "vendored gcc failed to execute"; exit 1 }
-          & $pkgc --version
-          if ($LASTEXITCODE -ne 0) { Write-Error "vendored pkg-config failed to execute"; exit 1 }
-
-          # Prove pkg-config sees the libraries we installed
-          cmd /c `"$pkgc`" --print-errors --exists gtk+-3.0
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve gtk+-3.0"; exit 1 }
-          cmd /c `"$pkgc`" --print-errors --exists sqlite3
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve sqlite3"; exit 1 }
-
-          # Python WILL be pulled in by GTK deps; we remove it later. Don't fail here.
-          # Just surface whether it showed up so we can observe the behavior.
-          $env:MSYSTEM = 'UCRT64'
-          & $pac -Qq mingw-w64-ucrt-x86_64-python 1>$null 2>$null
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "Note: mingw-w64-ucrt-x86_64-python present after init (expected via GTK deps); will remove later."
-          }
-
-          # Output the library versions installed for troubleshooting
-          Write-Host "MSYS Library versions installed:"
-          & $pac -Q
-
-          # Pin tool choices for downstream (regardless of PATH order)
-          "CC=$gcc"                  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "PKG_CONFIG=$pkgc"         | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          # Helpful for Ruby native gems that honor these
-          "PKG_CONFIG_PATH=$($msys)\ucrt64\lib\pkgconfig;$($msys)\lib\pkgconfig" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-
-      # Install required gems (pruned list)
-      - name: Install required gems
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-          CC: gcc
-          PKG_CONFIG: pkg-config
-        run: |
-          gem install sqlite3 --platform ruby -- --enable-system-libraries --with-sqlite3-include=${env:MSYS2_ROOT}/ucrt64/include --with-sqlite3-lib=${env:MSYS2_ROOT}/ucrt64/lib
-          gem install ascii_charts ffi gtk3 json kramdown logger os ostruct redis sequel terminal-table tzinfo tzinfo-data webrick --no-document
-
-      # Optional experiment: validate Ruby GTK/sqlite3 runtime
-      - name: Validate Ruby GTK/sqlite3 runtime
-        if: ${{ env.EXP_VALIDATE_RUBY_GTK == 'true' }}
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          $pkgc = Join-Path $msys 'ucrt64\bin\pkg-config.exe'
-          # Prepend vendored MSYS; keep the rest so ruby.exe is still found
-          $env:Path = "$msys\ucrt64\bin;$msys\usr\bin;$env:Path"
-
-          # Resolve ruby.exe from PATH (hostedtoolcache)
-          $rubyExe = (& "$env:SystemRoot\System32\where.exe" ruby 2>$null | Select-Object -First 1)
-          if (-not $rubyExe) { Write-Error "ruby.exe not found on PATH"; exit 1 }
-
-          # Prove vendored tools win
-          $gccFirst = @(& "$env:SystemRoot\System32\where.exe" gcc 2>$null)[0]
-          $pcFirst  = @(& "$env:SystemRoot\System32\where.exe" pkg-config 2>$null)[0]
-          if (-not $gccFirst -or -not $pcFirst) { Write-Error "Missing gcc/pkg-config"; exit 1 }
-          if (-not $gccFirst.StartsWith('C:\Ruby4Lich5\msys64', 'OrdinalIgnoreCase')) { Write-Error "gcc resolves to non-vendored: $gccFirst"; exit 1 }
-          if (-not $pcFirst.StartsWith('C:\Ruby4Lich5\msys64', 'OrdinalIgnoreCase')) { Write-Error "pkg-config resolves to non-vendored: $pcFirst"; exit 1 }
-
-          # pkg-config sanity (explicit vendored path, strict/minimal style)
-          cmd /c `"$pkgc`" --print-errors --exists gtk+-3.0
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve gtk+-3.0"; exit 1 }
-          cmd /c `"$pkgc`" --print-errors --exists sqlite3
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve sqlite3"; exit 1 }
-
-          # IMPORTANT: correct Ruby code, correct quoting
-          #  - constant is Gtk (not GTK)
-          #  - keep quotes around string literals
-          #  - pass an empty ARGV to Gtk.init to avoid surprises
-          $rb = 'require "gtk3"; require "sqlite3"; puts "ruby=#{RUBY_VERSION}"; Gtk.init([]); puts "GTK.init OK"'
-          #  Use the Stop Parsing Operator ( --% ) for PowerShell to avoid interpolation in the string above
-          & $rubyExe -e --% $rb
-          if ($LASTEXITCODE -ne 0) { Write-Error "Ruby GTK3/sqlite3 load failed"; exit 1 }
-
-          # Print out installed gems for troubleshooting
-          Write-Host "Gems installed:"
-          gem list
-
-      # (Optional) Remove Python to keep the bundle lean. Mode is driven by EXP_PRUNE_PYTHON_MODE:
-      #   - 'files'  : delete python binaries/trees by glob (default)
-      #   - 'pacman' : uninstall python packages via pacman, then also run the files sweep
-      #   - 'off'    : skip this step entirely (use the job/step-level if: to skip)
-      - name: Prune Python from bundled MSYS2 (mode=${{ env.EXP_PRUNE_PYTHON_MODE || 'files' }})
-        if: ${{ env.EXP_PRUNE_PYTHON_MODE != 'off' }}
-        shell: powershell
-        env:
-          EXP_PRUNE_PYTHON_MODE: ${{ env.EXP_PRUNE_PYTHON_MODE }}
-        run: |
-          $msys   = 'C:\Ruby4Lich5\msys64'
-          if (!(Test-Path $msys)) { Write-Host "No MSYS2 at $msys; skipping."; exit 0 }
-
-          # Report size BEFORE
-          $beforeMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          Write-Host "Python-prune: before = $beforeMB MB"
-
-          $mode   = "${env:EXP_PRUNE_PYTHON_MODE}"; if (-not $mode) { $mode = 'files' }
-          $pacman = Join-Path $msys 'usr\bin\pacman.exe'
-
-          if ($mode -eq 'pacman' -and (Test-Path $pacman)) {
-            $env:MSYSTEM = 'UCRT64'
-            $installed = & $pacman -Qq 2>$null; if ($LASTEXITCODE -ne 0) { $installed = @() }
-            $pattern   = '^(python($|[0-9]))|(mingw-w64-(ucrt-)?x86_64-python.*)$'
-            $py = @($installed | Where-Object { $_ -match $pattern })
-            if ($py.Count -gt 0) {
-              Write-Host "pacman removing: $($py -join ' ')"
-              & $pacman -Rns --noconfirm @py 1>$null 2>$null
-              if ($LASTEXITCODE -ne 0) {
-                Write-Warning "pacman -Rns failed; retrying -Rdd"
-                & $pacman -Rdd --noconfirm @py 1>$null 2>$null
-              }
-            } else {
-              Write-Host "pacman: no python packages installed"
-            }
-            # fall through to files sweep for belt-and-suspenders
-          } else {
-            Write-Host "pacman phase skipped (mode='$mode' or pacman missing); doing files sweep"
-          }
-
-          # Files sweep (runs for mode=files and mode=pacman)
-          $targets = @(
-            "$msys\ucrt64\bin\python*.exe",
-            "$msys\ucrt64\lib\python*",
-            "$msys\mingw64\bin\python*.exe",
-            "$msys\mingw64\lib\python*",
-            "$msys\usr\bin\python*.exe",
-            "$msys\usr\lib\python*"
-          )
-          $removed = 0
-          foreach ($g in $targets) {
-            Get-ChildItem -Path $g -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object {
-              Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $_.FullName
-              $removed++
-            }
-          }
-          Write-Host "files sweep removed ≈ $removed paths"
-
-          # Report size AFTER
-          $afterMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          $savedMB = [math]::Max(0, $beforeMB - $afterMB)
-          Write-Host "Python-prune: after  = $afterMB MB (saved $savedMB MB)"
-
-      # Bulk prune of MSYS non-runtime trees (report size delta)
-      - name: Bulk prune non-runtime trees (report delta)
-        if: ${{ env.EXP_PRUNE_BULK == 'true' }}
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          Write-Host "::group::MSYS2 size report & prune"
-          # Report size BEFORE
-          $beforeMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          Write-Host "MSYS2-prune: before = $beforeMB MB"
-
-          $paths = @(
-            Join-Path $msys 'var\cache\pacman\pkg'
-            Join-Path $msys 'usr\share\man'
-            Join-Path $msys 'usr\share\doc'
-            Join-Path $msys 'usr\share\info'
-            Join-Path $msys 'usr\share\locale'
-            Join-Path $msys 'usr\lib\clang'
-          )
-          foreach ($p in $paths) {
-            if (Test-Path $p) {
-              Write-Host "Removing $p ..."
-              Remove-Item $p -Recurse -Force -ErrorAction SilentlyContinue
-            } else {
-              Write-Host "Skip (not present): $p"
-            }
-          }
-
-          # Report size AFTER
-          $afterMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          $savedMB = [math]::Max(0, $beforeMB - $afterMB)
-          Write-Host "MSYS2-prune: after  = $afterMB MB (saved $savedMB MB)"
-          Write-Host "::endgroup::"
-
-
-      # Pull the packaged Lich payload from the just-created Release
-      # Re-run safety: 'gh release download' overwrites local files by default; we unzip into ./Lich5/.
-      - name: Download core Lich payload from the Release
-        if: ${{ needs.release.outputs.release_created == 'true' }}
+      - name: Upload installer to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release download "${{ needs.release.outputs.tag_name }}" -p 'lich-5.zip'
-          unzip -q lich-5.zip
-          # Archive contains Lich5/ (capital L) to match the .iss Source paths
-
-      # Build Windows installer with Inno Setup
-      - name: Build Windows installer with Inno Setup
-        shell: powershell
-        run: |
-          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
-          if (!(Test-Path $iscc)) { Write-Error "ISCC.exe not found at $iscc"; exit 1 }
-          & $iscc "R4LGTK3.iss"
-          $code = $LASTEXITCODE
-          if ($code -ne 0) {
-            Write-Error "ISCC exited with code $code (likely missing SignTool or another PATH-dependent tool)."
-            exit $code
-          }
-          if (!(Test-Path .\Output\Ruby4Lich5.exe)) { Write-Error "Expected Output\Ruby4Lich5.exe not found"; exit 1 }
-          Move-Item -Path .\Output\Ruby4Lich5.exe -Destination .\Ruby4Lich5.exe -Force
-
-      - name: Upload installer to Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
+          set -euo pipefail
           gh release upload "${{ needs.release.outputs.tag_name }}" Ruby4Lich5.exe --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release-on-push-stable.yaml
+++ b/.github/workflows/release-on-push-stable.yaml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # PURPOSE
-#   Create stable tags/releases on pushes to main, then build and upload
-#   artifacts (core zips, optional Windows installer) with a corrected,
+#   Create stable tags/releases on pushes to main, then package/upload core
+#   archives and attach the latest optional Ruby4Lich5 Windows installer.
 #   production-formatted release body/title as early as possible.
 #   Releases are created as DRAFT and require human review before publication.
 #
@@ -11,14 +11,13 @@
 # - No reliance on a local git checkout for GH release edits/uploads.
 # - Draft release body lookup is an optional fallback; PR body lookup must keep the
 #   packaging path alive when GitHub briefly cannot resolve a draft by tag.
-# - PR labels 'skip-installer' or 'no-installer' gate the installer build (case-insensitive).
+# - PR labels 'skip-installer' or 'no-installer' gate installer attachment (case-insensitive).
 #
 # OUTPUTS (selected)
 # - release: steps.rp.outputs.release_created, steps.rp.outputs.tag_name
 # - installer_gate: steps.gate.outputs.installer (true|false)
 #
 # EXTENSION POINTS
-# - EXP_* env toggles at top of file
 # - "Transform body" step: header/footer/normalization rules only (no network)
 # -----------------------------------------------------------------------------
 name: release-please (stable on push)
@@ -43,15 +42,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-
-env:
-  # --- Experiments / toggles (live) ---
-  # python prune behavior: files | pacman | off
-  EXP_PRUNE_PYTHON_MODE: files
-  # prune the large non-runtime trees (man/doc/info/locale/cache/clang)
-  EXP_PRUNE_BULK: 'true'
-  # run ruby runtime validation via Gtk.init (not just requires)
-  EXP_VALIDATE_RUBY_GTK: 'true'
 
 jobs:
   release:
@@ -343,7 +333,7 @@ jobs:
         run: |
           gh release upload "${{ steps.rp.outputs.tag_name }}" lich-5.tar.gz lich-5.zip
 
-  # 5) Build Windows installer (Ruby4Lich5.exe)
+  # 5) Attach the latest Ruby4Lich5 installer (Ruby4Lich5.exe)
   installer_gate:
     needs: release
     if: ${{ needs.release.outputs.release_created == 'true' }}
@@ -410,306 +400,22 @@ jobs:
   build_installer:
     needs: [release, installer_gate]
     if: ${{ needs.release.outputs.release_created == 'true' && needs.installer_gate.outputs.installer == 'true' }}
-    runs-on: windows-latest
-    timeout-minutes: 120
-
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      # Pin Ruby explicitly on windows-latest
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
-        with:
-          bundler-cache: false
-
-      # Install Inno Setup
-      - name: Install Inno Setup
-        shell: powershell
+      - name: Download latest Ruby4Lich5 installer
+        shell: bash
         run: |
-          choco feature disable -n=showDownloadProgress
-          choco install -y --limit-output innosetup
+          set -euo pipefail
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output Ruby4Lich5.exe \
+            https://github.com/Lich5/Ruby4Lich5/releases/latest/download/Ruby4Lich5.exe
+          test -s Ruby4Lich5.exe
 
-      # Install MSYS2 directly into the app tree
-      - name: Install MSYS2 into app tree
-        shell: powershell
-        run: |
-          choco feature disable -n=showDownloadProgress
-          choco install -y --limit-output msys2 --params '"/InstallDir:C:\Ruby4Lich5\msys64 /NoUpdate"'
-
-      # Build sanitized PATH that prefers vendored MSYS2 (Option A) and cache it
-      - name: Build sanitized PATH for vendored MSYS2
-        id: vendormsys
-        shell: powershell
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          if (!(Test-Path $msys)) { Write-Error "Expected $msys to exist at this point"; exit 1 }
-          $orig = $env:Path -split ';'
-          $filtered = $orig | Where-Object {
-            $_ -and
-            ($_ -notlike '*\Ruby\*\x64\msys64\*') -and   # drop runner DevKit MSYS2
-            ($_ -ne 'C:\mingw64\bin') -and               # drop global mingw
-            ($_ -notmatch '^C:\\Strawberry(\\|$)')       # drop Strawberry toolchain
-          }
-          $san = @("$msys\ucrt64\bin","$msys\usr\bin") + $filtered
-          $joined = ($san -join ';')
-          "PATH_VENDOR_MSYS=$joined" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "path=$joined" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "RI_DEVKIT=" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Initialize MSYS2 (minimal UCRT64; no meta toolchain)
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys   = 'C:\Ruby4Lich5\msys64'
-          $pacman = Join-Path $msys 'usr\bin\pacman.exe'
-          if (!(Test-Path $pacman)) { Write-Error "pacman not found at $pacman"; exit 1 }
-
-          $env:MSYSTEM = 'UCRT64'
-          & $pacman -Sy --noconfirm
-          & $pacman -S --needed --noconfirm `
-            mingw-w64-ucrt-x86_64-gcc `
-            mingw-w64-ucrt-x86_64-gcc-libs `
-            mingw-w64-ucrt-x86_64-make `
-            mingw-w64-ucrt-x86_64-pkgconf `
-            mingw-w64-ucrt-x86_64-gobject-introspection `
-            mingw-w64-ucrt-x86_64-sqlite3 `
-            mingw-w64-ucrt-x86_64-gtk3 `
-            make
-
-      # Sanity checks: ensure vendored toolchain resolves first & libs are discoverable
-      - name: Dependency validation (toolchain & pkg-config)
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          $gcc  = Join-Path $msys 'ucrt64\bin\gcc.exe'
-          $pkgc = Join-Path $msys 'ucrt64\bin\pkg-config.exe'
-          $pac  = Join-Path $msys 'usr\bin\pacman.exe'
-      
-          if (!(Test-Path $pac))  { Write-Error "pacman not found at $pac"; exit 1 }
-          if (!(Test-Path $gcc))  { Write-Error "vendored gcc not found at $gcc"; exit 1 }
-          if (!(Test-Path $pkgc)) { Write-Error "vendored pkg-config not found at $pkgc"; exit 1 }
-      
-          # Prove the vendored tools run
-          & $gcc --version | Select-Object -First 1
-          if ($LASTEXITCODE -ne 0) { Write-Error "vendored gcc failed to execute"; exit 1 }
-          & $pkgc --version
-          if ($LASTEXITCODE -ne 0) { Write-Error "vendored pkg-config failed to execute"; exit 1 }
-      
-          # Prove pkg-config sees the libraries we installed
-          cmd /c `"$pkgc`" --print-errors --exists gtk+-3.0
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve gtk+-3.0"; exit 1 }
-          cmd /c `"$pkgc`" --print-errors --exists sqlite3
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve sqlite3"; exit 1 }
-      
-          # Python WILL be pulled in by GTK deps; we remove it later. Don't fail here.
-          # Just surface whether it showed up so we can observe the behavior.
-          $env:MSYSTEM = 'UCRT64'
-          & $pac -Qq mingw-w64-ucrt-x86_64-python 1>$null 2>$null
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "Note: mingw-w64-ucrt-x86_64-python present after init (expected via GTK deps); will remove later."
-          }
-
-          # Output the library versions installed for troubleshooting
-          Write-Host "MSYS Library versions installed:"
-          & $pac -Q
-
-          # Pin tool choices for downstream (regardless of PATH order)
-          "CC=$gcc"                  | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "PKG_CONFIG=$pkgc"         | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          # Helpful for Ruby native gems that honor these
-          "PKG_CONFIG_PATH=$($msys)\ucrt64\lib\pkgconfig;$($msys)\lib\pkgconfig" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-
-      # Install required gems (pruned list)
-      - name: Install required gems
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-          CC: gcc
-          PKG_CONFIG: pkg-config
-        run: |
-          gem install sqlite3 --platform ruby -- --enable-system-libraries --with-sqlite3-include=${env:MSYS2_ROOT}/ucrt64/include --with-sqlite3-lib=${env:MSYS2_ROOT}/ucrt64/lib
-          gem install ascii_charts ffi gtk3 json kramdown logger os ostruct redis sequel terminal-table tzinfo tzinfo-data webrick --no-document
-
-      # Optional experiment: validate Ruby actually initializes GTK (not just require)
-      - name: Validate Ruby GTK/sqlite3 runtime
-        if: ${{ env.EXP_VALIDATE_RUBY_GTK == 'true' }}
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          # Prepend vendored MSYS; keep the rest so ruby.exe is still found
-          $env:Path = "$msys\ucrt64\bin;$msys\usr\bin;$env:Path"
-      
-          # Resolve ruby.exe from PATH (hostedtoolcache)
-          $rubyExe = (& "$env:SystemRoot\System32\where.exe" ruby 2>$null | Select-Object -First 1)
-          if (-not $rubyExe) { Write-Error "ruby.exe not found on PATH"; exit 1 }
-      
-          # Prove vendored tools win
-          $gccFirst = @(& "$env:SystemRoot\System32\where.exe" gcc 2>$null)[0]
-          $pcFirst  = @(& "$env:SystemRoot\System32\where.exe" pkg-config 2>$null)[0]
-          if (-not $gccFirst -or -not $pcFirst) { Write-Error "Missing gcc/pkg-config"; exit 1 }
-          if (-not $gccFirst.StartsWith('C:\Ruby4Lich5\msys64', 'OrdinalIgnoreCase')) { Write-Error "gcc resolves to non-vendored: $gccFirst"; exit 1 }
-          if (-not $pcFirst.StartsWith('C:\Ruby4Lich5\msys64', 'OrdinalIgnoreCase')) { Write-Error "pkg-config resolves to non-vendored: $pcFirst"; exit 1 }
-      
-          # pkg-config sanity
-          cmd /c pkg-config --print-errors --exists gtk+-3.0
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve gtk+-3.0"; exit 1 }
-          cmd /c pkg-config --print-errors --exists sqlite3
-          if ($LASTEXITCODE -ne 0) { Write-Error "pkg-config cannot resolve sqlite3"; exit 1 }
-      
-          # IMPORTANT: correct Ruby code, correct quoting
-          #  - constant is Gtk (not GTK)
-          #  - keep quotes around string literals
-          #  - pass an empty ARGV to Gtk.init to avoid surprises
-          $rb = 'require "gtk3"; require "sqlite3"; puts "ruby=#{RUBY_VERSION}"; Gtk.init([]); puts "GTK.init OK"'
-          #  Use the Stop Parsing Operator ( --% ) for PowerShell to avoid interpolation in the string above
-          & $rubyExe -e --% $rb
-          if ($LASTEXITCODE -ne 0) { Write-Error "Ruby GTK3/sqlite3 load failed"; exit 1 }
-
-          # Print out installed gems for troubleshooting
-          Write-Host "Gems installed:"
-          gem list
-
-      # (Optional) Remove Python to keep the bundle lean. Mode is driven by EXP_PRUNE_PYTHON_MODE:
-      #   - 'files'  : delete python binaries/trees by glob (default)
-      #   - 'pacman' : uninstall python packages via pacman, then also run the files sweep
-      #   - 'off'    : skip this step entirely (use the job/step-level if: to skip)
-      - name: Prune Python from bundled MSYS2 (mode=${{ env.EXP_PRUNE_PYTHON_MODE || 'files' }})
-        if: ${{ env.EXP_PRUNE_PYTHON_MODE != 'off' }}
-        shell: powershell
-        env:
-          EXP_PRUNE_PYTHON_MODE: ${{ env.EXP_PRUNE_PYTHON_MODE }}
-        run: |
-          $msys   = 'C:\Ruby4Lich5\msys64'
-          if (!(Test-Path $msys)) { Write-Host "No MSYS2 at $msys; skipping."; exit 0 }
-
-          # Report size BEFORE
-          $beforeMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          Write-Host "Python-prune: before = $beforeMB MB"
-
-          $mode   = "${env:EXP_PRUNE_PYTHON_MODE}"; if (-not $mode) { $mode = 'files' }
-          $pacman = Join-Path $msys 'usr\bin\pacman.exe'
-
-          if ($mode -eq 'pacman' -and (Test-Path $pacman)) {
-            $env:MSYSTEM = 'UCRT64'
-            $installed = & $pacman -Qq 2>$null; if ($LASTEXITCODE -ne 0) { $installed = @() }
-            $pattern   = '^(python($|[0-9]))|(mingw-w64-(ucrt-)?x86_64-python.*)$'
-            $py = @($installed | Where-Object { $_ -match $pattern })
-            if ($py.Count -gt 0) {
-              Write-Host "pacman removing: $($py -join ' ')"
-              & $pacman -Rns --noconfirm @py 1>$null 2>$null
-              if ($LASTEXITCODE -ne 0) {
-                Write-Warning "pacman -Rns failed; retrying -Rdd"
-                & $pacman -Rdd --noconfirm @py 1>$null 2>$null
-              }
-            } else {
-              Write-Host "pacman: no python packages installed"
-            }
-            # fall through to files sweep for belt-and-suspenders
-          } else {
-            Write-Host "pacman phase skipped (mode='$mode' or pacman missing); doing files sweep"
-          }
-
-          # Files sweep (runs for mode=files and mode=pacman)
-          $targets = @(
-            "$msys\ucrt64\bin\python*.exe",
-            "$msys\ucrt64\lib\python*",
-            "$msys\mingw64\bin\python*.exe",
-            "$msys\mingw64\lib\python*",
-            "$msys\usr\bin\python*.exe",
-            "$msys\usr\lib\python*"
-          )
-          $removed = 0
-          foreach ($g in $targets) {
-            Get-ChildItem -Path $g -Recurse -Force -ErrorAction SilentlyContinue | ForEach-Object {
-              Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $_.FullName
-              $removed++
-            }
-          }
-          Write-Host "files sweep removed ≈ $removed paths"
-
-          # Report size AFTER
-          $afterMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          $savedMB = [math]::Max(0, $beforeMB - $afterMB)
-          Write-Host "Python-prune: after  = $afterMB MB (saved $savedMB MB)"
-
-      # Bulk prune of MSYS non-runtime trees (report size delta)
-      - name: Bulk prune non-runtime trees (report delta)
-        if: ${{ env.EXP_PRUNE_BULK == 'true' }}
-        shell: powershell
-        env:
-          PATH: ${{ steps.vendormsys.outputs.path }}
-          RI_DEVKIT: ''
-        run: |
-          $msys = 'C:\Ruby4Lich5\msys64'
-          Write-Host "::group::MSYS2 size report & prune"
-          # Report size BEFORE
-          $beforeMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          Write-Host "MSYS2-prune: before = $beforeMB MB"
-
-          $paths = @(
-            Join-Path $msys 'var\cache\pacman\pkg'
-            Join-Path $msys 'usr\share\man'
-            Join-Path $msys 'usr\share\doc'
-            Join-Path $msys 'usr\share\info'
-            Join-Path $msys 'usr\share\locale'
-            Join-Path $msys 'usr\lib\clang'
-          )
-          foreach ($p in $paths) {
-            if (Test-Path $p) {
-              Write-Host "Removing $p ..."
-              Remove-Item $p -Recurse -Force -ErrorAction SilentlyContinue
-            } else {
-              Write-Host "Skip (not present): $p"
-            }
-          }
-
-          # Report size AFTER
-          $afterMB = [math]::Round((Get-ChildItem -Recurse $msys | Measure-Object Length -Sum).Sum / 1MB)
-          $savedMB = [math]::Max(0, $beforeMB - $afterMB)
-          Write-Host "MSYS2-prune: after  = $afterMB MB (saved $savedMB MB)"
-          Write-Host "::endgroup::"
-
-      
-      # Pull the packaged Lich payload from the just-created Release
-      - name: Download core Lich payload from the Release
-        if: ${{ needs.release.outputs.release_created == 'true' && needs.installer_gate.outputs.installer == 'true' }}
+      - name: Upload installer to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release download "${{ needs.release.outputs.tag_name }}" -p 'lich-5.zip'
-          unzip -q lich-5.zip
-          # Archive contains Lich5/ (capital L) to match the .iss Source paths
-
-     # Build Windows installer with Inno Setup
-      - name: Build Windows installer with Inno Setup
-        shell: powershell
-        run: |
-          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
-          if (!(Test-Path $iscc)) { Write-Error "ISCC.exe not found at $iscc"; exit 1 }
-          & $iscc "R4LGTK3.iss"
-          $code = $LASTEXITCODE
-          if ($code -ne 0) {
-            Write-Error "ISCC exited with code $code (likely missing SignTool or another PATH-dependent tool)."
-            exit $code
-          }
-          if (!(Test-Path .\Output\Ruby4Lich5.exe)) { Write-Error "Expected Output\Ruby4Lich5.exe not found"; exit 1 }
-          Move-Item -Path .\Output\Ruby4Lich5.exe -Destination .\Ruby4Lich5.exe -Force
-
-      - name: Upload installer to draft release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          gh release upload "${{ needs.release.outputs.tag_name }}" Ruby4Lich5.exe
+          set -euo pipefail
+          gh release upload "${{ needs.release.outputs.tag_name }}" Ruby4Lich5.exe --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Windows releases now include the latest prebuilt Ruby4Lich5 installer.
  - Stable and prerelease packages continue to include the core archive downloads.
  - Installer inclusion remains conditional for releases where it is disabled.
  - Release summaries now clearly indicate whether the installer was attached or skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->