### PR TITLE
fix(all): align --announce with --update for Ruby version

### DIFF
--- a/lib/common/update/release_installer.rb
+++ b/lib/common/update/release_installer.rb
@@ -28,6 +28,8 @@ module Lich
         # TOP_LEVEL_FILES so that optional payload (e.g. Gemfile.lock, which older
         # release tarballs may omit) never gates an update.
         REQUIRED_ARCHIVE_ITEMS = %w[lib lich.rbw Gemfile LICENSE].freeze
+        REQUIRED_RUBY_PATTERN = /REQUIRED_RUBY\s*=\s*["']([^"']+)["']/.freeze
+        GEMSTONE_INSTALL_URL = 'https://gswiki.play.net/Lich:Software/Installation'
 
         # @param client [GitHubClient] GitHub API client instance
         # @param resolver [ChannelResolver] channel resolver instance
@@ -41,6 +43,8 @@ module Lich
           @holder = nil
           @new_features = nil
           @zipfile = nil
+          @release_tag = nil
+          @required_ruby = nil
         end
 
         # Displays announcement if new version available.
@@ -59,7 +63,13 @@ module Lich
                 respond @new_features
                 respond ''
                 respond ''
-                respond "If you are interested in updating, run '#{$clean_lich_char}lich5-update --update' now."
+                if ruby_upgrade_required?
+                  respond "Lich version #{@update_to} requires Ruby #{@required_ruby} or higher."
+                  respond "Your current Ruby version is #{RUBY_VERSION}."
+                  respond "Upgrade Ruby before updating Lich: #{GEMSTONE_INSTALL_URL}"
+                else
+                  respond "If you are interested in updating, run '#{$clean_lich_char}lich5-update --update' now."
+                end
                 respond ''
               end
             else
@@ -95,9 +105,28 @@ module Lich
             respond "Update notice: no release tarball found in assets (prep_update)."
             return
           end
