### PR TITLE
fix(all): resilient ActiveSessions ownership + shutdown watchdog

### DIFF
--- a/lib/common/shutdown_watchdog.rb
+++ b/lib/common/shutdown_watchdog.rb
@@ -59,16 +59,22 @@ module Lich
             return false if @armed
 
             @armed = true
-          end
 
-          @thread = Thread.new do
-            expired = @mutex.synchronize do
-              @condition.wait(@mutex, timeout) if @armed
-              @armed
-            end
-            if expired
-              dump_diagnostics(timeout)
-              on_expire.call
+            # Create the thread and record @thread while still holding the lock
+            # so the thread can identify itself. An arm/disarm/arm sequence can
+            # leave an earlier thread parked in the wait; gating on
+            # @thread == Thread.current ensures only the currently armed
+            # watchdog can expire, so a superseded thread never forces an exit.
+            @thread = Thread.new do
+              expired = @mutex.synchronize do
+                current = -> { @armed && @thread == Thread.current }
+                @condition.wait(@mutex, timeout) if current.call
+                current.call
+              end
+              if expired
+                dump_diagnostics(timeout)
+                on_expire.call
+              end
             end
           end
           true

--- a/lib/common/shutdown_watchdog.rb
+++ b/lib/common/shutdown_watchdog.rb
@@ -19,7 +19,7 @@ module Lich
     # process to exit, letting the OS reclaim all resources.
     #
     # It is intentionally dependency-light and cross-platform: plain Ruby
-    # threads, a condition variable for prompt disarm, and +exit!+.
+    # threads, a condition variable for prompt disarm, and +Process.exit!+.
     module ShutdownWatchdog
       # Default deadline, in seconds, before a stuck shutdown is forced.
       #
@@ -61,9 +61,12 @@ module Lich
         #
         # @param timeout [Numeric] deadline in seconds; +<= 0+ disables (no-op)
         # @param on_expire [#call] action taken when the deadline elapses;
-        #   defaults to an immediate, un-trappable process exit
+        #   defaults to an immediate, un-trappable process exit. Must be a real,
+        #   resolvable call: +Process.exit!+ is used (not a bare +exit!+, which
+        #   resolves against this module and raises +NoMethodError+, silently
+        #   defeating the force-exit guarantee).
         # @return [Boolean] true when a watchdog thread was started
-        def arm(timeout: configured_timeout, on_expire: -> { exit!(1) })
+        def arm(timeout: configured_timeout, on_expire: -> { Process.exit!(1) })
           return false if timeout.to_f <= 0
 
           @mutex.synchronize do
@@ -77,10 +80,22 @@ module Lich
             # @thread == Thread.current ensures only the currently armed
             # watchdog can expire, so a superseded thread never forces an exit.
             @thread = Thread.new do
+              # Anchor the deadline to the monotonic clock and re-wait on every
+              # wakeup. ConditionVariable#wait can return early on a spurious
+              # wakeup, and disarm/broadcast also wakes it; only a wakeup at or
+              # after the genuine deadline counts as expiry. Without this loop a
+              # spurious wakeup while still armed would force an exit before the
+              # configured timeout.
+              deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout.to_f
               expired = @mutex.synchronize do
-                current = -> { @armed && @thread == Thread.current }
-                @condition.wait(@mutex, timeout) if current.call
-                current.call
+                loop do
+                  break false unless @armed && @thread == Thread.current
+
+                  remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                  break true if remaining <= 0
+
+                  @condition.wait(@mutex, remaining)
+                end
               end
               if expired
                 dump_diagnostics(timeout)

--- a/lib/common/shutdown_watchdog.rb
+++ b/lib/common/shutdown_watchdog.rb
@@ -30,7 +30,18 @@ module Lich
       DEFAULT_TIMEOUT_SECONDS = 60
 
       # Name of the +lich_settings+ row that overrides {DEFAULT_TIMEOUT_SECONDS}.
-      # A value of +0+ (or negative) disables the watchdog.
+      #
+      # Operator reference:
+      # * The value is a whole number of seconds.
+      # * A positive value sets the force-exit deadline.
+      # * An explicit +0+ or negative value disables the watchdog.
+      # * A missing or non-numeric value falls back to {DEFAULT_TIMEOUT_SECONDS};
+      #   a malformed value is logged and never silently disables the watchdog.
+      #
+      # @example Set the deadline to 90 seconds from an in-game console
+      #   ;e Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) VALUES('shutdown_watchdog_timeout','90')")
+      # @example Disable the watchdog
+      #   ;e Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) VALUES('shutdown_watchdog_timeout','0')")
       #
       # @return [String]
       SETTING_NAME = 'shutdown_watchdog_timeout'
@@ -99,15 +110,27 @@ module Lich
           @mutex.synchronize { @armed }
         end
 
-        # Resolves the configured deadline from +lich_settings+, falling back to
-        # {DEFAULT_TIMEOUT_SECONDS} when unset or unreadable.
+        # Resolves the configured deadline from +lich_settings+.
+        #
+        # Falls back to {DEFAULT_TIMEOUT_SECONDS} when the setting is unset,
+        # unreadable, or non-numeric. A malformed value is logged and treated as
+        # the default rather than being coerced to +0+, so a typo cannot silently
+        # disable the watchdog; only an explicit numeric value of +0+ or less
+        # disables it.
         #
         # @return [Integer]
         def configured_timeout
           return DEFAULT_TIMEOUT_SECONDS unless defined?(Lich) && Lich.respond_to?(:db) && Lich.db
 
-          value = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='#{SETTING_NAME}';")
-          value.nil? ? DEFAULT_TIMEOUT_SECONDS : value.to_i
+          raw = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='#{SETTING_NAME}';")
+          return DEFAULT_TIMEOUT_SECONDS if raw.nil?
+
+          parsed = Integer(raw.to_s.strip, exception: false)
+          if parsed.nil?
+            log_line("invalid #{SETTING_NAME}=#{raw.inspect}; falling back to #{DEFAULT_TIMEOUT_SECONDS}s")
+            return DEFAULT_TIMEOUT_SECONDS
+          end
+          parsed
         rescue StandardError
           DEFAULT_TIMEOUT_SECONDS
         end

--- a/lib/common/shutdown_watchdog.rb
+++ b/lib/common/shutdown_watchdog.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require_relative 'shutdown_log'
+
+module Lich
+  module Common
+    # Guarantees that a shutting-down Lich process actually terminates.
+    #
+    # The teardown sequence runs several steps that can block indefinitely --
+    # notably inline +before_dying+/+at_exit+ script hooks, +Vars.save+,
+    # +Game.close+ (socket linger), database close, and lifecycle unregister IO.
+    # None of them are individually time-bounded. If one hangs, the process
+    # never reaches +exit+ and continues to hold its OS resources (open sockets,
+    # advisory locks) until it is killed by hand.
+    #
+    # This watchdog is armed at the start of teardown and disarmed once teardown
+    # completes. If the deadline elapses first, it dumps every thread's
+    # backtrace (so the debug log records *what* was stuck) and then forces the
+    # process to exit, letting the OS reclaim all resources.
+    #
+    # It is intentionally dependency-light and cross-platform: plain Ruby
+    # threads, a condition variable for prompt disarm, and +exit!+.
+    module ShutdownWatchdog
+      # Default deadline, in seconds, before a stuck shutdown is forced.
+      #
+      # Chosen to comfortably exceed a healthy teardown (bounded script drain
+      # plus state/socket/database closeout) while still bounding a hang.
+      #
+      # @return [Integer]
+      DEFAULT_TIMEOUT_SECONDS = 60
+
+      # Name of the +lich_settings+ row that overrides {DEFAULT_TIMEOUT_SECONDS}.
+      # A value of +0+ (or negative) disables the watchdog.
+      #
+      # @return [String]
+      SETTING_NAME = 'shutdown_watchdog_timeout'
+
+      @mutex = Mutex.new
+      @condition = ConditionVariable.new
+      @armed = false
+      @thread = nil
+
+      class << self
+        # Arms the watchdog.
+        #
+        # Spawns a single background thread that waits up to +timeout+ seconds.
+        # If the watchdog is still armed when the deadline elapses, it dumps
+        # diagnostics and invokes +on_expire+. A subsequent {disarm} wakes the
+        # thread immediately and prevents +on_expire+ from running.
+        #
+        # @param timeout [Numeric] deadline in seconds; +<= 0+ disables (no-op)
+        # @param on_expire [#call] action taken when the deadline elapses;
+        #   defaults to an immediate, un-trappable process exit
+        # @return [Boolean] true when a watchdog thread was started
+        def arm(timeout: configured_timeout, on_expire: -> { exit!(1) })
+          return false if timeout.to_f <= 0
+
+          @mutex.synchronize do
+            return false if @armed
+
+            @armed = true
+          end
+
+          @thread = Thread.new do
+            expired = @mutex.synchronize do
+              @condition.wait(@mutex, timeout) if @armed
+              @armed
+            end
+            if expired
+              dump_diagnostics(timeout)
+              on_expire.call
+            end
+          end
+          true
+        end
+
+        # Disarms the watchdog, waking the waiting thread so it exits without
+        # forcing termination. Idempotent and safe to call when not armed.
+        #
+        # @return [void]
+        def disarm
+          @mutex.synchronize do
+            @armed = false
+            @condition.broadcast
+          end
+          nil
+        end
+
+        # Returns whether the watchdog is currently armed.
+        #
+        # @return [Boolean]
+        def armed?
+          @mutex.synchronize { @armed }
+        end
+
+        # Resolves the configured deadline from +lich_settings+, falling back to
+        # {DEFAULT_TIMEOUT_SECONDS} when unset or unreadable.
+        #
+        # @return [Integer]
+        def configured_timeout
+          return DEFAULT_TIMEOUT_SECONDS unless defined?(Lich) && Lich.respond_to?(:db) && Lich.db
+
+          value = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='#{SETTING_NAME}';")
+          value.nil? ? DEFAULT_TIMEOUT_SECONDS : value.to_i
+        rescue StandardError
+          DEFAULT_TIMEOUT_SECONDS
+        end
+
+        private
+
+        # Writes a full thread backtrace dump to the shutdown/debug logs so the
+        # cause of a hung teardown is captured before the process is forced down.
+        #
+        # @param timeout [Numeric] the deadline that elapsed, for the log header
+        # @return [void]
+        def dump_diagnostics(timeout)
+          header = "ActiveShutdownWatchdog: shutdown exceeded #{timeout}s -- forcing exit pid=#{Process.pid}"
+          log_line(header)
+          Thread.list.each do |thread|
+            label = thread.name || thread.object_id
+            backtrace = (thread.backtrace || ['<no backtrace>']).join("\n\t")
+            log_line("thread #{label} status=#{thread.status.inspect}\n\t#{backtrace}")
+          end
+        rescue StandardError
+          nil
+        end
+
+        # Emits one diagnostic line to whichever loggers are available.
+        #
+        # @param message [String]
+        # @return [void]
+        def log_line(message)
+          Lich::Common::ShutdownLog.error(message) if defined?(Lich::Common::ShutdownLog)
+          Lich.log("warning: #{message}") if defined?(Lich) && Lich.respond_to?(:log)
+        end
+      end
+    end
+  end
+end

