### PR TITLE
fix(all): keep ActiveSessions owner discovery stable under session churn

### DIFF
--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -45,6 +45,22 @@ module Lich
       # @return [String]
       DISCOVERY_FILENAME = 'lich-active-sessions.json'
 
+      # Number of times a discovered owner is probed before it is treated as
+      # unreachable during an election decision.
+      #
+      # A single probe can time out transiently while the host is saturated by
+      # bulk session churn (mass login/logout), even against a perfectly healthy
+      # owner. Re-probing before electing a replacement prevents a disruptive,
+      # unnecessary takeover.
+      #
+      # @return [Integer]
+      OWNER_PROBE_ATTEMPTS = 3
+
+      # Delay, in seconds, between owner responsiveness probes.
+      #
+      # @return [Float]
+      OWNER_PROBE_BACKOFF_SECONDS = 0.1
+
       @registry = nil
       @server = nil
       @service_client = nil
@@ -89,6 +105,12 @@ module Lich
       # @param allow_bootstrap [Boolean] when false, never start a new server
       # @return [Boolean]
       def self.ensure_service_internal!(allow_bootstrap:)
+        # This process already owns a healthy server: keep the shared discovery
+        # pointer authoritative and reuse it. This self-heals a pointer that was
+        # cleared or overwritten by a peer, without a disruptive re-election.
+        return true if serving_owner_reasserted?
+
+        # A healthy peer owner is already reachable on the fast path.
         return true if service_available?
         return false unless allow_bootstrap
 
@@ -97,65 +119,133 @@ module Lich
         # while still preventing creation of a brand-new owner after disable.
         return false unless enabled?
 
+        # A single probe can time out transiently under heavy churn. Re-probe
+        # with a short backoff before electing ourselves so we do not take over
+        # from a briefly-overloaded but healthy owner. Performed outside the
+        # bootstrap lock so it never stalls peer threads in this process.
+        return true if service_responsive?
+
         @mutex.synchronize do
+          # Another thread or process may have won election while we waited for
+          # the lock.
           return true if service_available?
 
-          # If this process previously owned a server whose accept thread
-          # died, the TCPServer socket is still bound but unserviceable.
-          # Stop it to release the port before attempting a fresh start.
-          if @server && !@server.running?
-            Lich.log("warning: ActiveSessions in-process zombie detected pid=#{Process.pid} -- releasing socket") if Lich.respond_to?(:log)
-            @server.stop
-            @server = nil
-          end
-
-          # Detect cross-process zombie: discovery points to another process
-          # whose service is unresponsive (dead accept thread holding the port).
-          discovery = load_discovery
-          if discovery[:owner_pid] && discovery[:owner_pid] != Process.pid
-            return true if service_available?
-
-            owner_alive = begin
-              Process.kill(0, discovery[:owner_pid])
-              true
-            rescue Errno::ESRCH
-              false
-            rescue Errno::EPERM
-              true
-            end
-
-            if owner_alive
-              Lich.log(
-                "warning: ActiveSessions cross-process zombie: " \
-                "owner pid=#{discovery[:owner_pid]} alive but unresponsive, clearing stale discovery"
-              ) if Lich.respond_to?(:log)
-              delete_discovery_if_owner(discovery[:owner_pid], discovery[:auth_token])
-              return false
-            end
-
-            delete_discovery_if_owner(discovery[:owner_pid])
-          end
-
-          @registry ||= Registry.new
-          @server ||= Server.new(
-            host: DEFAULT_HOST,
-            port: DEFAULT_PORT,
-            registry: @registry,
-            auth_token: SecureRandom.hex(32)
-          )
-          unless @server.start
-            @server = nil
-            return false
-          end
-
-          write_discovery(owner_pid: Process.pid, auth_token: @server.auth_token)
-          true
+          release_in_process_zombie!
+          bootstrap_owner!
         end
       rescue StandardError => e
         Lich.log("warning: ActiveSessions service unavailable: #{e.class}: #{e.message}") if Lich.respond_to?(:log)
         false
       end
       private_class_method :ensure_service_internal!