-          @update_to = latest['tag_name'].to_s.sub('v', '')
+          @release_tag = latest['tag_name'].to_s
+          @update_to = @release_tag.sub(/^v/, '')
           @new_features = latest['body'].to_s.gsub(/\#\# What's Changed.+$/m, '').gsub(/<!--[\s\S]*?-->/, '')
           @zipfile = release_asset.fetch('browser_download_url')
+        end
+
+        # Reads the target release's Ruby floor without downloading its archive.
+        # A failed metadata read must not suppress an otherwise valid update notice.
+        #
+        # @return [Boolean] true when the running Ruby is too old for the release
+        def ruby_upgrade_required?
+          return false if @release_tag.nil? || @release_tag.empty?
+
+          version_url = "https://raw.githubusercontent.com/#{GITHUB_REPO}/#{@release_tag}/lib/version.rb"
+          version_content = @client.http_get(version_url, auth: false)
+          match = version_content&.match(REQUIRED_RUBY_PATTERN)
+          return false unless match
+
+          @required_ruby = match[1]
+          Gem::Version.new(RUBY_VERSION) < Gem::Version.new(@required_ruby)
+        rescue ArgumentError
+          false
         end
 
         # Handles beta update requests (full install or individual file).
@@ -314,7 +343,7 @@ module Lich
           version_file_path = File.join(source_dir, "lib", "version.rb")
           if File.exist?(version_file_path)
             version_file_content = File.read(version_file_path)
-            if (match = version_file_content.match(/REQUIRED_RUBY\s*=\s*["']([^"']+)["']/))
+            if (match = version_file_content.match(REQUIRED_RUBY_PATTERN))
               required_ruby_version = match[1]
               current_ruby_version = RUBY_VERSION
               if Gem::Version.new(current_ruby_version) < Gem::Version.new(required_ruby_version)
@@ -327,7 +356,7 @@ module Lich
                 respond "Please update your Ruby installation before updating Lich."
                 respond
                 respond "DragonRealms - https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich"
-                respond "Gemstone IV  - https://gswiki.play.net/Lich:Software/Installation"
+                respond "Gemstone IV  - #{GEMSTONE_INSTALL_URL}"
                 respond
                 return false
               end

--- a/lib/common/update/release_installer.rb
+++ b/lib/common/update/release_installer.rb
@@ -29,7 +29,7 @@ module Lich
         # release tarballs may omit) never gates an update.
         REQUIRED_ARCHIVE_ITEMS = %w[lib lich.rbw Gemfile LICENSE].freeze
         REQUIRED_RUBY_PATTERN = /REQUIRED_RUBY\s*=\s*["']([^"']+)["']/.freeze
-        GEMSTONE_INSTALL_URL = 'https://gswiki.play.net/Lich:Software/Installation'
+        GEMSTONE_INSTALL_URL = 'https://gswiki.play.net/Lich:Software/Installation'.freeze
 
         # @param client [GitHubClient] GitHub API client instance
         # @param resolver [ChannelResolver] channel resolver instance
@@ -52,6 +52,8 @@ module Lich
         # @return [void]
         def announce
           prep_update
+          return unless @update_to
+
           if "#{LICH_VERSION}".chr == '5'
             if Gem::Version.new(@current) < Gem::Version.new(@update_to)
               unless @new_features.empty?

--- a/spec/lib/common/update/release_installer_spec.rb
+++ b/spec/lib/common/update/release_installer_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative 'update_spec_helper'
+
+RSpec.describe Lich::Util::Update::ReleaseInstaller do
+  subject(:installer) { described_class.new(client, resolver, snapshot_manager) }
+
+  let(:client) { instance_double(Lich::Util::Update::GitHubClient) }
+  let(:resolver) { instance_double(Lich::Util::Update::ChannelResolver) }
+  let(:snapshot_manager) { instance_double(Lich::Util::Update::SnapshotManager) }
+  let(:release) do
+    {
+      'tag_name'   => 'v5.19.0',
+      'prerelease' => false,
+      'body'       => 'Release notes',
+      'assets'     => [
+        {
+          'name'                 => Lich::Util::Update::ASSET_TARBALL_NAME,
+          'browser_download_url' => 'https://example.test/lich-5.tar.gz'
+        }
+      ]
+    }
+  end
+  let(:messages) { [] }
+
+  before do
+    allow(client).to receive(:fetch_github_json).and_return(release)
+    allow(installer).to receive(:respond) { |message = ''| messages << message }
+    allow(installer).to receive(:_respond) { |message| messages << message }
+    allow(installer).to receive(:monsterbold_start).and_return('')
+    allow(installer).to receive(:monsterbold_end).and_return('')
+    stub_const('RUBY_VERSION', '3.4.7')
+  end
+
+  describe '#announce' do
+    it 'warns about the target Ruby floor and does not invite an incompatible update' do
+      allow(client).to receive(:http_get).and_return("REQUIRED_RUBY = '4.0'\n")
+
+      installer.announce
+
+      expect(messages).to include('Lich version 5.19.0 requires Ruby 4.0 or higher.')
+      expect(messages).to include('Your current Ruby version is 3.4.7.')
+      expect(messages).to include(
+        'Upgrade Ruby before updating Lich: https://gswiki.play.net/Lich:Software/Installation'
+      )
+      expect(messages.grep(/If you are interested in updating/)).to be_empty
+    end
+
+    it 'retains the normal update invitation when Ruby satisfies the target floor' do
+      allow(client).to receive(:http_get).and_return("REQUIRED_RUBY = '3.0'\n")
+
+      installer.announce
+
+      expect(messages).to include(a_string_matching(/If you are interested in updating, run '.*lich5-update --update' now\./))
+      expect(messages.grep(/Upgrade Ruby/)).to be_empty
+    end
+
+    it 'retains the normal update invitation when target Ruby metadata is unavailable' do
+      allow(client).to receive(:http_get).and_return(nil)
+
+      installer.announce
+
+      expect(messages).to include(a_string_matching(/If you are interested in updating, run '.*lich5-update --update' now\./))
+    end
+  end
+end

--- a/spec/lib/common/update/release_installer_spec.rb
+++ b/spec/lib/common/update/release_installer_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe Lich::Util::Update::ReleaseInstaller do
   end
 
   describe '#announce' do
+    it 'returns when release preparation does not identify an update version' do
+      allow(client).to receive(:fetch_github_json).and_return(nil)
+
+      expect { installer.announce }.not_to raise_error
+    end
+
     it 'warns about the target Ruby floor and does not invite an incompatible update' do
       allow(client).to receive(:http_get).and_return("REQUIRED_RUBY = '4.0'\n")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update notifications now identify when a release requires a newer Ruby version.
  * Displays the required and current Ruby versions when an upgrade is needed.
  * Provides a Gemstone IV upgrade link for incompatible environments.

* **Bug Fixes**
  * Preserves standard update guidance when compatibility information is unavailable or the current Ruby version is sufficient.
  * Improves handling of invalid release compatibility metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->