--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -352,12 +352,27 @@ module Lich
           registry: @registry,
           auth_token: SecureRandom.hex(32)
         )
+
+        # Once the lock is held, any failure before discovery is published must
+        # roll the lock (and a started server) back. Otherwise this process
+        # holds the ownership lock without a reachable, discoverable service --
+        # locking every peer out while being unable to serve itself.
         unless @server.start
           @server = nil
+          release_ownership_lock
           return false
         end
 
-        write_discovery(owner_pid: Process.pid, auth_token: @server.auth_token, port: @server.port)
+        begin
+          write_discovery(owner_pid: Process.pid, auth_token: @server.auth_token, port: @server.port)
+        rescue StandardError => e
+          Lich.log("warning: ActiveSessions discovery publish failed: #{e.class}: #{e.message}") if Lich.respond_to?(:log)
+          @server.stop
+          @server = nil
+          release_ownership_lock
+          return false
+        end
+
         true
       end
       private_class_method :claim_ownership_and_start!

--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -409,12 +409,20 @@ module Lich
       end
       private_class_method :release_ownership_lock
 
+      # Returns the base directory shared by local coordination files
+      # (the discovery record and the ownership lock).
+      #
+      # @return [String]
+      def self.coordination_dir
+        defined?(TEMP_DIR) ? TEMP_DIR : Dir.tmpdir
+      end
+      private_class_method :coordination_dir
+
       # Returns the on-disk ownership lock path shared by local sessions.
       #
       # @return [String]
       def self.lock_path
-        base_dir = defined?(TEMP_DIR) ? TEMP_DIR : Dir.tmpdir
-        File.join(base_dir, LOCK_FILENAME)
+        File.join(coordination_dir, LOCK_FILENAME)
       end
       private_class_method :lock_path
 
@@ -422,8 +430,7 @@ module Lich
       #
       # @return [String]
       def self.discovery_path
-        base_dir = defined?(TEMP_DIR) ? TEMP_DIR : Dir.tmpdir
-        File.join(base_dir, DISCOVERY_FILENAME)
+        File.join(coordination_dir, DISCOVERY_FILENAME)
       end
       private_class_method :discovery_path
 

--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -21,6 +21,14 @@ module Lich
     # - session registration and removal
     # - read-only snapshot retrieval
     #
+    # Ownership is coordinated with a cross-process advisory file lock
+    # (see {acquire_ownership_lock}) rather than a fixed, well-known TCP port.
+    # The single process that holds the lock binds an ephemeral port and
+    # publishes it in the discovery file; peers read that port to reach the
+    # owner. Because the kernel releases an advisory lock the instant its owning
+    # process dies, a crashed owner never blocks a successor, and there is no
+    # fixed port for a stuck process to squat.
+    #
     # The service is intentionally dormant unless its feature flag is enabled.
     # When disabled, all public entry points return inert values rather than
     # raising, so feature consumers can safely probe for availability.
@@ -35,20 +43,30 @@ module Lich
       # @return [String]
       DEFAULT_HOST = '127.0.0.1'
 
-      # Default TCP port used by the local service.
+      # Port passed to the transport to request an OS-assigned ephemeral port.
+      # The actual bound port is read back after {Server#start} and published in
+      # the discovery file.
       #
       # @return [Integer]
-      DEFAULT_PORT = 42_857
+      EPHEMERAL_PORT = 0
 
-      # Filename used to publish the current owner token for local clients.
+      # Filename used to publish the current owner metadata for local clients.
       #
       # @return [String]
       DISCOVERY_FILENAME = 'lich-active-sessions.json'
 
+      # Filename of the advisory lock used to elect a single service owner
+      # across processes.
+      #
+      # @return [String]
+      LOCK_FILENAME = 'lich-active-sessions.lock'
+
       @registry = nil
       @server = nil
+      @lock_file = nil
       @service_client = nil
       @service_client_token = nil
+      @service_client_port = nil
       @mutex = Mutex.new
       @service_client_mutex = Mutex.new
 
@@ -69,8 +87,9 @@ module Lich
 
       # Starts the local service if no healthy service is already responding.
       #
-      # The first process to win startup becomes the in-process server owner.
-      # All later callers reuse the same endpoint through the client adapter.
+      # The first process to win the ownership lock becomes the in-process
+      # server owner. All later callers reuse the same endpoint through the
+      # client adapter.
       #
       # @return [Boolean] true when a healthy service is available
       def self.ensure_service!
@@ -89,6 +108,11 @@ module Lich
       # @param allow_bootstrap [Boolean] when false, never start a new server
       # @return [Boolean]
       def self.ensure_service_internal!(allow_bootstrap:)
+        # Fast path 1: this process already owns a healthy server -- reuse it
+        # without touching discovery or the lock.
+        return true if owns_running_server?
+
+        # Fast path 2: a peer owner is reachable at the discovered port.
         return true if service_available?
         return false unless allow_bootstrap
 
@@ -98,58 +122,13 @@ module Lich
         return false unless enabled?
 
         @mutex.synchronize do
+          # Another thread or process may have won ownership while we waited
+          # for the lock.
+          return true if owns_running_server?
           return true if service_available?
 
-          # If this process previously owned a server whose accept thread
-          # died, the TCPServer socket is still bound but unserviceable.
-          # Stop it to release the port before attempting a fresh start.
-          if @server && !@server.running?
-            Lich.log("warning: ActiveSessions in-process zombie detected pid=#{Process.pid} -- releasing socket") if Lich.respond_to?(:log)
-            @server.stop
-            @server = nil
-          end
-
-          # Detect cross-process zombie: discovery points to another process
-          # whose service is unresponsive (dead accept thread holding the port).
-          discovery = load_discovery
-          if discovery[:owner_pid] && discovery[:owner_pid] != Process.pid
-            return true if service_available?
-
-            owner_alive = begin
-              Process.kill(0, discovery[:owner_pid])
-              true
-            rescue Errno::ESRCH
-              false
-            rescue Errno::EPERM
-              true
-            end
-
-            if owner_alive
-              Lich.log(
-                "warning: ActiveSessions cross-process zombie: " \
-                "owner pid=#{discovery[:owner_pid]} alive but unresponsive, clearing stale discovery"
-              ) if Lich.respond_to?(:log)
-              delete_discovery_if_owner(discovery[:owner_pid], discovery[:auth_token])
-              return false
-            end
-
-            delete_discovery_if_owner(discovery[:owner_pid])
-          end
-
-          @registry ||= Registry.new
-          @server ||= Server.new(
-            host: DEFAULT_HOST,
-            port: DEFAULT_PORT,
-            registry: @registry,
-            auth_token: SecureRandom.hex(32)
-          )
-          unless @server.start
-            @server = nil
-            return false
-          end
-
-          write_discovery(owner_pid: Process.pid, auth_token: @server.auth_token)
-          true
+          release_in_process_zombie!
+          claim_ownership_and_start!
         end
       rescue StandardError => e
         Lich.log("warning: ActiveSessions service unavailable: #{e.class}: #{e.message}") if Lich.respond_to?(:log)
@@ -253,12 +232,14 @@ module Lich
         {
           source: 'ActiveSessionsAPI',
           owner_pid: discovery[:owner_pid],
+          port: discovery[:port],
           updated_at: discovery[:updated_at],
           service_available: service_available?
         }.compact
       end
 
-      # Stops the in-process server if this process owns one.
+      # Stops the in-process server if this process owns one, releasing the
+      # ownership lock and clearing the published discovery record.
       #
       # This is intended for explicit service shutdown paths, not ordinary
       # lifecycle teardown for every session consumer.
@@ -269,25 +250,31 @@ module Lich
           @server&.stop
           @server = nil
           @registry = nil
+          release_ownership_lock
         end
         @service_client_mutex.synchronize do
           @service_client = nil
           @service_client_token = nil
+          @service_client_port = nil
         end
         delete_discovery_if_owned
       end
 
       # Returns a client configured from the current discovery record.
       #
+      # Returns nil unless discovery advertises both an auth token and the
+      # owner's ephemeral port.
+      #
       # @return [Lich::InternalAPI::ActiveSessions::Client, nil]
       def self.service_client
         discovery = load_discovery
-        return nil unless discovery[:auth_token]
+        return nil unless discovery[:auth_token] && discovery[:port]
 
         @service_client_mutex.synchronize do
-          if @service_client.nil? || @service_client_token != discovery[:auth_token]
-            @service_client = Client.new(host: DEFAULT_HOST, port: DEFAULT_PORT, auth_token: discovery[:auth_token])
+          if @service_client.nil? || @service_client_token != discovery[:auth_token] || @service_client_port != discovery[:port]
+            @service_client = Client.new(host: DEFAULT_HOST, port: discovery[:port], auth_token: discovery[:auth_token])
             @service_client_token = discovery[:auth_token]
+            @service_client_port = discovery[:port]
           end
           @service_client
         end
@@ -320,6 +307,117 @@ module Lich
       end
       private_class_method :service_available?
 