+
+      # Ensures the shared discovery pointer advertises this process whenever it
+      # owns a running server, rewriting the pointer only when it is missing or
+      # stale.
+      #
+      # Because only one process can hold the service port at a time, a running
+      # in-process server is proof that this process is the true owner; any
+      # discovery record naming a different owner is therefore stale. Re-writing
+      # it here lets an owner recover a pointer that a peer deleted or clobbered
+      # after a transient false positive, within a single heartbeat, instead of
+      # the pointer staying lost until this process exits.
+      #
+      # @return [Boolean] true when this process owns a healthy server
+      def self.serving_owner_reasserted?
+        @mutex.synchronize do
+          return false unless owns_running_server?
+
+          reassert_discovery_unlocked!
+          true
+        end
+      end
+      private_class_method :serving_owner_reasserted?
+
+      # Returns whether this process holds a server with a live accept loop.
+      #
+      # @return [Boolean]
+      def self.owns_running_server?
+        !@server.nil? && @server.running?
+      end
+      private_class_method :owns_running_server?
+
+      # Rewrites the discovery pointer to this process when it is absent or does
+      # not already match this owner's pid and token.
+      #
+      # @note The caller must hold {@mutex}.
+      # @return [void]
+      def self.reassert_discovery_unlocked!
+        discovery = load_discovery
+        return if discovery[:owner_pid] == Process.pid && discovery[:auth_token] == @server.auth_token
+
+        write_discovery(owner_pid: Process.pid, auth_token: @server.auth_token)
+      end
+      private_class_method :reassert_discovery_unlocked!
+
+      # Probes the discovered service repeatedly with a short backoff so a
+      # transient timeout under load does not read as an unreachable owner.
+      #
+      # @param attempts [Integer] number of probe attempts
+      # @param backoff [Float] delay in seconds between attempts
+      # @return [Boolean] true when any probe succeeds
+      def self.service_responsive?(attempts: OWNER_PROBE_ATTEMPTS, backoff: OWNER_PROBE_BACKOFF_SECONDS)
+        attempts.times do |attempt|
+          return true if service_available?
+
+          sleep(backoff) unless attempt == attempts - 1
+        end
+        false
+      end
+      private_class_method :service_responsive?
+
+      # Stops and clears an in-process server whose accept loop has died, so its
+      # still-bound socket is released before a fresh bind is attempted.
+      #
+      # @note The caller must hold {@mutex}.
+      # @return [void]
+      def self.release_in_process_zombie!
+        return unless @server && !@server.running?
+
+        Lich.log("warning: ActiveSessions in-process zombie detected pid=#{Process.pid} -- releasing socket") if Lich.respond_to?(:log)
+        @server.stop
+        @server = nil
+      end
+      private_class_method :release_in_process_zombie!
+
+      # Binds a fresh owner server for this process and publishes discovery.
+      #
+      # The bind itself is the authority on whether another owner still holds
+      # the port, which avoids trusting the bare liveness of a possibly-recycled
+      # pid:
+      #
+      # * A successful bind means no live owner held the port (it exited, or its
+      #   pid was recycled by an unrelated process), so we become the owner and
+      #   overwrite any stale discovery pointer.
+      # * A failed bind means a real owner still holds the port, so we leave its
+      #   discovery pointer untouched and back off until a later tick. We never
+      #   delete a peer's pointer, so a healthy owner is never knocked offline by
+      #   a transient probe failure.
+      #
+      # @note The caller must hold {@mutex}.
+      # @return [Boolean] true when this process became the owner
+      def self.bootstrap_owner!
+        @registry ||= Registry.new
+        @server ||= Server.new(
+          host: DEFAULT_HOST,
+          port: DEFAULT_PORT,
+          registry: @registry,
+          auth_token: SecureRandom.hex(32)
+        )
+
+        unless @server.start
+          @server = nil
+          return false
+        end
+
+        write_discovery(owner_pid: Process.pid, auth_token: @server.auth_token)
+        true
+      end
+      private_class_method :bootstrap_owner!
 
       # Registers or updates a session record in the local service.
       #

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
     described_class.instance_variable_set(:@server, nil)
     described_class.instance_variable_set(:@mutex, Mutex.new)
     allow(described_class).to receive(:enabled?).and_return(true)
+    # The election path re-probes a discovered owner with a short backoff
+    # before taking over. Neutralize the real delay so the suite stays fast
+    # while still exercising the retry logic.
+    allow(described_class).to receive(:sleep)
   end
 
   after do
