### PR TITLE
fix(dr): common-healing.rb -  DRCH.bind_wound: only dispose a dislodged item while it is in hand

### DIFF
--- a/lib/dragonrealms/commons/common-healing.rb
+++ b/lib/dragonrealms/commons/common-healing.rb
@@ -359,7 +359,15 @@ module Lich
         case result
         when *TEND_DISLODGE_PATTERNS
           dislodge_match = result.match(/^You \w+ remove (?:a|the|some) (?<item>.+) from/)
-          DRCI.dispose_trash(dislodge_match[:item], get_settings.worn_trashcan, get_settings.worn_trashcan_verb) if dislodge_match
+          # Only dispose the item the tend just removed, and only while it is in
+          # hand. A freshly dislodged item (e.g. a crossbow bolt) lands in a free
+          # hand; disposing it there is safe. But if the item is gone (the maze
+          # can yank you out and clear your hands the instant it drops), a blind
+          # dispose_trash would GET a same-named item from a worn container --
+          # trashing the character's own ammunition -- so skip it in that case.
+          if dislodge_match && DRCI.in_hands?(dislodge_match[:item])
+            DRCI.dispose_trash(dislodge_match[:item], get_settings.worn_trashcan, get_settings.worn_trashcan_verb)
+          end
           bind_wound(body_part, person)
         when *TEND_FAILURE_PATTERNS
           false

--- a/spec/lib/dragonrealms/commons/common_healing_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_healing_spec.rb
@@ -1028,6 +1028,98 @@ RSpec.describe Lich::DragonRealms::DRCH do
       expect(DRC).to receive(:bput).with('tend Muleoak right arm', any_args).and_return('You work carefully at tending')
       described_class.bind_wound('right arm', 'Muleoak')
     end
+
+    # -- Dislodged lodged items (crossbow bolts, arrows, ...) -----------------
+    #
+    # Tending out a lodged item drops it into a free hand; bind_wound disposes
+    # that item and re-tends. The disposal must target ONLY the item just
+    # removed, and only while it is actually in hand -- otherwise a blind
+    # dispose_trash would GET a same-named item from a worn container (the
+    # character's own ammunition) if the removed item has vanished (e.g. the
+    # Droughtman's Maze yanks you out and clears your hands the instant the bolt
+    # drops). in_hands? / dispose_trash come from the shared spec_helper DRCI.
+    context 'when a tend dislodges a lodged item' do
+      let(:removed_abdomen) do
+        'You skillfully remove the crossbow bolt from your abdomen leaving the wound no worse than it was before.'
+      end
+      let(:tended) { 'That area is not bleeding.' }
+
+      it 'disposes the removed item when it is in hand, then re-tends to a terminal' do
+        allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+        allow(DRCI).to receive(:in_hands?).with('crossbow bolt').and_return(true)
+        expect(DRCI).to receive(:dispose_trash).with('crossbow bolt', anything, anything)
+
+        expect(described_class.bind_wound('abdomen')).to be true
+      end
+
+      it 'does NOT dispose (never grabs a like-named item) when the dislodged item is gone from hand' do
+        # The regression: hand cleared by the maze eject before disposal runs.
+        allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+        allow(DRCI).to receive(:in_hands?).with('crossbow bolt').and_return(false)
+        expect(DRCI).not_to receive(:dispose_trash)
+
+        described_class.bind_wound('abdomen')
+      end
+
+      it 'treats a nil in-hands result as not-in-hand and skips disposal' do
+        allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+        allow(DRCI).to receive(:in_hands?).and_return(nil)
+        expect(DRCI).not_to receive(:dispose_trash)
+
+        described_class.bind_wound('abdomen')
+      end
+
+      it 'checks in-hands against the exact removed item, not the whole message' do
+        allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+        allow(DRCI).to receive(:in_hands?).and_return(false)
+
+        described_class.bind_wound('abdomen')
+
+        expect(DRCI).to have_received(:in_hands?).with('crossbow bolt')
+      end
+
+      it 'captures a "some"-quantified dislodged item' do
+        removed_plural = 'You deftly remove some crossbow bolts from your abdomen leaving the wound no worse than it was before.'
+        allow(DRC).to receive(:bput).and_return(removed_plural, tended)
+        allow(DRCI).to receive(:in_hands?).with('crossbow bolts').and_return(true)
+        expect(DRCI).to receive(:dispose_trash).with('crossbow bolts', anything, anything)
+
+        described_class.bind_wound('abdomen')
+      end
+
+      it 'keeps dislodging and disposing each removed item until the area yields a terminal' do
+        removed_bolt = 'You deftly remove a crossbow bolt from your chest leaving the wound no worse than it was before.'
+        removed_arrow = 'You skillfully remove the arrow from your chest leaving the wound no worse than it was before.'
+        allow(DRC).to receive(:bput).and_return(removed_bolt, removed_arrow, 'You work carefully at tending your wound.')
+        allow(DRCI).to receive(:in_hands?).and_return(true)
+        expect(DRCI).to receive(:dispose_trash).with('crossbow bolt', anything, anything).ordered
+        expect(DRCI).to receive(:dispose_trash).with('arrow', anything, anything).ordered
+
+        expect(described_class.bind_wound('chest')).to be true
+      end
+
+      it 'does not attempt disposal (or an in-hands check) for a dislodge line with no removable item' do
+        # The clay-fragment dislodge line matches TEND_DISLODGE_PATTERNS but has
+        # no "remove <item> from" capture, so dislodge_match is nil.
+        allow(DRC).to receive(:bput).and_return('As you reach for the clay fragment it crumbles to dust.', tended)
+        expect(DRCI).not_to receive(:in_hands?)
+        expect(DRCI).not_to receive(:dispose_trash)
+
+        described_class.bind_wound('chest')
+      end
+
+      it 'preserves the person argument across dislodge recursion' do
+        allow(DRCI).to receive(:in_hands?).and_return(false)
+        allow(DRC).to receive(:bput).and_return(
+          'You skillfully remove the crossbow bolt from your chest leaving the wound no worse than it was before.',
+          tended
+        )
+
+        described_class.bind_wound('chest', 'Muleoak')
+
+        expect(DRC).to have_received(:bput).with('tend Muleoak chest', any_args).twice
+      end
+    end
   end
 
   describe '.unwrap_wound' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1735,6 +1735,13 @@ end unless defined?(Lich::Util)
 module Kernel
   def pause(_seconds = nil); end unless method_defined?(:pause)
 