+      # Returns whether this process holds a server with a live accept loop.
+      #
+      # Because ownership is gated by an exclusive advisory lock, a running
+      # in-process server is proof that this process is the sole owner.
+      #
+      # @return [Boolean]
+      def self.owns_running_server?
+        !@server.nil? && @server.running?
+      end
+      private_class_method :owns_running_server?
+
+      # Stops and clears an in-process server whose accept loop has died so a
+      # fresh ephemeral listener can be bound. The ownership lock is retained,
+      # so this process simply re-publishes on the next bind.
+      #
+      # @note The caller must hold {@mutex}.
+      # @return [void]
+      def self.release_in_process_zombie!
+        return unless @server && !@server.running?
+
+        Lich.log("warning: ActiveSessions in-process zombie detected pid=#{Process.pid} -- rebinding") if Lich.respond_to?(:log)
+        @server.stop
+        @server = nil
+      end
+      private_class_method :release_in_process_zombie!
+
+      # Attempts to become the service owner and start the listener.
+      #
+      # Acquires the exclusive ownership lock (unless already held by this
+      # process from a prior bind), binds an ephemeral port, and publishes the
+      # owner metadata. If the lock is held by a live peer, no server is
+      # started and the peer is reused instead.
+      #
+      # @note The caller must hold {@mutex}.
+      # @return [Boolean] true when a healthy service is available afterwards
+      def self.claim_ownership_and_start!
+        return service_available? unless own_lock? || acquire_ownership_lock
+
+        @registry ||= Registry.new
+        @server ||= Server.new(
+          host: DEFAULT_HOST,
+          port: EPHEMERAL_PORT,
+          registry: @registry,
+          auth_token: SecureRandom.hex(32)
+        )
+        unless @server.start
+          @server = nil
+          return false
+        end
+
+        write_discovery(owner_pid: Process.pid, auth_token: @server.auth_token, port: @server.port)
+        true
+      end
+      private_class_method :claim_ownership_and_start!
+
+      # Returns whether this process currently holds the ownership lock.
+      #
+      # @return [Boolean]
+      def self.own_lock?
+        !@lock_file.nil?
+      end
+      private_class_method :own_lock?
+
+      # Attempts to acquire the cross-process ownership lock without blocking.
+      #
+      # On success the lock file handle is retained for the process lifetime so
+      # the advisory lock is held until this process releases it or exits (the
+      # kernel releases it automatically on process death).
+      #
+      # @note The caller must hold {@mutex}.
+      # @return [Boolean] true when the lock was acquired by this process
+      def self.acquire_ownership_lock
+        file = File.open(lock_path, File::RDWR | File::CREAT, 0o600)
+        if file.flock(File::LOCK_EX | File::LOCK_NB)
+          @lock_file = file
+          true
+        else
+          file.close
+          false
+        end
+      rescue StandardError => e
+        Lich.log("warning: ActiveSessions ownership lock unavailable: #{e.class}: #{e.message}") if Lich.respond_to?(:log)
+        false
+      end
+      private_class_method :acquire_ownership_lock
+
+      # Releases the ownership lock held by this process, if any.
+      #
+      # @note The caller must hold {@mutex}.
+      # @return [void]
+      def self.release_ownership_lock
+        return unless @lock_file
+
+        @lock_file.flock(File::LOCK_UN)
+        @lock_file.close
+      rescue StandardError
+        nil
+      ensure
+        @lock_file = nil
+      end
+      private_class_method :release_ownership_lock
+
+      # Returns the on-disk ownership lock path shared by local sessions.
+      #
+      # @return [String]
+      def self.lock_path
+        base_dir = defined?(TEMP_DIR) ? TEMP_DIR : Dir.tmpdir
+        File.join(base_dir, LOCK_FILENAME)
+      end
+      private_class_method :lock_path
+
       # Returns the on-disk discovery file path shared by local sessions.
       #
       # @return [String]
@@ -341,16 +439,19 @@ module Lich
       end
       private_class_method :load_discovery
 
-      # Persists the current service owner metadata so peer sessions can reuse
-      # the active service instead of starting a competing owner.
+      # Persists the current service owner metadata so peer sessions can reach
+      # the active service at its ephemeral port instead of starting a competing
+      # owner.
       #
       # @param owner_pid [Integer]
       # @param auth_token [String]
+      # @param port [Integer] the owner's bound ephemeral port
       # @return [void]
-      def self.write_discovery(owner_pid:, auth_token:)
+      def self.write_discovery(owner_pid:, auth_token:, port:)
         payload = {
           owner_pid: owner_pid,
           auth_token: auth_token,
+          port: port,
           updated_at: Time.now.to_i
         }
         temp_path = "#{discovery_path}.#{Process.pid}.tmp"
@@ -378,13 +479,10 @@ module Lich
       # deletion attempt.
       #
       # @param expected_owner_pid [Integer]
-      # @param expected_auth_token [String, nil] when provided, also requires
-      #   the token to match so a fresh rewrite by the same PID is not deleted
       # @return [void]
-      def self.delete_discovery_if_owner(expected_owner_pid, expected_auth_token = nil)
+      def self.delete_discovery_if_owner(expected_owner_pid)
         current = load_discovery
         return unless current[:owner_pid].to_i == expected_owner_pid.to_i
-        return if expected_auth_token && current[:auth_token] != expected_auth_token
 
         File.delete(discovery_path) if File.exist?(discovery_path)
       rescue StandardError
@@ -392,8 +490,8 @@ module Lich
       end
       private_class_method :delete_discovery_if_owner
 
-      # Removes the discovery file when the current process still owns the
-      # service and the shared registry is now empty.
+      # Removes the discovery file and stops the service when the current
+      # process still owns the service and the shared registry is now empty.
       #
       # @return [void]
       def self.cleanup_discovery_if_last_session!
@@ -409,6 +507,12 @@ module Lich
       rescue StandardError
         nil
       end
+
+      # Best-effort teardown registered so a normally-exiting owner promptly
+      # releases its listener, ownership lock, and discovery pointer -- letting
+      # a surviving peer take over without waiting for OS-level cleanup. Safe
+      # and inert for non-owner processes.
+      at_exit { stop_service! rescue nil }
     end
   end
 end

--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -328,8 +328,16 @@ module Lich
         return unless @server && !@server.running?
 
         Lich.log("warning: ActiveSessions in-process zombie detected pid=#{Process.pid} -- rebinding") if Lich.respond_to?(:log)
-        @server.stop
-        @server = nil
+        # Clear the reference in an ensure so a raising stop still drops the dead
+        # server. Otherwise a failed stop would leave @server pointing at the
+        # corpse, and every later retry would re-enter this method, call the same
+        # raising stop, and never rebind. The failure still propagates so the
+        # current attempt reports unavailable; the next attempt starts clean.
+        begin
+          @server.stop
+        ensure
+          @server = nil
+        end
       end
       private_class_method :release_in_process_zombie!
 
@@ -404,6 +412,11 @@ module Lich
         end
       rescue StandardError => e
         Lich.log("warning: ActiveSessions ownership lock unavailable: #{e.class}: #{e.message}") if Lich.respond_to?(:log)
