### PR TITLE
fix(dr): equipmanager.rb - reliable ranged-weapon transitions - stow ammo after unload + verify offhand wield hand

### DIFF
--- a/lib/dragonrealms/commons/equipmanager.rb
+++ b/lib/dragonrealms/commons/equipmanager.rb
@@ -314,19 +314,23 @@ module Lich
           return false
         end
 
-        if get_item?(weapon)
-          swap_to_skill?(weapon.name, skill) if skill && weapon.swappable
-          if DRCI.in_right_hand?(weapon)
-            case DRC.bput('swap', *DRCI::SWAP_HANDS_SUCCESS_PATTERNS, *DRCI::SWAP_HANDS_FAILURE_PATTERNS)
-            when *DRCI::SWAP_HANDS_SUCCESS_PATTERNS
-              return true
-            else
-              return false
-            end
+        return false unless get_item?(weapon)
+
+        swap_to_skill?(weapon.name, skill) if skill && weapon.swappable
+
+        # We want the weapon in the LEFT (off) hand. If it landed in the right hand
+        # (e.g. get placed it there), swap it over; if it's already in the left
+        # hand, we're done -- previously this returned false in that case.
+        if DRCI.in_right_hand?(weapon)
+          case DRC.bput('swap', *DRCI::SWAP_HANDS_SUCCESS_PATTERNS, *DRCI::SWAP_HANDS_FAILURE_PATTERNS)
+          when *DRCI::SWAP_HANDS_SUCCESS_PATTERNS
+            return true
+          else
+            return false
           end
         end
 
-        return false
+        DRCI.in_left_hand?(weapon)
       end
 
       # @deprecated Use {#wield_weapon_offhand?} instead.
@@ -357,7 +361,7 @@ module Lich
         if get_item?(weapon)
           swap_to_skill?(weapon.name, skill) if skill && weapon.swappable
 
-          if offhand && DRC.right_hand
+          if offhand && DRCI.in_right_hand?(weapon)
             case DRC.bput('swap', *DRCI::SWAP_HANDS_SUCCESS_PATTERNS, *DRCI::SWAP_HANDS_FAILURE_PATTERNS)
             when *DRCI::SWAP_HANDS_SUCCESS_PATTERNS
               return true
@@ -786,11 +790,15 @@ module Lich
       # @see DRCI::UNLOAD_WEAPON_FAILURE_PATTERNS
       def unload_weapon(name)
         result = DRC.bput("unload my #{name}", *DRCI::UNLOAD_WEAPON_SUCCESS_PATTERNS, *DRCI::UNLOAD_WEAPON_FAILURE_PATTERNS)
+        waitrt? # wait out the unload roundtime so the ammo/hand state has settled before we act on it
+
         ammo_match = result&.match(/^(?:Your .*?\b(?<ammo>[\w]+)\b fall.* from your .* to your feet\.)$/)
-        if ammo_match
-          # Ammo fell to ground because hands are full.
-          # Lower weapon, stow ammo, then pick it back up.
-          ammo = ammo_match[:ammo]
+        ground_match = result&.match?(/As you release the string/) ? result.match(/the (?<ammo>\w+) tumbles/) : nil
+
+        if ammo_match || ground_match
+          # Ammo ended up on the GROUND (hands were full, or it tumbled). Lower the
+          # weapon, stow the ammo from your feet, then pick the weapon back up.
+          ammo = (ammo_match || ground_match)[:ammo]
           unless DRCI.lower_item?(name)
             Lich::Messaging.msg("bold", "EquipmentManager: Unable to lower #{name} to pick up ammo")
             return
@@ -799,31 +807,17 @@ module Lich
           unless DRCI.get_item?(name)
             Lich::Messaging.msg("bold", "EquipmentManager: Unable to pick #{name} back up after unloading")
           end
-        elsif result&.match?(/As you release the string/)
-          # Ammo tumbled to the ground (e.g., "As you release the string, the arrow tumbles to the ground.")
-          # Same recovery as ammo falling to feet: lower weapon, stow ammo, pick weapon back up.
-          ammo_ground_match = result.match(/the (?<ammo>\w+) tumbles/)
-          if ammo_ground_match
-            ammo = ammo_ground_match[:ammo]
-            unless DRCI.lower_item?(name)
-              Lich::Messaging.msg("bold", "EquipmentManager: Unable to lower #{name} to pick up ammo")
-              return
-            end
-            DRCI.put_away_item?(ammo)
-            unless DRCI.get_item?(name)
-              Lich::Messaging.msg("bold", "EquipmentManager: Unable to pick #{name} back up after unloading")
-            end
-          end
-        elsif result&.match?(/^(?:You unload|You .* unloading)/)
-          # Ammo is in hand, stow whichever hand isn't holding the weapon.
-          unless DRCI.in_left_hand?(name)
-            Lich::Messaging.msg("bold", "EquipmentManager: Unable to stow ammo from left hand") unless DRCI.stow_hand('left')
-          end
-          unless DRCI.in_right_hand?(name)
-            Lich::Messaging.msg("bold", "EquipmentManager: Unable to stow ammo from right hand") unless DRCI.stow_hand('right')
+        else
+          # Ammo is sitting in a hand. Stow whichever hand is NOT the weapon, comparing
+          # by NOUN against the actual hand contents rather than trusting the unload
+          # response text (which can be "You stop aiming." and shadow "You unload ...").
+          weapon_noun = DRC.get_noun(name)
+          [['left', DRC.left_hand], ['right', DRC.right_hand]].each do |side, held|
+            next if held.nil? || DRC.get_noun(held) == weapon_noun
+
+            Lich::Messaging.msg("bold", "EquipmentManager: Unable to stow ammo from #{side} hand") unless DRCI.stow_hand(side)
           end
         end