+  # Stands in for the real global_defs get_settings (character-scoped settings).
+  # Returns an OpenStruct so any setting key (e.g. worn_trashcan) reads back nil
+  # by default; override per example with allow(self).to receive(:get_settings).
+  def get_settings(_character_suffixes = [])
+    OpenStruct.new
+  end unless method_defined?(:get_settings)
+
   def waitrt?; end unless method_defined?(:waitrt?)
 
   def waitcastrt?; end unless method_defined?(:waitcastrt?)


### PR DESCRIPTION
## Problem

Tending out a lodged item (a crossbow bolt, arrow, ...) can destroy the character's **own ammunition**.

`bind_wound`, on a dislodge, calls `dispose_trash(item, ...)`:

```ruby
when *TEND_DISLODGE_PATTERNS
  dislodge_match = result.match(/^You \w+ remove (?:a|the|some) (?<item>.+) from/)
  DRCI.dispose_trash(dislodge_match[:item], get_settings.worn_trashcan, get_settings.worn_trashcan_verb) if dislodge_match
```

`dispose_trash` starts with `get_item_if_not_held?(item)`, whose fallback is a blind `get <item>` that reaches into worn containers. Normally the tended-out item is already in a free hand, so `in_hands?` short-circuits and the right item is trashed. But if the item has left the hand before disposal runs, that blind GET matches a same-named item in a rucksack/quiver.

Real reproduction (Droughtman's Maze crossbow trap): the maze yanked the character out (`the floor grating underfoot swings open... you turn around to find yourself refreshed and reattired at...`) in the window between the tend removing the bolt and the disposal running. Hands were cleared, so `get crossbow bolt` grabbed the player's own bolts from their rucksack and dumped them in the trash bucket:

```
tend my abdomen
You skillfully remove the crossbow bolt from your abdomen ...
(ejected to the Recovery Room)
get my crossbow bolt
You get some crossbow bolts from inside your fighter's rucksack.   <- own ammo
put my crossbow bolt in bucket
You drop some crossbow bolts in a bucket of viscous gloop.          <- destroyed
```

## Fix

Guard the disposal on `DRCI.in_hands?`: dispose only the item the tend just removed, and only while it is actually held.

```ruby
when *TEND_DISLODGE_PATTERNS
  dislodge_match = result.match(/^You \w+ remove (?:a|the|some) (?<item>.+) from/)
  if dislodge_match && DRCI.in_hands?(dislodge_match[:item])
    DRCI.dispose_trash(dislodge_match[:item], get_settings.worn_trashcan, get_settings.worn_trashcan_verb)
  end
  bind_wound(body_part, person)
```

When the removed item is in hand (the normal case), behavior is unchanged -- `get_item_if_not_held?` short-circuits on the held item, no container reach. When the item is gone, disposal is skipped rather than grabbing a like-named item.

**Trade-off:** in the rare case where a tend removes an item while both hands are full and it drops to the ground, this leaves it on the floor instead of trashing it -- a cosmetic change versus the risk of deleting the player's ammunition. (During `tendme` a hand is freed first, so that path is unaffected.)

## Tests

New `.bind_wound` dislodge specs cover: in-hand disposal + re-tend to a terminal; the **not-in-hand regression** (no grab, no dispose); nil in-hands; the exact-item in-hands check (not the whole message); `"some"`-quantified items; multi-item recursion (each removed item disposed in order); the no-removable-item dislodge line (clay fragment); and person-argument preservation across recursion. A `get_settings` double was added to `spec_helper` (used by the disposal path) alongside the existing `DRCI` double.

Full suite: **4931 examples, 0 failures**. `rubocop` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)