+        # If File.open succeeded but flock raised, the handle is open and was
+        # never recorded as the owning lock. Close it here so repeated failures
+        # (e.g. Errno::ENOLCK on a filesystem without locking) cannot leak file
+        # descriptors. Skip when ownership was recorded (flock returned true).
+        file.close if file && !file.closed? && !@lock_file.equal?(file)
         false
       end
       private_class_method :acquire_ownership_lock

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -63,6 +63,7 @@ reconnect_if_wanted = proc {
   require File.join(LIB_DIR, 'common', 'shutdown_intent.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_log.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_script_drain.rb')
+  require File.join(LIB_DIR, 'common', 'shutdown_watchdog.rb')
 
   run_orderly_user_shutdown = proc {
     Lich::Common::OrderlyShutdown.request_user_exit(
@@ -991,6 +992,14 @@ reconnect_if_wanted = proc {
     # Lich continues script before_dying hooks, Vars.save, socket closeout, and
     # database closeout.  Lifecycle.stop remains later in shutdown and is the
     # point where this process is removed from the ActiveSessions registry.
+    # Guard the teardown steps below: several (inline before_dying/at_exit
+    # script hooks, Vars.save, Game.close linger, database close, lifecycle
+    # unregister IO) have no individual timeout and can hang, leaving the
+    # process alive and holding its sockets. The watchdog dumps thread
+    # backtraces and forces exit if teardown stalls; it is disarmed once the
+    # unbounded steps complete, before the deliberate reconnect/exec path.
+    Lich::Common::ShutdownWatchdog.arm if defined?(Lich::Common::ShutdownWatchdog)
+
     Lich::Common::ShutdownLog.info('marking session disconnected...')
     shutdown_step.call('ActiveSessions connection update') do
       Lich::InternalAPI::ActiveSessions::Lifecycle.update_connected(false) if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle)
@@ -1038,6 +1047,9 @@ reconnect_if_wanted = proc {
     shutdown_step.call('SessionLifecycle stop') do
       Lich::Common::SessionLifecycle.stop if defined?(Lich::Common::SessionLifecycle)
     end
+    # Unbounded teardown is complete; stand down before the deliberate
+    # reconnect sleep/exec and process exit so neither is force-killed.
+    Lich::Common::ShutdownWatchdog.disarm if defined?(Lich::Common::ShutdownWatchdog)
     flush_shutdown_trace.call
     shutdown_step.call('reconnect hook') { reconnect_if_wanted.call } # keep after closeout; may launch a replacement session
     clean_user_shutdown = Lich::Common::ShutdownCoordinator.orderly_user_exit? &&

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -65,14 +65,16 @@ reconnect_if_wanted = proc {
   require File.join(LIB_DIR, 'common', 'shutdown_script_drain.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_watchdog.rb')
 
-  run_orderly_user_shutdown = proc {
+  run_orderly_user_shutdown = proc { |source: :primary_frontend|
     # Guard the user-initiated ("...exit") drain too: it kills scripts and runs
     # their before_dying hooks inline (any of which can hang) before the main
     # teardown/watchdog below is reached, so arm here as well. arm is
-    # idempotent, so the later arm during teardown is a no-op.
+    # idempotent, so the later arm during teardown is a no-op. Both the primary
+    # and detachable frontend exit paths route through here so neither can run
+    # the hang-prone inline drain without the watchdog armed.
     Lich::Common::ShutdownWatchdog.arm if defined?(Lich::Common::ShutdownWatchdog)
     Lich::Common::OrderlyShutdown.request_user_exit(
-      source: :primary_frontend,
+      source: source,
       active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))
     )
   }
@@ -856,10 +858,11 @@ reconnect_if_wanted = proc {
               end
               client_string = "#{$cmd_prefix}#{client_string}" # if $frontend =~ /^(?:wizard|avalon)$/
               if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
-                Lich::Common::OrderlyShutdown.request_user_exit(
-                  source: :detachable_frontend,
-                  active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))
-                )
+                # Route through the guarded proc so the watchdog is armed before
+                # the inline before_dying drain, exactly as the primary frontend
+                # path does. A bare request_user_exit here would run the same
+                # hang-prone drain unprotected.
+                run_orderly_user_shutdown.call(source: :detachable_frontend)
                 break
               end
               begin

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -66,6 +66,11 @@ reconnect_if_wanted = proc {
   require File.join(LIB_DIR, 'common', 'shutdown_watchdog.rb')
 
   run_orderly_user_shutdown = proc {
+    # Guard the user-initiated ("...exit") drain too: it kills scripts and runs
+    # their before_dying hooks inline (any of which can hang) before the main
+    # teardown/watchdog below is reached, so arm here as well. arm is
+    # idempotent, so the later arm during teardown is a no-op.
+    Lich::Common::ShutdownWatchdog.arm if defined?(Lich::Common::ShutdownWatchdog)
     Lich::Common::OrderlyShutdown.request_user_exit(
       source: :primary_frontend,
       active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))

--- a/spec/lib/common/shutdown_watchdog_spec.rb
+++ b/spec/lib/common/shutdown_watchdog_spec.rb
@@ -83,6 +83,65 @@ RSpec.describe Lich::Common::ShutdownWatchdog do
 
       expect(first).to be_empty
     end
+
+    it 'uses an un-trappable Process.exit! as the default on_expire' do
+      # Regression for the shipped defect: the default lambda was a bare
+      # exit!(1), which resolved against the module and raised NoMethodError --
+      # neutering the force-exit guarantee. The default must call a real method.
+      exited = Queue.new
+      allow(Process).to receive(:exit!) { |code| exited << code }
+
+      described_class.arm(timeout: 0.02) # no on_expire -> exercise the real default
+
+      expect(Timeout.timeout(2) { exited.pop }).to eq(1)
+    end
+
+    it 'ignores a spurious condition-variable wakeup and fires only after the real deadline' do
+      # Regression: ConditionVariable#wait can return before its timeout on a
+      # spurious wakeup. The watchdog must re-wait against a monotonic deadline
+      # rather than treat any wakeup while armed as expiry.
+      fired = Queue.new
+      described_class.arm(timeout: 0.2, on_expire: -> { fired << :expired })
+
+      sleep 0.05 # let the watchdog thread park in the timed wait
+      mutex = described_class.instance_variable_get(:@mutex)
+      condition = described_class.instance_variable_get(:@condition)
+      mutex.synchronize { condition.signal } # spurious wakeup, still armed
+
+      sleep 0.02
+      expect(fired).to be_empty # the 0.2s deadline has not elapsed yet
+      expect(described_class.armed?).to be(true)
+
+      expect(Timeout.timeout(2) { fired.pop }).to eq(:expired) # still fires eventually
+    end
+
+    it 'still forces exit when diagnostics logging raises' do
+      allow(Lich::Common::ShutdownLog).to receive(:error).and_raise(StandardError, 'log sink down')
+      fired = Queue.new
+      described_class.arm(timeout: 0.02, on_expire: -> { fired << :expired })
+
+      expect(Timeout.timeout(2) { fired.pop }).to eq(:expired)
+    end
+
+    it 'treats a non-numeric timeout as disabled rather than arming' do
+      expect(described_class.arm(timeout: 'not-a-number', on_expire: -> { raise 'should not run' })).to be(false)
+      expect(described_class.armed?).to be(false)
+    end
+
+    it 'derives the deadline from configured_timeout when none is supplied' do
+      allow(described_class).to receive(:configured_timeout).and_return(0)
+      expect(described_class.arm(on_expire: -> { raise 'should not run' })).to be(false)
+    end
+
+    it 'admits only one winner when many threads race to arm' do
+      results = Queue.new
+      threads = Array.new(20) { Thread.new { results << described_class.arm(timeout: 5, on_expire: -> {}) } }
+      threads.each(&:join)
+
+      outcomes = Array.new(results.size) { results.pop }
+      expect(outcomes.count(true)).to eq(1)
+      expect(outcomes.count(false)).to eq(19)
+    end
   end
 
   describe '.disarm' do
@@ -115,6 +174,39 @@ RSpec.describe Lich::Common::ShutdownWatchdog do
       allow(Lich).to receive(:db).and_return(double(get_first_value: '0'))
 
       expect(described_class.configured_timeout).to eq(0)
+    end
+
+    it 'falls back to the default when the setting row is absent (nil)' do
+      allow(Lich).to receive(:db).and_return(double(get_first_value: nil))
+
+      expect(described_class.configured_timeout).to eq(described_class::DEFAULT_TIMEOUT_SECONDS)
+    end
+
+    it 'falls back to the default when the settings query raises' do
+      db = double
+      allow(db).to receive(:get_first_value).and_raise(StandardError, 'db locked')
+      allow(Lich).to receive(:db).and_return(db)
+
+      expect(described_class.configured_timeout).to eq(described_class::DEFAULT_TIMEOUT_SECONDS)
+    end
+
+    it 'parses a value with surrounding whitespace' do
+      allow(Lich).to receive(:db).and_return(double(get_first_value: '  90  '))
+
+      expect(described_class.configured_timeout).to eq(90)
+    end
+
+    it 'preserves an explicit negative value as an intentional disable' do
+      allow(Lich).to receive(:db).and_return(double(get_first_value: '-5'))
+
+      expect(described_class.configured_timeout).to eq(-5)
+    end
+
+    it 'rejects a non-integer numeric string and never silently disables' do
+      allow(Lich).to receive(:db).and_return(double(get_first_value: '90.5'))
+      allow(Lich).to receive(:log)
+
+      expect(described_class.configured_timeout).to eq(described_class::DEFAULT_TIMEOUT_SECONDS)
     end
   end
 end

--- a/spec/lib/common/shutdown_watchdog_spec.rb
+++ b/spec/lib/common/shutdown_watchdog_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'timeout'
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/shutdown_watchdog'
+
+RSpec.describe Lich::Common::ShutdownWatchdog do
+  before do
+    described_class.instance_variable_set(:@armed, false)
+    described_class.instance_variable_set(:@thread, nil)
+    described_class.instance_variable_set(:@mutex, Mutex.new)
+    described_class.instance_variable_set(:@condition, ConditionVariable.new)
+  end
+
+  after do
+    described_class.disarm
+    described_class.instance_variable_get(:@thread)&.join(1)
+  end
+
+  describe '.arm' do
+    it 'invokes on_expire after the deadline elapses' do
+      fired = Queue.new
+      expect(described_class.arm(timeout: 0.02, on_expire: -> { fired << :expired })).to be(true)
+
+      expect(Timeout.timeout(2) { fired.pop }).to eq(:expired)
+    end
+
+    it 'dumps thread diagnostics before forcing exit' do
+      allow(Lich::Common::ShutdownLog).to receive(:error)
+      fired = Queue.new
+      described_class.arm(timeout: 0.02, on_expire: -> { fired << :expired })
+
+      Timeout.timeout(2) { fired.pop }
+
+      expect(Lich::Common::ShutdownLog).to have_received(:error).at_least(:once)
+    end
+
+    it 'does not fire once disarmed before the deadline' do
+      fired = Queue.new
+      described_class.arm(timeout: 5, on_expire: -> { fired << :expired })
+
+      described_class.disarm
+      described_class.instance_variable_get(:@thread)&.join(1)
+
+      sleep 0.05
+      expect(fired).to be_empty
+    end
+
+    it 'is a no-op when the timeout is zero (disabled)' do
+      expect(described_class.arm(timeout: 0, on_expire: -> { raise 'should not run' })).to be(false)
+      expect(described_class.armed?).to be(false)
+    end
+
+    it 'is a no-op when the timeout is negative' do
+      expect(described_class.arm(timeout: -5, on_expire: -> { raise 'should not run' })).to be(false)
+    end
+
+    it 'refuses to arm twice concurrently' do
+      described_class.arm(timeout: 5, on_expire: -> {})
+      expect(described_class.arm(timeout: 5, on_expire: -> {})).to be(false)
+    end
+
+    it 'can be re-armed after being disarmed' do
+      described_class.arm(timeout: 5, on_expire: -> {})
+      described_class.disarm
+      described_class.instance_variable_get(:@thread)&.join(1)
+
+      expect(described_class.arm(timeout: 5, on_expire: -> {})).to be(true)
+    end
+  end
+
+  describe '.disarm' do
+    it 'is safe to call when not armed' do
+      expect { described_class.disarm }.not_to raise_error
+      expect(described_class.armed?).to be(false)
+    end
+  end
+
+  describe '.configured_timeout' do
+    it 'falls back to the default when no settings backend is available' do
+      hide_const('Lich')
+      expect(described_class.configured_timeout).to eq(described_class::DEFAULT_TIMEOUT_SECONDS)
+    end
+  end
+end

--- a/spec/lib/common/shutdown_watchdog_spec.rb
+++ b/spec/lib/common/shutdown_watchdog_spec.rb
@@ -97,5 +97,24 @@ RSpec.describe Lich::Common::ShutdownWatchdog do
       hide_const('Lich')
       expect(described_class.configured_timeout).to eq(described_class::DEFAULT_TIMEOUT_SECONDS)
     end
+
+    it 'falls back to the default (never silently disables) on a malformed value' do
+      allow(Lich).to receive(:db).and_return(double(get_first_value: 'abc'))
+      allow(Lich).to receive(:log)
+
+      expect(described_class.configured_timeout).to eq(described_class::DEFAULT_TIMEOUT_SECONDS)
+    end
+
+    it 'honors an explicit positive override' do
+      allow(Lich).to receive(:db).and_return(double(get_first_value: '90'))
+
+      expect(described_class.configured_timeout).to eq(90)
+    end
+
+    it 'treats an explicit non-positive value as an intentional disable' do
+      allow(Lich).to receive(:db).and_return(double(get_first_value: '0'))
+
+      expect(described_class.configured_timeout).to eq(0)
+    end
   end
 end

--- a/spec/lib/common/shutdown_watchdog_spec.rb
+++ b/spec/lib/common/shutdown_watchdog_spec.rb
@@ -68,6 +68,21 @@ RSpec.describe Lich::Common::ShutdownWatchdog do
 
       expect(described_class.arm(timeout: 5, on_expire: -> {})).to be(true)
     end
+
+    it 'does not let a disarmed thread fire after a subsequent re-arm' do
+      # Regression: an arm/disarm/arm sequence must not let the first (canceled)
+      # thread observe the second arming's @armed flag and force an exit.
+      first = Queue.new
+      described_class.arm(timeout: 0.05, on_expire: -> { first << :first })
+      described_class.disarm
+      first_thread = described_class.instance_variable_get(:@thread)
+
+      described_class.arm(timeout: 5, on_expire: -> {})
+      first_thread&.join(1)
+      sleep 0.15 # well past the first arming's 0.05s deadline
+
+      expect(first).to be_empty
+    end
   end
 
   describe '.disarm' do

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
       expect(read_discovery[:port]).to eq(56_000)
     end
 
-    it 'returns false and clears @server when the bind fails' do
+    it 'rolls back the lock and clears @server when the bind fails, so a successor can take over' do
       dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
       allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
       allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
@@ -145,6 +145,26 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
       expect(described_class.ensure_service!).to be(false)
       expect(described_class.instance_variable_get(:@server)).to be_nil
       expect(File.exist?(discovery_file)).to be(false)
+      # Regression: a failed bind must release the ownership lock so a peer
+      # (or this process on a later tick) can win it -- not strand it.
+      expect(described_class.instance_variable_get(:@lock_file)).to be_nil
+      expect(described_class.send(:acquire_ownership_lock)).to be(true)
+    end
+
+    it 'rolls back the server and lock when discovery publication fails' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      doomed = server_double(auth_token: 'started-token', port: 45_000, start: true)
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(doomed)
+      # Simulate a discovery write failure (e.g. File.rename over an existing
+      # file failing on Windows) after the server has already started.
+      allow(described_class).to receive(:write_discovery).and_raise(Errno::EACCES, 'rename failed')
+
+      expect(described_class.ensure_service!).to be(false)
+      expect(doomed).to have_received(:stop)
+      expect(described_class.instance_variable_get(:@server)).to be_nil
+      expect(described_class.instance_variable_get(:@lock_file)).to be_nil
+      expect(described_class.send(:acquire_ownership_lock)).to be(true)
     end
   end
 

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
       described_class.instance_variable_set(:@server, nil)
     end
 
-    it 'surfaces false when stopping a dead in-process server raises' do
+    it 'clears the dead server and recovers on retry when stopping it raises' do
       dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
       allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
       zombie = instance_double(
@@ -206,9 +206,35 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
       allow(zombie).to receive(:stop).and_raise(Errno::EBADF, 'bad fd during stop')
       described_class.instance_variable_set(:@server, zombie)
 
+      # The attempt that trips over the raising stop surfaces false...
       expect(described_class.ensure_service!).to be(false)
+      # ...but the dead reference must be cleared, or every future attempt would
+      # re-enter the same raising stop and the process could never rebind.
+      expect(described_class.instance_variable_get(:@server)).to be_nil
 
-      described_class.instance_variable_set(:@server, nil)
+      # A subsequent attempt binds a fresh listener instead of reusing the corpse.
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .and_return(server_double(auth_token: 'rebound-token', port: 42_000))
+      expect(described_class.ensure_service!).to be(true)
+      expect(read_discovery[:port]).to eq(42_000)
+    end
+
+    it 'closes the opened lock file (no fd leak) when flock raises' do
+      # File.open succeeds but flock blows up (e.g. a filesystem without record
+      # locking). The handle must be closed since it was never recorded as the
+      # owning lock.
+      leaked = instance_double(File, closed?: false)
+      allow(leaked).to receive(:flock).and_raise(Errno::ENOLCK, 'no locks available')
+      allow(leaked).to receive(:close)
+      allow(File).to receive(:open).and_call_original
+      allow(File).to receive(:open)
+        .with(File.join(temp_dir, 'lich-active-sessions.lock'), anything, anything)
+        .and_return(leaked)
+      allow(Lich).to receive(:log)
+
+      expect(described_class.send(:acquire_ownership_lock)).to be(false)
+      expect(leaked).to have_received(:close)
+      expect(described_class.instance_variable_get(:@lock_file)).to be_nil
     end
   end
 
@@ -405,7 +431,8 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
         out: writer
       )
       writer.close
-      expect(reader.gets).to eq("locked\n")
+      # Normalize the line ending: a child on a CRLF platform emits "locked\r\n".
+      expect(reader.gets.to_s.chomp).to eq('locked')
 
       # Denied while the external holder is alive.
       expect(described_class.send(:acquire_ownership_lock)).to be(false)

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -352,4 +352,56 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
       expect(described_class.query_snapshot[:error]).to eq('active sessions service unavailable')
     end
   end
+
+  describe 'ownership lock is close-on-exec' do
+    it 'holds the lock file close-on-exec so a reconnect exec cannot inherit it' do
+      allow(Lich::InternalAPI::ActiveSessions::Client)
+        .to receive(:new).and_return(instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false))
+      allow(Lich::InternalAPI::ActiveSessions::Server)
+        .to receive(:new).and_return(server_double(auth_token: 'owner-token', port: 40_000))
+
+      expect(described_class.ensure_service!).to be(true)
+
+      lock_file = described_class.instance_variable_get(:@lock_file)
+      expect(lock_file).not_to be_nil
+      expect(lock_file.close_on_exec?).to be(true)
+    end
+  end
+
+  # Exercises the crash-safety guarantee the whole design rests on: the kernel
+  # releases an advisory lock when its holder dies, so a successor can take over
+  # a lock a departed owner never got to release. This needs a real second
+  # process, so it is skipped where process spawning/signals are unavailable.
+  describe 'cross-process ownership handoff (integration)' do
+    it 'grants the lock to a successor after the holder is killed' do
+      skip 'requires process spawn + signals' unless Process.respond_to?(:kill)
+
+      lock = File.join(temp_dir, 'lich-active-sessions.lock')
+      reader, writer = IO.pipe
+      holder = spawn(
+        RbConfig.ruby, '-e',
+        "f = File.open(#{lock.inspect}, File::RDWR | File::CREAT, 0o600); " \
+        "f.flock(File::LOCK_EX); $stdout.puts('locked'); $stdout.flush; sleep 30",
+        out: writer
+      )
+      writer.close
+      expect(reader.gets).to eq("locked\n")
+
+      # Denied while the external holder is alive.
+      expect(described_class.send(:acquire_ownership_lock)).to be(false)
+
+      Process.kill('KILL', holder)
+      Process.wait(holder)
+      holder = nil
+
+      # Granted once the kernel releases the dead holder's lock.
+      expect(described_class.send(:acquire_ownership_lock)).to be(true)
+    ensure
+      reader&.close
+      if holder
+        Process.kill('KILL', holder) rescue nil
+        Process.wait(holder) rescue nil
+      end
+    end
+  end
 end

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -8,12 +8,18 @@ require_relative '../../../lib/internal_api/active_sessions'
 
 RSpec.describe Lich::InternalAPI::ActiveSessions do
   let(:temp_dir) { Dir.mktmpdir('active-sessions-spec') }
+  let(:discovery_file) { File.join(temp_dir, 'lich-active-sessions.json') }
 
   before do
     stub_const('TEMP_DIR', temp_dir)
     described_class.instance_variable_set(:@registry, nil)
     described_class.instance_variable_set(:@server, nil)
+    described_class.instance_variable_set(:@lock_file, nil)
+    described_class.instance_variable_set(:@service_client, nil)
+    described_class.instance_variable_set(:@service_client_token, nil)
+    described_class.instance_variable_set(:@service_client_port, nil)
     described_class.instance_variable_set(:@mutex, Mutex.new)
+    described_class.instance_variable_set(:@service_client_mutex, Mutex.new)
     allow(described_class).to receive(:enabled?).and_return(true)
   end
 
@@ -22,496 +28,328 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
     FileUtils.rm_rf(temp_dir)
   end
 
-  it 'starts a tokenized owner and writes discovery metadata' do
-    fake_server = instance_double(
+  # Builds a Server test double with the fields the election path reads back.
+  #
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def server_double(auth_token:, port:, start: true, running: true)
+    instance_double(
       Lich::InternalAPI::ActiveSessions::Server,
-      start: true,
-      stop: nil
-    )
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
-    allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(fake_server)
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:ping).and_return(false, true)
-    allow(fake_server).to receive(:auth_token).and_return('generated-token')
-
-    expect(described_class.ensure_service!).to be(true)
-
-    discovery = JSON.parse(File.read(File.join(temp_dir, 'lich-active-sessions.json')), symbolize_names: true)
-    expect(discovery[:owner_pid]).to eq(Process.pid)
-    expect(discovery[:auth_token]).to eq('generated-token')
-    expect(File.stat(File.join(temp_dir, 'lich-active-sessions.json')).mode & 0o777).to eq(0o600)
-  end
-
-  it 'reuses an existing healthy owner instead of creating a new server' do
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true)
-    File.write(
-      File.join(temp_dir, 'lich-active-sessions.json'),
-      JSON.dump(owner_pid: 123, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
-
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-    expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-
-    expect(described_class.ensure_service!).to be(true)
-  end
-
-  it 'returns sanitized service metadata without exposing the auth token' do
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true)
-    File.write(
-      File.join(temp_dir, 'lich-active-sessions.json'),
-      JSON.dump(owner_pid: 321, auth_token: 'shared-token', updated_at: 1_700_000_000)
-    )
-
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-
-    expect(described_class.service_info).to eq(
-      source: 'ActiveSessionsAPI',
-      owner_pid: 321,
-      updated_at: 1_700_000_000,
-      service_available: true
-    )
-  end
-
-  it 'removes the discovery file when the owner is also the last remaining session' do
-    File.write(
-      File.join(temp_dir, 'lich-active-sessions.json'),
-      JSON.dump(owner_pid: Process.pid, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
-
-    allow(described_class).to receive(:query_snapshot).and_return(
-      source: 'ActiveSessionsAPI',
-      total: 0,
-      connected: 0,
-      detachable: 0,
-      sessions: []
-    )
-    allow(described_class).to receive(:stop_service!).and_call_original
-
-    described_class.cleanup_discovery_if_last_session!
-
-    expect(File.exist?(File.join(temp_dir, 'lich-active-sessions.json'))).to be(false)
-  end
-
-  it 'keeps the discovery file when the snapshot is a fallback error' do
-    discovery_file = File.join(temp_dir, 'lich-active-sessions.json')
-    File.write(
-      discovery_file,
-      JSON.dump(owner_pid: Process.pid, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
-
-    allow(described_class).to receive(:query_snapshot).and_return(
-      source: 'ActiveSessionsAPI',
-      total: 0,
-      connected: 0,
-      detachable: 0,
-      sessions: [],
-      error: 'service unavailable'
-    )
-
-    described_class.cleanup_discovery_if_last_session!
-
-    expect(File.exist?(discovery_file)).to be(true)
-  end
-
-  describe '.ensure_service!' do
-    # Stubs the service_client path to report no healthy external service,
-    # forcing ensure_service! into the "start a new server" branch.
-    #
-    # @return [void]
-    def stub_no_external_service
-      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
-      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
-      allow(dead_client).to receive(:ping).and_return(false)
-    end
-
-    context 'when the existing server has a dead accept thread' do
-      it 'stops the zombie, starts a replacement, and writes a fresh discovery file' do
-        zombie_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          running?: false,
-          stop: nil,
-          auth_token: 'zombie-token'
-        )
-        described_class.instance_variable_set(:@server, zombie_server)
-        stub_no_external_service
-
-        fresh_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: true,
-          stop: nil,
-          auth_token: 'fresh-token'
-        )
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(fresh_server)
-
-        expect(zombie_server).to receive(:stop).ordered
-        expect(described_class.ensure_service!).to be(true)
-
-        discovery = JSON.parse(
-          File.read(File.join(temp_dir, 'lich-active-sessions.json')),
-          symbolize_names: true
-        )
-        expect(discovery[:auth_token]).to eq('fresh-token')
-        expect(discovery[:owner_pid]).to eq(Process.pid)
-
-        # Clean up injected double before after block calls stop_service!
-        described_class.instance_variable_set(:@server, nil)
-      end
-    end
-
-    context 'when the existing server has a healthy accept thread' do
-      it 'reuses the healthy service without creating a new server' do
-        healthy_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true)
-        allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(healthy_client)
-        File.write(
-          File.join(temp_dir, 'lich-active-sessions.json'),
-          JSON.dump(owner_pid: Process.pid, auth_token: 'healthy-token', updated_at: Time.now.to_i)
-        )
-
-        expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-        expect(described_class.ensure_service!).to be(true)
-      end
-    end
-
-    context 'when no prior server exists' do
-      it 'creates a new server without zombie cleanup' do
-        stub_no_external_service
-
-        fresh_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: true,
-          stop: nil,
-          auth_token: 'cold-start-token'
-        )
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(fresh_server)
-
-        expect(described_class.ensure_service!).to be(true)
-
-        discovery = JSON.parse(
-          File.read(File.join(temp_dir, 'lich-active-sessions.json')),
-          symbolize_names: true
-        )
-        expect(discovery[:auth_token]).to eq('cold-start-token')
-      end
-    end
-
-    context 'when the zombie is cleaned up but the replacement fails to start' do
-      it 'returns false without writing a discovery file' do
-        zombie_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          running?: false,
-          stop: nil,
-          auth_token: 'zombie-token'
-        )
-        described_class.instance_variable_set(:@server, zombie_server)
-        stub_no_external_service
-
-        doomed_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: false,
-          stop: nil,
-          auth_token: 'doomed-token'
-        )
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(doomed_server)
-
-        expect(described_class.ensure_service!).to be(false)
-        expect(File.exist?(File.join(temp_dir, 'lich-active-sessions.json'))).to be(false)
-
-        described_class.instance_variable_set(:@server, nil)
-      end
-    end
-
-    context 'when zombie server.stop raises during cleanup' do
-      it 'catches the error at the outer rescue and returns false' do
-        zombie_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          running?: false,
-          auth_token: 'zombie-token'
-        )
-        allow(zombie_server).to receive(:stop).and_raise(Errno::EBADF, 'bad fd during stop')
-        described_class.instance_variable_set(:@server, zombie_server)
-        stub_no_external_service
-
-        expect(described_class.ensure_service!).to be(false)
-
-        described_class.instance_variable_set(:@server, nil)
-      end
-    end
-
-    context 'when discovery points to a dead owner process' do
-      it 'deletes the stale discovery file and bootstraps a new server' do
-        stub_no_external_service
-        File.write(
-          File.join(temp_dir, 'lich-active-sessions.json'),
-          JSON.dump(owner_pid: 99_999_999, auth_token: 'dead-owner-token', updated_at: Time.now.to_i)
-        )
-        allow(Process).to receive(:kill).with(0, 99_999_999).and_raise(Errno::ESRCH)
-
-        fresh_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: true,
-          stop: nil,
-          auth_token: 'replacement-token'
-        )
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(fresh_server)
-
-        expect(described_class.ensure_service!).to be(true)
-
-        discovery = JSON.parse(
-          File.read(File.join(temp_dir, 'lich-active-sessions.json')),
-          symbolize_names: true
-        )
-        expect(discovery[:owner_pid]).to eq(Process.pid)
-        expect(discovery[:auth_token]).to eq('replacement-token')
-      end
-    end
-
-    context 'when discovery points to an alive but unresponsive owner' do
-      it 'deletes the stale discovery file and returns false without attempting to bind' do
-        stub_no_external_service
-        File.write(
-          File.join(temp_dir, 'lich-active-sessions.json'),
-          JSON.dump(owner_pid: 99_999_998, auth_token: 'zombie-owner-token', updated_at: Time.now.to_i)
-        )
-        allow(Process).to receive(:kill).with(0, 99_999_998).and_return(nil)
-
-        expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-        expect(described_class.ensure_service!).to be(false)
-        expect(File.exist?(File.join(temp_dir, 'lich-active-sessions.json'))).to be(false)
-      end
-    end
-
-    context 'when server start fails' do
-      it 'clears the @server reference so subsequent ticks do not report a zombie' do
-        stub_no_external_service
-
-        doomed_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: false,
-          stop: nil,
-          auth_token: 'doomed-token'
-        )
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(doomed_server)
-
-        expect(described_class.ensure_service!).to be(false)
-        expect(described_class.instance_variable_get(:@server)).to be_nil
-      end
-    end
-
-    context 'owner self-recovery: accept thread dies and heartbeat restarts it' do
-      it 'detects the dead accept thread and starts a replacement server on the next tick' do
-        stub_no_external_service
-
-        # First call: owner bootstraps successfully
-        original_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: true,
-          stop: nil,
-          auth_token: 'original-token'
-        )
-        allow(original_server).to receive(:running?).and_return(true)
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(original_server)
-
-        expect(described_class.ensure_service!).to be(true)
-
-        # Accept thread dies between ticks
-        allow(original_server).to receive(:running?).and_return(false)
-
-        # Heartbeat tick: should detect zombie, stop it, and bootstrap replacement
-        replacement_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: true,
-          stop: nil,
-          auth_token: 'recovered-token'
-        )
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(replacement_server)
-
-        expect(original_server).to receive(:stop)
-        expect(described_class.ensure_service!).to be(true)
-
-        discovery = JSON.parse(
-          File.read(File.join(temp_dir, 'lich-active-sessions.json')),
-          symbolize_names: true
-        )
-        expect(discovery[:auth_token]).to eq('recovered-token')
-
-        described_class.instance_variable_set(:@server, nil)
-      end
-    end
-
-    context 'peer behavior while owner is recovering' do
-      it 'does not attempt to bind on the first tick when zombie owner is alive' do
-        stub_no_external_service
-
-        File.write(
-          File.join(temp_dir, 'lich-active-sessions.json'),
-          JSON.dump(owner_pid: 99_999_997, auth_token: 'zombie-token', updated_at: Time.now.to_i)
-        )
-        allow(Process).to receive(:kill).with(0, 99_999_997).and_return(nil)
-
-        expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-        expect(described_class.ensure_service!).to be(false)
-      end
-
-      it 'fails gracefully on subsequent ticks after discovery is cleared' do
-        stub_no_external_service
-
-        doomed_server = instance_double(
-          Lich::InternalAPI::ActiveSessions::Server,
-          start: false,
-          stop: nil,
-          auth_token: 'doomed-token'
-        )
-        allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(doomed_server)
-
-        results = 3.times.map { described_class.ensure_service! }
-
-        expect(results).to all(be(false))
-        expect(described_class.instance_variable_get(:@server)).to be_nil
-      end
-    end
-  end
-
-  it 'queries a discovered service without consulting the local feature flag state' do
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
-    File.write(
-      File.join(temp_dir, 'lich-active-sessions.json'),
-      JSON.dump(owner_pid: 123, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
-
-    allow(described_class).to receive(:enabled?).and_return(false)
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:snapshot).and_return(
-      ok: true,
-      payload: {
-        source: 'ActiveSessionsAPI',
-        total: 1,
-        connected: 1,
-        detachable: 1,
-        sessions: [{ session_name: 'Char1' }]
-      }
-    )
-
-    expect(described_class.query_snapshot[:total]).to eq(1)
-  end
-
-  it 'can register after the caller already admitted the feature gate without re-reading the flag' do
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
-    File.write(
-      File.join(temp_dir, 'lich-active-sessions.json'),
-      JSON.dump(owner_pid: 123, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
-
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:ping).and_return(true)
-    allow(fake_client).to receive(:upsert).and_return(ok: true)
-
-    expect(described_class).not_to receive(:enabled?)
-
-    expect(described_class.send(:register_session_admitted, { pid: 12_345 })).to be(true)
-  end
-
-  it 'bootstraps a replacement owner from admitted registration when no healthy service remains' do
-    # No discovery file: simulates the previous owner having exited.
-    fake_server = instance_double(
-      Lich::InternalAPI::ActiveSessions::Server,
-      start: true,
+      start: start,
       stop: nil,
-      auth_token: 'failover-token'
+      running?: running,
+      auth_token: auth_token,
+      port: port
     )
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
-
-    allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).and_return(fake_server)
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:upsert).and_return(ok: true)
-
-    expect(described_class).to receive(:enabled?).and_return(true)
-
-    expect(described_class.send(:register_session_admitted, { pid: Process.pid })).to be(true)
-
-    discovery = JSON.parse(
-      File.read(File.join(temp_dir, 'lich-active-sessions.json')),
-      symbolize_names: true
-    )
-    expect(discovery[:owner_pid]).to eq(Process.pid)
-    expect(discovery[:auth_token]).to eq('failover-token')
   end
 
