### PR TITLE
feat(all): add macOS limited gem recovery

### DIFF
--- a/docs/macos-bundler-recovery.md
+++ b/docs/macos-bundler-recovery.md
@@ -1,8 +1,8 @@
 # macOS Bundler recovery
 
-Lich can repair missing default runtime gems on macOS through a user-approved
-Bundler install. This is a narrow compatibility path for normal runtime gems
-such as `ox`; it is not a macOS GTK installer.
+Lich can repair missing default runtime gems on macOS through a user-approved,
+transactional Bundler install. This is a narrow compatibility path for normal
+runtime gems such as `ox`; it is not a macOS GTK installer.
 
 ## Scope
 
@@ -20,23 +20,25 @@ such as `ox`; it is not a macOS GTK installer.
    `make`.
 3. A native macOS dialog lists the missing gems and asks for approval. No gem
    download or install happens until approval.
-4. Lich copies `Gemfile`, plus `Gemfile.lock` when it was shipped, into staging.
-   A child process runs `bundle install` with a private `BUNDLE_PATH`. A shipped
+4. Lich copies `Gemfile`, plus `Gemfile.lock` when it was shipped, into staging
+   beneath `temp/`. A child process runs `bundle install` there. A shipped
    lockfile is used with `BUNDLE_FROZEN=true`; otherwise Bundler resolves and
    creates a lockfile only inside staging. The live Lich files are never changed.
-5. Bundler writes only beneath `lich-5/.lich-bundler-gems/.staging-*`. If every
-   dependency installs successfully, Lich atomically renames that directory to
-   a new private bundle and atomically updates `active.json`.
-6. Lich relaunches. At the next boot, GemCheck adds the activated bundle's
-   RubyGems home before checking dependencies.
+5. After Lich exits, a hidden helper promotes only the missing gems and runtime
+   dependencies that the real `Gem.dir` cannot satisfy. It backs up every
+   touched installed gem, validates the canonical installation, and restores
+   the backup if any install or validation step fails.
+6. The helper removes staging and backup data, then relaunches Lich. `gem list`
+   therefore reports every recovered gem normally.
 
 If Bundler cannot reach a source, a build fails, or the process is interrupted
-before promotion, the active RubyGems paths and active record are unchanged.
-The incomplete staging directory is removed. Bundler output is retained in
+before promotion, the canonical RubyGems directory is unchanged. The incomplete
+staging directory is removed. Bundler output is retained in
 `temp/lich5-bundler-recovery.log`; GemCheck records the recovery event or
 failure in `temp/lich5-missing-gems.log`.
 
-This path intentionally does not install into the system or user `GEM_HOME`.
-It also does not provide cryptographic verification equivalent to the
+This path installs into the `Gem.dir` of the Ruby that launched Lich, never an
+arbitrary user-selected `GEM_HOME`. It also does not provide cryptographic
+verification equivalent to the
 Ruby4Lich5 Windows manifest: when a release includes a lockfile, it constrains
 versions; when it does not, Bundler resolves from its configured sources.

--- a/docs/macos-bundler-recovery.md
+++ b/docs/macos-bundler-recovery.md
@@ -1,0 +1,40 @@
+# macOS Bundler recovery
+
+Lich can repair missing default runtime gems on macOS through a user-approved,
+frozen Bundler install. This is a narrow compatibility path for normal runtime
+gems such as `ox`; it is not a macOS GTK installer.
+
+## Scope
+
+- macOS only; Linux keeps the ordinary missing-gem message.
+- Only the `:default` Bundler group is eligible.
+- `gtk`, `development`, `vscode`, and `profanity` are explicitly excluded.
+- GTK remains required for a graphical launch unless `--no-gui` or `--no-gtk`
+  is present, but Lich never attempts to install GTK through this path.
+
+## Recovery flow
+
+1. Lich detects a missing default runtime gem.
+2. It performs local preflight checks: Gemfile/lockfile, Bundler availability,
+   and—for native defaults such as Ox—Ruby headers, Xcode Command Line Tools,
+   and `make`.
+3. A native macOS dialog lists the missing gems and asks for approval. No gem
+   download or install happens until approval.
+4. A child process runs `bundle install` with `BUNDLE_FROZEN=true` and a private
+   `BUNDLE_PATH`. `Gemfile.lock` is never rewritten.
+5. Bundler writes only beneath `lich-5/.lich-bundler-gems/.staging-*`. If every
+   dependency installs successfully, Lich atomically renames that directory to
+   a new private bundle and atomically updates `active.json`.
+6. Lich relaunches. At the next boot, GemCheck adds the activated bundle's
+   RubyGems home before checking dependencies.
+
+If Bundler cannot reach a source, a build fails, or the process is interrupted
+before promotion, the active RubyGems paths and active record are unchanged.
+The incomplete staging directory is removed. Bundler output is retained in
+`temp/lich5-bundler-recovery.log`; GemCheck records the recovery event or
+failure in `temp/lich5-missing-gems.log`.
+
+This path intentionally does not install into the system or user `GEM_HOME`.
+It also does not provide cryptographic verification equivalent to the
+Ruby4Lich5 Windows manifest: the frozen lockfile constrains versions, but the
+gems still originate from Bundler's configured sources.

--- a/docs/macos-bundler-recovery.md
+++ b/docs/macos-bundler-recovery.md
@@ -15,8 +15,8 @@ runtime gems such as `ox`; it is not a macOS GTK installer.
 ## Recovery flow
 
 1. Lich detects a missing default runtime gem.
-2. It performs local preflight checks: Gemfile, Bundler availability, and—for
-   native defaults such as Ox—Ruby headers, Xcode Command Line Tools, and
+2. It performs local preflight checks: Gemfile, Bundler availability, and -- for
+   native defaults such as Ox -- Ruby headers, Xcode Command Line Tools, and
    `make`.
 3. A native macOS dialog lists the missing gems and asks for approval. No gem
    download or install happens until approval.

--- a/docs/macos-bundler-recovery.md
+++ b/docs/macos-bundler-recovery.md
@@ -1,8 +1,8 @@
 # macOS Bundler recovery
 
-Lich can repair missing default runtime gems on macOS through a user-approved,
-frozen Bundler install. This is a narrow compatibility path for normal runtime
-gems such as `ox`; it is not a macOS GTK installer.
+Lich can repair missing default runtime gems on macOS through a user-approved
+Bundler install. This is a narrow compatibility path for normal runtime gems
+such as `ox`; it is not a macOS GTK installer.
 
 ## Scope
 
@@ -15,13 +15,15 @@ gems such as `ox`; it is not a macOS GTK installer.
 ## Recovery flow
 
 1. Lich detects a missing default runtime gem.
-2. It performs local preflight checks: Gemfile/lockfile, Bundler availability,
-   and—for native defaults such as Ox—Ruby headers, Xcode Command Line Tools,
-   and `make`.
+2. It performs local preflight checks: Gemfile, Bundler availability, and—for
+   native defaults such as Ox—Ruby headers, Xcode Command Line Tools, and
+   `make`.
 3. A native macOS dialog lists the missing gems and asks for approval. No gem
    download or install happens until approval.
-4. A child process runs `bundle install` with `BUNDLE_FROZEN=true` and a private
-   `BUNDLE_PATH`. `Gemfile.lock` is never rewritten.
+4. Lich copies `Gemfile`, plus `Gemfile.lock` when it was shipped, into staging.
+   A child process runs `bundle install` with a private `BUNDLE_PATH`. A shipped
+   lockfile is used with `BUNDLE_FROZEN=true`; otherwise Bundler resolves and
+   creates a lockfile only inside staging. The live Lich files are never changed.
 5. Bundler writes only beneath `lich-5/.lich-bundler-gems/.staging-*`. If every
    dependency installs successfully, Lich atomically renames that directory to
    a new private bundle and atomically updates `active.json`.
@@ -36,5 +38,5 @@ failure in `temp/lich5-missing-gems.log`.
 
 This path intentionally does not install into the system or user `GEM_HOME`.
 It also does not provide cryptographic verification equivalent to the
-Ruby4Lich5 Windows manifest: the frozen lockfile constrains versions, but the
-gems still originate from Bundler's configured sources.
+Ruby4Lich5 Windows manifest: when a release includes a lockfile, it constrains
+versions; when it does not, Bundler resolves from its configured sources.

--- a/lib/bundler_recovery.rb
+++ b/lib/bundler_recovery.rb
@@ -1,65 +1,69 @@
 # frozen_string_literal: true
 
-require 'digest'
 require 'fileutils'
 require 'json'
 require 'open3'
 require 'rbconfig'
+require 'rubygems/installer'
 require 'securerandom'
+require 'tmpdir'
 
 module Lich
-  # Stages a non-GTK Bundler install on macOS and activates it only after the
-  # complete bundle was installed successfully. An existing lockfile is used
-  # in frozen mode; otherwise Bundler resolves solely within staging. The
-  # active bundle is stored below Lich's own directory, never in the system or
-  # user GEM_HOME.
+  # Recovers missing non-GTK runtime gems on macOS. Bundler resolves and builds
+  # in Lich's temporary directory first. A detached helper then promotes only
+  # the missing gems and their unavailable runtime dependencies into Gem.dir,
+  # rolling back every touched gem if validation fails.
   class BundlerRecovery
-    STORE_DIRNAME = '.lich-bundler-gems'
-    ACTIVE_FILENAME = 'active.json'
     LOG_FILENAME = 'lich5-bundler-recovery.log'
+    LOCK_FILENAME = '.lich-bundler-recovery.lock'
     EXCLUDED_GROUPS = %w[gtk development vscode profanity].freeze
     NATIVE_DEFAULT_GEMS = %w[ox sqlite3].freeze
 
-    # Result of staging and activating a Bundler recovery bundle.
-    Result = Struct.new(:error, :log_path, keyword_init: true) do
-      # @return [Boolean]
+    Result = Struct.new(:error, :log_path, :restart_required, keyword_init: true) do
       def success?
         error.nil?
       end
     end
 
     class << self
-      # @return [Boolean] whether the deliberately narrow initial recovery
-      #   implementation is supported by the current runtime.
       def supported?
         RUBY_PLATFORM.match?(/darwin/)
       end
 
-      # Activates the previously promoted private bundle, if it matches this
-      # Ruby runtime. Invalid or incomplete records are ignored fail-closed.
-      # @param lich_dir [String]
-      # @return [Boolean]
-      def activate!(lich_dir:)
-        return false unless supported?
+      # Runs after the Lich process exits. The helper owns promotion, rollback,
+      # cleanup, and restart so the running Ruby never changes its own gems.
+      def run_macos_replacement(payload_path)
+        payload = JSON.parse(File.read(payload_path))
+        new(lich_dir: payload.fetch('lich_dir'), gem_home: payload.fetch('gem_home'))
+          .send(:run_macos_replacement!, payload)
+        true
+      rescue StandardError => e
+        log_helper_failure(payload || payload_path, e)
+        false
+      end
 
-        new(lich_dir:).activate!
+      def log_helper_failure(payload_or_path, error)
+        payload = payload_or_path.is_a?(Hash) ? payload_or_path : JSON.parse(File.read(payload_or_path)) rescue {}
+        path = File.join(payload.fetch('temp_dir', Dir.tmpdir), LOG_FILENAME)
+        File.open(path, 'a') { |file| file.puts("[#{Time.now}] macOS gem promotion failed\n  #{error.class}: #{error.message}\n") }
+      rescue StandardError
+        nil
       end
     end
 
-    # @param lich_dir [String] absolute Lich installation directory
-    def initialize(lich_dir:)
+    def initialize(lich_dir:, gem_home: Gem.dir, helper_launcher: nil, installer: nil)
       @lich_dir = File.expand_path(lich_dir)
+      @gem_home = File.expand_path(gem_home)
+      @helper_launcher = helper_launcher || method(:launch_macos_helper)
+      @installer = installer || method(:install_gem)
     end
 
-    # Performs non-mutating checks required to build a staged bundle.
-    # @param missing [Array<String>]
-    # @return [String, nil] a user-actionable failure reason, if any
     def preflight(missing)
       return 'macOS Bundler recovery is not supported by this Ruby runtime' unless self.class.supported?
       return "Gemfile not found at #{gemfile}" unless File.file?(gemfile)
       return "Ruby executable is not available at #{Gem.ruby}" unless File.executable?(Gem.ruby)
       return 'Bundler is not available from this Ruby runtime' unless command_available?(Gem.ruby, '-S', 'bundle', '--version')
-      return nil unless native_default_gem_missing?(missing)
+      return nil unless (Array(missing) & NATIVE_DEFAULT_GEMS).any?
 
       return "Ruby development headers are not available at #{ruby_headers}" unless File.directory?(ruby_headers)
       return 'Xcode Command Line Tools are required to build native Ruby gems' unless command_available?('xcrun', '--find', 'clang')
@@ -68,124 +72,45 @@ module Lich
       nil
     end
 
