### PR TITLE
fix(all): Quit Gtk.main cleanly

### DIFF
--- a/lib/common/gtk.rb
+++ b/lib/common/gtk.rb
@@ -59,16 +59,20 @@ module Lich
       end
     end
 
-    # Performs explicit GTK teardown before Ruby process exit.
+    # Destroys retained GTK receivers and releases retained Ruby callbacks.
     #
     # ruby-gnome will otherwise release surviving widget wrappers during Ruby
     # finalization, which can dispose native GTK objects in an unsafe order.
-    # Core-owned shutdown paths should call this helper on the GTK thread so
-    # widgets are destroyed deterministically before interpreter cleanup.
+    # This may run after Gtk.main has returned, so it must not stop the GTK
+    # main loop itself.
     #
-    # @return [Object, nil] GTK main quit result when available
-    def self.shutdown_gtk!
+    # @return [Boolean] true when cleanup work was performed
+    def self.cleanup_gtk!
       retained_receivers = with_gtk_registry_lock { gtk_signal_handlers.keys.dup }
+      callbacks_retained = with_gtk_registry_lock do
+        gtk_timeout_callbacks.any? || gtk_idle_callbacks.any?
+      end
+      return false if retained_receivers.empty? && !callbacks_retained
 
       retained_receivers.each do |receiver|
         next unless receiver.respond_to?(:destroy)
@@ -82,7 +86,14 @@ module Lich
       end
 
       clear_gtk_retention_registries
+      true
+    end
 
+    # Performs core-owned GTK shutdown before Ruby process exit.
+    #
+    # @return [Object, nil] GTK main quit result when available
+    def self.shutdown_gtk!
+      cleanup_gtk!
       Gtk.lich_main_quit if defined?(Gtk) && Gtk.respond_to?(:lich_main_quit)
     end
 
@@ -134,7 +145,8 @@ module Lich
     # * **Loop not running**: a queued block would never be serviced. Ordinary
     #   callers clear retained Ruby references only. The terminal `lich.rbw`
     #   backstop passes +direct: true+ after `Gtk.main` returns on the GTK thread;
-    #   only that path destroys surviving widgets directly in place.
+    #   only that path destroys surviving widgets directly in place. Gtk.main
+    #   has already returned there, so it must not call Gtk.main_quit.
     #
     # If GTK is unavailable, the queue cannot be serviced, the work cannot be
     # queued, or it does not finish within +timeout+, the retention registries are
@@ -151,7 +163,7 @@ module Lich
       unless gtk_main_loop_running?
         if direct
           begin
-            shutdown_gtk!
+            cleanup_gtk!
           rescue StandardError => e
             Lich.log "warning: Failed to run direct GTK shutdown before exit: #{e.class}: #{e.message}"
             clear_gtk_retention_registries

--- a/spec/lib/common/gtk_spec.rb
+++ b/spec/lib/common/gtk_spec.rb
@@ -162,6 +162,12 @@ RSpec.describe 'Lich::Common GTK hardening' do
     expect(Gtk.main_quit_calls).to eq(1)
   end
 
+  it 'quits the GTK main loop when no retained GTK cleanup remains' do
+    expect(Lich::Common.cleanup_gtk!).to be(false)
+    expect(Lich::Common.shutdown_gtk!).to eq(:main_quit_called)
+    expect(Gtk.main_quit_calls).to eq(1)
+  end
+
   describe 'shutdown_gtk_before_exit' do
     context 'while the GTK main loop is running' do
       # The launcher and the main game loop call this from a thread other than
@@ -245,6 +251,7 @@ RSpec.describe 'Lich::Common GTK hardening' do
 
         expect(widget.destroyed?).to be true
         expect(Lich::Common.with_gtk_registry_lock { Lich::Common.gtk_signal_handlers }).to be_empty
+        expect(Gtk.main_quit_calls).to eq(0)
       end
 
       it 'clears retained Ruby references without direct widget teardown for non-terminal callers' do
@@ -262,23 +269,12 @@ RSpec.describe 'Lich::Common GTK hardening' do
         expect(Lich::Common.with_gtk_registry_lock { Lich::Common.gtk_idle_callbacks[idle_id] }).to be_nil
       end
 
-      it 'clears registries when direct teardown fails' do
-        Gtk.main_quit_failure = true
-        widget = Gtk::Widget.new
-        widget.signal_connect('clicked') { :clicked }
-        allow(Lich::Common).to receive(:clear_gtk_retention_registries).and_call_original
-
-        expect { Lich::Common.shutdown_gtk_before_exit(direct: true) }.not_to raise_error
-
-        expect(Lich).to have_received(:log).with(/Failed to run direct GTK shutdown before exit/)
-        expect(Lich::Common).to have_received(:clear_gtk_retention_registries).at_least(:once)
-      end
-
       it 'is a clean no-op when nothing remains to tear down' do
         expect(Gtk).not_to receive(:queue)
 
         expect { Lich::Common.shutdown_gtk_before_exit(direct: true) }.not_to raise_error
         expect(Lich::Common.with_gtk_registry_lock { Lich::Common.gtk_signal_handlers }).to be_empty
+        expect(Gtk.main_quit_calls).to eq(0)
       end
     end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GTK shutdown handling to prevent unnecessary main-loop termination after the loop has already exited.
  * Ensured retained GTK resources are consistently cleaned up during application teardown.
  * Improved behavior when no GTK resources remain to be released. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->