-  it 'does not bootstrap from admitted registration when the kill-switch is disabled' do
-    allow(described_class).to receive(:enabled?).and_return(false)
-
-    expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-
-    expect(described_class.send(:register_session_admitted, { pid: Process.pid })).to be(false)
+  # Writes a discovery file with the given fields.
+  #
+  # @return [void]
+  def write_discovery_file(owner_pid:, auth_token:, port:, updated_at: Time.now.to_i)
+    File.write(discovery_file, JSON.dump(owner_pid: owner_pid, auth_token: auth_token, port: port, updated_at: updated_at))
   end
 
-  it 'can reuse an existing service after the caller already admitted the feature gate' do
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true)
-    File.write(
-      File.join(temp_dir, 'lich-active-sessions.json'),
-      JSON.dump(owner_pid: 123, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
-
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-
-    expect(described_class).not_to receive(:enabled?)
-    expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-
-    expect(described_class.send(:ensure_service_internal!, allow_bootstrap: false)).to be(true)
+  # Reads and symbolizes the on-disk discovery file.
+  #
+  # @return [Hash]
+  def read_discovery
+    JSON.parse(File.read(discovery_file), symbolize_names: true)
   end
 
-  it 'does not bootstrap a new service from an admitted path once the real flag is off' do
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
+  describe 'ownership election' do
+    it 'acquires the lock, binds an ephemeral port, and publishes it in discovery' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .with(hash_including(port: Lich::InternalAPI::ActiveSessions::EPHEMERAL_PORT))
+        .and_return(server_double(auth_token: 'generated-token', port: 54_321))
 
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:ping).and_return(false)
+      expect(described_class.ensure_service!).to be(true)
 
-    expect(described_class).not_to receive(:enabled?)
-    expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-    expect(described_class.send(:ensure_service_internal!, allow_bootstrap: false)).to be(false)
+      discovery = read_discovery
+      expect(discovery[:owner_pid]).to eq(Process.pid)
+      expect(discovery[:auth_token]).to eq('generated-token')
+      expect(discovery[:port]).to eq(54_321)
+      expect(File.stat(discovery_file).mode & 0o777).to eq(0o600)
+      expect(File.exist?(File.join(temp_dir, 'lich-active-sessions.lock'))).to be(true)
+    end
+
+    it 'reuses a healthy peer owner at the published port without binding' do
+      healthy_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(healthy_client)
+      write_discovery_file(owner_pid: 123, auth_token: 'shared-token', port: 49_000)
+
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.ensure_service!).to be(true)
+      expect(Lich::InternalAPI::ActiveSessions::Client).to have_received(:new).with(hash_including(port: 49_000))
+    end
+
+    it 'reuses the peer when the ownership lock is held by a live peer' do
+      # Fast-path probe misses, then the peer answers after we decline to bind.
+      peer_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
+      allow(peer_client).to receive(:ping).and_return(false, true)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(peer_client)
+      write_discovery_file(owner_pid: 4242, auth_token: 'peer-token', port: 51_000)
+      allow(described_class).to receive(:acquire_ownership_lock).and_return(false)
+
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.ensure_service!).to be(true)
+    end
+
+    it 'takes over a stale discovery from a departed owner by re-acquiring the free lock' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      write_discovery_file(owner_pid: 99_999_999, auth_token: 'departed-token', port: 40_000)
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .and_return(server_double(auth_token: 'takeover-token', port: 55_555))
+
+      expect(described_class.ensure_service!).to be(true)
+
+      discovery = read_discovery
+      expect(discovery[:owner_pid]).to eq(Process.pid)
+      expect(discovery[:auth_token]).to eq('takeover-token')
+      expect(discovery[:port]).to eq(55_555)
+    end
+
+    it 'degrades to unavailable (no bind, no split-brain) when the lock cannot be opened' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      allow(File).to receive(:open).and_call_original
+      allow(File).to receive(:open)
+        .with(File.join(temp_dir, 'lich-active-sessions.lock'), anything, anything)
+        .and_raise(Errno::EACCES, 'locked down')
+
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.ensure_service!).to be(false)
+      expect(File.exist?(discovery_file)).to be(false)
+    end
+
+    it 'treats discovery without a published port as no service and bootstraps' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      # Legacy/partial discovery: token present but no port.
+      File.write(discovery_file, JSON.dump(owner_pid: 777, auth_token: 'portless-token', updated_at: Time.now.to_i))
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .and_return(server_double(auth_token: 'fresh-token', port: 56_000))
+
+      expect(described_class.ensure_service!).to be(true)
+      expect(read_discovery[:port]).to eq(56_000)
+    end
+
+    it 'returns false and clears @server when the bind fails' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .and_return(server_double(auth_token: 'doomed-token', port: 0, start: false))
+
+      expect(described_class.ensure_service!).to be(false)
+      expect(described_class.instance_variable_get(:@server)).to be_nil
+      expect(File.exist?(discovery_file)).to be(false)
+    end
   end
 