-    # Installs every non-excluded dependency into a private staging bundle,
-    # then atomically promotes that bundle and activation record. A shipped
-    # lockfile is copied into staging and used frozen; an absent lockfile is
-    # resolved and created only in staging. A failed download or native build
-    # never changes the active RubyGems path or Lich's Gemfile files.
-    # @param missing [Array<String>]
-    # @return [Result]
+    # Stages a complete resolver result, but promotes only the requested gems
+    # and runtime dependencies not already satisfiable in the real Gem.dir.
     def recover(missing)
-      if (reason = preflight(missing))
-        return failure(reason)
-      end
+      reason = preflight(missing)
+      return failure(reason) if reason
 
-      FileUtils.mkdir_p(store_root)
-      staging_path = File.join(store_root, ".staging-#{Process.pid}-#{SecureRandom.hex(8)}")
+      FileUtils.mkdir_p(temp_dir)
+      work_dir = Dir.mktmpdir('lich-bundler-recovery-', temp_dir)
+      staging_path = File.join(work_dir, 'staging')
       staged_gemfile, frozen = stage_gemfile_files(staging_path)
-      environment = bundler_environment(staging_path, staged_gemfile, frozen: frozen)
-
-      stdout, stderr, status = Open3.capture3(
-        environment, Gem.ruby, '-S', 'bundle', 'install', chdir: @lich_dir
-      )
+      stdout, stderr, status = Open3.capture3(bundler_environment(staging_path, staged_gemfile, frozen: frozen),
+                                              Gem.ruby, '-S', 'bundle', 'install', chdir: @lich_dir)
       transcript = "#{stdout}#{stderr}"
       write_transcript(transcript, status.success?)
-
       return failure("Bundler install failed (see #{log_path})") unless status.success?
-      return failure("Bundler did not create its staged gem home (see #{log_path})") unless File.directory?(gem_home(staging_path))
-      return failure("Bundler did not create a staged lockfile (see #{log_path})") unless File.file?(staged_lockfile(staging_path))
 
-      target_id = bundle_id(staged_lockfile(staging_path))
-      target_path = File.join(store_root, target_id)
-      File.rename(staging_path, target_path)
-      write_active_record(target_id)
-      Result.new(log_path: log_path)
+      packages = promotion_packages(missing, staging_path)
+      payload_path = File.join(work_dir, 'macos-gem-promotion.json')
+      File.write(payload_path, JSON.generate(promotion_payload(work_dir, packages)))
+      @helper_launcher.call(payload_path)
+      work_dir = nil # The helper cleans its verified staging data after promotion.
+      Result.new(log_path: log_path, restart_required: true)
     rescue StandardError => e
       failure("#{e.class}: #{e.message}")
     ensure
-      FileUtils.rm_rf(staging_path) if defined?(staging_path) && File.exist?(staging_path)
-    end
-
-    # Activates a prior bundle for the current process without calling
-    # Bundler.setup. RubyGems discovers specifications in the private bundle
-    # just as it does from the runtime's normal gem paths.
-    # @return [Boolean]
-    def activate!
-      record = read_active_record
-      return false unless compatible_record?(record)
-
-      home = gem_home(File.join(store_root, record.fetch('bundle_id')))
-      return false unless File.directory?(home)
-
-      original_home = Gem.dir
-      Gem.use_paths(original_home, [original_home, home, *Gem.path].uniq)
-      Gem::Specification.reset
-      true
-    rescue StandardError
-      false
+      FileUtils.rm_rf(work_dir) if defined?(work_dir) && work_dir && Dir.exist?(work_dir)
     end
 
     private
 
-    # @return [String]
-    def gemfile
-      File.join(@lich_dir, 'Gemfile')
-    end
+    def gemfile = File.join(@lich_dir, 'Gemfile')
+    def lockfile = File.join(@lich_dir, 'Gemfile.lock')
+    def temp_dir = defined?(TEMP_DIR) ? TEMP_DIR : File.join(@lich_dir, 'temp')
+    def log_path = File.join(temp_dir, LOG_FILENAME)
+    def ruby_headers = RbConfig::CONFIG.fetch('rubyhdrdir')
+    def ruby_api = RbConfig::CONFIG.fetch('ruby_version')
+    def staged_home(staging_path) = File.join(staging_path, 'ruby', ruby_api)
+    def staged_lockfile(staging_path) = File.join(staging_path, 'Gemfile.lock')
 
-    # @return [String]
-    def lockfile
-      File.join(@lich_dir, 'Gemfile.lock')
-    end
-
-    # @return [String]
-    def store_root
-      File.join(@lich_dir, STORE_DIRNAME)
-    end
-
-    # @return [String]
-    def active_record_path
-      File.join(store_root, ACTIVE_FILENAME)
-    end
-
-    # @return [String]
-    def log_path
-      temp_dir = defined?(TEMP_DIR) ? TEMP_DIR : File.join(@lich_dir, 'temp')
-      File.join(temp_dir, LOG_FILENAME)
-    end
-
-    # @return [String]
-    def ruby_api
-      RbConfig::CONFIG.fetch('ruby_version')
-    end
-
-    # @param bundle_path [String]
-    # @return [String]
-    def gem_home(bundle_path)
-      File.join(bundle_path, 'ruby', ruby_api)
-    end
-
-    # @param resolved_lockfile [String]
-    # @return [String]
-    def bundle_id(resolved_lockfile)
-      runtime = "#{RUBY_ENGINE}-#{ruby_api}-#{RUBY_PLATFORM}".gsub(/[^A-Za-z0-9._-]/, '_')
-      digest = Digest::SHA256.file(resolved_lockfile).hexdigest[0, 16]
-      "#{runtime}-#{digest}-#{SecureRandom.hex(4)}"
-    end
-
-    # @param missing [Array<String>]
-    # @return [Boolean]
-    def native_default_gem_missing?(missing)
-      (Array(missing) & NATIVE_DEFAULT_GEMS).any?
-    end
-
-    # @return [String]
-    def ruby_headers
-      RbConfig::CONFIG.fetch('rubyhdrdir')
-    end
-
-    # @param command [String]
-    # @param arguments [Array<String>]
-    # @return [Boolean]
     def command_available?(command, *arguments)
       _stdout, _stderr, status = Open3.capture3(command, *arguments)
       status.success?
@@ -193,11 +118,6 @@ module Lich
       false
     end
 
-    # Copies the release Gemfile and, when available, its lockfile into the
-    # staging directory. Bundler can therefore resolve a missing lockfile
-    # without changing any file in the live Lich installation.
-    # @param staging_path [String]
-    # @return [Array(String, Boolean)] staged Gemfile path and frozen-mode flag
     def stage_gemfile_files(staging_path)
       FileUtils.mkdir_p(staging_path)
       staged_gemfile = File.join(staging_path, 'Gemfile')
@@ -207,72 +127,187 @@ module Lich
       [staged_gemfile, frozen]
     end
 
-    # @param staging_path [String]
-    # @return [String]
-    def staged_lockfile(staging_path)
-      File.join(staging_path, 'Gemfile.lock')
-    end
-
-    # @param staging_path [String]
-    # @param staged_gemfile [String]
-    # @param frozen [Boolean]
-    # @return [Hash<String, String>]
     def bundler_environment(staging_path, staged_gemfile, frozen:)
       existing_without = ENV.fetch('BUNDLE_WITHOUT', '').split(/[:\s]+/)
       {
-        'BUNDLE_FROZEN'     => frozen ? 'true' : 'false',
-        'BUNDLE_GEMFILE'    => staged_gemfile,
-        'BUNDLE_PATH'       => staging_path,
-        'BUNDLE_WITH'       => nil,
-        'BUNDLE_WITHOUT'    => (existing_without + EXCLUDED_GROUPS).reject(&:empty?).uniq.join(':'),
+        'BUNDLE_FROZEN' => frozen ? 'true' : 'false', 'BUNDLE_GEMFILE' => staged_gemfile,
+        'BUNDLE_PATH' => staging_path, 'BUNDLE_WITH' => nil,
+        'BUNDLE_WITHOUT' => (existing_without + EXCLUDED_GROUPS).reject(&:empty?).uniq.join(':'),
         'BUNDLE_DEPLOYMENT' => 'false'
       }
     end
 
