### PR TITLE
fix(all): lower game socket keepalive idle from 120s to 30s

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -435,7 +435,7 @@ module Lich
             SocketConfigurator.configure(@socket,
                                          keepalive: {
                                            enable: true,
-                                           idle: 120,      # 2 minutes before first keepalive
+                                           idle: 30,       # 30s idle before first keepalive; defensive against L3/L4 idle reapers (best-effort, see SocketConfigurator)
                                            interval: 30    # 30 seconds between keepalive probes
                                          },
                                          linger: {


### PR DESCRIPTION
## Summary

Lower the game socket's TCP keepalive **idle** time from `120` to `30` seconds so the OS starts probing an otherwise-silent socket much sooner. This is a cheap, defensive mitigation against intermediaries that reap quiet TCP flows -- **not** a proven root-cause fix (see Scope below).

## Problem

`Game.open` configures the game socket with `SocketConfigurator.configure(..., keepalive: { enable: true, idle: 120, interval: 30 })`. `idle: 120` means the OS does not send its first keepalive probe until **120 seconds** of silence.

On a quiet game connection (no player input, sparse server output), sessions were observed dropping:

```
info: shutdown requested reason=game_eof source=game_reader
info: marking session disconnected...
```

`game_eof` means the reader received a peer **FIN** (EOF). This is a peer-close, so it is independent of `READ_TIMEOUT_SECONDS` (#1426) -- raising that timeout does not help, because the connection is already gone.

## Fix

Set `idle: 30`. The OS now sends keepalive traffic after 30s of silence instead of 120s. More frequent keepalive probes reset idle timers on any L3/L4 intermediary (NAT gateway, firewall, router) that reaps quiet TCP flows, at a cost of one ACK-only probe per 30s of silence. No effect on active connections.

## Scope and caveats

This is a **mitigation**, not a demonstrated root-cause fix. Being explicit so the change is not oversold:

- **The `game_eof` log does not prove NAT/firewall reaping.** A clean FIN is consistent with several causes: an L4 NAT/firewall tearing down the flow, a stateful L7 proxy, or the **game server itself** closing an idle session. (A pure L3/L4 NAT that merely expires its mapping typically does *not* send a FIN -- the client would instead see an RST or timeout on its next send.) Lowering keepalive idle helps the L3/L4 case; it will **not** prevent an application- or L7-level idle disconnect, because keepalive probes carry no payload.
- **Dead-peer detection time is platform-dependent** (via `SocketConfigurator`):
  - **Unix (macOS/BSD):** `TCP_KEEPCNT` is 5 -> ~3 min.
  - **Linux:** `TCP_USER_TIMEOUT` (120s) governs -> ~2.5 min.
  - **Windows:** the probe count is not settable via `WSAIoctl` (Vista+ fixes it at 10), so detection is ~5.5 min. If the `WSAIoctl` path fails, the socket falls back to the Windows default idle (2 hours) and this change has no effect.

## Notes

- One-line change (plus the inline comment).
- Keepalive is best-effort per platform; `SocketConfigurator` already handles `TCP_KEEPIDLE`/`TCP_KEEPALIVE` differences and rescues unsupported options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)