-  it 'still honors the normal gate for callers using only the public API surface' do
-    allow(described_class).to receive(:enabled?).and_return(false)
+  describe 'in-process recovery' do
+    it 'reuses its own healthy server without touching discovery or the lock' do
+      described_class.instance_variable_set(:@server, server_double(auth_token: 'live-token', port: 47_000, running: true))
 
-    expect(described_class.register_session({ pid: 12_345 })).to be(false)
-    expect(described_class.unregister_session(pid: 12_345)).to be(false)
-    expect(described_class.ensure_service!).to be(false)
+      expect(described_class).not_to receive(:service_available?)
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.ensure_service!).to be(true)
+
+      described_class.instance_variable_set(:@server, nil)
+    end
+
+    it 'rebinds a fresh ephemeral listener when its own accept loop has died' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      zombie = server_double(auth_token: 'zombie-token', port: 41_000, running: false)
+      described_class.instance_variable_set(:@server, zombie)
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .and_return(server_double(auth_token: 'rebound-token', port: 42_000))
+
+      expect(zombie).to receive(:stop)
+      expect(described_class.ensure_service!).to be(true)
+      expect(read_discovery[:port]).to eq(42_000)
+
+      described_class.instance_variable_set(:@server, nil)
+    end
+
+    it 'surfaces false when stopping a dead in-process server raises' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      zombie = instance_double(
+        Lich::InternalAPI::ActiveSessions::Server,
+        running?: false,
+        auth_token: 'zombie-token',
+        port: 41_000
+      )
+      allow(zombie).to receive(:stop).and_raise(Errno::EBADF, 'bad fd during stop')
+      described_class.instance_variable_set(:@server, zombie)
+
+      expect(described_class.ensure_service!).to be(false)
+
+      described_class.instance_variable_set(:@server, nil)
+    end
   end
 