-    # @param target_id [String]
-    # @return [void]
-    def write_active_record(target_id)
-      record = {
-        'schema'      => 1,
-        'bundle_id'   => target_id,
-        'ruby_api'    => ruby_api,
-        'ruby_engine' => RUBY_ENGINE,
-        'platform'    => RUBY_PLATFORM
+    def promotion_packages(missing, staging_path)
+      home = staged_home(staging_path)
+      raise 'Bundler did not create its staged gem home' unless File.directory?(home)
+
+      specs = Dir.glob(File.join(home, 'specifications', '*.gemspec')).filter_map { |path| Gem::Specification.load(path) }
+      by_name = specs.group_by(&:name)
+      selected = Array(missing).uniq.map { |name| select_staged_spec(by_name, name, Gem::Requirement.default) }
+      queue = selected.dup
+      until queue.empty?
+        spec = queue.shift
+        spec.runtime_dependencies.each do |dependency|
+          next if runtime_specs(dependency.name).any? { |installed| dependency.match?(installed) }
+
+          candidate = select_staged_spec(by_name, dependency.name, dependency.requirement)
+          next if selected.any? { |chosen| chosen.full_name == candidate.full_name }
+
+          selected << candidate
+          queue << candidate
+        end
+      end
+      selected.map do |spec|
+        archive = File.join(home, 'cache', spec.file_name)
+        raise "Bundler did not cache #{spec.full_name}" unless File.file?(archive)
+
+        { 'name' => spec.name, 'version' => spec.version.to_s, 'path' => archive }
+      end
+    end
+
+    def select_staged_spec(by_name, name, requirement)
+      spec = Array(by_name[name]).find { |candidate| requirement.satisfied_by?(candidate.version) }
+      raise "Bundler did not stage a compatible #{name} gem" unless spec
+
+      spec
+    end
+
+    # Limits the closure decision to the Ruby that runs Lich, never GEM_PATH.
+    def canonical_specs(name)
+      Dir.glob(File.join(@gem_home, 'specifications', "#{name}-*.gemspec")).filter_map { |path| Gem::Specification.load(path) }
+    end
+
+    # Bundled/default gems can reside outside Gem.dir when GEM_HOME is set.
+    # They are valid runtime dependencies, but never promotion targets: the
+    # helper only writes, backs up, and validates packages under @gem_home.
+    def runtime_specs(name)
+      [@gem_home, Gem.default_dir].uniq.flat_map do |root|
+        Dir.glob(File.join(root, 'specifications', "#{name}-*.gemspec")).filter_map { |path| Gem::Specification.load(path) }
+      end
+    end
+
+    def promotion_payload(work_dir, packages)
+      {
+        'schema' => 1, 'parent_pid' => Process.pid, 'lich_dir' => @lich_dir,
+        'gem_home' => @gem_home, 'temp_dir' => temp_dir, 'work_dir' => work_dir,
+        'packages' => packages, 'restart' => { 'program' => File.join(@lich_dir, 'lich.rbw'), 'argv' => ARGV, 'chdir' => @lich_dir }
       }
-      temporary_path = "#{active_record_path}.tmp-#{Process.pid}-#{SecureRandom.hex(4)}"
-      File.write(temporary_path, JSON.generate(record))
-      File.rename(temporary_path, active_record_path)
+    end
+
+    def launch_macos_helper(payload_path)
+      helper_path = File.join(File.dirname(payload_path), 'run-macos-gem-promotion.rb')
+      File.write(helper_path, "require #{File.expand_path(__FILE__).inspect}\nexit(Lich::BundlerRecovery.run_macos_replacement(ARGV.fetch(0)) ? 0 : 1)\n")
+      Process.spawn(Gem.ruby, helper_path, payload_path, chdir: @lich_dir, out: File::NULL, err: File::NULL)
+    end
+
+    def run_macos_replacement!(payload)
+      validate_payload!(payload)
+      wait_for_parent_exit(payload.fetch('parent_pid'))
+      with_install_lock do
+        rollback = File.join(payload.fetch('work_dir'), 'rollback')
+        names = payload.fetch('packages').map { |package| package.fetch('name') }.uniq
+        backup_existing_packages(names, rollback)
+        begin
+          payload.fetch('packages').each { |package| @installer.call(package.fetch('path')) }
+          verify_packages!(payload.fetch('packages'))
+        rescue StandardError
+          remove_packages(names)
+          restore_backup(rollback)
+          raise
+        end
+      end
+      restart_lich(payload.fetch('restart'))
     ensure
-      FileUtils.rm_f(temporary_path) if defined?(temporary_path)
+      FileUtils.rm_rf(payload.fetch('work_dir')) if payload.is_a?(Hash) && payload['work_dir']
     end
 
-    # @return [Hash, nil]
-    def read_active_record
-      return unless File.file?(active_record_path)
-
-      JSON.parse(File.read(active_record_path))
-    rescue JSON::ParserError
-      nil
+    def validate_payload!(payload)
+      required = %w[parent_pid lich_dir gem_home temp_dir work_dir packages restart]
+      raise 'invalid macOS gem promotion payload' unless payload.is_a?(Hash) && payload['schema'] == 1 && required.all? { |key| payload.key?(key) }
+      raise 'invalid macOS gem promotion package list' unless payload['packages'].is_a?(Array) && !payload['packages'].empty?
+      payload['packages'].each do |package|
+        path = package.fetch('path')
+        raise 'unsafe staged gem package' unless File.file?(path) && path.start_with?("#{payload.fetch('work_dir')}/")
+      end
     end
 
-    # @param record [Hash, nil]
-    # @return [Boolean]
-    def compatible_record?(record)
-      return false unless record.is_a?(Hash)
-      return false unless record['schema'] == 1
-      return false unless record['ruby_api'] == ruby_api && record['ruby_engine'] == RUBY_ENGINE
-      return false unless record['platform'] == RUBY_PLATFORM
+    def wait_for_parent_exit(pid)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 120
+      loop do
+        Process.kill(0, Integer(pid))
+        raise 'timed out waiting for Lich to exit before gem promotion' if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
 
-      record['bundle_id'].is_a?(String) && record['bundle_id'].match?(/\A[A-Za-z0-9._-]+\z/)
+        sleep 0.1
+      rescue Errno::ESRCH
+        return
+      end
     end
 
-    # @param transcript [String]
-    # @param success [Boolean]
-    # @return [void]
+    def with_install_lock
+      FileUtils.mkdir_p(@gem_home)
+      File.open(File.join(@gem_home, LOCK_FILENAME), File::RDWR | File::CREAT, 0o600) { |lock| lock.flock(File::LOCK_EX); yield }
+    end
+
+    def install_gem(path)
+      Gem::Installer.at(path, install_dir: @gem_home, ignore_dependencies: true, wrappers: false).install
+    end
+
+    def backup_existing_packages(names, rollback)
+      names.flat_map { |name| canonical_specs(name) }.uniq(&:loaded_from).each do |spec|
+        package_paths(spec).each { |path| move_to_backup(path, rollback) }
+      end
+    end
+
+    def package_paths(spec)
+      [spec.full_gem_path, spec.loaded_from, spec.extension_dir, File.join(@gem_home, 'cache', spec.file_name)]
+        .select { |path| File.exist?(path) && path.start_with?("#{@gem_home}/") }
+    end
+
+    def move_to_backup(path, rollback)
+      relative = path.delete_prefix("#{@gem_home}/")
+      destination = File.join(rollback, relative)
+      FileUtils.mkdir_p(File.dirname(destination))
+      FileUtils.mv(path, destination)
+    end
+
+    def remove_packages(names)
+      names.flat_map { |name| canonical_specs(name) }.uniq(&:loaded_from).each do |spec|
+        package_paths(spec).each { |path| FileUtils.rm_rf(path) }
+      end
+    end
+
+    def restore_backup(rollback)
+      Dir.glob(File.join(rollback, '**', '*'), File::FNM_DOTMATCH).sort_by(&:length).reverse_each do |path|
+        next if File.directory?(path)
+
+        relative = path.delete_prefix("#{rollback}/")
+        destination = File.join(@gem_home, relative)
+        FileUtils.mkdir_p(File.dirname(destination))
+        FileUtils.mv(path, destination)
+      end
+    end
+
+    def verify_packages!(packages)
+      Gem::Specification.reset
+      Gem.use_paths(@gem_home, [@gem_home])
+      packages.each do |package|
+        requirement = Gem::Requirement.new("= #{package.fetch('version')}")
+        installed = canonical_specs(package.fetch('name'))
+        raise "#{package.fetch('name')} was not installed" unless installed.any? { |spec| requirement.satisfied_by?(spec.version) }
+      end
+      packages.select { |package| NATIVE_DEFAULT_GEMS.include?(package.fetch('name')) }.each { |package| require package.fetch('name') }
+    end
+
+    def restart_lich(restart)
+      raise 'invalid Lich restart program' unless File.file?(restart.fetch('program'))
+
+      Process.spawn(Gem.ruby, restart.fetch('program'), *restart.fetch('argv'), chdir: restart.fetch('chdir'), out: File::NULL, err: File::NULL)
+    end
+
     def write_transcript(transcript, success)
       FileUtils.mkdir_p(File.dirname(log_path))
       File.open(log_path, 'a') do |file|
-        file.puts "[#{Time.now}] macOS Bundler recovery #{success ? 'succeeded' : 'failed'}"
+        file.puts "[#{Time.now}] macOS Bundler recovery #{success ? 'staged' : 'failed'}"
         file.puts "  Gemfile: #{gemfile}"
         file.puts "  Lockfile: #{File.file?(lockfile) ? 'staged from release' : 'resolved in staging'}"
         file.puts "  Excluded groups: #{EXCLUDED_GROUPS.join(', ')}"
@@ -283,8 +318,6 @@ module Lich
       nil
     end
 
-    # @param message [String]
-    # @return [Result]
     def failure(message)
       write_transcript(message, false)
       Result.new(error: message, log_path: log_path)

--- a/lib/bundler_recovery.rb
+++ b/lib/bundler_recovery.rb
@@ -33,9 +33,10 @@ module Lich
       # Runs after the Lich process exits. The helper owns promotion, rollback,
       # cleanup, and restart so the running Ruby never changes its own gems.
       def run_macos_replacement(payload_path)
+        payload = nil
         payload = JSON.parse(File.read(payload_path))
         new(lich_dir: payload.fetch('lich_dir'), gem_home: payload.fetch('gem_home'))
-          .send(:run_macos_replacement!, payload)
+          .send(:run_macos_replacement!, payload, payload_path: payload_path)
         true
       rescue StandardError => e
         log_helper_failure(payload || payload_path, e)
@@ -161,7 +162,7 @@ module Lich
         archive = File.join(home, 'cache', spec.file_name)
         raise "Bundler did not cache #{spec.full_name}" unless File.file?(archive)
 
-        { 'name' => spec.name, 'version' => spec.version.to_s, 'path' => archive }
+        { 'name' => spec.name, 'version' => spec.version.to_s, 'full_name' => spec.full_name, 'path' => archive }
       end
     end
 
@@ -200,35 +201,38 @@ module Lich
       Process.spawn(Gem.ruby, helper_path, payload_path, chdir: @lich_dir, out: File::NULL, err: File::NULL)
     end
 
-    def run_macos_replacement!(payload)
-      validate_payload!(payload)
+    def run_macos_replacement!(payload, payload_path:)
+      cleanup_target = validate_payload!(payload, payload_path)
       wait_for_parent_exit(payload.fetch('parent_pid'))
       with_install_lock do
-        rollback = File.join(payload.fetch('work_dir'), 'rollback')
-        names = payload.fetch('packages').map { |package| package.fetch('name') }.uniq
-        backup_existing_packages(names, rollback)
+        rollback = File.join(cleanup_target, 'rollback')
+        backup_existing_packages(payload.fetch('packages'), rollback)
         begin
           payload.fetch('packages').each { |package| @installer.call(package.fetch('path')) }
           verify_packages!(payload.fetch('packages'))
         rescue StandardError
-          remove_packages(names)
+          remove_packages(payload.fetch('packages'))
           restore_backup(rollback)
           raise
         end
       end
       restart_lich(payload.fetch('restart'))
     ensure
-      FileUtils.rm_rf(payload.fetch('work_dir')) if payload.is_a?(Hash) && payload['work_dir']
+      FileUtils.rm_rf(cleanup_target) if defined?(cleanup_target) && cleanup_target
     end
 
-    def validate_payload!(payload)
+    def validate_payload!(payload, payload_path)
       required = %w[parent_pid lich_dir gem_home temp_dir work_dir packages restart]
       raise 'invalid macOS gem promotion payload' unless payload.is_a?(Hash) && payload['schema'] == 1 && required.all? { |key| payload.key?(key) }
       raise 'invalid macOS gem promotion package list' unless payload['packages'].is_a?(Array) && !payload['packages'].empty?
+      workspace = File.dirname(File.expand_path(payload_path))
+      raise 'invalid macOS gem promotion workspace' unless File.expand_path(payload.fetch('work_dir')) == workspace
       payload['packages'].each do |package|
-        path = package.fetch('path')
-        raise 'unsafe staged gem package' unless File.file?(path) && path.start_with?("#{payload.fetch('work_dir')}/")
+        %w[name version full_name path].each { |key| package.fetch(key) }
+        path = File.expand_path(package.fetch('path'))
+        raise 'unsafe staged gem package' unless File.file?(path) && path.start_with?("#{workspace}/")
       end
+      workspace
     end
 
     def wait_for_parent_exit(pid)
@@ -252,8 +256,8 @@ module Lich
       Gem::Installer.at(path, install_dir: @gem_home, ignore_dependencies: true, wrappers: false).install
     end
 
-    def backup_existing_packages(names, rollback)
-      names.flat_map { |name| canonical_specs(name) }.uniq(&:loaded_from).each do |spec|
+    def backup_existing_packages(packages, rollback)
+      exact_specs(packages).each do |spec|
         package_paths(spec).each { |path| move_to_backup(path, rollback) }
       end
     end
@@ -270,8 +274,8 @@ module Lich
       FileUtils.mv(path, destination)
     end
 
-    def remove_packages(names)
-      names.flat_map { |name| canonical_specs(name) }.uniq(&:loaded_from).each do |spec|
+    def remove_packages(packages)
+      exact_specs(packages).each do |spec|
         package_paths(spec).each { |path| FileUtils.rm_rf(path) }
       end
     end
@@ -293,9 +297,16 @@ module Lich
       packages.each do |package|
         requirement = Gem::Requirement.new("= #{package.fetch('version')}")
         installed = canonical_specs(package.fetch('name'))
-        raise "#{package.fetch('name')} was not installed" unless installed.any? { |spec| requirement.satisfied_by?(spec.version) }
+        exact = installed.find { |spec| spec.full_name == package.fetch('full_name') && requirement.satisfied_by?(spec.version) }
+        raise "#{package.fetch('full_name')} was not installed" unless exact
       end
       packages.select { |package| NATIVE_DEFAULT_GEMS.include?(package.fetch('name')) }.each { |package| require package.fetch('name') }
+    end
+
+    def exact_specs(packages)
+      packages.flat_map do |package|
+        canonical_specs(package.fetch('name')).select { |spec| spec.full_name == package.fetch('full_name') }
+      end.uniq(&:loaded_from)
     end
 
     def restart_lich(restart)

--- a/lib/bundler_recovery.rb
+++ b/lib/bundler_recovery.rb
@@ -8,9 +8,11 @@ require 'rbconfig'
 require 'securerandom'
 
 module Lich
-  # Stages a frozen, non-GTK Bundler install on macOS and activates it only
-  # after the complete bundle was installed successfully. The active bundle is
-  # stored below Lich's own directory, never in the system or user GEM_HOME.
+  # Stages a non-GTK Bundler install on macOS and activates it only after the
+  # complete bundle was installed successfully. An existing lockfile is used
+  # in frozen mode; otherwise Bundler resolves solely within staging. The
+  # active bundle is stored below Lich's own directory, never in the system or
+  # user GEM_HOME.
   class BundlerRecovery
     STORE_DIRNAME = '.lich-bundler-gems'
     ACTIVE_FILENAME = 'active.json'
@@ -49,13 +51,12 @@ module Lich
       @lich_dir = File.expand_path(lich_dir)
     end
 
-    # Performs non-mutating checks required to build a frozen bundle.
+    # Performs non-mutating checks required to build a staged bundle.
     # @param missing [Array<String>]
     # @return [String, nil] a user-actionable failure reason, if any
     def preflight(missing)
       return 'macOS Bundler recovery is not supported by this Ruby runtime' unless self.class.supported?
       return "Gemfile not found at #{gemfile}" unless File.file?(gemfile)
-      return "Gemfile.lock not found at #{lockfile}" unless File.file?(lockfile)
       return "Ruby executable is not available at #{Gem.ruby}" unless File.executable?(Gem.ruby)
       return 'Bundler is not available from this Ruby runtime' unless command_available?(Gem.ruby, '-S', 'bundle', '--version')
       return nil unless native_default_gem_missing?(missing)
@@ -67,9 +68,11 @@ module Lich
       nil
     end
 
-    # Installs every non-excluded locked dependency into a private staging
-    # bundle, then atomically promotes that bundle and activation record.
-    # A failed download or native build never changes the active RubyGems path.
+    # Installs every non-excluded dependency into a private staging bundle,
+    # then atomically promotes that bundle and activation record. A shipped
+    # lockfile is copied into staging and used frozen; an absent lockfile is
+    # resolved and created only in staging. A failed download or native build
+    # never changes the active RubyGems path or Lich's Gemfile files.
     # @param missing [Array<String>]
     # @return [Result]
     def recover(missing)
@@ -79,9 +82,8 @@ module Lich
 
       FileUtils.mkdir_p(store_root)
       staging_path = File.join(store_root, ".staging-#{Process.pid}-#{SecureRandom.hex(8)}")
-      target_id = bundle_id
-      target_path = File.join(store_root, target_id)
-      environment = bundler_environment(staging_path)
+      staged_gemfile, frozen = stage_gemfile_files(staging_path)
+      environment = bundler_environment(staging_path, staged_gemfile, frozen: frozen)
 
       stdout, stderr, status = Open3.capture3(
         environment, Gem.ruby, '-S', 'bundle', 'install', chdir: @lich_dir
@@ -91,7 +93,10 @@ module Lich
 
       return failure("Bundler install failed (see #{log_path})") unless status.success?
       return failure("Bundler did not create its staged gem home (see #{log_path})") unless File.directory?(gem_home(staging_path))
+      return failure("Bundler did not create a staged lockfile (see #{log_path})") unless File.file?(staged_lockfile(staging_path))
 
+      target_id = bundle_id(staged_lockfile(staging_path))
+      target_path = File.join(store_root, target_id)
       File.rename(staging_path, target_path)
       write_active_record(target_id)
       Result.new(log_path: log_path)
@@ -159,10 +164,11 @@ module Lich
       File.join(bundle_path, 'ruby', ruby_api)
     end
 
+    # @param resolved_lockfile [String]
     # @return [String]
-    def bundle_id
+    def bundle_id(resolved_lockfile)
       runtime = "#{RUBY_ENGINE}-#{ruby_api}-#{RUBY_PLATFORM}".gsub(/[^A-Za-z0-9._-]/, '_')
-      digest = Digest::SHA256.file(lockfile).hexdigest[0, 16]
+      digest = Digest::SHA256.file(resolved_lockfile).hexdigest[0, 16]
       "#{runtime}-#{digest}-#{SecureRandom.hex(4)}"
     end
 
@@ -187,17 +193,39 @@ module Lich
       false
     end
 
+    # Copies the release Gemfile and, when available, its lockfile into the
+    # staging directory. Bundler can therefore resolve a missing lockfile
+    # without changing any file in the live Lich installation.
     # @param staging_path [String]
-    # @return [Hash<String, String, nil>]
-    def bundler_environment(staging_path)
+    # @return [Array(String, Boolean)] staged Gemfile path and frozen-mode flag
+    def stage_gemfile_files(staging_path)
+      FileUtils.mkdir_p(staging_path)
+      staged_gemfile = File.join(staging_path, 'Gemfile')
+      FileUtils.cp(gemfile, staged_gemfile)
+      frozen = File.file?(lockfile)
+      FileUtils.cp(lockfile, staged_lockfile(staging_path)) if frozen
+      [staged_gemfile, frozen]
+    end
+
+    # @param staging_path [String]
+    # @return [String]
+    def staged_lockfile(staging_path)
+      File.join(staging_path, 'Gemfile.lock')
+    end
+
+    # @param staging_path [String]
+    # @param staged_gemfile [String]
+    # @param frozen [Boolean]
+    # @return [Hash<String, String>]
+    def bundler_environment(staging_path, staged_gemfile, frozen:)
       existing_without = ENV.fetch('BUNDLE_WITHOUT', '').split(/[:\s]+/)
       {
-        'BUNDLE_FROZEN'     => 'true',
-        'BUNDLE_GEMFILE'    => gemfile,
+        'BUNDLE_FROZEN'     => frozen ? 'true' : 'false',
+        'BUNDLE_GEMFILE'    => staged_gemfile,
         'BUNDLE_PATH'       => staging_path,
         'BUNDLE_WITH'       => nil,
         'BUNDLE_WITHOUT'    => (existing_without + EXCLUDED_GROUPS).reject(&:empty?).uniq.join(':'),
-        'BUNDLE_DEPLOYMENT' => nil
+        'BUNDLE_DEPLOYMENT' => 'false'
       }
     end
 
@@ -246,7 +274,7 @@ module Lich
       File.open(log_path, 'a') do |file|
         file.puts "[#{Time.now}] macOS Bundler recovery #{success ? 'succeeded' : 'failed'}"
         file.puts "  Gemfile: #{gemfile}"
-        file.puts "  Lockfile: #{lockfile}"
+        file.puts "  Lockfile: #{File.file?(lockfile) ? 'staged from release' : 'resolved in staging'}"
         file.puts "  Excluded groups: #{EXCLUDED_GROUPS.join(', ')}"
         file.puts transcript
         file.puts

--- a/lib/bundler_recovery.rb
+++ b/lib/bundler_recovery.rb
@@ -5,7 +5,6 @@ require 'json'
 require 'open3'
 require 'rbconfig'
 require 'rubygems/installer'
-require 'securerandom'
 require 'tmpdir'
 
 module Lich
@@ -44,11 +43,29 @@ module Lich
       end
 
       def log_helper_failure(payload_or_path, error)
-        payload = payload_or_path.is_a?(Hash) ? payload_or_path : JSON.parse(File.read(payload_or_path)) rescue {}
-        path = File.join(payload.fetch('temp_dir', Dir.tmpdir), LOG_FILENAME)
+        payload = helper_payload(payload_or_path)
+        path = File.join(payload.fetch('temp_dir', helper_temp_dir(payload_or_path)), LOG_FILENAME)
         File.open(path, 'a') { |file| file.puts("[#{Time.now}] macOS gem promotion failed\n  #{error.class}: #{error.message}\n") }
       rescue StandardError
         nil
+      end
+
+      private
+
+      def helper_payload(payload_or_path)
+        return payload_or_path if payload_or_path.is_a?(Hash)
+
+        JSON.parse(File.read(payload_or_path))
+      rescue StandardError
+        {}
+      end
+
+      def helper_temp_dir(payload_or_path)
+        return Dir.tmpdir unless payload_or_path.is_a?(String)
+
+        File.dirname(File.dirname(File.expand_path(payload_or_path)))
+      rescue StandardError
+        Dir.tmpdir
       end
     end
 
@@ -198,7 +215,9 @@ module Lich
     def launch_macos_helper(payload_path)
       helper_path = File.join(File.dirname(payload_path), 'run-macos-gem-promotion.rb')
       File.write(helper_path, "require #{File.expand_path(__FILE__).inspect}\nexit(Lich::BundlerRecovery.run_macos_replacement(ARGV.fetch(0)) ? 0 : 1)\n")
-      Process.spawn(Gem.ruby, helper_path, payload_path, chdir: @lich_dir, out: File::NULL, err: File::NULL)
+      File.open(log_path, 'a') do |log|
+        Process.spawn(Gem.ruby, helper_path, payload_path, chdir: @lich_dir, out: File::NULL, err: log)
+      end
     end
 
     def run_macos_replacement!(payload, payload_path:)
@@ -293,7 +312,7 @@ module Lich
 
     def verify_packages!(packages)
       Gem::Specification.reset
-      Gem.use_paths(@gem_home, [@gem_home])
+      Gem.use_paths(@gem_home, [@gem_home, Gem.default_dir].uniq)
       packages.each do |package|
         requirement = Gem::Requirement.new("= #{package.fetch('version')}")
         installed = canonical_specs(package.fetch('name'))

--- a/lib/bundler_recovery.rb
+++ b/lib/bundler_recovery.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'rbconfig'
+require 'securerandom'
+
+module Lich
+  # Stages a frozen, non-GTK Bundler install on macOS and activates it only
+  # after the complete bundle was installed successfully. The active bundle is
+  # stored below Lich's own directory, never in the system or user GEM_HOME.
+  class BundlerRecovery
+    STORE_DIRNAME = '.lich-bundler-gems'
+    ACTIVE_FILENAME = 'active.json'
+    LOG_FILENAME = 'lich5-bundler-recovery.log'
+    EXCLUDED_GROUPS = %w[gtk development vscode profanity].freeze
+    NATIVE_DEFAULT_GEMS = %w[ox sqlite3].freeze
+
+    # Result of staging and activating a Bundler recovery bundle.
+    Result = Struct.new(:error, :log_path, keyword_init: true) do
+      # @return [Boolean]
+      def success?
+        error.nil?
+      end
+    end
+
+    class << self
+      # @return [Boolean] whether the deliberately narrow initial recovery
+      #   implementation is supported by the current runtime.
+      def supported?
+        RUBY_PLATFORM.match?(/darwin/)
+      end
+
+      # Activates the previously promoted private bundle, if it matches this
+      # Ruby runtime. Invalid or incomplete records are ignored fail-closed.
+      # @param lich_dir [String]
+      # @return [Boolean]
+      def activate!(lich_dir:)
+        return false unless supported?
+
+        new(lich_dir:).activate!
+      end
+    end
+
+    # @param lich_dir [String] absolute Lich installation directory
+    def initialize(lich_dir:)
+      @lich_dir = File.expand_path(lich_dir)
+    end
+
+    # Performs non-mutating checks required to build a frozen bundle.
+    # @param missing [Array<String>]
+    # @return [String, nil] a user-actionable failure reason, if any
+    def preflight(missing)
+      return 'macOS Bundler recovery is not supported by this Ruby runtime' unless self.class.supported?
+      return "Gemfile not found at #{gemfile}" unless File.file?(gemfile)
+      return "Gemfile.lock not found at #{lockfile}" unless File.file?(lockfile)
+      return "Ruby executable is not available at #{Gem.ruby}" unless File.executable?(Gem.ruby)
+      return 'Bundler is not available from this Ruby runtime' unless command_available?(Gem.ruby, '-S', 'bundle', '--version')
+      return nil unless native_default_gem_missing?(missing)
+
+      return "Ruby development headers are not available at #{ruby_headers}" unless File.directory?(ruby_headers)
+      return 'Xcode Command Line Tools are required to build native Ruby gems' unless command_available?('xcrun', '--find', 'clang')
+      return 'make is required to build native Ruby gems' unless command_available?('make', '--version')
+
+      nil
+    end
+
+    # Installs every non-excluded locked dependency into a private staging
+    # bundle, then atomically promotes that bundle and activation record.
+    # A failed download or native build never changes the active RubyGems path.
+    # @param missing [Array<String>]
+    # @return [Result]
+    def recover(missing)
+      if (reason = preflight(missing))
+        return failure(reason)
+      end
+
+      FileUtils.mkdir_p(store_root)
+      staging_path = File.join(store_root, ".staging-#{Process.pid}-#{SecureRandom.hex(8)}")
+      target_id = bundle_id
+      target_path = File.join(store_root, target_id)
+      environment = bundler_environment(staging_path)
+
+      stdout, stderr, status = Open3.capture3(
+        environment, Gem.ruby, '-S', 'bundle', 'install', chdir: @lich_dir
+      )
+      transcript = "#{stdout}#{stderr}"
+      write_transcript(transcript, status.success?)
+
+      return failure("Bundler install failed (see #{log_path})") unless status.success?
+      return failure("Bundler did not create its staged gem home (see #{log_path})") unless File.directory?(gem_home(staging_path))
+
+      File.rename(staging_path, target_path)
+      write_active_record(target_id)
+      Result.new(log_path: log_path)
+    rescue StandardError => e
+      failure("#{e.class}: #{e.message}")
+    ensure
+      FileUtils.rm_rf(staging_path) if defined?(staging_path) && File.exist?(staging_path)
+    end
+
+    # Activates a prior bundle for the current process without calling
+    # Bundler.setup. RubyGems discovers specifications in the private bundle
+    # just as it does from the runtime's normal gem paths.
+    # @return [Boolean]
+    def activate!
+      record = read_active_record
+      return false unless compatible_record?(record)
+
+      home = gem_home(File.join(store_root, record.fetch('bundle_id')))
+      return false unless File.directory?(home)
+
+      original_home = Gem.dir
+      Gem.use_paths(original_home, [original_home, home, *Gem.path].uniq)
+      Gem::Specification.reset
+      true
+    rescue StandardError
+      false
+    end
+
+    private
+
+    # @return [String]
+    def gemfile
+      File.join(@lich_dir, 'Gemfile')
+    end
+
+    # @return [String]
+    def lockfile
+      File.join(@lich_dir, 'Gemfile.lock')
+    end
+
+    # @return [String]
+    def store_root
+      File.join(@lich_dir, STORE_DIRNAME)
+    end
+
+    # @return [String]
+    def active_record_path
+      File.join(store_root, ACTIVE_FILENAME)
+    end
+
+    # @return [String]
+    def log_path
+      temp_dir = defined?(TEMP_DIR) ? TEMP_DIR : File.join(@lich_dir, 'temp')
+      File.join(temp_dir, LOG_FILENAME)
+    end
+
+    # @return [String]
+    def ruby_api
+      RbConfig::CONFIG.fetch('ruby_version')
+    end
+
+    # @param bundle_path [String]
+    # @return [String]
+    def gem_home(bundle_path)
+      File.join(bundle_path, 'ruby', ruby_api)
+    end
+
+    # @return [String]
+    def bundle_id
+      runtime = "#{RUBY_ENGINE}-#{ruby_api}-#{RUBY_PLATFORM}".gsub(/[^A-Za-z0-9._-]/, '_')
+      digest = Digest::SHA256.file(lockfile).hexdigest[0, 16]
+      "#{runtime}-#{digest}-#{SecureRandom.hex(4)}"
+    end
+
+    # @param missing [Array<String>]
+    # @return [Boolean]
+    def native_default_gem_missing?(missing)
+      (Array(missing) & NATIVE_DEFAULT_GEMS).any?
+    end
+
+    # @return [String]
+    def ruby_headers
+      RbConfig::CONFIG.fetch('rubyhdrdir')
+    end
+
+    # @param command [String]
+    # @param arguments [Array<String>]
+    # @return [Boolean]
+    def command_available?(command, *arguments)
+      _stdout, _stderr, status = Open3.capture3(command, *arguments)
+      status.success?
+    rescue StandardError
+      false
+    end
+
+    # @param staging_path [String]
+    # @return [Hash<String, String, nil>]
+    def bundler_environment(staging_path)
+      existing_without = ENV.fetch('BUNDLE_WITHOUT', '').split(/[:\s]+/)
+      {
+        'BUNDLE_FROZEN'     => 'true',
+        'BUNDLE_GEMFILE'    => gemfile,
+        'BUNDLE_PATH'       => staging_path,
+        'BUNDLE_WITH'       => nil,
+        'BUNDLE_WITHOUT'    => (existing_without + EXCLUDED_GROUPS).reject(&:empty?).uniq.join(':'),
+        'BUNDLE_DEPLOYMENT' => nil
+      }
+    end
+
+    # @param target_id [String]
+    # @return [void]
+    def write_active_record(target_id)
+      record = {
+        'schema'      => 1,
+        'bundle_id'   => target_id,
+        'ruby_api'    => ruby_api,
+        'ruby_engine' => RUBY_ENGINE,
+        'platform'    => RUBY_PLATFORM
+      }
+      temporary_path = "#{active_record_path}.tmp-#{Process.pid}-#{SecureRandom.hex(4)}"
+      File.write(temporary_path, JSON.generate(record))
+      File.rename(temporary_path, active_record_path)
+    ensure
+      FileUtils.rm_f(temporary_path) if defined?(temporary_path)
+    end
+
+    # @return [Hash, nil]
+    def read_active_record
+      return unless File.file?(active_record_path)
+
+      JSON.parse(File.read(active_record_path))
+    rescue JSON::ParserError
+      nil
+    end
+
+    # @param record [Hash, nil]
+    # @return [Boolean]
+    def compatible_record?(record)
+      return false unless record.is_a?(Hash)
+      return false unless record['schema'] == 1
+      return false unless record['ruby_api'] == ruby_api && record['ruby_engine'] == RUBY_ENGINE
+      return false unless record['platform'] == RUBY_PLATFORM
+
+      record['bundle_id'].is_a?(String) && record['bundle_id'].match?(/\A[A-Za-z0-9._-]+\z/)
+    end
+
+    # @param transcript [String]
+    # @param success [Boolean]
+    # @return [void]
+    def write_transcript(transcript, success)
+      FileUtils.mkdir_p(File.dirname(log_path))
+      File.open(log_path, 'a') do |file|
+        file.puts "[#{Time.now}] macOS Bundler recovery #{success ? 'succeeded' : 'failed'}"
+        file.puts "  Gemfile: #{gemfile}"
+        file.puts "  Lockfile: #{lockfile}"
+        file.puts "  Excluded groups: #{EXCLUDED_GROUPS.join(', ')}"
+        file.puts transcript
+        file.puts
+      end
+    rescue StandardError
+      nil
+    end
+
+    # @param message [String]
+    # @return [Result]
+    def failure(message)
+      write_transcript(message, false)
+      Result.new(error: message, log_path: log_path)
+    end
+  end
+end

--- a/lib/bundler_recovery.rb
+++ b/lib/bundler_recovery.rb
@@ -225,7 +225,16 @@ module Lich
       wait_for_parent_exit(payload.fetch('parent_pid'))
       with_install_lock do
         rollback = File.join(cleanup_target, 'rollback')
-        backup_existing_packages(payload.fetch('packages'), rollback)
+        begin
+          backup_existing_packages(payload.fetch('packages'), rollback)
+        rescue StandardError
+          begin
+            restore_backup(rollback)
+          rescue StandardError
+            # Preserve the backup failure as the actionable recovery error.
+          end
+          raise
+        end
         begin
           payload.fetch('packages').each { |package| @installer.call(package.fetch('path')) }
           verify_packages!(payload.fetch('packages'))

--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -35,6 +35,10 @@ module Lich
     def verify!(*groups)
       groups = [:default] if groups.empty?
       configure_gemfile!
+      # Bundler rebuilds RubyGems' paths while it first reads the Gemfile.
+      # Do that before adding a promoted private macOS bundle, or its path is
+      # discarded and the next check incorrectly requests another recovery.
+      Bundler.definition
       activate_bundler_recovery!
 
       missing = missing_gems(groups)
@@ -148,9 +152,10 @@ module Lich
       recovery.recover(gem_names, force: force, plan: plan)
     end
 
-    # Runs a consented, frozen Bundler repair for the default non-GTK runtime
-    # gems on macOS. The recovery object stages its full bundle before making
-    # the new private RubyGems home active.
+    # Runs a consented Bundler repair for the default non-GTK runtime gems on
+    # macOS. The recovery object uses a shipped lockfile when present, or
+    # resolves only within staging before making the private RubyGems home
+    # active.
     # @param gem_names [Array<String>]
     # @param groups [Array<Symbol>]
     # @return [BundlerRecovery::Result, nil]
@@ -211,8 +216,8 @@ module Lich
       return :unavailable unless BundlerRecovery.supported?
 
       body = "Required Ruby gems are not installed:\n#{Array(gem_names).map { |name| "  - #{name}" }.join("\n")}\n\n" \
-             "Lich can install the locked non-GTK runtime bundle to its private directory now.\n" \
-             "Gemfile.lock will not be changed.\n\nInstall now?"
+             "Lich can install the non-GTK runtime bundle to its private directory now.\n" \
+             "Your Gemfile and Gemfile.lock will not be changed.\n\nInstall now?"
       script = %(display dialog #{macos_dialog_body(body)} with title #{TITLE.inspect} ) +
                %(buttons {"Install", "Cancel"} default button "Install" with icon caution ) +
                "giving up after #{BUNDLER_RECOVERY_TIMEOUT_SECONDS}"

--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -1,5 +1,6 @@
 # lib/gemcheck.rb
 require 'bundler'
+require_relative 'bundler_recovery'
 require_relative 'dependency_recovery'
 
 module Lich
@@ -16,6 +17,7 @@ module Lich
     RELEASE_URL     = 'https://github.com/elanthia-online/lich-5/releases/latest'
     LOG_FILENAME    = 'lich5-missing-gems.log'
     CONSENT_TIMEOUT_SECONDS = 120
+    BUNDLER_RECOVERY_TIMEOUT_SECONDS = 120
 
     # Records why a recovery did not run without treating that decision as a
     # manifest or Bundler failure.
@@ -33,29 +35,49 @@ module Lich
     def verify!(*groups)
       groups = [:default] if groups.empty?
       configure_gemfile!
+      activate_bundler_recovery!
 
       missing = missing_gems(groups)
       return if missing.empty?
 
-      unless self_healing_supported?
-        alert(missing: missing, groups: groups)
+      if self_healing_supported?
+        result = recover_with_consent!(missing, groups: groups)
+        exit 1 unless result
+        exit 0 if result.restart_required
+
+        if result.success?
+          missing = missing_gems(groups)
+          return if missing.empty?
+
+          alert(missing: missing, groups: groups)
+        else
+          alert(missing: missing, groups: groups,
+                error: DependencyRecovery::Error.new(result.error))
+        end
         exit 1
       end
 
-      result = recover_with_consent!(missing, groups: groups)
-      exit 1 unless result
-      exit 0 if result.restart_required
+      if bundler_recovery_supported?(groups)
+        result = recover_with_bundler_consent!(missing, groups: groups)
+        exit 1 unless result
 
-      if result.success?
-        missing = missing_gems(groups)
-        return if missing.empty?
+        if result.success?
+          write_bundler_recovery_log(missing: missing, groups: groups, result: result)
+          begin
+            relaunch_after_bundler_recovery!
+          rescue SystemCallError => e
+            alert(missing: missing, groups: groups, error: e)
+            exit 1
+          end
+          exit 0
+        end
 
-        alert(missing: missing, groups: groups)
+        alert(missing: missing, groups: groups, error: DependencyRecovery::Error.new(result.error))
+        exit 1
       else
-        alert(missing: missing, groups: groups,
-              error: DependencyRecovery::Error.new(result.error))
+        alert(missing: missing, groups: groups)
+        exit 1
       end
-      exit 1
     end
 
     # Ensures Bundler resolves Lich's Gemfile even when the app is launched
@@ -75,6 +97,23 @@ module Lich
     # @return [Boolean]
     def self_healing_supported?
       Gem.win_platform?
+    end
+
+    # The initial non-Windows recovery is deliberately macOS-only and only
+    # covers default runtime gems. GTK remains outside this Bundler path.
+    # @param groups [Array<Symbol>]
+    # @return [Boolean]
+    def bundler_recovery_supported?(groups)
+      BundlerRecovery.supported? && Array(groups).map(&:to_sym) == [:default]
+    end
+
+    # Adds a prior atomically promoted macOS bundle to RubyGems before Bundler
+    # inspects installed specifications. No Bundler.setup call is made.
+    # @return [Boolean]
+    def activate_bundler_recovery!
+      return false unless defined?(LICH_DIR) && BundlerRecovery.supported?
+
+      BundlerRecovery.activate!(lich_dir: LICH_DIR)
     end
 
     # Chooses the dependency groups that must be present before normal startup.
@@ -107,6 +146,27 @@ module Lich
 
       write_recovery_log(missing: gem_names, groups: groups, units: plan.units)
       recovery.recover(gem_names, force: force, plan: plan)
+    end
+
+    # Runs a consented, frozen Bundler repair for the default non-GTK runtime
+    # gems on macOS. The recovery object stages its full bundle before making
+    # the new private RubyGems home active.
+    # @param gem_names [Array<String>]
+    # @param groups [Array<Symbol>]
+    # @return [BundlerRecovery::Result, nil]
+    def recover_with_bundler_consent!(gem_names, groups: [:default])
+      recovery = BundlerRecovery.new(lich_dir: LICH_DIR)
+      if (reason = recovery.preflight(gem_names))
+        return BundlerRecovery::Result.new(error: reason)
+      end
+
+      decision = confirm_bundler_recovery(gem_names)
+      unless decision == :approved
+        report_bundler_consent_failure(gem_names, groups, consent_failure_reason(decision))
+        return nil
+      end
+
+      recovery.recover(gem_names)
     end
 
     # Requests one consent decision for every affected unit before any artifact
@@ -145,6 +205,30 @@ module Lich
       :unavailable
     end
 
+    # @param gem_names [Array<String>]
+    # @return [Symbol] :approved, :declined, :timed_out, or :unavailable
+    def confirm_bundler_recovery(gem_names)
+      return :unavailable unless BundlerRecovery.supported?
+
+      body = "Required Ruby gems are not installed:\n#{Array(gem_names).map { |name| "  - #{name}" }.join("\n")}\n\n" \
+             "Lich can install the locked non-GTK runtime bundle to its private directory now.\n" \
+             "Gemfile.lock will not be changed.\n\nInstall now?"
+      script = %(display dialog #{macos_dialog_body(body)} with title #{TITLE.inspect} ) +
+               %(buttons {"Install", "Cancel"} default button "Install" with icon caution ) +
+               "giving up after #{BUNDLER_RECOVERY_TIMEOUT_SECONDS}"
+      output = IO.popen(['osascript', '-'], 'r+') do |io|
+        io.write(script)
+        io.close_write
+        io.read
+      end
+      return :timed_out if output.include?('gave up:true')
+      return :approved if output.include?('button returned:Install')
+
+      :declined
+    rescue StandardError
+      :unavailable
+    end
+
     # @param units [Array<Hash>] validated manifest recovery units
     # @return [String]
     def build_recovery_prompt(units)
@@ -176,6 +260,15 @@ module Lich
       error = ConsentError.new(reason)
       missing = units.flat_map { |unit| Array(unit['members']) }.uniq
       write_log(missing: missing, groups: groups, error: error)
+      show_notice("Required gem#{'s' if missing.length != 1} #{missing.join(', ')} not installed. Exiting.")
+    end
+
+    # @param missing [Array<String>]
+    # @param groups [Array<Symbol>]
+    # @param reason [String]
+    # @return [void]
+    def report_bundler_consent_failure(missing, groups, reason)
+      write_log(missing: missing, groups: groups, error: ConsentError.new(reason))
       show_notice("Required gem#{'s' if missing.length != 1} #{missing.join(', ')} not installed. Exiting.")
     end
 
@@ -253,11 +346,21 @@ module Lich
 
     # @param missing [Array<String>]
     # @param groups [Array<Symbol>]
+    # @param result [BundlerRecovery::Result]
+    # @return [void]
+    def write_bundler_recovery_log(missing:, groups:, result:)
+      write_log(missing: missing, groups: groups, event: 'Bundler recovery',
+                recovery_note: "Private non-GTK bundle staged and activated. Details: #{result.log_path}")
+    end
+
+    # @param missing [Array<String>]
+    # @param groups [Array<Symbol>]
     # @param error [Exception, nil]
     # @param event [String] log event name
     # @param recovery_units [Array<Hash>, nil] approved manifest units
+    # @param recovery_note [String, nil] additional approved recovery detail
     # @return [void]
-    def write_log(missing: [], groups: [:default], error: nil, event: 'failure', recovery_units: nil)
+    def write_log(missing: [], groups: [:default], error: nil, event: 'failure', recovery_units: nil, recovery_note: nil)
       log_path = File.join(TEMP_DIR, LOG_FILENAME)
       # verify! can run before init.rb creates TEMP_DIR (fresh install), so
       # ensure the directory exists or the alert would cite a log we never wrote.
@@ -272,6 +375,11 @@ module Lich
           recovery_units.each do |unit|
             f.puts "    - #{recovery_unit_label(unit)}: #{Array(unit['members']).join(', ')}"
           end
+          f.puts
+        end
+
+        if recovery_note
+          f.puts "  Recovery: #{recovery_note}"
           f.puts
         end
 
@@ -366,6 +474,7 @@ module Lich
     def show_notice(body)
       case RUBY_PLATFORM
       when /mswin|mingw|cygwin/ then notice_windows(body)
+      when /darwin/             then alert_macos(body)
       else                           alert_linux(body)
       end
     rescue StandardError
@@ -377,6 +486,16 @@ module Lich
     def notice_windows(body)
       require 'win32ole'
       WIN32OLE.new('WScript.Shell').Popup(body, CONSENT_TIMEOUT_SECONDS, TITLE, 64) # OK + information icon
+    end
+
+    # Relaunches using the known Lich Ruby entrypoint after a private macOS
+    # bundle was atomically activated. exec keeps the original command-line
+    # arguments while ensuring RubyGems rebuilds its specification state.
+    # @return [void]
+    def relaunch_after_bundler_recovery!
+      entrypoint = File.join(LICH_DIR, 'lich.rbw')
+      entrypoint = File.expand_path($PROGRAM_NAME) unless File.file?(entrypoint)
+      exec(Gem.ruby, entrypoint, *ARGV)
     end
 
     # @param body [String]

--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -35,11 +35,7 @@ module Lich
     def verify!(*groups)
       groups = [:default] if groups.empty?
       configure_gemfile!
-      # Bundler rebuilds RubyGems' paths while it first reads the Gemfile.
-      # Do that before adding a promoted private macOS bundle, or its path is
-      # discarded and the next check incorrectly requests another recovery.
       Bundler.definition
-      activate_bundler_recovery!
 
       missing = missing_gems(groups)
       return if missing.empty?
@@ -67,13 +63,7 @@ module Lich
 
         if result.success?
           write_bundler_recovery_log(missing: missing, groups: groups, result: result)
-          begin
-            relaunch_after_bundler_recovery!
-          rescue SystemCallError => e
-            alert(missing: missing, groups: groups, error: e)
-            exit 1
-          end
-          exit 0
+          exit(result.restart_required ? 0 : 1)
         end
 
         alert(missing: missing, groups: groups, error: DependencyRecovery::Error.new(result.error))
@@ -109,15 +99,6 @@ module Lich
     # @return [Boolean]
     def bundler_recovery_supported?(groups)
       BundlerRecovery.supported? && Array(groups).map(&:to_sym) == [:default]
-    end
-
-    # Adds a prior atomically promoted macOS bundle to RubyGems before Bundler
-    # inspects installed specifications. No Bundler.setup call is made.
-    # @return [Boolean]
-    def activate_bundler_recovery!
-      return false unless defined?(LICH_DIR) && BundlerRecovery.supported?
-
-      BundlerRecovery.activate!(lich_dir: LICH_DIR)
     end
 
     # Chooses the dependency groups that must be present before normal startup.
@@ -491,16 +472,6 @@ module Lich
     def notice_windows(body)
       require 'win32ole'
       WIN32OLE.new('WScript.Shell').Popup(body, CONSENT_TIMEOUT_SECONDS, TITLE, 64) # OK + information icon
-    end
-
-    # Relaunches using the known Lich Ruby entrypoint after a private macOS
-    # bundle was atomically activated. exec keeps the original command-line
-    # arguments while ensuring RubyGems rebuilds its specification state.
-    # @return [void]
-    def relaunch_after_bundler_recovery!
-      entrypoint = File.join(LICH_DIR, 'lich.rbw')
-      entrypoint = File.expand_path($PROGRAM_NAME) unless File.file?(entrypoint)
-      exec(Gem.ruby, entrypoint, *ARGV)
     end
 
     # @param body [String]

--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -35,7 +35,6 @@ module Lich
     def verify!(*groups)
       groups = [:default] if groups.empty?
       configure_gemfile!
-      Bundler.definition
 
       missing = missing_gems(groups)
       return if missing.empty?

--- a/spec/lib/bundler_recovery_spec.rb
+++ b/spec/lib/bundler_recovery_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Lich::BundlerRecovery do
 
       expect(recovery.preflight(['ascii_charts'])).to be_nil
     end
+
+    it 'does not require a shipped lockfile' do
+      FileUtils.rm_f(File.join(@lich_dir, 'Gemfile.lock'))
+      allow(recovery).to receive(:command_available?).and_return(true)
+
+      expect(recovery.preflight(['ascii_charts'])).to be_nil
+    end
   end
 
   describe '#recover' do
@@ -47,6 +54,7 @@ RSpec.describe Lich::BundlerRecovery do
           @install_environment = environment
           bundle_path = environment.fetch('BUNDLE_PATH')
           FileUtils.mkdir_p(File.join(bundle_path, 'ruby', RbConfig::CONFIG.fetch('ruby_version')))
+          File.write(File.join(bundle_path, 'Gemfile.lock'), "GEM\n  specs:\n")
           ['installed', '', status]
         else
           ['Bundler 4', '', status]
@@ -54,7 +62,7 @@ RSpec.describe Lich::BundlerRecovery do
       end
     end
 
-    it 'stages the frozen non-GTK bundle before atomically activating it' do
+    it 'stages the non-GTK bundle before atomically activating it' do
       result = recovery.recover(['ox'])
       store = File.join(@lich_dir, described_class::STORE_DIRNAME)
       record = JSON.parse(File.read(File.join(store, described_class::ACTIVE_FILENAME)))
@@ -71,6 +79,20 @@ RSpec.describe Lich::BundlerRecovery do
       expect(@install_environment.fetch('BUNDLE_FROZEN')).to eq('true')
       expect(@install_environment.fetch('BUNDLE_WITHOUT').split(':'))
         .to include('gtk', 'development', 'vscode', 'profanity')
+    end
+
+    it 'resolves only in staging when the release package has no lockfile' do
+      FileUtils.rm_f(File.join(@lich_dir, 'Gemfile.lock'))
+
+      result = recovery.recover(['ox'])
+      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
+      record = JSON.parse(File.read(File.join(store, described_class::ACTIVE_FILENAME)))
+      promoted_lockfile = File.join(store, record.fetch('bundle_id'), 'Gemfile.lock')
+
+      expect(result).to be_success
+      expect(@install_environment.fetch('BUNDLE_FROZEN')).to eq('false')
+      expect(File).not_to exist(File.join(@lich_dir, 'Gemfile.lock'))
+      expect(File).to exist(promoted_lockfile)
     end
 
     it 'does not activate or retain a staged bundle when Bundler fails' do

--- a/spec/lib/bundler_recovery_spec.rb
+++ b/spec/lib/bundler_recovery_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe Lich::BundlerRecovery do
     end
 
     it 'restores the exact backed-up package and does not restart when installation fails' do
+      original = write_installed_spec('recovery-target', '1.0.0', marker: 'preserve')
       replacement = write_installed_spec('recovery-target', '2.0.0', marker: 'old')
       work_dir = Dir.mktmpdir('promotion-', @lich_dir)
       payload, path = payload_for(work_dir, replacement)
@@ -208,6 +209,8 @@ RSpec.describe Lich::BundlerRecovery do
       expect { subject.send(:run_macos_replacement!, payload, payload_path: path) }.to raise_error('install failed')
       expect(File.read(File.join(@gem_home, 'gems', replacement.full_name, 'marker'))).to eq('old')
       expect(File).to exist(File.join(@gem_home, 'specifications', "#{replacement.full_name}.gemspec"))
+      expect(File.read(File.join(@gem_home, 'gems', original.full_name, 'marker'))).to eq('preserve')
+      expect(File).to exist(File.join(@gem_home, 'specifications', "#{original.full_name}.gemspec"))
       expect(File).not_to exist(work_dir)
     end
 

--- a/spec/lib/bundler_recovery_spec.rb
+++ b/spec/lib/bundler_recovery_spec.rb
@@ -8,133 +8,117 @@ require_relative '../../lib/bundler_recovery'
 RSpec.describe Lich::BundlerRecovery do
   let(:status) { instance_double(Process::Status, success?: true) }
 
-  before do
-    allow(described_class).to receive(:supported?).and_return(true)
-  end
-
   around do |example|
     Dir.mktmpdir('lich-bundler-recovery-spec') do |dir|
       @lich_dir = dir
+      @gem_home = File.join(dir, 'runtime-gems')
       File.write(File.join(dir, 'Gemfile'), "source 'https://rubygems.org'\n")
-      File.write(File.join(dir, 'Gemfile.lock'), "GEM\n  specs:\n")
       example.run
     end
   end
 
-  subject(:recovery) { described_class.new(lich_dir: @lich_dir) }
+  def recovery(&launcher)
+    helper = lambda do |path|
+      launcher.call(path)
+      FileUtils.rm_rf(File.dirname(path)) # Mirrors detached helper cleanup in unit tests.
+    end
+    described_class.new(lich_dir: @lich_dir, gem_home: @gem_home, helper_launcher: helper)
+  end
+
+  before { allow(described_class).to receive(:supported?).and_return(true) }
 
   describe '#preflight' do
-    it 'requires the macOS native build tools when Ox is missing' do
-      allow(recovery).to receive(:command_available?).and_return(true)
-      allow(recovery).to receive(:ruby_headers).and_return('/missing/ruby/headers')
+    it 'requires native build tools when Ox is missing' do
+      subject = recovery { |_| }
+      allow(subject).to receive(:command_available?).and_return(true)
+      allow(subject).to receive(:ruby_headers).and_return('/missing/ruby/headers')
 
-      expect(recovery.preflight(['ox'])).to include('Ruby development headers')
+      expect(subject.preflight(['ox'])).to include('Ruby development headers')
     end
 
-    it 'does not require a compiler for a pure Ruby missing gem' do
-      allow(recovery).to receive(:command_available?).and_return(true)
+    it 'does not require a lockfile for a pure Ruby missing gem' do
+      subject = recovery { |_| }
+      allow(subject).to receive(:command_available?).and_return(true)
 
-      expect(recovery.preflight(['ascii_charts'])).to be_nil
-    end
-
-    it 'does not require a shipped lockfile' do
-      FileUtils.rm_f(File.join(@lich_dir, 'Gemfile.lock'))
-      allow(recovery).to receive(:command_available?).and_return(true)
-
-      expect(recovery.preflight(['ascii_charts'])).to be_nil
+      expect(subject.preflight(['ascii_charts'])).to be_nil
     end
   end
 
   describe '#recover' do
     before do
-      allow(recovery).to receive(:preflight).and_return(nil)
-      allow(Open3).to receive(:capture3) do |*arguments, **_options|
-        environment = arguments.first
-        if environment.is_a?(Hash)
-          @install_environment = environment
-          bundle_path = environment.fetch('BUNDLE_PATH')
-          FileUtils.mkdir_p(File.join(bundle_path, 'ruby', RbConfig::CONFIG.fetch('ruby_version')))
-          File.write(File.join(bundle_path, 'Gemfile.lock'), "GEM\n  specs:\n")
-          ['installed', '', status]
-        else
-          ['Bundler 4', '', status]
-        end
+      allow_any_instance_of(described_class).to receive(:preflight).and_return(nil)
+      allow_any_instance_of(described_class).to receive(:promotion_packages)
+        .and_return([{ 'name' => 'ox', 'version' => '2.14.28', 'path' => '/verified/ox.gem' }])
+      allow(Open3).to receive(:capture3).and_return(['installed', '', status])
+    end
+
+    it 'stages Bundler work in temp, then schedules an exit-time canonical promotion' do
+      payload = nil
+      subject = recovery { |path| payload = JSON.parse(File.read(path)) }
+
+      result = subject.recover(['ox'])
+
+      expect(result).to be_success
+      expect(result.restart_required).to be(true)
+      expect(payload).to include('gem_home' => @gem_home, 'lich_dir' => @lich_dir)
+      expect(payload.fetch('packages')).to eq([{ 'name' => 'ox', 'version' => '2.14.28', 'path' => '/verified/ox.gem' }])
+      expect(File.directory?(payload.fetch('work_dir'))).to be(false)
+      expect(File).not_to exist(File.join(@lich_dir, '.lich-bundler-gems'))
+    end
+
+    it 'uses a staged lockfile in frozen mode when one was shipped' do
+      File.write(File.join(@lich_dir, 'Gemfile.lock'), "GEM\n")
+      environment = nil
+      allow(Open3).to receive(:capture3) do |env, *_args, **_options|
+        environment = env
+        ['installed', '', status]
       end
+      subject = recovery { |_| }
+
+      subject.recover(['ox'])
+
+      expect(environment.fetch('BUNDLE_FROZEN')).to eq('true')
+      expect(environment.fetch('BUNDLE_WITHOUT').split(':')).to include('gtk', 'development', 'vscode', 'profanity')
     end
 
-    it 'stages the non-GTK bundle before atomically activating it' do
-      result = recovery.recover(['ox'])
-      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
-      record = JSON.parse(File.read(File.join(store, described_class::ACTIVE_FILENAME)))
-
-      expect(result).to be_success
-      expect(record).to include('schema' => 1, 'ruby_api' => RbConfig::CONFIG.fetch('ruby_version'))
-      expect(File.directory?(File.join(store, record.fetch('bundle_id'), 'ruby', record.fetch('ruby_api')))).to be(true)
-      expect(Dir.children(store)).not_to include(a_string_starting_with('.staging-'))
-    end
-
-    it 'excludes GTK and non-runtime groups from the Bundler child environment' do
-      recovery.recover(['ox'])
-
-      expect(@install_environment.fetch('BUNDLE_FROZEN')).to eq('true')
-      expect(@install_environment.fetch('BUNDLE_WITHOUT').split(':'))
-        .to include('gtk', 'development', 'vscode', 'profanity')
-    end
-
-    it 'resolves only in staging when the release package has no lockfile' do
-      FileUtils.rm_f(File.join(@lich_dir, 'Gemfile.lock'))
-
-      result = recovery.recover(['ox'])
-      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
-      record = JSON.parse(File.read(File.join(store, described_class::ACTIVE_FILENAME)))
-      promoted_lockfile = File.join(store, record.fetch('bundle_id'), 'Gemfile.lock')
-
-      expect(result).to be_success
-      expect(@install_environment.fetch('BUNDLE_FROZEN')).to eq('false')
-      expect(File).not_to exist(File.join(@lich_dir, 'Gemfile.lock'))
-      expect(File).to exist(promoted_lockfile)
-    end
-
-    it 'does not activate or retain a staged bundle when Bundler fails' do
+    it 'cleans staging when Bundler fails before a helper is scheduled' do
       allow(status).to receive(:success?).and_return(false)
+      called = false
+      subject = recovery { |_| called = true }
 
-      result = recovery.recover(['ox'])
-      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
+      result = subject.recover(['ox'])
 
       expect(result).not_to be_success
-      expect(File).not_to exist(File.join(store, described_class::ACTIVE_FILENAME))
-      expect(Dir.children(store)).not_to include(a_string_starting_with('.staging-'))
+      expect(called).to be(false)
+      expect(Dir.glob(File.join(subject.send(:temp_dir), 'lich-bundler-recovery-*'))).to be_empty
     end
   end
 
-  describe '#activate!' do
-    it 'adds only a compatible promoted bundle to RubyGems' do
-      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
-      bundle_id = 'bundle-test'
-      home = File.join(store, bundle_id, 'ruby', RbConfig::CONFIG.fetch('ruby_version'))
-      FileUtils.mkdir_p(home)
-      active_record = {
-        'schema'      => 1,
-        'bundle_id'   => bundle_id,
-        'ruby_api'    => RbConfig::CONFIG.fetch('ruby_version'),
-        'ruby_engine' => RUBY_ENGINE,
-        'platform'    => RUBY_PLATFORM
-      }
-      File.write(File.join(store, described_class::ACTIVE_FILENAME), JSON.generate(active_record))
+  describe 'staged package selection' do
+    it 'selects only missing gems and unavailable runtime dependencies' do
+      staging = File.join(@lich_dir, 'staging')
+      home = File.join(staging, 'ruby', RbConfig::CONFIG.fetch('ruby_version'))
+      specs = File.join(home, 'specifications')
+      cache = File.join(home, 'cache')
+      FileUtils.mkdir_p([specs, cache])
 
-      expect(Gem).to receive(:use_paths).with(Gem.dir, array_including(home))
-      expect(Gem::Specification).to receive(:reset)
+      ox = Gem::Specification.new do |spec|
+        spec.name = 'ox'
+        spec.version = '2.14.28'
+        spec.summary = 'test'
+        spec.authors = ['Lich']
+        spec.add_runtime_dependency 'lich-recovery-support', '>= 4.0'
+      end
+      support = Gem::Specification.new { |spec| spec.name = 'lich-recovery-support'; spec.version = '4.1.2'; spec.summary = 'test'; spec.authors = ['Lich'] }
+      unrelated = Gem::Specification.new { |spec| spec.name = 'redis'; spec.version = '5.4.1'; spec.summary = 'test'; spec.authors = ['Lich'] }
+      [ox, support, unrelated].each do |spec|
+        File.write(File.join(specs, "#{spec.full_name}.gemspec"), spec.to_ruby)
+        File.write(File.join(cache, spec.file_name), '')
+      end
 
-      expect(recovery.activate!).to be(true)
-    end
+      packages = recovery { |_| }.send(:promotion_packages, ['ox'], staging)
 
-    it 'ignores a malformed active record without changing RubyGems paths' do
-      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
-      FileUtils.mkdir_p(store)
-      File.write(File.join(store, described_class::ACTIVE_FILENAME), '{not-json')
-
-      expect(Gem).not_to receive(:use_paths)
-      expect(recovery.activate!).to be(false)
+      expect(packages.map { |package| package.fetch('name') }).to contain_exactly('ox', 'lich-recovery-support')
     end
   end
 end

--- a/spec/lib/bundler_recovery_spec.rb
+++ b/spec/lib/bundler_recovery_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+require_relative '../../lib/bundler_recovery'
+
+RSpec.describe Lich::BundlerRecovery do
+  let(:status) { instance_double(Process::Status, success?: true) }
+
+  before do
+    allow(described_class).to receive(:supported?).and_return(true)
+  end
+
+  around do |example|
+    Dir.mktmpdir('lich-bundler-recovery-spec') do |dir|
+      @lich_dir = dir
+      File.write(File.join(dir, 'Gemfile'), "source 'https://rubygems.org'\n")
+      File.write(File.join(dir, 'Gemfile.lock'), "GEM\n  specs:\n")
+      example.run
+    end
+  end
+
+  subject(:recovery) { described_class.new(lich_dir: @lich_dir) }
+
+  describe '#preflight' do
+    it 'requires the macOS native build tools when Ox is missing' do
+      allow(recovery).to receive(:command_available?).and_return(true)
+      allow(recovery).to receive(:ruby_headers).and_return('/missing/ruby/headers')
+
+      expect(recovery.preflight(['ox'])).to include('Ruby development headers')
+    end
+
+    it 'does not require a compiler for a pure Ruby missing gem' do
+      allow(recovery).to receive(:command_available?).and_return(true)
+
+      expect(recovery.preflight(['ascii_charts'])).to be_nil
+    end
+  end
+
+  describe '#recover' do
+    before do
+      allow(recovery).to receive(:preflight).and_return(nil)
+      allow(Open3).to receive(:capture3) do |*arguments, **_options|
+        environment = arguments.first
+        if environment.is_a?(Hash)
+          @install_environment = environment
+          bundle_path = environment.fetch('BUNDLE_PATH')
+          FileUtils.mkdir_p(File.join(bundle_path, 'ruby', RbConfig::CONFIG.fetch('ruby_version')))
+          ['installed', '', status]
+        else
+          ['Bundler 4', '', status]
+        end
+      end
+    end
+
+    it 'stages the frozen non-GTK bundle before atomically activating it' do
+      result = recovery.recover(['ox'])
+      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
+      record = JSON.parse(File.read(File.join(store, described_class::ACTIVE_FILENAME)))
+
+      expect(result).to be_success
+      expect(record).to include('schema' => 1, 'ruby_api' => RbConfig::CONFIG.fetch('ruby_version'))
+      expect(File.directory?(File.join(store, record.fetch('bundle_id'), 'ruby', record.fetch('ruby_api')))).to be(true)
+      expect(Dir.children(store)).not_to include(a_string_starting_with('.staging-'))
+    end
+
+    it 'excludes GTK and non-runtime groups from the Bundler child environment' do
+      recovery.recover(['ox'])
+
+      expect(@install_environment.fetch('BUNDLE_FROZEN')).to eq('true')
+      expect(@install_environment.fetch('BUNDLE_WITHOUT').split(':'))
+        .to include('gtk', 'development', 'vscode', 'profanity')
+    end
+
+    it 'does not activate or retain a staged bundle when Bundler fails' do
+      allow(status).to receive(:success?).and_return(false)
+
+      result = recovery.recover(['ox'])
+      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
+
+      expect(result).not_to be_success
+      expect(File).not_to exist(File.join(store, described_class::ACTIVE_FILENAME))
+      expect(Dir.children(store)).not_to include(a_string_starting_with('.staging-'))
+    end
+  end
+
+  describe '#activate!' do
+    it 'adds only a compatible promoted bundle to RubyGems' do
+      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
+      bundle_id = 'bundle-test'
+      home = File.join(store, bundle_id, 'ruby', RbConfig::CONFIG.fetch('ruby_version'))
+      FileUtils.mkdir_p(home)
+      active_record = {
+        'schema'      => 1,
+        'bundle_id'   => bundle_id,
+        'ruby_api'    => RbConfig::CONFIG.fetch('ruby_version'),
+        'ruby_engine' => RUBY_ENGINE,
+        'platform'    => RUBY_PLATFORM
+      }
+      File.write(File.join(store, described_class::ACTIVE_FILENAME), JSON.generate(active_record))
+
+      expect(Gem).to receive(:use_paths).with(Gem.dir, array_including(home))
+      expect(Gem::Specification).to receive(:reset)
+
+      expect(recovery.activate!).to be(true)
+    end
+
+    it 'ignores a malformed active record without changing RubyGems paths' do
+      store = File.join(@lich_dir, described_class::STORE_DIRNAME)
+      FileUtils.mkdir_p(store)
+      File.write(File.join(store, described_class::ACTIVE_FILENAME), '{not-json')
+
+      expect(Gem).not_to receive(:use_paths)
+      expect(recovery.activate!).to be(false)
+    end
+  end
+end

--- a/spec/lib/bundler_recovery_spec.rb
+++ b/spec/lib/bundler_recovery_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Lich::BundlerRecovery do
     end
   end
 
-  def recovery(&launcher)
+  def recovery(installer: nil, &launcher)
     helper = lambda do |path|
       launcher.call(path)
       FileUtils.rm_rf(File.dirname(path)) # Mirrors detached helper cleanup in unit tests.
     end
-    described_class.new(lich_dir: @lich_dir, gem_home: @gem_home, helper_launcher: helper)
+    described_class.new(lich_dir: @lich_dir, gem_home: @gem_home, helper_launcher: helper, installer: installer)
   end
 
   before { allow(described_class).to receive(:supported?).and_return(true) }
@@ -48,7 +48,7 @@ RSpec.describe Lich::BundlerRecovery do
     before do
       allow_any_instance_of(described_class).to receive(:preflight).and_return(nil)
       allow_any_instance_of(described_class).to receive(:promotion_packages)
-        .and_return([{ 'name' => 'ox', 'version' => '2.14.28', 'path' => '/verified/ox.gem' }])
+        .and_return([{ 'name' => 'ox', 'version' => '2.14.28', 'full_name' => 'ox-2.14.28', 'path' => '/verified/ox.gem' }])
       allow(Open3).to receive(:capture3).and_return(['installed', '', status])
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Lich::BundlerRecovery do
       expect(result).to be_success
       expect(result.restart_required).to be(true)
       expect(payload).to include('gem_home' => @gem_home, 'lich_dir' => @lich_dir)
-      expect(payload.fetch('packages')).to eq([{ 'name' => 'ox', 'version' => '2.14.28', 'path' => '/verified/ox.gem' }])
+      expect(payload.fetch('packages')).to eq([{ 'name' => 'ox', 'version' => '2.14.28', 'full_name' => 'ox-2.14.28', 'path' => '/verified/ox.gem' }])
       expect(File.directory?(payload.fetch('work_dir'))).to be(false)
       expect(File).not_to exist(File.join(@lich_dir, '.lich-bundler-gems'))
     end
@@ -119,6 +119,88 @@ RSpec.describe Lich::BundlerRecovery do
       packages = recovery { |_| }.send(:promotion_packages, ['ox'], staging)
 
       expect(packages.map { |package| package.fetch('name') }).to contain_exactly('ox', 'lich-recovery-support')
+    end
+  end
+
+  describe 'detached promotion transaction' do
+    def write_installed_spec(name, version, marker:)
+      spec = Gem::Specification.new do |entry|
+        entry.name = name
+        entry.version = version
+        entry.summary = 'test'
+        entry.authors = ['Lich']
+      end
+      FileUtils.mkdir_p([File.join(@gem_home, 'specifications'), File.join(@gem_home, 'gems', spec.full_name)])
+      File.write(File.join(@gem_home, 'specifications', "#{spec.full_name}.gemspec"), spec.to_ruby)
+      File.write(File.join(@gem_home, 'gems', spec.full_name, 'marker'), marker)
+      spec
+    end
+
+    def payload_for(work_dir, spec)
+      archive = File.join(work_dir, "#{spec.full_name}.gem")
+      File.write(archive, 'verified test archive')
+      path = File.join(work_dir, 'macos-gem-promotion.json')
+      payload = {
+        'schema' => 1, 'parent_pid' => Process.pid, 'lich_dir' => @lich_dir,
+        'gem_home' => @gem_home, 'temp_dir' => File.dirname(work_dir), 'work_dir' => work_dir,
+        'packages' => [{ 'name' => spec.name, 'version' => spec.version.to_s, 'full_name' => spec.full_name, 'path' => archive }],
+        'restart' => { 'program' => File.join(@lich_dir, 'lich.rbw'), 'argv' => [], 'chdir' => @lich_dir }
+      }
+      File.write(path, JSON.generate(payload))
+      [payload, path]
+    end
+
+    def install_spec(spec, marker:)
+      FileUtils.mkdir_p([File.join(@gem_home, 'specifications'), File.join(@gem_home, 'gems', spec.full_name)])
+      File.write(File.join(@gem_home, 'specifications', "#{spec.full_name}.gemspec"), spec.to_ruby)
+      File.write(File.join(@gem_home, 'gems', spec.full_name, 'marker'), marker)
+    end
+
+    it 'promotes the exact package, preserves another version, validates, and restarts' do
+      original = write_installed_spec('recovery-target', '1.0.0', marker: 'preserve')
+      replacement = write_installed_spec('recovery-target', '2.0.0', marker: 'old')
+      work_dir = Dir.mktmpdir('promotion-', @lich_dir)
+      payload, path = payload_for(work_dir, replacement)
+      subject = recovery(installer: ->(_) { install_spec(replacement, marker: 'new') }) { |_| }
+      allow(subject).to receive(:wait_for_parent_exit)
+      expect(subject).to receive(:restart_lich).with(payload.fetch('restart'))
+
+      subject.send(:run_macos_replacement!, payload, payload_path: path)
+
+      expect(File.read(File.join(@gem_home, 'gems', replacement.full_name, 'marker'))).to eq('new')
+      expect(File.read(File.join(@gem_home, 'gems', original.full_name, 'marker'))).to eq('preserve')
+      expect(File).not_to exist(work_dir)
+    end
+
+    it 'restores the exact backed-up package and does not restart when installation fails' do
+      replacement = write_installed_spec('recovery-target', '2.0.0', marker: 'old')
+      work_dir = Dir.mktmpdir('promotion-', @lich_dir)
+      payload, path = payload_for(work_dir, replacement)
+      subject = recovery(installer: lambda { |_|
+        install_spec(replacement, marker: 'new')
+        raise 'install failed'
+      }) { |_| }
+      allow(subject).to receive(:wait_for_parent_exit)
+      expect(subject).not_to receive(:restart_lich)
+
+      expect { subject.send(:run_macos_replacement!, payload, payload_path: path) }.to raise_error('install failed')
+      expect(File.read(File.join(@gem_home, 'gems', replacement.full_name, 'marker'))).to eq('old')
+      expect(File).to exist(File.join(@gem_home, 'specifications', "#{replacement.full_name}.gemspec"))
+      expect(File).not_to exist(work_dir)
+    end
+
+    it 'does not clean a payload-supplied workspace unless it matches the payload directory' do
+      replacement = Gem::Specification.new { |entry| entry.name = 'recovery-target'; entry.version = '2.0.0'; entry.summary = 'test'; entry.authors = ['Lich'] }
+      work_dir = Dir.mktmpdir('promotion-', @lich_dir)
+      payload, path = payload_for(work_dir, replacement)
+      protected_dir = Dir.mktmpdir('protected-', @lich_dir)
+      payload['work_dir'] = protected_dir
+      File.write(path, JSON.generate(payload))
+      subject = recovery { |_| }
+
+      expect { subject.send(:run_macos_replacement!, payload, payload_path: path) }.to raise_error('invalid macOS gem promotion workspace')
+      expect(File).to exist(protected_dir)
+      FileUtils.rm_rf([work_dir, protected_dir])
     end
   end
 end

--- a/spec/lib/bundler_recovery_spec.rb
+++ b/spec/lib/bundler_recovery_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe Lich::BundlerRecovery do
     end
   end
 
+  describe '.run_macos_replacement' do
+    it 'logs malformed helper payloads in the Lich temp directory inferred from the payload path' do
+      temp = File.join(@lich_dir, 'temp')
+      FileUtils.mkdir_p(temp)
+      workspace = Dir.mktmpdir('promotion-', temp)
+      payload_path = File.join(workspace, 'macos-gem-promotion.json')
+      File.write(payload_path, '{invalid-json')
+
+      expect(described_class.run_macos_replacement(payload_path)).to be(false)
+      expect(File.read(File.join(temp, described_class::LOG_FILENAME))).to include('macOS gem promotion failed')
+    end
+  end
+
   describe '#recover' do
     before do
       allow_any_instance_of(described_class).to receive(:preflight).and_return(nil)
@@ -170,6 +183,15 @@ RSpec.describe Lich::BundlerRecovery do
       expect(File.read(File.join(@gem_home, 'gems', replacement.full_name, 'marker'))).to eq('new')
       expect(File.read(File.join(@gem_home, 'gems', original.full_name, 'marker'))).to eq('preserve')
       expect(File).not_to exist(work_dir)
+    end
+
+    it 'keeps Ruby default gems available while verifying the promoted package' do
+      replacement = write_installed_spec('recovery-target', '2.0.0', marker: 'new')
+      subject = recovery { |_| }
+      package = { 'name' => replacement.name, 'version' => replacement.version.to_s, 'full_name' => replacement.full_name }
+
+      expect(Gem).to receive(:use_paths).with(@gem_home, [@gem_home, Gem.default_dir].uniq)
+      subject.send(:verify_packages!, [package])
     end
 
     it 'restores the exact backed-up package and does not restart when installation fails' do

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -70,13 +70,6 @@ RSpec.describe Lich::GemCheck do
         described_class.verify!
       end
 
-      it 'initializes Bundler before activating a promoted private bundle' do
-        expect(Bundler).to receive(:definition).ordered.and_call_original
-        expect(described_class).to receive(:activate_bundler_recovery!).ordered
-
-        described_class.verify!
-      end
-
       it 'defaults to the :default group when none is given' do
         expect(described_class).to receive(:missing_gems).with([:default]).and_return([])
         described_class.verify!
@@ -126,24 +119,21 @@ RSpec.describe Lich::GemCheck do
     end
 
     context 'when macOS atomic Bundler recovery is available for default gems' do
-      let(:bundler_result) { Lich::BundlerRecovery::Result.new(log_path: '/tmp/bundler-recovery.log') }
+      let(:bundler_result) { Lich::BundlerRecovery::Result.new(log_path: '/tmp/bundler-recovery.log', restart_required: true) }
 
       before do
         allow(described_class).to receive(:missing_gems)
           .with([:default]).and_return(['ox'])
         allow(described_class).to receive(:self_healing_supported?).and_return(false)
         allow(described_class).to receive(:bundler_recovery_supported?).with([:default]).and_return(true)
-        allow(described_class).to receive(:activate_bundler_recovery!)
         allow(described_class).to receive(:recover_with_bundler_consent!)
           .with(['ox'], groups: [:default])
           .and_return(bundler_result)
       end
 
-      it 'logs the approved recovery and relaunches instead of continuing in the stale process' do
+      it 'logs the approved recovery and exits so the detached helper can promote and relaunch' do
         expect(described_class).to receive(:write_bundler_recovery_log)
           .with(missing: ['ox'], groups: [:default], result: bundler_result)
-        expect(described_class).to receive(:relaunch_after_bundler_recovery!)
-
         expect { described_class.verify! }.to raise_error(SystemExit) do |error|
           expect(error.status).to eq(0)
         end
@@ -152,7 +142,6 @@ RSpec.describe Lich::GemCheck do
       it 'reports a failed staged recovery without attempting a relaunch' do
         failed_result = Lich::BundlerRecovery::Result.new(error: 'compiler unavailable')
         allow(described_class).to receive(:recover_with_bundler_consent!).and_return(failed_result)
-        expect(described_class).not_to receive(:relaunch_after_bundler_recovery!)
         expect(described_class).to receive(:alert) do |missing:, groups:, error:|
           expect(missing).to eq(['ox'])
           expect(groups).to eq([:default])

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe Lich::GemCheck do
         described_class.verify!
       end
 
+      it 'initializes Bundler before activating a promoted private bundle' do
+        expect(Bundler).to receive(:definition).ordered.and_call_original
+        expect(described_class).to receive(:activate_bundler_recovery!).ordered
+
+        described_class.verify!
+      end
+
       it 'defaults to the :default group when none is given' do
         expect(described_class).to receive(:missing_gems).with([:default]).and_return([])
         described_class.verify!

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -106,11 +106,52 @@ RSpec.describe Lich::GemCheck do
         allow(described_class).to receive(:missing_gems)
           .with([:default]).and_return(['ox'])
         allow(described_class).to receive(:self_healing_supported?).and_return(false)
+        allow(described_class).to receive(:bundler_recovery_supported?).with([:default]).and_return(false)
       end
 
       it 'uses the ordinary missing-gem alert without fetching a manifest' do
         expect(described_class).not_to receive(:recover_with_consent!)
         expect(described_class).to receive(:alert).with(missing: ['ox'], groups: [:default])
+        expect { described_class.verify! }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+    end
+
+    context 'when macOS atomic Bundler recovery is available for default gems' do
+      let(:bundler_result) { Lich::BundlerRecovery::Result.new(log_path: '/tmp/bundler-recovery.log') }
+
+      before do
+        allow(described_class).to receive(:missing_gems)
+          .with([:default]).and_return(['ox'])
+        allow(described_class).to receive(:self_healing_supported?).and_return(false)
+        allow(described_class).to receive(:bundler_recovery_supported?).with([:default]).and_return(true)
+        allow(described_class).to receive(:activate_bundler_recovery!)
+        allow(described_class).to receive(:recover_with_bundler_consent!)
+          .with(['ox'], groups: [:default])
+          .and_return(bundler_result)
+      end
+
+      it 'logs the approved recovery and relaunches instead of continuing in the stale process' do
+        expect(described_class).to receive(:write_bundler_recovery_log)
+          .with(missing: ['ox'], groups: [:default], result: bundler_result)
+        expect(described_class).to receive(:relaunch_after_bundler_recovery!)
+
+        expect { described_class.verify! }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(0)
+        end
+      end
+
+      it 'reports a failed staged recovery without attempting a relaunch' do
+        failed_result = Lich::BundlerRecovery::Result.new(error: 'compiler unavailable')
+        allow(described_class).to receive(:recover_with_bundler_consent!).and_return(failed_result)
+        expect(described_class).not_to receive(:relaunch_after_bundler_recovery!)
+        expect(described_class).to receive(:alert) do |missing:, groups:, error:|
+          expect(missing).to eq(['ox'])
+          expect(groups).to eq([:default])
+          expect(error.message).to eq('compiler unavailable')
+        end
+
         expect { described_class.verify! }.to raise_error(SystemExit) do |error|
           expect(error.status).to eq(1)
         end
@@ -349,6 +390,16 @@ RSpec.describe Lich::GemCheck do
 
       allow(Gem).to receive(:win_platform?).and_return(false)
       expect(described_class.self_healing_supported?).to be(false)
+    end
+  end
+
+  describe '.bundler_recovery_supported?' do
+    before { allow(Lich::BundlerRecovery).to receive(:supported?).and_return(true) }
+
+    it 'is limited to the default runtime group so GTK cannot enter this path' do
+      expect(described_class.bundler_recovery_supported?([:default])).to be(true)
+      expect(described_class.bundler_recovery_supported?([:default, :gtk])).to be(false)
+      expect(described_class.bundler_recovery_supported?([:gtk])).to be(false)
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-approved macOS Bundler recovery flow for missing default runtime gems.
  * Safely stages Bundler work in a temporary area, validates exact gem versions before promoting, and relaunches after success.
  * Extended consent prompts and outcome handling for approved, declined, and unavailable recovery cases.

* **Documentation**
  * Added a macOS-only guide explaining eligibility, exclusions, lockfile behavior, installation targets, and troubleshooting logs.

* **Tests**
  * Added/expanded coverage for Bundler recovery selection, staging/failure cleanup, and macOS consent outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->