-        waitrt?
       end
 
       # Stows a weapon in its configured location (sheath, wear, tie, container, or general stow).

--- a/lib/dragonrealms/commons/equipmanager.rb
+++ b/lib/dragonrealms/commons/equipmanager.rb
@@ -807,10 +807,14 @@ module Lich
           unless DRCI.get_item?(name)
             Lich::Messaging.msg("bold", "EquipmentManager: Unable to pick #{name} back up after unloading")
           end
-        else
-          # Ammo is sitting in a hand. Stow whichever hand is NOT the weapon, comparing
-          # by NOUN against the actual hand contents rather than trusting the unload
-          # response text (which can be "You stop aiming." and shadow "You unload ...").
+        elsif result && DRCI::UNLOAD_WEAPON_SUCCESS_PATTERNS.any? { |pattern| pattern.match?(result) }
+          # Unload succeeded with the ammo now in a hand. Stow whichever hand is NOT
+          # the weapon, comparing by NOUN against the actual hand contents -- robust to
+          # the <dialogData ...AimTimer...> tag the game prepends (which the old
+          # ^-anchored /^(?:You unload|...)/ branch missed) and to ammo nouns that
+          # contain the weapon noun (e.g. "crossbow bolt"). Guarded on a positive
+          # success match so an unload failure or a bput timeout can't stow an
+          # unrelated off-hand item.
           weapon_noun = DRC.get_noun(name)
           [['left', DRC.left_hand], ['right', DRC.right_hand]].each do |side, held|
             next if held.nil? || DRC.get_noun(held) == weapon_noun

--- a/spec/lib/dragonrealms/commons/equipmanager_spec.rb
+++ b/spec/lib/dragonrealms/commons/equipmanager_spec.rb
@@ -684,6 +684,81 @@ RSpec.describe Lich::DragonRealms::EquipmentManager do
     end
   end
 
+  describe '#unload_weapon in-hand ammo' do
+    let(:settings) { double('settings', gear_sets: {}, sort_auto_head: false, gear: []) }
+    let(:em) { described_class.new(settings) }
+
+    before do
+      allow(em).to receive(:waitrt?)
+      allow(DRCI).to receive(:stow_hand).and_return(true)
+    end
+
+    it 'stows the ammo hand (not the weapon hand) even when the unload line carries a <dialogData> tag, and does not mistake "crossbow bolt" for the crossbow' do
+      allow(DRC).to receive(:bput)
+        .with('unload my crossbow', any_args)
+        .and_return("<dialogData id='AimTimerDialog'><timer id='firingTimer' value='0' /> </dialogData>You unload the crossbow.")
+      allow(DRC).to receive(:right_hand).and_return('battle crossbow') # weapon, noun: crossbow
+      allow(DRC).to receive(:left_hand).and_return('crossbow bolt')    # ammo, noun: bolt
+
+      em.unload_weapon('crossbow')
+
+      expect(DRCI).to have_received(:stow_hand).with('left')
+      expect(DRCI).not_to have_received(:stow_hand).with('right')
+    end
+
+    it 'does not stow an unrelated off-hand item when the unload fails' do
+      allow(DRC).to receive(:bput)
+        .with('unload my crossbow', any_args)
+        .and_return("But your crossbow isn't loaded.")
+      allow(DRC).to receive(:right_hand).and_return('battle crossbow')
+      allow(DRC).to receive(:left_hand).and_return('steel bola') # legitimate off-hand weapon
+
+      em.unload_weapon('crossbow')
+
+      expect(DRCI).not_to have_received(:stow_hand)
+    end
+
+    it 'does not stow anything when bput returns nil (timeout)' do
+      allow(DRC).to receive(:bput).and_return(nil)
+      allow(DRC).to receive(:right_hand).and_return('battle crossbow')
+      allow(DRC).to receive(:left_hand).and_return('steel bola')
+
+      em.unload_weapon('crossbow')
+
+      expect(DRCI).not_to have_received(:stow_hand)
+    end
+  end
+
+  describe '#wield_weapon_offhand?' do
+    let(:settings) { double('settings', gear_sets: {}, sort_auto_head: false, gear: []) }
+    let(:em) { described_class.new(settings) }
+    let(:weapon) do
+      double('weapon', short_name: 'bola', name: 'bola', short_regex: /\bbola/i, swappable: false)
+    end
+
+    before do
+      allow(em).to receive(:item_by_desc).with('bola').and_return(weapon)
+      allow(em).to receive(:get_item?).with(weapon).and_return(true)
+    end
+
+    it 'returns true (not a spurious false) and does not swap when the weapon is already in the left/off hand' do
+      allow(DRCI).to receive(:in_right_hand?).with(weapon).and_return(false)
+      allow(DRCI).to receive(:in_left_hand?).with(weapon).and_return(true)
+      expect(DRC).not_to receive(:bput)
+
+      expect(em.wield_weapon_offhand?('bola')).to be true
+    end
+
+    it 'swaps to the off hand when the weapon landed in the right hand' do
+      allow(DRCI).to receive(:in_right_hand?).with(weapon).and_return(true)
+      expect(DRC).to receive(:bput)
+        .with('swap', *DRCI::SWAP_HANDS_SUCCESS_PATTERNS, *DRCI::SWAP_HANDS_FAILURE_PATTERNS)
+        .and_return('You move a steel bola to your left hand.')
+
+      expect(em.wield_weapon_offhand?('bola')).to be true
+    end
+  end
+
   # --- return_held_gear failure_patterns --------------------------------
 
   describe '#return_held_gear passes failure_patterns to stow_helper' do