-  it 'can unregister after the caller already admitted the feature gate without re-reading the flag' do
-    fake_client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
-    File.write(
-      File.join(temp_dir, 'lich-active-sessions.json'),
-      JSON.dump(owner_pid: 123, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
+  describe '.service_info' do
+    it 'reports the discovered owner and port without exposing the auth token' do
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new)
+        .and_return(instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true))
+      write_discovery_file(owner_pid: 321, auth_token: 'shared-token', port: 45_000, updated_at: 1_700_000_000)
 
-    allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:ping).and_return(true)
-    allow(fake_client).to receive(:remove).and_return(ok: true)
-
-    expect(described_class).not_to receive(:enabled?)
-    expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
-
-    expect(described_class.send(:unregister_session_admitted, pid: 12_345)).to be(true)
+      expect(described_class.service_info).to eq(
+        source: 'ActiveSessionsAPI',
+        owner_pid: 321,
+        port: 45_000,
+        updated_at: 1_700_000_000,
+        service_available: true
+      )
+    end
   end
 
-  it 'keeps discovery when query_snapshot reports active sessions after the flag is off' do
-    discovery_file = File.join(temp_dir, 'lich-active-sessions.json')
-    File.write(
-      discovery_file,
-      JSON.dump(owner_pid: Process.pid, auth_token: 'shared-token', updated_at: Time.now.to_i)
-    )
+  describe '.stop_service! and discovery cleanup' do
+    it 'removes the discovery file when the owner is also the last remaining session' do
+      write_discovery_file(owner_pid: Process.pid, auth_token: 'shared-token', port: 46_000)
+      allow(described_class).to receive(:query_snapshot).and_return(
+        source: 'ActiveSessionsAPI', total: 0, connected: 0, detachable: 0, sessions: []
+      )
 
-    allow(described_class).to receive(:query_snapshot).and_return(
-      source: 'ActiveSessionsAPI',
-      total: 2,
-      connected: 2,
-      detachable: 1,
-      sessions: [{ session_name: 'Tsetem' }, { session_name: 'Another' }]
-    )
+      described_class.cleanup_discovery_if_last_session!
 
