### PR TITLE
chore(all): reorganize .gitignore and fix .github/scripts tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,38 +1,53 @@
+# --- Generated / runtime directories ---
 backup/
-data/
 data44/
 dist/
 logs/
 maps/
-scripts/
-!.github/scripts/
 temp/
+
+# --- Runtime data / scripts (root only; symlink-safe on *nix) ---
+# On *nix these are symlinks (files, not dirs). A single root-anchored, slash-less
+# rule ignores each whether it resolves to a directory or a symlinked file, and
+# (being anchored) never matches nested dirs such as .github/scripts.
+/data
+/scripts
+
+# --- Local tooling / config ---
 jinxp
 .pre-commit-config.yaml
 .rubocop.yml
 .rubocop/
+
+# --- Editors / IDEs ---
 *.swp
-logo.png
-fly64.png
-fly64.ico
-.DS_Store
-# handle symlinks since these are files on *nix
-data
-scripts
 .vscode
 .idea
 .claude
+
+# --- OS files ---
+.DS_Store
+
+# --- Project images ---
+logo.png
+fly64.png
+fly64.ico
+
+# --- Docs / Markdown ---
+# Ignore markdown everywhere, then re-include the docs we track.
 doc/yard/
 *.md
 !docs/*.md
 !spec/README.md
 !spec/fixtures/README.md
 !bench/README.md
-# Test database artifacts
+
+# --- Test database artifacts ---
 spec/*.db
 spec/*.db3
-!spec/fixtures/*.db3
-# Test artifacts
+
+# --- Test artifacts ---
 spec/.rspec_status
-# Debug logs
+
+# --- Debug logs ---
 debug-*.log


### PR DESCRIPTION
## What
- Reorganize `.gitignore` into commented sections (runtime dirs, data/scripts, tooling/config, editors, OS files, images, docs/markdown, test artifacts) for readability. The regrouping alone changes no pattern semantics.
- Anchor the root `data`/`scripts` rules to `/data` and `/scripts`. The previously unanchored `scripts` rule matched `.github/scripts` at any depth and silently re-ignored it, defeating the `!.github/scripts/` negation.
- Collapse redundant trailing-slash forms: a single anchored, slash-less `/data` (`/scripts`) already ignores the entry whether it resolves to a directory or a *nix symlinked file, so `/data/` and `/scripts/` were dropped.
- Remove now-inert negations: `!.github/scripts/` (nothing ignores that path anymore) and `!spec/fixtures/*.db3` (a no-op — `spec/*.db3` never matched the `fixtures/` subdirectory).

## Why
`.github/scripts/` holds the CI helper scripts (`curate-pre-branch.sh`, the conflict/syntax strategies, and shared `lib/*.sh`). They were effectively git-ignored, so new files added there would not appear in `git status` and could be missed in commits. Anchoring the root rules restores the intended behavior of tracking `.github/scripts/`.

## Behavior impact
- The 13 files under `.github/scripts/` are already committed, so nothing is added to or removed from the repo. The fix restores `git status` visibility for new files placed there.
- Verified with `git check-ignore` across all 1,087 tracked paths: the only status change is those 13 `.github/scripts/**` files going ignored -> tracked. `spec/fixtures/lich.db3` stays tracked; root `data`/`scripts` and their contents stay ignored.
- Anchoring side effect: a hypothetical nested `*/data/` or `*/scripts/` directory would no longer be ignored. No such directory exists in the tree, so there is no practical impact.

## Notes
- ASCII-only, LF line endings, trailing newline preserved.
- Tooling-only; typed `chore` so release-please does not cut a release.