### PR DESCRIPTION
Updated to address review: added the failure-path success guard, corrected root cause 2, and added regression tests.

## Summary
Fixes combat gear-swapping fumbles when transitioning off a ranged weapon
(crossbow / bow / staff-sling). The ammunition (e.g. a `crossbow bolt`) was left in
a hand after `unload` and never stowed, which cascaded into downstream failures.

## Problem
When `combat-trainer` switched from a loaded ranged weapon to a melee/offhand weapon,
the ammo stayed in hand. That single stuck item caused:
- `skin` / `loot` / `stow` to fail with "You need a free hand" and loop.
- The offhand-weapon logic (which assumed a `get` lands in the right hand, then swaps)
  to scramble, ending in `jab` (no `left`) against the ammo →
  "Wouldn't it be better if you used a melee weapon?".

## Root causes (`EquipmentManager#unload_weapon`)
1. **Acted mid-roundtime** — the ammo-stow ran before the trailing `waitrt?`, i.e.
   during the ~3s unload RT, before hand state settled.
2. **Anchored regex vs. the `<dialogData>` tag** — the in-hand branch used its own
   `^`-anchored `/^(?:You unload|You .* unloading)/`. The game prepends an aim/firing
   timer tag (`<dialogData id='AimTimerDialog'>…</dialogData>You unload …`), so
   `^You unload` no longer matched and the branch was skipped.
   `DRCI::UNLOAD_WEAPON_SUCCESS_PATTERNS` already handle the optional tag; the inline
   regex did not.
3. **Weapon/ammo noun collision** — the check compared against the weapon name, and a
   `crossbow bolt` contains `crossbow`, so a text match treated the bolt as the weapon
   and skipped stowing it.

## Changes (`lib/dragonrealms/commons/equipmanager.rb`)
- `unload_weapon`:
  - move `waitrt?` up so RT/hand state settles before acting;
  - consolidate the two ground-fall branches (feet / tumbles);
  - gate the in-hand stow on a **positive `UNLOAD_WEAPON_SUCCESS_PATTERNS` match**
    (handles the `<dialogData>` tag) instead of a blanket `else`, so an unload failure
    or a `bput` timeout can't stow an unrelated off-hand item;
  - identify weapon vs. ammo by **noun** (`DRC.get_noun`) against actual hand contents.
- `wield_weapon_offhand?`: return success when the weapon is already in the off (left)
  hand instead of a spurious `false`; only swap from the right hand.
- `wield_weapon?`: the offhand branch swaps on `offhand && DRCI.in_right_hand?(weapon)`
  (is the *weapon* in the right hand?) rather than `offhand && DRC.right_hand`
  (is *anything* in the right hand?).

## Tests (`spec/lib/dragonrealms/commons/equipmanager_spec.rb`)
- in-hand stow with a `<dialogData>`-prefixed unload line — asserts the ammo hand is
  stowed and the weapon hand is not (also covers the `crossbow bolt` noun collision);
- unload **failure** does not stow an unrelated off-hand item;
- `bput` **nil/timeout** stows nothing;
- `wield_weapon_offhand?` returns `true` (not a spurious `false`) and does not `swap`
  when already off-handed; and swaps when the weapon landed in the right hand.

## Testing
Existing `equipmanager_spec.rb` suite passes; new regression tests added for the above.
Reproduced and verified in-game with a crossbow → wakizashi → offhand-bola rotation:
before, the bolt was left in hand and blocked skin/loot and flipped `jab left` → `jab`;
after, the ammo is stowed on unload and the rotation completes cleanly. Ground-fall
recovery (ammo falls to feet / tumbles) is preserved.