-    described_class.cleanup_discovery_if_last_session!
+      expect(File.exist?(discovery_file)).to be(false)
+    end
 
-    expect(File.exist?(discovery_file)).to be(true)
+    it 'keeps the discovery file when the snapshot is a fallback error' do
+      write_discovery_file(owner_pid: Process.pid, auth_token: 'shared-token', port: 46_000)
+      allow(described_class).to receive(:query_snapshot).and_return(
+        source: 'ActiveSessionsAPI', total: 0, connected: 0, detachable: 0, sessions: [], error: 'service unavailable'
+      )
+
+      described_class.cleanup_discovery_if_last_session!
+
+      expect(File.exist?(discovery_file)).to be(true)
+    end
+
+    it 'keeps discovery when other sessions remain registered' do
+      write_discovery_file(owner_pid: Process.pid, auth_token: 'shared-token', port: 46_000)
+      allow(described_class).to receive(:query_snapshot).and_return(
+        source: 'ActiveSessionsAPI', total: 2, connected: 2, detachable: 1,
+        sessions: [{ session_name: 'Tsetem' }, { session_name: 'Another' }]
+      )
+
+      described_class.cleanup_discovery_if_last_session!
+
+      expect(File.exist?(discovery_file)).to be(true)
+    end
+
+    it 'releases the ownership lock so a successor can acquire it' do
+      dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(dead_client)
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .and_return(server_double(auth_token: 'first-token', port: 43_000))
+      expect(described_class.ensure_service!).to be(true)
+      expect(described_class.instance_variable_get(:@lock_file)).not_to be_nil
+
+      described_class.stop_service!
+
+      expect(described_class.instance_variable_get(:@lock_file)).to be_nil
+      # The lock file object must be closed (fd released) after stop.
+      lock = File.open(File.join(temp_dir, 'lich-active-sessions.lock'), File::RDWR | File::CREAT, 0o600)
+      expect(lock.flock(File::LOCK_EX | File::LOCK_NB)).to be_truthy
+      lock.flock(File::LOCK_UN)
+      lock.close
+    end
+  end
+
+  describe 'admitted lifecycle paths' do
+    it 'registers via an already-admitted path without re-reading the flag' do
+      client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true, upsert: { ok: true })
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(client)
+      write_discovery_file(owner_pid: 123, auth_token: 'shared-token', port: 48_000)
+
+      expect(described_class).not_to receive(:enabled?)
+      expect(described_class.send(:register_session_admitted, { pid: 12_345 })).to be(true)
+    end
+
+    it 'bootstraps a replacement owner from admitted registration when no service remains' do
+      client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false, upsert: { ok: true })
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(client)
+      allow(Lich::InternalAPI::ActiveSessions::Server).to receive(:new)
+        .and_return(server_double(auth_token: 'failover-token', port: 44_000))
+
+      expect(described_class).to receive(:enabled?).and_return(true)
+      expect(described_class.send(:register_session_admitted, { pid: Process.pid })).to be(true)
+
+      discovery = read_discovery
+      expect(discovery[:owner_pid]).to eq(Process.pid)
+      expect(discovery[:auth_token]).to eq('failover-token')
+      expect(discovery[:port]).to eq(44_000)
+    end
+
+    it 'does not bootstrap from an admitted path when the kill switch is off' do
+      allow(described_class).to receive(:enabled?).and_return(false)
+
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.send(:register_session_admitted, { pid: Process.pid })).to be(false)
+    end
+
+    it 'reuses an existing service from a non-bootstrapping admitted path' do
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new)
+        .and_return(instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true))
+      write_discovery_file(owner_pid: 123, auth_token: 'shared-token', port: 48_000)
+
+      expect(described_class).not_to receive(:enabled?)
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.send(:ensure_service_internal!, allow_bootstrap: false)).to be(true)
+    end
+
+    it 'does not bootstrap from a non-bootstrapping admitted path when unreachable' do
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new)
+        .and_return(instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false))
+
+      expect(described_class).not_to receive(:enabled?)
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.send(:ensure_service_internal!, allow_bootstrap: false)).to be(false)
+    end
+
+    it 'unregisters via an already-admitted path without re-reading the flag' do
+      client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: true, remove: { ok: true })
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(client)
+      write_discovery_file(owner_pid: 123, auth_token: 'shared-token', port: 48_000)
+
+      expect(described_class).not_to receive(:enabled?)
+      expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+      expect(described_class.send(:unregister_session_admitted, pid: 12_345)).to be(true)
+    end
+  end
+
+  describe 'public gate + read-only query' do
+    it 'honors the disabled gate on the public API surface' do
+      allow(described_class).to receive(:enabled?).and_return(false)
+
+      expect(described_class.register_session({ pid: 12_345 })).to be(false)
+      expect(described_class.unregister_session(pid: 12_345)).to be(false)
+      expect(described_class.ensure_service!).to be(false)
+    end
+
+    it 'queries a discovered service without consulting the feature flag' do
+      client = instance_double(Lich::InternalAPI::ActiveSessions::Client)
+      allow(client).to receive(:snapshot).and_return(
+        ok: true,
+        payload: { source: 'ActiveSessionsAPI', total: 1, connected: 1, detachable: 1, sessions: [{ session_name: 'Char1' }] }
+      )
+      allow(Lich::InternalAPI::ActiveSessions::Client).to receive(:new).and_return(client)
+      write_discovery_file(owner_pid: 123, auth_token: 'shared-token', port: 48_000)
+
+      allow(described_class).to receive(:enabled?).and_return(false)
+      expect(described_class.query_snapshot[:total]).to eq(1)
+    end
+
+    it 'reports unavailable when discovery lacks a published port' do
+      File.write(discovery_file, JSON.dump(owner_pid: 123, auth_token: 'portless', updated_at: Time.now.to_i))
+
+      expect(described_class.query_snapshot[:error]).to eq('active sessions service unavailable')
+    end
   end
 end


### PR DESCRIPTION
## Problem

The Active Sessions service can become unreachable for a long stretch after a session fails to exit cleanly. Two independent defects combine:

1. **Shutdown has no timeout on any step.** An inline `before_dying`/`at_exit` script hook (run synchronously during the script drain), `Vars.save`, `Game.close` socket linger, database close, or a lifecycle unregister can block indefinitely, so the process never reaches `exit`.
2. **The service listens on a single hardcoded TCP port.** A process that hangs on shutdown keeps that port bound, so no other session can bind it to become the owner (`EADDRINUSE`) — no owner is elected, no discovery record is published, and nothing can register until the stuck process is killed by hand.

The observed failure mode: sessions run and log in normally, but never appear in the Active Sessions snapshot; tooling that waits on registration times out until the stuck process is killed.

## Changes

### Shutdown watchdog (`lib/common/shutdown_watchdog.rb`)
Armed at the start of teardown — both the connection-loss teardown **and** the user-initiated (`;exit`) orderly shutdown, since the latter drains scripts (and runs `before_dying` hooks inline) before the main teardown is reached. Disarmed once the unbounded steps complete, before the deliberate reconnect `sleep`/`exec`. If the deadline elapses first, it **dumps every thread's backtrace** to the shutdown log (so a hang is diagnosable) and then **forces the process to exit**, releasing all sockets and locks. Timeout configurable via a `lich_settings` row (`shutdown_watchdog_timeout`, default **60s**; `0` disables). Pure Ruby — cross-platform. `arm` is idempotent.

### Advisory-lock ownership + ephemeral port (`lib/internal_api/active_sessions*`)
The single process that acquires an exclusive `flock` on a lock file binds an **OS-assigned ephemeral port** and publishes it in the discovery file; peers read that port to reach the owner. Because the kernel releases an advisory lock the instant its holder dies, **a crashed owner never blocks a successor, and there is no fixed port for a stuck process to squat.** The prior PID-liveness "cross-process zombie" heuristic is removed — lock ownership is authoritative, so PID reuse and transient probe timeouts can no longer trigger a destructive takeover. A normally-exiting owner releases the listener, the lock, and the discovery pointer promptly (`stop_service!` + `at_exit`). The lock file is close-on-exec (Ruby default; asserted in a test) so a reconnect `exec` cannot inherit it.

`flock` is already used cross-platform in this codebase (DB-maintenance and gem-recovery paths). Acquisition failures degrade to "service unavailable" rather than risking two owners.

## Rollout — restart all sessions (not hot-compatible)
The discovery schema gains a `:port` field and ownership moves from fixed-port binding to a file lock. **A running old (fixed-port) owner does not hold the flock, so a new-code session's lock acquire succeeds and it binds its own ephemeral port — yielding two owners with two registries (split-brain) until every session is on the new code.** Roll out by draining/restarting all local sessions together rather than mixing versions. Only the module itself reads the discovery file in shipped code, so the schema change is otherwise self-contained.

## Tests
- Election coverage: lock acquired → ephemeral bind → port published; live peer holds the lock → reuse without binding; departed owner → free lock re-acquired and republished; discovery missing a port → treated as unavailable; lock file unopenable → graceful, no bind, no split-brain; in-process accept-loop death → rebind a fresh ephemeral listener; lock released on `stop_service!`.
- **Cross-process integration test:** a successor acquires the lock after the holder is `SIGKILL`ed (exercises the kernel crash-release guarantee the design depends on; skipped where spawn/signals are unavailable).
- Close-on-exec assertion on the lock file.
- Watchdog suite: fires after the deadline, dumps diagnostics, disarm prevents firing, disabled at `0`/negative, idempotent arm, re-arm after disarm.
- `rubocop` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Added a shutdown watchdog that tracks stalled teardown, emits thread diagnostics, and force-terminates after a configurable timeout (with optional disable).
  * Integrated watchdog handling into both orderly user shutdown and the main shutdown sequence to avoid lingering processes.

* **Bug Fixes**
  * Reworked active-session coordination across processes using published connection details to improve recovery, ownership election, and shutdown cleanup.
  * Improved service metadata reporting while keeping sensitive connection credentials hidden.

* **Tests**
  * Expanded test coverage for shutdown timeouts/diagnostics, watchdog arm/disarm behavior, active-session ownership recovery, and cross-process handoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->