@@ -238,13 +242,14 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
     end
 
     context 'when discovery points to a dead owner process' do
-      it 'deletes the stale discovery file and bootstraps a new server' do
+      it 'binds a replacement and overwrites the stale pointer' do
+        # The former owner exited, so the port is free and the bind succeeds,
+        # replacing the stale pointer with this process.
         stub_no_external_service
         File.write(
           File.join(temp_dir, 'lich-active-sessions.json'),
           JSON.dump(owner_pid: 99_999_999, auth_token: 'dead-owner-token', updated_at: Time.now.to_i)
         )
-        allow(Process).to receive(:kill).with(0, 99_999_999).and_raise(Errno::ESRCH)
 
         fresh_server = instance_double(
           Lich::InternalAPI::ActiveSessions::Server,
@@ -265,18 +270,76 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
       end
     end
 
-    context 'when discovery points to an alive but unresponsive owner' do
-      it 'deletes the stale discovery file and returns false without attempting to bind' do
+    context 'when discovery points to an owner that still holds the port' do
+      it 'backs off without deleting the healthy owner\'s discovery pointer' do
+        # A single probe fails transiently, but the owner is real and still
+        # holds the port, so the replacement bind fails with EADDRINUSE.
+        # Regression guard: earlier builds deleted the pointer here, knocking a
+        # healthy owner offline for every peer under churn.
         stub_no_external_service
+        discovery_file = File.join(temp_dir, 'lich-active-sessions.json')
+        File.write(
+          discovery_file,
+          JSON.dump(owner_pid: 99_999_998, auth_token: 'live-owner-token', updated_at: Time.now.to_i)
+        )
+
+        contended_server = instance_double(
+          Lich::InternalAPI::ActiveSessions::Server,
+          start: false,
+          stop: nil,
+          auth_token: 'would-be-token'
+        )
+        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(contended_server)
+
+        expect(described_class.ensure_service!).to be(false)
+
+        discovery = JSON.parse(File.read(discovery_file), symbolize_names: true)
+        expect(discovery[:owner_pid]).to eq(99_999_998)
+        expect(discovery[:auth_token]).to eq('live-owner-token')
+      end
+    end
+
+    context 'when discovery names an owner whose pid was recycled and the port is free' do
+      it 'takes over via a successful bind and overwrites the stale pointer' do
+        # The recorded pid appears alive (recycled by an unrelated process),
+        # but nobody holds the service port, so the bind succeeds. The bind --
+        # not the bare liveness of a recycled pid -- decides ownership.
+        stub_no_external_service
+        discovery_file = File.join(temp_dir, 'lich-active-sessions.json')
+        File.write(
+          discovery_file,
+          JSON.dump(owner_pid: 99_999_998, auth_token: 'recycled-pid-token', updated_at: Time.now.to_i)
+        )
+
+        fresh_server = instance_double(
+          Lich::InternalAPI::ActiveSessions::Server,
+          start: true,
+          stop: nil,
+          auth_token: 'takeover-token'
+        )
+        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(fresh_server)
+
+        expect(described_class.ensure_service!).to be(true)
+
+        discovery = JSON.parse(File.read(discovery_file), symbolize_names: true)
+        expect(discovery[:owner_pid]).to eq(Process.pid)
+        expect(discovery[:auth_token]).to eq('takeover-token')
+      end
+    end
+
+    context 'when a discovered owner answers on a retry after a transient miss' do
+      it 'reuses the owner and never elects a replacement' do
+        # First probe misses (churn-induced timeout), second probe succeeds.
+        flaky_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
+        allow(flaky_client).to receive(:ping).and_return(false, true)
+        allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(flaky_client)
         File.write(
           File.join(temp_dir, 'lich-active-sessions.json'),
-          JSON.dump(owner_pid: 99_999_998, auth_token: 'zombie-owner-token', updated_at: Time.now.to_i)
+          JSON.dump(owner_pid: 4242, auth_token: 'flaky-owner-token', updated_at: Time.now.to_i)
         )
-        allow(Process).to receive(:kill).with(0, 99_999_998).and_return(nil)
 
         expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-        expect(described_class.ensure_service!).to be(false)
-        expect(File.exist?(File.join(temp_dir, 'lich-active-sessions.json'))).to be(false)
+        expect(described_class.ensure_service!).to be(true)
       end
     end
 
@@ -339,17 +402,30 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
     end
 
     context 'peer behavior while owner is recovering' do
-      it 'does not attempt to bind on the first tick when zombie owner is alive' do
+      it 'leaves the recovering owner\'s discovery pointer intact when the bind is contended' do
+        # While an owner recovers its own accept thread it still holds the port,
+        # so a peer's takeover bind fails. The peer must back off without
+        # deleting the pointer, letting the owner re-assert itself.
         stub_no_external_service
-
+        discovery_file = File.join(temp_dir, 'lich-active-sessions.json')
         File.write(
-          File.join(temp_dir, 'lich-active-sessions.json'),
-          JSON.dump(owner_pid: 99_999_997, auth_token: 'zombie-token', updated_at: Time.now.to_i)
+          discovery_file,
+          JSON.dump(owner_pid: 99_999_997, auth_token: 'recovering-owner-token', updated_at: Time.now.to_i)
         )
-        allow(Process).to receive(:kill).with(0, 99_999_997).and_return(nil)
 
-        expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+        contended_server = instance_double(
+          Lich::InternalAPI::ActiveSessions::Server,
+          start: false,
+          stop: nil,
+          auth_token: 'would-be-token'
+        )
+        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(contended_server)
+
         expect(described_class.ensure_service!).to be(false)
+
+        discovery = JSON.parse(File.read(discovery_file), symbolize_names: true)
+        expect(discovery[:owner_pid]).to eq(99_999_997)
+        expect(discovery[:auth_token]).to eq('recovering-owner-token')
       end
 
       it 'fails gracefully on subsequent ticks after discovery is cleared' do
@@ -368,6 +444,73 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
         expect(results).to all(be(false))
         expect(described_class.instance_variable_get(:@server)).to be_nil
       end
+    end
+  end
+
+  describe 'owner discovery self-heal' do
+    # Installs a running-owner server double for this process so the owner
+    # fast path in ensure_service_internal! is exercised.
+    #
+    # @param auth_token [String] token the owned server advertises
+    # @return [RSpec::Mocks::InstanceVerifyingDouble] the installed server double
+    def install_running_owner(auth_token:)
+      server = instance_double(
+        Lich::InternalAPI::ActiveSessions::Server,
+        running?: true,
+        auth_token: auth_token,
+        stop: nil
+      )
+      described_class.instance_variable_set(:@server, server)
+      server
+    end
+
+    it 'recreates a discovery pointer that a peer deleted, within one tick' do
+      install_running_owner(auth_token: 'owner-token')
+      # Regression guard for the churn incident: a peer cleared the pointer,
+      # so nothing is on disk when this owner's heartbeat runs.
+      expect(described_class.ensure_service!).to be(true)
+
+      discovery = JSON.parse(
+        File.read(File.join(temp_dir, 'lich-active-sessions.json')),
+        symbolize_names: true
+      )
+      expect(discovery[:owner_pid]).to eq(Process.pid)
+      expect(discovery[:auth_token]).to eq('owner-token')
+    end
+
+    it 'overwrites a discovery pointer that a peer redirected to another owner' do
+      install_running_owner(auth_token: 'owner-token')
+      File.write(
+        File.join(temp_dir, 'lich-active-sessions.json'),
+        JSON.dump(owner_pid: 777, auth_token: 'usurper-token', updated_at: Time.now.to_i)
+      )
+
+      expect(described_class.ensure_service!).to be(true)
+
+      discovery = JSON.parse(
+        File.read(File.join(temp_dir, 'lich-active-sessions.json')),
+        symbolize_names: true
+      )
+      expect(discovery[:owner_pid]).to eq(Process.pid)
+      expect(discovery[:auth_token]).to eq('owner-token')
+    end
+
+    it 'does not rewrite discovery when the pointer already matches this owner' do
+      install_running_owner(auth_token: 'owner-token')
+      File.write(
+        File.join(temp_dir, 'lich-active-sessions.json'),
+        JSON.dump(owner_pid: Process.pid, auth_token: 'owner-token', updated_at: 1_700_000_000)
+      )
+
+      expect(described_class).not_to receive(:write_discovery)
+      expect(described_class.ensure_service!).to be(true)
+    end
+
+    it 'reuses the owned server without probing an external service' do
+      install_running_owner(auth_token: 'owner-token')
+
+      expect(described_class).not_to receive(:service_available?)
+      expect(described_class.ensure_service!).to be(true)
     end
   end
 


### PR DESCRIPTION
## Problem

During heavy session churn -- the weekly bulk-login run does mass premium-account swaps (killing/spawning owner-eligible sessions) then rapidly launches ~14 short-lived alt sessions per account -- the Active Sessions service becomes unreliable: sessions that are genuinely running are **absent from the snapshot for seconds-to-minutes**. Operator tooling reported "session not found" for 14/14 characters whose Lich logs show they ran to completion; a calm retry minutes later succeeded 14/14. The service was healthy before and after.

## Root cause

The cross-process "zombie" heuristic in `ensure_service_internal!` deleted the discovery pointer of a **still-healthy, still-listening owner** whenever:

1. a single 1s `Client#ping` timed out transiently (the host is saturated by bulk logins), or
2. the recorded `owner_pid` had been **recycled** by an unrelated churn process (so `Process.kill(0, pid)` reported it "alive").

Because the owner only wrote discovery at bootstrap and **never republished it**, and because a successor could not bind the still-held port (`EADDRINUSE`), the service went dark for every non-owner process until the owner process exited. In production this showed as bursts of 5-19 concurrent `clearing stale discovery` warnings at churn timestamps and multi-hour gaps between owner elections while the owner held the port throughout.

## Fix

Makes failover resilient without a persistence rewrite:

- **Owner self-heal** -- a process that owns a running server now re-asserts the shared discovery pointer on its heartbeat, rewriting it only when missing or stale. A pointer wrongly cleared by a peer reappears within one heartbeat instead of staying lost until the owner exits. (This alone would have prevented the incident.)
- **Tolerate transient probe failures** -- a discovered owner is re-probed with a short backoff before any takeover, so a churn-induced timeout doesn't trigger a disruptive election.
- **Bind-as-arbiter** -- the port bind is now the sole authority on whether a live owner remains. A successful bind takes over and overwrites a stale pointer (covers recycled pids and clean exits); a failed bind leaves the peer's pointer untouched and backs off. **The service never deletes a peer's discovery pointer**, so a healthy owner is never knocked offline by a transient false positive. This also removes the platform-fragile reliance on bare pid liveness.

The election is decomposed into small single-responsibility helpers (`serving_owner_reasserted?`, `service_responsive?`, `release_in_process_zombie!`, `bootstrap_owner!`), each fully YARD-documented.

## Tests

`spec/lib/internal_api/active_sessions_spec.rb` updated to assert the corrected contract and extended with adversarial/boundary coverage:

- owner self-heal after a peer **deletes** the pointer (recreated within one tick)
- owner self-heal after a peer **redirects** the pointer to another owner (overwritten)
- idempotence: no rewrite when the pointer already matches
- **retry tolerance**: an owner that answers on the 2nd probe is reused, never re-elected
- **recycled-pid takeover**: pid looks alive but the port is free -> bind succeeds and overwrites
- **contended bind back-off**: bind fails (real owner holds the port) -> return false and leave the live owner's pointer intact

All ActiveSessions specs pass (77 examples, 0 failures); `rubocop -A` reports no offenses on the touched files.

## Scope / follow-up

Focused on the owner/failover instability. A natural follow-up is to seed a new owner's in-memory registry from the existing persistent session store (`SessionsSettings` / `SessionDatabaseAdapter`) so a legitimate re-election repopulates instantly instead of over one heartbeat interval; filed separately to keep this change reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service ownership handling during startup and recovery.
  * Prevented healthy but temporarily overloaded services from being unnecessarily taken over.
  * Added self-healing for missing or incorrect service discovery information.
  * Improved recovery from stale ownership records and interrupted server states.
  * Preserved existing service ownership during competing takeover attempts.

* **Tests**
  * Expanded coverage for service recovery, ownership contention, retry behavior, and discovery self-healing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->