### PR TITLE
feat(all): Add supervised child script lifecycle APIs

### DIFF
--- a/lib/common/orderly_shutdown.rb
+++ b/lib/common/orderly_shutdown.rb
@@ -43,12 +43,18 @@ module Lich
           ShutdownLog.begin_user_exit_summary!
           coordinator.request(reason: :user_exit, source: source)
 
-          scripts_provider ||= proc { Script.running + Script.hidden }
+          initial_scripts =
+            if scripts_provider
+              scripts_provider.call
+            else
+              Script.begin_shutdown
+            end
+          scripts_provider ||= proc { Script.shutdown_scripts }
           remaining_scripts = proc { scripts_provider.call.reject { |script| script.equal?(current_script) } }
 
-          run(
+          result = run(
             coordinator: coordinator,
-            initial_scripts: remaining_scripts.call,
+            initial_scripts: initial_scripts.reject { |script| script.equal?(current_script) },
             remaining_scripts: remaining_scripts,
             script_drain: script_drain,
             vars: vars,
@@ -56,6 +62,11 @@ module Lich
             active_sessions_lifecycle: active_sessions_lifecycle,
             slow_threshold: slow_threshold
           )
+          if current_script && initial_scripts.include?(current_script)
+            result.scripts_drained = false
+            result.completed = false
+          end
+          result
         end
 
         # Executes orderly user shutdown once.

--- a/lib/common/orderly_shutdown.rb
+++ b/lib/common/orderly_shutdown.rb
@@ -49,7 +49,7 @@ module Lich
             else
               Script.begin_shutdown
             end
-          scripts_provider ||= proc { Script.shutdown_scripts }
+          scripts_provider ||= proc { Script.progress_shutdown }
           remaining_scripts = proc { scripts_provider.call.reject { |script| script.equal?(current_script) } }
 
           result = run(

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -26,6 +26,7 @@ module Lich
 
     class Script
       VALID_KILL_CONTEXTS = [:runtime, :shutdown].freeze
+      CHILD_MUTEX_INITIALIZER = Mutex.new
 
       @@elevated_script_start = proc { |args|
         if args.empty?
@@ -288,6 +289,8 @@ module Lich
         end
       }
       @@running = Array.new
+      @@library_mutex = Mutex.new
+      @@loaded_libraries = Set.new
       @@kill_metrics_mutex = Mutex.new
       @@kill_metrics = {
         :minute            => nil,
@@ -549,6 +552,33 @@ module Lich
         @@running.dup
       end
 
+      def Script.subscript(&block)
+        SubScript.start(:parent => Script.current, :quiet => true, &block)
+      end
+
+      def Script.start_child(*args)
+        parent = Script.current
+        child = Script.start(*args)
+        return child unless parent && child
+
+        parent.register_child(child)
+      end
+
+      def Script.run_child(*args)
+        child = Script.start_child(*args)
+        child&.join
+        child
+      end
+
+      def Script.daemon_me
+        return false unless (script = Script.current)
+
+        script.hidden = true
+        script.no_kill_all = true
+        script.no_pause_all = true
+        script
+      end
+
       def Script.current
         if (script = @@running.find { |s| s.has_thread?(Thread.current) })
           sleep 0.2 while script.paused? and not script.ignore_pause
@@ -566,6 +596,39 @@ module Lich
         if (s = @@elevated_script_start.call(args))
           sleep 0.1 while @@running.include?(s)
         end
+      end
+
+      def Script.loadlib(library)
+        library_name = library.to_s.downcase
+        library_name = "lib#{library_name}" unless library_name.start_with?('lib')
+        raise ArgumentError, 'library name cannot be empty' if library_name == 'lib'
+        raise LoadError, "script library not found: #{library_name}" unless Script.exists?(library_name)
+
+        script = @@library_mutex.synchronize do
+          running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
+          if @@loaded_libraries.include?(library_name)
+            running
+          else
+            @@loaded_libraries.add(library_name)
+            started = running || Script.start(library_name)
+            @@loaded_libraries.delete(library_name) unless started
+            started
+          end
+        end
+
+        raise LoadError, "failed to start script library: #{library_name}" unless @@loaded_libraries.include?(library_name)
+
+        script&.join
+        true
+      end
+
+      def Script.reloadlibs
+        @@library_mutex.synchronize { @@loaded_libraries.dup }.each { |library| Script.run(library) }
+        true
+      end
+
+      def Script.libs
+        @@library_mutex.synchronize { @@loaded_libraries.dup }
       end
 
       def Script.running?(name)
@@ -619,6 +682,16 @@ module Lich
         else
           false
         end
+      end
+
+      def Script.kill_all(force: false, context: :runtime)
+        unless VALID_KILL_CONTEXTS.include?(context)
+          raise ArgumentError, "invalid script kill context: #{context.inspect}"
+        end
+
+        scripts = force ? Script.list : Script.running.reject(&:no_kill_all)
+        scripts.each { |script| script.kill(context: context) }
+        scripts.length
       end
 
       def Script.paused?(name)
@@ -992,6 +1065,7 @@ module Lich
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
+        @kill_requested = true
         source = @kill_source || caller[0..2]
 
         if context == :shutdown
@@ -1006,6 +1080,70 @@ module Lich
         end
 
         @name
+      end
+
+      def running?
+        @@running.include?(self)
+      end
+
+      def stopping?
+        @kill_requested == true
+      end
+
+      def join(timeout = nil)
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
+        @killer_mutex.synchronize do
+          @stopped_condition ||= ConditionVariable.new
+          while @@running.include?(self)
+            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC) if deadline
+            return nil if remaining && remaining <= 0
+
+            @stopped_condition.wait(@killer_mutex, remaining)
+          end
+        end
+        self
+      end
+
+      def kill_sync(context: :runtime, timeout: nil)
+        kill(context: context) if running?
+        join(timeout)
+      end
+
+      def register_child(script)
+        return nil unless script
+
+        script.hidden = true if hidden
+        script.no_kill_all = true if no_kill_all
+        script.no_pause_all = true if no_pause_all
+        accepted = child_scripts_mutex.synchronize do
+          unless @child_shutdown_started
+            @child_scripts ||= []
+            @child_scripts << script unless @child_scripts.include?(script)
+            true
+          end
+        end
+        unless accepted
+          script.kill_sync if script.running?
+          return nil
+        end
+
+        begin
+          script.at_exit { unregister_child(script) }
+        rescue NoMethodError
+          # A short-lived child may finish before its exit handler is registered.
+        ensure
+          unregister_child(script) unless script.running?
+        end
+        script
+      end
+
+      def unregister_child(script)
+        child_scripts_mutex.synchronize { @child_scripts&.delete(script) }
+        script
+      end
+
+      def child_scripts
+        child_scripts_mutex.synchronize { Array(@child_scripts).dup }
       end
 
       # Runs the script cleanup body used by {#kill}.
@@ -1049,6 +1187,7 @@ module Lich
                 end
               }
               @thread_group.add(Thread.current)
+              __stop_children(context)
               # Forward the kill context so die_with dependents torn down during
               # shutdown also run inline -- otherwise they route back through the
               # default :runtime path and re-spawn the thread-per-kill burst that
@@ -1079,6 +1218,7 @@ module Lich
               @upstream_buffer = LimitedArray.new
               @die_with = @at_exit_procs = @match_stack_labels = @match_stack_strings = nil
               @@running.delete(self)
+              @stopped_condition&.broadcast
               unless @quiet
                 if @killed_externally
                   respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
@@ -1104,6 +1244,27 @@ module Lich
         }
       end
       private :__run_kill_cleanup
+
+      def __stop_children(context)
+        children = child_scripts_mutex.synchronize do
+          @child_shutdown_started = true
+          current = Array(@child_scripts).dup
+          @child_scripts = []
+          current
+        end
+        children.each do |child|
+          child.kill(context: context) if child.running?
+          child.join
+        end
+      end
+      private :__stop_children
+
+      def child_scripts_mutex
+        return @child_scripts_mutex if @child_scripts_mutex
+
+        CHILD_MUTEX_INITIALIZER.synchronize { @child_scripts_mutex ||= Mutex.new }
+      end
+      private :child_scripts_mutex
 
       # Logs when {#kill} cannot allocate its normal cleanup thread.
       #
@@ -1274,6 +1435,83 @@ module Lich
       def custom?
         @custom
       end
+    end
+
+    class SubScript < Script
+      @@name_subscript_mutex = Mutex.new
+
+      def SubScript.start(parent: Script.current, quiet: true, &block)
+        raise ArgumentError, 'a block is required' unless block
+
+        new_script = SubScript.new(:quiet => quiet)
+        return false if parent && !parent.register_child(new_script)
+
+        new_thread = Thread.new {
+          100.times { break if Script.current == new_script; sleep 0.01 }
+
+          if (script = Script.current)
+            Thread.current.priority = 1
+            respond("--- Lich: #{script.name} active.") unless script.quiet
+            begin
+              block.call
+            rescue SystemExit
+              nil
+            rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => e
+              respond "--- Lich error: #{e}"
+              respond e.backtrace.first
+              Lich.log "Exception: #{e}\n\t#{e.backtrace.join("\n\t")}"
+            ensure
+              script.kill if script.running? && !script.stopping?
+            end
+          else
+            respond '--- Lich: failed to start subscript'
+          end
+        }
+        new_script.thread_group.add(new_thread)
+        new_script
+      end
+
+      # SubScript has no source file or eval string, so it initializes only the
+      # runtime state shared by ordinary scripts.
+      # rubocop:disable Lint/MissingSuper
+      def initialize(quiet: true)
+        @custom = false
+        @vars = []
+        @downstream_buffer = LimitedArray.new
+        @downstream_buffer.max_size = 400
+        @killer_mutex = Mutex.new
+        @want_downstream = true
+        @want_downstream_xml = false
+        @want_script_output = false
+        @upstream_buffer = LimitedArray.new
+        @want_upstream = false
+        @unique_buffer = LimitedArray.new
+        @at_exit_procs = []
+        @watchfor = {}
+        @hidden = false
+        @paused = false
+        @silent = false
+        @quiet = quiet
+        @safe = false
+        @no_echo = false
+        @thread_group = ThreadGroup.new
+        @die_with = []
+        @no_pause_all = false
+        @no_kill_all = false
+        @match_stack_labels = []
+        @match_stack_strings = []
+        @killed_externally = false
+        @kill_source = nil
+        @kill_requested = false
+        @ignore_pause = false
+        @@name_subscript_mutex.synchronize do
+          num = '1'
+          num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
+          @name = "subscript#{num}"
+          @@running.push(self)
+        end
+      end
+      # rubocop:enable Lint/MissingSuper
     end
 
     class ExecScript < Script

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -34,17 +34,20 @@ module Lich
       JOIN_WAIT_INTERVAL = 0.05
 
       # Nested lock order:
-      #   parent child list -> startup -> registry -> generated name
-      #   -> per-script lifecycle -> child relationship
-      # Finalization releases the relationship lock before taking a parent's
-      # child-list lock. Library coordination releases its mutex before starting
-      # or joining a script. Registry and lifecycle locks are never held while
-      # invoking script code or cleanup callbacks.
+      #   startup -> registry -> per-script lifecycle -> child relationship
+      # Child adoption takes the parent's child-list lock before the child's
+      # registry/lifecycle locks. Child launch reservations avoid holding that
+      # lock across startup. Finalization releases the relationship lock before
+      # taking a parent's child-list lock. Library coordination releases its
+      # mutex before starting or joining a script. Registry and lifecycle locks
+      # are never held while invoking script code or cleanup callbacks.
 
-      class ThreadGroupHandle
-        def initialize(script)
+      module ThreadGroupHandle
+        def __attach_script(script)
           @script = script
+          self
         end
+        private :__attach_script
 
         def add(thread)
           accepted = @script.__send__(:__register_worker, thread)
@@ -55,6 +58,15 @@ module Lich
 
         def list
           @script.__send__(:__worker_threads)
+        end
+
+        def enclose
+          @script.__send__(:__enclose_worker_group)
+          self
+        end
+
+        def enclosed?
+          @script.__send__(:__worker_group_enclosed?)
         end
       end
 
@@ -148,49 +160,50 @@ module Lich
             new_thread = Thread.new {
               next unless start_gate.pop
 
-              if (script = Script.current)
-                eval('script = Script.current', script_binding, script.name)
-                Thread.current.priority = 1
-                respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
-                begin
-                  Script.__send__(
-                    :__execute,
-                    script,
-                    :on_error => proc { |error| Script.__send__(:__report_script_error, script, error, :untrusted => !trusted) }
-                  ) do
-                    if trusted
-                      eval(script.labels[script.current_label].to_s, script_binding, script.name)
-                    else
-                      while (script = Script.current) and script.current_label
-                        proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
-                        Script.current.get_next_label
+              script = script_obj
+              begin
+                if Script.current
+                  eval('script = Script.current', script_binding, script.name)
+                  Thread.current.priority = 1
+                  respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
+                  begin
+                    Script.__send__(
+                      :__execute,
+                      script,
+                      :on_error       => proc { |error| Script.__send__(:__report_script_error, script, error, :untrusted => !trusted) },
+                      :propagate_jump => true
+                    ) do
+                      if trusted
+                        eval(script.labels[script.current_label].to_s, script_binding, script.name)
+                      else
+                        while (script = Script.current) and script.current_label
+                          proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
+                          Script.current.get_next_label
+                        end
                       end
                     end
+                  rescue JumpError => error
+                    if error == JUMP
+                      retry if Script.current.get_next_label != JUMP_ERROR
+                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
+                      respond error.backtrace.first
+                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{error.backtrace.join("\n\t")}"
+                      script.__send__(:__record_exit_error, JUMP_ERROR)
+                    else
+                      script.__send__(:__record_exit_error, error)
+                      Script.__send__(:__report_script_error, script, error, :untrusted => !trusted)
+                    end
                   end
-                rescue JumpError => error
-                  if error == JUMP
-                    retry if Script.current.get_next_label != JUMP_ERROR
-                    respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                    respond error.backtrace.first
-                    Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{error.backtrace.join("\n\t")}"
-                    script.__send__(:__record_exit_error, JUMP_ERROR)
-                  else
-                    script.__send__(:__record_exit_error, error)
-                    Script.__send__(:__report_script_error, script, error, :untrusted => !trusted)
-                  end
-                ensure
-                  script.kill if script.running? && !script.stopping?
+                else
+                  respond '--- error: out of cheese'
                 end
-              else
-                respond '--- error: out of cheese'
+              ensure
+                script.kill if script.running? && !script.stopping?
               end
             }
             script_obj.__send__(:__attach_startup_worker, new_thread)
-            if parent && !parent.__send__(:__adopt_child_locked, script_obj)
-              new_thread&.kill
-              script_obj.__send__(:__discard_startup)
-              next nil
-            end
+            next nil if parent && !parent.__send__(:__adopt_child, script_obj)
+
             script_obj.__send__(:__publish, true)
             setup_complete = true
           ensure
@@ -201,7 +214,7 @@ module Lich
               unless setup_complete && worker_released
                 new_thread&.kill
                 new_thread&.join
-                parent.__send__(:__unregister_child_locked, script_obj) if parent
+                parent.unregister_child(script_obj) if parent
                 script_obj.__send__(:__discard_startup)
               end
             end
@@ -564,7 +577,7 @@ module Lich
       end
       private_class_method :__warn_lich_too_old
 
-      def Script.__execute(script, on_error:)
+      def Script.__execute(script, on_error:, propagate_jump: false)
         yield
         script.__send__(:__record_successful_exit)
       rescue SystemExit => error
@@ -573,8 +586,11 @@ module Lich
         else
           script.__send__(:__record_exit_error, error)
         end
-      rescue JumpError
-        raise
+      rescue JumpError => error
+        raise if propagate_jump
+
+        script.__send__(:__record_exit_error, error)
+        on_error.call(error)
       rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => error
         script.__send__(:__record_exit_error, error)
         on_error.call(error)
@@ -770,8 +786,7 @@ module Lich
         if loading
           begin
             __join_library(library_name, loading)
-            __validate_library_completion(library_name, loading)
-            return true
+            return __commit_library_completion(library_name, loading)
           rescue LoadError => e
             raise if e.message.start_with?('cyclic script library dependency:')
 
@@ -830,34 +845,22 @@ module Lich
           raise
         end
 
-        error = script.exit_error
-        completed = script.completed_successfully?
-        @@library_mutex.synchronize do
-          if @@loading_libraries[library_name].equal?(script)
-            @@loading_libraries.delete(library_name)
-            if error || !completed
-              @@loaded_libraries.delete(library_name)
-            else
-              @@loaded_libraries.add(library_name)
-            end
-          end
-        end
-        __validate_library_completion(library_name, script)
-
-        true
+        __commit_library_completion(library_name, script)
       end
 
       def Script.reloadlibs
         current_library = Script.current&.name&.downcase
+        successful = true
         @@library_mutex.synchronize { @@loaded_libraries.dup }.each do |library|
           next if library == current_library
 
           @@library_mutex.synchronize { @@loaded_libraries.delete(library) }
           Script.loadlib(library)
         rescue LoadError => e
+          successful = false
           Lich.log("error: failed to reload script library #{library}: #{e.message}")
         end
-        true
+        successful
       end
 
       def Script.libs
@@ -894,6 +897,24 @@ module Lich
         end
       end
       private_class_method :__join_library
+
+      def Script.__commit_library_completion(library_name, script)
+        error = script.exit_error
+        completed = script.completed_successfully?
+        @@library_mutex.synchronize do
+          if @@loading_libraries[library_name].equal?(script)
+            @@loading_libraries.delete(library_name)
+            if error || !completed
+              @@loaded_libraries.delete(library_name)
+            else
+              @@loaded_libraries.add(library_name)
+            end
+          end
+        end
+        __validate_library_completion(library_name, script)
+        true
+      end
+      private_class_method :__commit_library_completion
 
       def Script.__validate_library_completion(library_name, script)
         error = script.exit_error
@@ -1440,7 +1461,7 @@ module Lich
       end
 
       def completed_successfully?
-        lifecycle_mutex.synchronize { @completed_successfully == true }
+        lifecycle_mutex.synchronize { @completed_successfully == true && !@exit_error }
       end
 
       # Waits for this script to finish. Without an explicit timeout, normal
@@ -1455,7 +1476,6 @@ module Lich
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
         cleanup_deadline = nil
         loop do
-          __refresh_deferred_stop
           running, stopping, cleanup_complete, current_worker = Script.__send__(:__registry_synchronize) do
             lifecycle_mutex.synchronize do
               [
@@ -1483,7 +1503,9 @@ module Lich
       end
 
       def kill_sync(context: :runtime, timeout: nil)
-        kill(context: context) if running?
+        if running?
+          timeout ? kill(context: context, :async => true) : kill(context: context)
+        end
         join(timeout)
       end
 
@@ -1507,9 +1529,7 @@ module Lich
       end
 
       def child_scripts
-        child_scripts_mutex.synchronize do
-          CHILD_RELATIONSHIP_MUTEX.synchronize { Array(@child_scripts).dup }
-        end
+        child_scripts_mutex.synchronize { Array(@child_scripts).dup }
       end
 
       # Runs the script cleanup body used by {#kill}.
@@ -1541,82 +1561,118 @@ module Lich
         # cleanup body twice over already-nilled state, not skip it.)
         return if @killer_mutex.owned?
 
-        @killer_mutex.synchronize {
-          lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
-          if running?
-            instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
-            started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
-            failed = false
-            begin
-              children = __begin_child_shutdown
-              stopping_threads = lifecycle_mutex.synchronize do
-                @stopping_threads = @thread_group.list.dup.reject { |thread| thread == Thread.current }
-              end
-              stopping_threads.each { |thread| thread.kill rescue nil }
-              @thread_group.add(Thread.current)
-              __stop_children(children, context)
-              @thread_group.add(Thread.current)
-              # Forward the kill context so die_with dependents torn down during
-              # shutdown also run inline -- otherwise they route back through the
-              # default :runtime path and re-spawn the thread-per-kill burst that
-              # inline shutdown teardown exists to avoid.
-              @die_with.each do |script_name|
-                Script.kill(script_name, context: context)
-                @thread_group.add(Thread.current)
-              end
-              @paused = false
-              @at_exit_procs.each { |p| report_errors { p.call } }
-              # Let each per-script-state subsystem (the hook registries, etc.)
-              # apply its own death policy for what this script registered.
-              # Subsystems register with ScriptDeath, so kill does not name them;
-              # cleanup keys on this instance (not its name), so a force: true
-              # sibling sharing our name is unaffected. Hooks persist by default
-              # (so register-and-exit patterns like ;alias keep working); a hook
-              # is only removed if it opted in with persist: false.
-              ScriptDeath.run(self)
-              # Release per-script watchfor procs (and the bindings they
-              # capture). The script is removed from @@running below, so they can
-              # never fire again; cleared to {} rather than nil so a concurrent
-              # new_downstream sweep still sees a safe, empty collection.
-            rescue
-              failed = true
-              respond "--- Lich: error: #{$!}"
-              Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-            ensure
+        begin
+          @killer_mutex.synchronize do
+            lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
+            if running?
+              instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
+              started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
+              failed = false
+              cleanup_body_complete = false
               begin
-                if instrument_kill
-                  finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-                  Script.__send__(
-                    :__record_kill_metric,
-                    :duration_ms => (finished_at - started_at) * 1000.0,
-                    :failed      => failed
-                  )
+                children = __begin_child_shutdown
+                stopping_threads = lifecycle_mutex.synchronize do
+                  @stopping_threads = @thread_group.list.dup.reject { |thread| thread == Thread.current }
                 end
+                stopping_threads.each { |thread| thread.kill rescue nil }
+                @thread_group.add(Thread.current)
+                __stop_children(children, context)
+                @thread_group.add(Thread.current)
+                # Shift each callback before invoking it. If this executor is
+                # cancelled, recovery resumes with the remaining callbacks.
+                while (script_name = @die_with.shift)
+                  failed = true unless __run_cleanup_callback do
+                    Script.kill(script_name, context: context)
+                    @thread_group.add(Thread.current)
+                  end
+                end
+                @paused = false
+                while (callback = @at_exit_procs.shift)
+                  failed = true unless __run_cleanup_callback { callback.call }
+                end
+                # ScriptDeath handlers are individually isolated by the
+                # registry and are safe to retry after executor cancellation.
+                ScriptDeath.run(self)
+                cleanup_body_complete = true
+              rescue SystemExit, ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => error
+                failed = true
+                __record_exit_error(error)
+                __report_cleanup_error(error)
+                cleanup_body_complete = true
               ensure
-                __complete_stop(source, context)
+                begin
+                  if instrument_kill && cleanup_body_complete
+                    finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                    Script.__send__(
+                      :__record_kill_metric,
+                      :duration_ms => (finished_at - started_at) * 1000.0,
+                      :failed      => failed
+                    )
+                  end
+                ensure
+                  __complete_stop(source, context) if cleanup_body_complete
+                end
               end
             end
           end
-        }
+        ensure
+          lifecycle_mutex.synchronize do
+            @cleanup_thread = nil if @cleanup_thread == Thread.current
+            @stopped_condition&.broadcast
+          end
+        end
       end
       private :__run_kill_cleanup
 
+      def __run_cleanup_callback
+        yield
+        true
+      rescue SystemExit, ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => error
+        __record_exit_error(error)
+        __report_cleanup_error(error)
+        false
+      end
+      private :__run_cleanup_callback
+
+      def __report_cleanup_error(error)
+        respond "--- Lich: error: #{error}"
+        Lich.log "error: #{error}\n\t#{error.backtrace.join("\n\t")}"
+      end
+      private :__report_cleanup_error
+
       def __launch_child
-        child_scripts_mutex.synchronize do
+        admitted = child_scripts_mutex.synchronize do
           return nil if @child_shutdown_started
 
+          @child_launches = @child_launches.to_i + 1
+          true
+        end
+        return nil unless admitted
+
+        begin
           yield
+        ensure
+          child_scripts_mutex.synchronize do
+            @child_launches -= 1
+            @child_launch_condition&.broadcast
+          end
         end
       end
       private :__launch_child
 
       def __register_child_locked(script)
         return nil if @child_shutdown_started
+
         script.__send__(:__while_running) do
           __adopt_child_locked(script)
         end
       end
       private :__register_child_locked
+
+      def __adopt_child(script)
+        child_scripts_mutex.synchronize { __adopt_child_locked(script) }
+      end
+      private :__adopt_child
 
       def __adopt_child_locked(script)
         return nil if @child_shutdown_started
@@ -1655,13 +1711,14 @@ module Lich
       private :__unregister_child_locked
 
       def __begin_child_shutdown
-        children = child_scripts_mutex.synchronize do
-          CHILD_RELATIONSHIP_MUTEX.synchronize do
-            @child_shutdown_started = true
-            Array(@child_scripts).dup
+        child_scripts_mutex.synchronize do
+          @child_shutdown_started = true
+          if @child_launches.to_i.positive?
+            @child_launch_condition ||= ConditionVariable.new
+            @child_launch_condition.wait(child_scripts_mutex) while @child_launches.to_i.positive?
           end
+          Array(@child_scripts).dup
         end
-        children
       end
       private :__begin_child_shutdown
 
@@ -1789,23 +1846,48 @@ module Lich
       end
       private :__worker_threads
 
+      def __enclose_worker_group
+        @thread_group.enclose
+        self
+      end
+      private :__enclose_worker_group
+
+      def __worker_group_enclosed?
+        @thread_group.enclosed?
+      end
+      private :__worker_group_enclosed?
+
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
           Script.__send__(:__registry_synchronize) do
-            lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+            @@running.push(self) unless @@running.include?(self)
           end
         end
         self
       end
       private :__publish
 
-      def __while_running
-        runnable = Script.__send__(:__registry_synchronize) do
-          lifecycle_mutex.synchronize { @@running.include?(self) && !stopping? }
+      def __publish_generated(prefix, admitted)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          Script.__send__(:__registry_synchronize) do
+            num = '1'
+            num.succ! while @@running.any? { |script| script.name == "#{prefix}#{num}" }
+            @name = "#{prefix}#{num}"
+            @@running.push(self)
+          end
         end
-        return nil unless runnable
+        self
+      end
+      private :__publish_generated
 
-        yield
+      def __while_running
+        Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            return nil unless @@running.include?(self) && !stopping?
+
+            yield
+          end
+        end
       end
       private :__while_running
 
@@ -1903,13 +1985,17 @@ module Lich
           lifecycle_mutex.synchronize do
             if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
                (!@cleanup_thread || !@cleanup_thread.alive?)
-              @cleanup_started = false
-              @cleanup_thread = nil
               true
             end
           end
         end
-        kill(:context => :shutdown) if abandoned_cleanup
+        if abandoned_cleanup
+          __run_kill_cleanup(
+            :source         => @kill_source || ['abandoned cleanup recovery'],
+            :context        => :shutdown,
+            :record_metrics => false
+          )
+        end
 
         should_refresh = Script.__send__(:__registry_synchronize) do
           lifecycle_mutex.synchronize do
@@ -1922,19 +2008,14 @@ module Lich
       private :__refresh_deferred_stop
 
       def __finalize_stop
-        claimed = lifecycle_mutex.synchronize do
-          next false if @cleanup_complete || @finalization_started
+        finalization_mutex = lifecycle_mutex.synchronize { @finalization_mutex ||= Mutex.new }
+        finalization_mutex.synchronize do
+          return if lifecycle_mutex.synchronize { @cleanup_complete }
 
-          @finalization_started = true
-        end
-        return unless claimed
-
-        parent = nil
-        begin
+          parent = nil
           CHILD_RELATIONSHIP_MUTEX.synchronize { parent = @parent_script }
           parent&.unregister_child(self)
           CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
-        ensure
           Script.__send__(:__registry_synchronize) do
             lifecycle_mutex.synchronize do
               @cleanup_complete = true
@@ -1991,7 +2072,7 @@ module Lich
       end
 
       def thread_group
-        @thread_group_handle ||= ThreadGroupHandle.new(self)
+        @thread_group_handle ||= ThreadGroup.new.extend(ThreadGroupHandle).__send__(:__attach_script, self)
       end
 
       def has_thread?(t)
@@ -2118,8 +2199,6 @@ module Lich
     end
 
     class SubScript < Script
-      @@name_subscript_mutex = Mutex.new
-
       def SubScript.start(parent: Script.current, quiet: true, &block)
         raise ArgumentError, 'a block is required' unless block
 
@@ -2137,8 +2216,9 @@ module Lich
               new_thread = Thread.new {
                 next unless start_gate.pop
 
-                if (script = Script.current)
-                  begin
+                script = new_script
+                begin
+                  if Script.current
                     Thread.current.priority = 1
                     respond("--- Lich: #{script.name} active.") unless script.quiet
                     Script.__send__(
@@ -2147,19 +2227,16 @@ module Lich
                       :on_error => proc { |error| Script.__send__(:__report_subscript_error, error) },
                       &block
                     )
-                  ensure
-                    script.kill if script.running? && !script.stopping?
+                  else
+                    respond '--- Lich: failed to start subscript'
                   end
-                else
-                  respond '--- Lich: failed to start subscript'
+                ensure
+                  script.kill if script.running? && !script.stopping?
                 end
               }
               new_script.__send__(:__attach_startup_worker, new_thread)
-              if parent && !parent.__send__(:__adopt_child_locked, new_script)
-                new_thread&.kill
-                new_script.__send__(:__discard_startup)
-                next false
-              end
+              next false if parent && !parent.__send__(:__adopt_child, new_script)
+
               new_script.__send__(:__publish, true)
               setup_complete = true
             ensure
@@ -2170,7 +2247,7 @@ module Lich
                 unless setup_complete && worker_released
                   new_thread&.kill
                   new_thread&.join
-                  parent.__send__(:__unregister_child_locked, new_script) if parent
+                  parent.unregister_child(new_script) if parent
                   new_script.__send__(:__discard_startup)
                 end
               end
@@ -2227,26 +2304,13 @@ module Lich
       end
 
       def __publish(admitted = false)
-        Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          Script.__send__(:__registry_synchronize) do
-            @@name_subscript_mutex.synchronize do
-              lifecycle_mutex.synchronize do
-                num = '1'
-                num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
-                @name = "subscript#{num}"
-                @@running.push(self)
-              end
-            end
-          end
-        end
-        self
+        __publish_generated('subscript', admitted)
       end
       private :__publish
       # rubocop:enable Lint/MissingSuper
     end
 
     class ExecScript < Script
-      @@name_exec_mutex = Mutex.new
       attr_reader :cmd_data
 
       def ExecScript.start(cmd_data, options = {})
@@ -2264,10 +2328,11 @@ module Lich
             new_thread = Thread.new {
               next unless start_gate.pop
 
-              if (script = Script.current)
-                Thread.current.priority = 1
-                respond("--- Lich: #{script.name} active.") unless script.quiet
-                begin
+              script = new_script
+              begin
+                if Script.current
+                  Thread.current.priority = 1
+                  respond("--- Lich: #{script.name} active.") unless script.quiet
                   Script.__send__(
                     :__execute,
                     script,
@@ -2277,11 +2342,11 @@ module Lich
                     eval('script = Script.current', script_binding, script.name.to_s)
                     eval(cmd_data, script_binding, script.name.to_s)
                   end
-                ensure
-                  script.kill if script.running? && !script.stopping?
+                else
+                  respond 'start_exec_script screwed up...'
                 end
-              else
-                respond 'start_exec_script screwed up...'
+              ensure
+                script.kill if script.running? && !script.stopping?
               end
             }
             new_script.__send__(:__attach_startup_worker, new_thread)
@@ -2349,19 +2414,7 @@ module Lich
       # rubocop:enable Lint/MissingSuper
 
       def __publish(admitted = false)
-        Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          Script.__send__(:__registry_synchronize) do
-            @@name_exec_mutex.synchronize do
-              lifecycle_mutex.synchronize do
-                num = '1'
-                num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
-                @name = "#{@name_prefix}#{num}"
-                @@running.push(self)
-              end
-            end
-          end
-        end
-        self
+        __publish_generated(@name_prefix, admitted)
       end
       private :__publish
 

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -32,6 +32,11 @@ module Lich
       CHILD_JOIN_TIMEOUT = 1.0
       SCRIPT_CLEANUP_TIMEOUT = 1.0
       JOIN_WAIT_INTERVAL = 0.05
+      RAW_THREAD_GROUP_ADD = ThreadGroup.instance_method(:add)
+      RAW_THREAD_GROUP_LIST = ThreadGroup.instance_method(:list)
+      RAW_THREAD_GROUP_ENCLOSE = ThreadGroup.instance_method(:enclose)
+      RAW_THREAD_GROUP_ENCLOSED = ThreadGroup.instance_method(:enclosed?)
+      CLEANUP_SCRIPT_THREAD_KEY = :lich_cleanup_script
 
       # Nested lock order:
       #   startup -> registry -> per-script lifecycle -> child relationship
@@ -50,6 +55,10 @@ module Lich
         private :__attach_script
 
         def add(thread)
+          unless thread.is_a?(Thread)
+            raise TypeError, "wrong argument type #{thread.class} (expected VM/thread)"
+          end
+
           accepted = @script.__send__(:__register_worker, thread)
           raise ThreadError, 'cannot add a worker to a stopping script' unless accepted
 
@@ -57,7 +66,7 @@ module Lich
         end
 
         def list
-          @script.__send__(:__worker_threads)
+          @script.__send__(:__public_worker_threads)
         end
 
         def enclose
@@ -119,7 +128,6 @@ module Lich
         registry_name = __script_registry_name(file_name)
         script_name = file_name.sub(/\.(?:lic|rb|cmd|wiz)(?:\.(?:gz|Z))?\z/i, '')
         startup_reservation = Object.new
-        startup_completed = false
         begin
           startup_status = __begin_start(startup_reservation, registry_name, :force => options[:force] == true)
           if startup_status == :shutdown
@@ -158,10 +166,10 @@ module Lich
           worker_released = false
           begin
             new_thread = Thread.new {
-              next unless start_gate.pop
-
-              script = script_obj
               begin
+                next unless start_gate.pop
+
+                script = script_obj
                 if Script.current
                   eval('script = Script.current', script_binding, script.name)
                   Thread.current.priority = 1
@@ -198,7 +206,7 @@ module Lich
                   respond '--- error: out of cheese'
                 end
               ensure
-                script.kill if script.running? && !script.stopping?
+                script_obj.kill if script_obj.running? && !script_obj.stopping?
               end
             }
             script_obj.__send__(:__attach_startup_worker, new_thread)
@@ -219,10 +227,9 @@ module Lich
               end
             end
           end
-          startup_completed = true
           script_obj
         ensure
-          __finish_start(startup_reservation, startup_completed ? script_obj : nil)
+          __finish_start(startup_reservation, setup_complete ? script_obj : nil)
         end
       }
       @@elevated_exists = proc { |script_name|
@@ -642,10 +649,30 @@ module Lich
       end
       private_class_method :__running_snapshot
 
+      def Script.__script_owning_thread_group(group)
+        __running_snapshot.find { |script| script.__send__(:__owns_public_thread_group?, group) }
+      end
+      private_class_method :__script_owning_thread_group
+
       def Script.__shutdown_snapshot
-        __registry_synchronize { (@@running + @@stopping).uniq }
+        __registry_synchronize do
+          __prune_completed_stops_locked
+          (@@running + @@stopping).uniq
+        end
       end
       private_class_method :__shutdown_snapshot
+
+      def Script.__prune_completed_stops_locked
+        @@stopping.reject! { |script| script.__send__(:__cleanup_complete?) }
+      end
+      private_class_method :__prune_completed_stops_locked
+
+      def Script.__discard_completed_stop(script)
+        __registry_synchronize do
+          @@stopping.delete(script) if script.__send__(:__cleanup_complete?)
+        end
+      end
+      private_class_method :__discard_completed_stop
 
       def Script.list
         __running_snapshot
@@ -666,7 +693,12 @@ module Lich
       def Script.begin_shutdown
         @@startup_mutex.synchronize do
           @@shutdown_started = true
-          @@startup_condition.wait(@@startup_mutex) until @@startup_reservations.empty?
+          until @@startup_reservations.empty?
+            __reap_abandoned_startups_locked
+            break if @@startup_reservations.empty?
+
+            @@startup_condition.wait(@@startup_mutex, JOIN_WAIT_INTERVAL)
+          end
           shutdown_scripts
         end
       end
@@ -674,24 +706,25 @@ module Lich
       def Script.__begin_start(reservation, name = nil, force: true)
         normalized_name = name&.downcase
         @@startup_mutex.synchronize do
+          __reap_abandoned_startups_locked
           return :shutdown if @@shutdown_started
           if normalized_name && !force
             running = __registry_synchronize { @@running.any? { |script| script.name.casecmp?(normalized_name) } }
-            starting = @@startup_reservations.value?(normalized_name)
+            starting = __startup_in_progress_locked?(normalized_name)
             return :duplicate if running || starting
           end
 
-          @@startup_reservations[reservation] = normalized_name
+          @@startup_reservations[reservation] = [normalized_name, Thread.current]
           :admitted
         end
       end
       private_class_method :__begin_start
 
-      def Script.__finish_start(reservation, script = nil)
+      def Script.__finish_start(reservation, script = nil, preserve_completed: false)
         @@startup_mutex.synchronize do
-          name = @@startup_reservations.delete(reservation)
+          name = @@startup_reservations.delete(reservation)&.first
           if name&.start_with?('lib')
-            @@completed_named_starts.delete(name)
+            @@completed_named_starts.delete(name) unless preserve_completed
             @@completed_named_starts[name] = script if script
           end
           @@startup_condition.broadcast
@@ -711,8 +744,11 @@ module Lich
       def Script.__take_completed_start(name)
         normalized_name = name.downcase
         @@startup_mutex.synchronize do
-          while @@startup_reservations.value?(normalized_name)
-            @@startup_condition.wait(@@startup_mutex)
+          while __startup_in_progress_locked?(normalized_name)
+            __reap_abandoned_startups_locked
+            break unless __startup_in_progress_locked?(normalized_name)
+
+            @@startup_condition.wait(@@startup_mutex, JOIN_WAIT_INTERVAL)
           end
           @@completed_named_starts.delete(normalized_name)
         end
@@ -726,6 +762,23 @@ module Lich
         end
       end
       private_class_method :__discard_completed_start
+
+      def Script.__peek_completed_start(name)
+        @@startup_mutex.synchronize { @@completed_named_starts[name.downcase] }
+      end
+      private_class_method :__peek_completed_start
+
+      def Script.__reap_abandoned_startups_locked
+        previous_size = @@startup_reservations.size
+        @@startup_reservations.delete_if { |_reservation, (_name, owner)| !owner.alive? }
+        @@startup_condition.broadcast if @@startup_reservations.size < previous_size
+      end
+      private_class_method :__reap_abandoned_startups_locked
+
+      def Script.__startup_in_progress_locked?(name)
+        @@startup_reservations.any? { |_reservation, (reserved_name, _owner)| reserved_name == name }
+      end
+      private_class_method :__startup_in_progress_locked?
 
       def Script.subscript(&block)
         SubScript.start(:parent => Script.current, :quiet => true, &block)
@@ -755,7 +808,9 @@ module Lich
       end
 
       def Script.current
-        if (script = __running_snapshot.find { |s| s.has_thread?(Thread.current) })
+        script = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
+        script ||= __running_snapshot.find { |candidate| candidate.has_thread?(Thread.current) }
+        if script
           sleep 0.2 while script.paused? and not script.ignore_pause
           script
         else
@@ -822,14 +877,21 @@ module Lich
           if start_required
             script = Script.start(library_name, { :force => true })
             raise LoadError, "failed to start script library: #{library_name}" unless script
-
-            @@library_mutex.synchronize { @@loading_libraries[library_name] = script }
-            __discard_completed_start(library_name, script)
           end
 
           [script, already_loaded, owns_loading]
         ensure
-          __finish_start(startup_reservation)
+          begin
+            __finish_start(startup_reservation, nil, :preserve_completed => start_required == true)
+          ensure
+            if start_required
+              script ||= __peek_completed_start(library_name)
+              if script
+                @@library_mutex.synchronize { @@loading_libraries[library_name] = script }
+                __discard_completed_start(library_name, script)
+              end
+            end
+          end
         end
         script, already_loaded, owns_loading = prepared
         return true if already_loaded
@@ -1373,12 +1435,11 @@ module Lich
       # ordinary script churn.
       #
       # Runtime kills run cleanup in a dedicated thread so the caller is not
-      # blocked. Shutdown kills run cleanup inline instead: the shutdown drain
-      # (see shutdown_script_drain.rb) kills every script in a tight loop, and on
-      # long sessions spawning one cleanup thread per script there pushes the
-      # process past the OS thread ceiling ("can't alloc thread"). Inline
-      # teardown at shutdown is also the order we want -- sequential, not a
-      # concurrent burst.
+      # blocked. The process shutdown drain runs cleanup inline: spawning one
+      # cleanup thread per script in long sessions can push the process past the
+      # OS thread ceiling ("can't alloc thread"). Shutdown requested from a
+      # normal script worker remains asynchronous so callback descendants belong
+      # to the target script rather than the caller.
       #
       # @param context [Symbol] :runtime for ordinary script stops, :shutdown
       #   when the owning Lich process is closing
@@ -1388,7 +1449,10 @@ module Lich
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
-        async = context != :shutdown if async.nil?
+        if async.nil?
+          shutdown_cleanup = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
+          async = context != :shutdown || (!Thread.current.group.equal?(ThreadGroup::Default) && !shutdown_cleanup)
+        end
         launch_token = Object.new
         cleanup_thread = nil
         cleanup_released = false
@@ -1416,8 +1480,8 @@ module Lich
               __run_kill_cleanup(source: source, context: context, record_metrics: true)
             }
             ThreadGroup::Default.add(cleanup_thread)
-            __attach_startup_worker(cleanup_thread)
-            lifecycle_mutex.synchronize { @cleanup_thread = cleanup_thread }
+            __attach_cleanup_worker(cleanup_thread)
+            __claim_cleanup_thread(cleanup_thread)
             cleanup_owned = true
             raise ThreadError, 'cleanup thread stopped before ownership transfer' unless cleanup_thread.alive?
 
@@ -1561,6 +1625,27 @@ module Lich
         # cleanup body twice over already-nilled state, not skip it.)
         return if @killer_mutex.owned?
 
+        previous_cleanup_script = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
+        previous_thread_group = Thread.current.group
+        cleanup_thread_group = __cleanup_worker_group
+        previous_group_owner = nil
+        moved_to_cleanup_group = false
+        move_allowed = previous_thread_group.equal?(ThreadGroup::Default)
+        unless move_allowed || previous_cleanup_script
+          previous_group_owner = Script.__send__(:__script_owning_thread_group, previous_thread_group)
+          move_allowed = previous_group_owner&.__send__(:__borrow_worker, Thread.current, cleanup_thread_group)
+        end
+        if move_allowed
+          begin
+            RAW_THREAD_GROUP_ADD.bind_call(cleanup_thread_group, Thread.current)
+            moved_to_cleanup_group = true
+          rescue ThreadError
+            previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
+            previous_group_owner&.__send__(:__return_borrowed_group, cleanup_thread_group)
+            nil
+          end
+        end
+        Thread.current.thread_variable_set(CLEANUP_SCRIPT_THREAD_KEY, self)
         begin
           @killer_mutex.synchronize do
             lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
@@ -1570,23 +1655,23 @@ module Lich
               failed = false
               cleanup_body_complete = false
               begin
-                children = __begin_child_shutdown
+                __close_child_launch_admission
                 stopping_threads = lifecycle_mutex.synchronize do
-                  @stopping_threads = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+                  @stopping_threads = __raw_worker_threads.reject { |thread| thread == Thread.current }
                 end
                 stopping_threads.each { |thread| thread.kill rescue nil }
-                @thread_group.add(Thread.current)
+                children = __wait_for_child_launches
                 __stop_children(children, context)
-                @thread_group.add(Thread.current)
                 # Shift each callback before invoking it. If this executor is
                 # cancelled, recovery resumes with the remaining callbacks.
+                @die_with ||= []
                 while (script_name = @die_with.shift)
                   failed = true unless __run_cleanup_callback do
                     Script.kill(script_name, context: context)
-                    @thread_group.add(Thread.current)
                   end
                 end
                 @paused = false
+                @at_exit_procs ||= []
                 while (callback = @at_exit_procs.shift)
                   failed = true unless __run_cleanup_callback { callback.call }
                 end
@@ -1616,6 +1701,22 @@ module Lich
             end
           end
         ensure
+          Thread.current.thread_variable_set(CLEANUP_SCRIPT_THREAD_KEY, previous_cleanup_script)
+          if moved_to_cleanup_group
+            begin
+              RAW_THREAD_GROUP_ADD.bind_call(previous_thread_group, Thread.current)
+              previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
+              previous_group_owner&.__send__(:__return_borrowed_group, cleanup_thread_group)
+            rescue ThreadError
+              begin
+                borrowed_group = ThreadGroup.new
+                previous_group_owner&.__send__(:__adopt_borrowed_group, borrowed_group)
+                RAW_THREAD_GROUP_ADD.bind_call(borrowed_group, Thread.current)
+              rescue ThreadError
+                nil
+              end
+            end
+          end
           lifecycle_mutex.synchronize do
             @cleanup_thread = nil if @cleanup_thread == Thread.current
             @stopped_condition&.broadcast
@@ -1710,9 +1811,15 @@ module Lich
       end
       private :__unregister_child_locked
 
-      def __begin_child_shutdown
+      def __close_child_launch_admission
         child_scripts_mutex.synchronize do
           @child_shutdown_started = true
+        end
+      end
+      private :__close_child_launch_admission
+
+      def __wait_for_child_launches
+        child_scripts_mutex.synchronize do
           if @child_launches.to_i.positive?
             @child_launch_condition ||= ConditionVariable.new
             @child_launch_condition.wait(child_scripts_mutex) while @child_launches.to_i.positive?
@@ -1720,7 +1827,7 @@ module Lich
           Array(@child_scripts).dup
         end
       end
-      private :__begin_child_shutdown
+      private :__wait_for_child_launches
 
       def __stop_children(children, context)
         return if children.empty?
@@ -1732,8 +1839,6 @@ module Lich
           child.kill(context: context, async: true) if child.running?
         rescue StandardError => e
           Lich.log("error: failed to stop child script #{child.name}: #{e}") if defined?(Lich) && Lich.respond_to?(:log)
-        ensure
-          @thread_group.add(Thread.current)
         end
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + CHILD_JOIN_TIMEOUT
@@ -1782,49 +1887,43 @@ module Lich
       end
       private :__record_successful_exit
 
+      def __cleanup_complete?
+        lifecycle_mutex.synchronize { @cleanup_complete == true }
+      end
+      private :__cleanup_complete?
+
       def __register_worker(thread)
         registration = Object.new
         tracked_rejection = false
         accepted = false
-        begin
-          accepted = Script.__send__(:__registry_synchronize) do
-            lifecycle_mutex.synchronize do
-              if @@running.include?(self) && !@kill_requested
-                @thread_group.add(thread)
-                true
-              else
-                @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
-                unless @worker_admission_closed
-                  @worker_registrations ||= Set.new
-                  @worker_registrations.add(registration)
-                  tracked_rejection = true
-                end
-                false
+        accepted = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            if @@running.include?(self) && !@kill_requested
+              __raw_add_worker(thread)
+              true
+            else
+              @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
+              unless @worker_admission_closed
+                @worker_registrations ||= Set.new
+                @worker_registrations.add(registration)
+                tracked_rejection = true
               end
+              false
             end
           end
+        end
+        accepted
+      ensure
+        begin
           unless accepted
-            thread.kill
-            thread.join unless thread == Thread.current
-          end
-          accepted
-        rescue StandardError => error
-          thread.kill
-          begin
-            thread.join unless thread == Thread.current
-          rescue StandardError
-            nil
-          end
-          raise error
-        ensure
-          unless accepted
-            thread.kill
             begin
+              thread.kill
               thread.join unless thread == Thread.current
             rescue StandardError
               nil
             end
           end
+        ensure
           if tracked_rejection
             lifecycle_mutex.synchronize do
               @worker_registrations&.delete(registration)
@@ -1835,31 +1934,116 @@ module Lich
       end
       private :__register_worker
 
+      def __raw_add_worker(thread)
+        RAW_THREAD_GROUP_ADD.bind_call(@thread_group, thread)
+      end
+      private :__raw_add_worker
+
+      def __raw_worker_threads
+        groups = [@thread_group, @cleanup_thread_group, *Array(@borrowed_thread_groups)].compact
+        group_threads = groups.flat_map { |group| RAW_THREAD_GROUP_LIST.bind_call(group) }
+        (group_threads + Array(@borrowed_workers)).uniq
+      end
+      private :__raw_worker_threads
+
+      def __public_worker_threads
+        RAW_THREAD_GROUP_LIST.bind_call(@thread_group).dup
+      end
+      private :__public_worker_threads
+
+      def __owns_public_thread_group?(group)
+        @thread_group.equal?(group)
+      end
+      private :__owns_public_thread_group?
+
+      def __borrow_worker(thread, group)
+        lifecycle_mutex.synchronize do
+          return false if @kill_requested || @cleanup_complete
+
+          @borrowed_workers ||= Set.new
+          @borrowed_workers.add(thread)
+          @borrowed_thread_groups ||= Set.new
+          @borrowed_thread_groups.add(group)
+          true
+        end
+      end
+      private :__borrow_worker
+
+      def __return_borrowed_worker(thread)
+        lifecycle_mutex.synchronize do
+          @borrowed_workers&.delete(thread)
+          @stopped_condition&.broadcast
+        end
+      end
+      private :__return_borrowed_worker
+
+      def __adopt_borrowed_group(group)
+        lifecycle_mutex.synchronize do
+          @borrowed_thread_groups ||= Set.new
+          @borrowed_thread_groups.add(group)
+          @stopped_condition&.broadcast
+        end
+      end
+      private :__adopt_borrowed_group
+
+      def __return_borrowed_group(group)
+        lifecycle_mutex.synchronize do
+          @borrowed_thread_groups&.delete(group)
+          @stopped_condition&.broadcast
+        end
+      end
+      private :__return_borrowed_group
+
       def __attach_startup_worker(thread)
-        @thread_group.add(thread)
+        __raw_add_worker(thread)
         thread
       end
       private :__attach_startup_worker
 
+      def __claim_cleanup_thread(thread)
+        lifecycle_mutex.synchronize { @cleanup_thread = thread }
+        thread
+      end
+      private :__claim_cleanup_thread
+
+      def __cleanup_worker_group
+        lifecycle_mutex.synchronize { @cleanup_thread_group ||= ThreadGroup.new }
+      end
+      private :__cleanup_worker_group
+
+      def __attach_cleanup_worker(thread)
+        RAW_THREAD_GROUP_ADD.bind_call(__cleanup_worker_group, thread)
+        thread
+      end
+      private :__attach_cleanup_worker
+
       def __worker_threads
-        @thread_group.list.dup
+        __raw_worker_threads
       end
       private :__worker_threads
 
       def __enclose_worker_group
-        @thread_group.enclose
+        lifecycle_mutex.synchronize { RAW_THREAD_GROUP_ENCLOSE.bind_call(@thread_group) }
         self
       end
       private :__enclose_worker_group
 
       def __worker_group_enclosed?
-        @thread_group.enclosed?
+        lifecycle_mutex.synchronize { RAW_THREAD_GROUP_ENCLOSED.bind_call(@thread_group) }
       end
       private :__worker_group_enclosed?
+
+      def __managed_thread_group
+        lifecycle_mutex.synchronize do
+          @thread_group_handle ||= @thread_group.extend(ThreadGroupHandle).__send__(:__attach_script, self)
+        end
+      end
+      private :__managed_thread_group
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
           Script.__send__(:__registry_synchronize) do
+            Script.__send__(:__prune_completed_stops_locked)
             @@running.push(self) unless @@running.include?(self)
           end
         end
@@ -1870,6 +2054,7 @@ module Lich
       def __publish_generated(prefix, admitted)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
           Script.__send__(:__registry_synchronize) do
+            Script.__send__(:__prune_completed_stops_locked)
             num = '1'
             num.succ! while @@running.any? { |script| script.name == "#{prefix}#{num}" }
             @name = "#{prefix}#{num}"
@@ -1916,7 +2101,7 @@ module Lich
           @watchfor = {}
           @downstream_buffer = LimitedArray.new
           @upstream_buffer = LimitedArray.new
-          @die_with = @at_exit_procs = @match_stack_labels = @match_stack_strings = nil
+          @match_stack_labels = @match_stack_strings = nil
           unless @quiet
             if @killed_externally
               respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
@@ -1928,7 +2113,7 @@ module Lich
           late_workers = nil
           Script.__send__(:__registry_synchronize) do
             lifecycle_mutex.synchronize do
-              late_workers = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+              late_workers = __raw_worker_threads.reject { |thread| thread == Thread.current }
               @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
               @@running.delete(self)
               @stopped_condition&.broadcast
@@ -1944,7 +2129,7 @@ module Lich
       def __wait_for_worker_shutdown(wait:)
         loop do
           workers = lifecycle_mutex.synchronize do
-            current_workers = @thread_group.list.dup
+            current_workers = __raw_worker_threads
             @stopping_threads = (Array(@stopping_threads) + current_workers).uniq
             @stopping_threads.reject { |thread| thread == Thread.current || thread == @cleanup_thread || !thread.alive? }
           end
@@ -2016,13 +2201,12 @@ module Lich
           CHILD_RELATIONSHIP_MUTEX.synchronize { parent = @parent_script }
           parent&.unregister_child(self)
           CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
-          Script.__send__(:__registry_synchronize) do
-            lifecycle_mutex.synchronize do
-              @cleanup_complete = true
-              @@stopping.delete(self)
-              @stopped_condition&.broadcast
-            end
+          lifecycle_mutex.synchronize do
+            @die_with = @at_exit_procs = nil
+            @cleanup_complete = true
+            @stopped_condition&.broadcast
           end
+          Script.__send__(:__discard_completed_stop, self)
         end
       end
       private :__finalize_stop
@@ -2072,11 +2256,11 @@ module Lich
       end
 
       def thread_group
-        @thread_group_handle ||= ThreadGroup.new.extend(ThreadGroupHandle).__send__(:__attach_script, self)
+        __managed_thread_group
       end
 
       def has_thread?(t)
-        @thread_group.list.include?(t)
+        __raw_worker_threads.include?(t)
       end
 
       def pause
@@ -2214,10 +2398,10 @@ module Lich
             worker_released = false
             begin
               new_thread = Thread.new {
-                next unless start_gate.pop
-
-                script = new_script
                 begin
+                  next unless start_gate.pop
+
+                  script = new_script
                   if Script.current
                     Thread.current.priority = 1
                     respond("--- Lich: #{script.name} active.") unless script.quiet
@@ -2231,7 +2415,7 @@ module Lich
                     respond '--- Lich: failed to start subscript'
                   end
                 ensure
-                  script.kill if script.running? && !script.stopping?
+                  new_script.kill if new_script.running? && !new_script.stopping?
                 end
               }
               new_script.__send__(:__attach_startup_worker, new_thread)
@@ -2326,10 +2510,10 @@ module Lich
           worker_released = false
           begin
             new_thread = Thread.new {
-              next unless start_gate.pop
-
-              script = new_script
               begin
+                next unless start_gate.pop
+
+                script = new_script
                 if Script.current
                   Thread.current.priority = 1
                   respond("--- Lich: #{script.name} active.") unless script.quiet
@@ -2346,7 +2530,7 @@ module Lich
                   respond 'start_exec_script screwed up...'
                 end
               ensure
-                script.kill if script.running? && !script.stopping?
+                new_script.kill if new_script.running? && !new_script.stopping?
               end
             }
             new_script.__send__(:__attach_startup_worker, new_thread)

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -721,8 +721,9 @@ module Lich
 
       def Script.run_child(*args)
         child = Script.start_child(*args)
-        child&.join
-        child
+        return nil unless child
+
+        child.join ? child : nil
       end
 
       def Script.daemon_me
@@ -1439,6 +1440,12 @@ module Lich
         lifecycle_mutex.synchronize { @completed_successfully == true }
       end
 
+      # Waits for this script to finish. Without an explicit timeout, normal
+      # execution may run indefinitely, but teardown is bounded by
+      # SCRIPT_CLEANUP_TIMEOUT once a stop has been requested.
+      #
+      # @param timeout [Numeric, nil] maximum seconds for the entire wait
+      # @return [Script, nil] this script on completion, or nil on timeout
       def join(timeout = nil)
         raise ArgumentError, 'timeout must be non-negative' if timeout && timeout.negative?
 

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -33,10 +33,13 @@ module Lich
       SCRIPT_CLEANUP_TIMEOUT = 1.0
       JOIN_WAIT_INTERVAL = 0.05
 
-      # Lock order:
-      #   startup -> registry -> per-script lifecycle -> child ownership
-      # Library coordination never holds its mutex while starting or joining a
-      # script. No lock in this hierarchy may be held while invoking script code.
+      # Nested lock order:
+      #   parent child list -> startup -> registry -> generated name
+      #   -> per-script lifecycle -> child relationship
+      # Finalization releases the relationship lock before taking a parent's
+      # child-list lock. Library coordination releases its mutex before starting
+      # or joining a script. Registry and lifecycle locks are never held while
+      # invoking script code or cleanup callbacks.
 
       class ThreadGroupHandle
         def initialize(script)

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -30,6 +30,13 @@ module Lich
       CHILD_RELATIONSHIP_MUTEX = Mutex.new
       LIFECYCLE_MUTEX_INITIALIZER = Mutex.new
       CHILD_JOIN_TIMEOUT = 1.0
+      SCRIPT_CLEANUP_TIMEOUT = 1.0
+      JOIN_WAIT_INTERVAL = 0.05
+
+      # Lock order:
+      #   startup -> registry -> per-script lifecycle -> child ownership
+      # Library coordination never holds its mutex while starting or joining a
+      # script. No lock in this hierarchy may be held while invoking script code.
 
       class ThreadGroupHandle
         def initialize(script)
@@ -376,6 +383,7 @@ module Lich
       @@stopping = Array.new
       @@startup_mutex = Mutex.new
       @@startup_condition = ConditionVariable.new
+      @@registry_mutex = Mutex.new
       @@startup_reservations = {}
       @@completed_named_starts = {}
       @@shutdown_started = false
@@ -647,14 +655,35 @@ module Lich
       end
       private_class_method :__warn_lich_too_old
 
+      def Script.__registry_synchronize(&block)
+        @@registry_mutex.synchronize(&block)
+      end
+      private_class_method :__registry_synchronize
+
+      def Script.__running_snapshot
+        __registry_synchronize { @@running.dup }
+      end
+      private_class_method :__running_snapshot
+
+      def Script.__shutdown_snapshot
+        __registry_synchronize { (@@running + @@stopping).uniq }
+      end
+      private_class_method :__shutdown_snapshot
+
       def Script.list
-        @@running.dup
+        __running_snapshot
       end
 
       def Script.shutdown_scripts
-        scripts = (@@running + @@stopping).uniq
+        __shutdown_snapshot
+      end
+
+      # Advances teardown that lost its cleanup executor, then returns the
+      # scripts still participating in shutdown.
+      def Script.progress_shutdown
+        scripts = __shutdown_snapshot
         scripts.each { |script| script.__send__(:__refresh_deferred_stop) }
-        (@@running + @@stopping).uniq
+        __shutdown_snapshot
       end
 
       def Script.begin_shutdown
@@ -670,7 +699,7 @@ module Lich
         @@startup_mutex.synchronize do
           return :shutdown if @@shutdown_started
           if normalized_name && !force
-            running = @@running.any? { |script| script.name.casecmp?(normalized_name) }
+            running = __registry_synchronize { @@running.any? { |script| script.name.casecmp?(normalized_name) } }
             starting = @@startup_reservations.value?(normalized_name)
             return :duplicate if running || starting
           end
@@ -748,7 +777,7 @@ module Lich
       end
 
       def Script.current
-        if (script = @@running.find { |s| s.has_thread?(Thread.current) })
+        if (script = __running_snapshot.find { |s| s.has_thread?(Thread.current) })
           sleep 0.2 while script.paused? and not script.ignore_pause
           script
         else
@@ -762,7 +791,7 @@ module Lich
 
       def Script.run(*args)
         if (s = @@elevated_script_start.call(args, nil))
-          sleep 0.1 while @@running.include?(s)
+          s.join
         end
       end
 
@@ -800,7 +829,7 @@ module Lich
 
           completed_start = __take_completed_start(library_name) if startup_status == :duplicate
           script, already_loaded, owns_loading, started_here = @@library_mutex.synchronize do
-            running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
+            running = __running_snapshot.find { |candidate| candidate.name.casecmp?(library_name) }
             if (loading = @@loading_libraries[library_name])
               [loading, false, false, false]
             elsif (candidate = completed_start || running)
@@ -918,7 +947,7 @@ module Lich
       private_class_method :__library_dependency_reaches?
 
       def Script.running?(name)
-        @@running.any? { |i| (i.name =~ /^#{name}$/i) }
+        __running_snapshot.any? { |i| (i.name =~ /^#{name}$/i) }
       end
 
       def Script.pause(name = nil)
@@ -926,7 +955,8 @@ module Lich
           Script.current.pause
           Script.current
         else
-          if (s = (@@running.find { |i| (i.name == name) and not i.paused? }) || (@@running.find { |i| (i.name =~ /^#{name}$/i) and not i.paused? }))
+          running = __running_snapshot
+          if (s = (running.find { |i| (i.name == name) and not i.paused? }) || (running.find { |i| (i.name =~ /^#{name}$/i) and not i.paused? }))
             s.pause
             true
           else
@@ -936,7 +966,8 @@ module Lich
       end
 
       def Script.unpause(name)
-        if (s = (@@running.find { |i| (i.name == name) and i.paused? }) || (@@running.find { |i| (i.name =~ /^#{name}$/i) and i.paused? }))
+        running = __running_snapshot
+        if (s = (running.find { |i| (i.name == name) and i.paused? }) || (running.find { |i| (i.name =~ /^#{name}$/i) and i.paused? }))
           s.unpause
           true
         else
@@ -960,7 +991,8 @@ module Lich
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
-        if (s = (@@running.find { |i| i.name == name }) || (@@running.find { |i| i.name =~ /^#{name}$/i }))
+        running = __running_snapshot
+        if (s = (running.find { |i| i.name == name }) || (running.find { |i| i.name =~ /^#{name}$/i }))
           s.killed_externally = true
           s.kill_source = caller[0..2]
           s.kill(context: context)
@@ -981,7 +1013,8 @@ module Lich
       end
 
       def Script.paused?(name)
-        if (s = (@@running.find { |i| i.name == name }) || (@@running.find { |i| i.name =~ /^#{name}$/i }))
+        running = __running_snapshot
+        if (s = (running.find { |i| i.name == name }) || (running.find { |i| i.name =~ /^#{name}$/i }))
           s.paused?
         else
           nil
@@ -993,19 +1026,19 @@ module Lich
       end
 
       def Script.new_downstream_xml(line)
-        for script in @@running
+        for script in __running_snapshot
           script.downstream_buffer.push(line.chomp) if script.want_downstream_xml
         end
       end
 
       def Script.new_upstream(line)
-        for script in @@running
+        for script in __running_snapshot
           script.upstream_buffer.push(line.chomp) if script.want_upstream
         end
       end
 
       def Script.new_downstream(line)
-        @@running.each { |script|
+        __running_snapshot.each { |script|
           script.downstream_buffer.push(line.chomp) if script.want_downstream
           unless script.watchfor.empty?
             script.watchfor.each_pair { |trigger, action|
@@ -1038,7 +1071,7 @@ module Lich
       end
 
       def Script.new_script_output(line)
-        for script in @@running
+        for script in __running_snapshot
           script.downstream_buffer.push(line.chomp) if script.want_script_output
         end
       end
@@ -1089,7 +1122,7 @@ module Lich
 
       def Script.running
         list = Array.new
-        for script in @@running
+        for script in __running_snapshot
           list.push(script) unless script.hidden
         end
         return list
@@ -1101,7 +1134,7 @@ module Lich
 
       def Script.hidden
         list = Array.new
-        for script in @@running
+        for script in __running_snapshot
           list.push(script) if script.hidden
         end
         return list
@@ -1374,15 +1407,17 @@ module Lich
         start_gate = Queue.new if async
         source = @kill_source || caller[0..2]
         begin
-          start_cleanup = lifecycle_mutex.synchronize do
-            next false unless @@running.include?(self)
-            next false if @cleanup_started
+          start_cleanup = Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              next false unless @@running.include?(self)
+              next false if @cleanup_started
 
-            @kill_requested = true
-            @cleanup_started = launch_token
-            @cleanup_launch_pending = true
-            @@stopping << self unless @@stopping.include?(self)
-            true
+              @kill_requested = true
+              @cleanup_started = launch_token
+              @cleanup_launch_pending = true
+              @@stopping << self unless @@stopping.include?(self)
+              true
+            end
           end
           return @name unless start_cleanup
 
@@ -1429,7 +1464,7 @@ module Lich
       end
 
       def running?
-        @@running.include?(self)
+        Script.__send__(:__registry_synchronize) { @@running.include?(self) }
       end
 
       def stopping?
@@ -1441,25 +1476,36 @@ module Lich
       end
 
       def join(timeout = nil)
+        raise ArgumentError, 'timeout must be non-negative' if timeout && timeout.negative?
+
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
+        cleanup_deadline = nil
         loop do
           __refresh_deferred_stop
-          completed = lifecycle_mutex.synchronize do
-            @stopped_condition ||= ConditionVariable.new
-            running = @@running.include?(self)
-            return self if !running && Array(@stopping_threads).include?(Thread.current)
-            return self if !running && @cleanup_complete
-
-            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC) if deadline
-            return nil if remaining && remaining <= 0
-
-            wait_for = running ? remaining : [remaining || 0.01, 0.01].min
-            @stopped_condition.wait(lifecycle_mutex, wait_for)
-            false
+          running, stopping, cleanup_complete, current_worker = Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              [
+                @@running.include?(self),
+                @kill_requested == true,
+                @cleanup_complete == true,
+                Array(@stopping_threads).include?(Thread.current)
+              ]
+            end
           end
-          break if completed
+          return self if !running && (cleanup_complete || current_worker)
+
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          cleanup_deadline ||= now + SCRIPT_CLEANUP_TIMEOUT if stopping
+          effective_deadline = [deadline, cleanup_deadline].compact.min
+          remaining = effective_deadline - now if effective_deadline
+          return nil if remaining && remaining <= 0
+
+          wait_for = remaining ? [remaining, JOIN_WAIT_INTERVAL].min : JOIN_WAIT_INTERVAL
+          lifecycle_mutex.synchronize do
+            @stopped_condition ||= ConditionVariable.new
+            @stopped_condition.wait(lifecycle_mutex, wait_for)
+          end
         end
-        self
       end
 
       def kill_sync(context: :runtime, timeout: nil)
@@ -1523,7 +1569,7 @@ module Lich
 
         @killer_mutex.synchronize {
           lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
-          if @@running.include?(self)
+          if running?
             instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
             started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
             failed = false
@@ -1710,18 +1756,20 @@ module Lich
         tracked_rejection = false
         accepted = false
         begin
-          accepted = lifecycle_mutex.synchronize do
-            if @@running.include?(self) && !@kill_requested
-              @thread_group.add(thread)
-              true
-            else
-              @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
-              unless @worker_admission_closed
-                @worker_registrations ||= Set.new
-                @worker_registrations.add(registration)
-                tracked_rejection = true
+          accepted = Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              if @@running.include?(self) && !@kill_requested
+                @thread_group.add(thread)
+                true
+              else
+                @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
+                unless @worker_admission_closed
+                  @worker_registrations ||= Set.new
+                  @worker_registrations.add(registration)
+                  tracked_rejection = true
+                end
+                false
               end
-              false
             end
           end
           unless accepted
@@ -1769,33 +1817,38 @@ module Lich
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+          Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+          end
         end
         self
       end
       private :__publish
 
       def __while_running
-        lifecycle_mutex.synchronize do
-          return nil unless @@running.include?(self) && !stopping?
-
-          yield
+        runnable = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize { @@running.include?(self) && !stopping? }
         end
+        return nil unless runnable
+
+        yield
       end
       private :__while_running
 
       def __discard_startup
         parent = nil
-        lifecycle_mutex.synchronize do
-          @@running.delete(self)
-          @@stopping.delete(self)
-          @worker_admission_closed = true
-          @cleanup_complete = true
-          CHILD_RELATIONSHIP_MUTEX.synchronize do
-            parent = @parent_script
-            @parent_script = nil
+        Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            @@running.delete(self)
+            @@stopping.delete(self)
+            @worker_admission_closed = true
+            @cleanup_complete = true
+            CHILD_RELATIONSHIP_MUTEX.synchronize do
+              parent = @parent_script
+              @parent_script = nil
+            end
+            @stopped_condition&.broadcast
           end
-          @stopped_condition&.broadcast
         end
         parent&.unregister_child(self)
         self
@@ -1816,13 +1869,16 @@ module Lich
             end
           end
         ensure
-          lifecycle_mutex.synchronize do
-            late_workers = @thread_group.list.dup.reject { |thread| thread == Thread.current }
-            @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
-            late_workers.each { |thread| thread.kill rescue nil }
-            @@running.delete(self)
-            @stopped_condition&.broadcast
+          late_workers = nil
+          Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              late_workers = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+              @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
+              @@running.delete(self)
+              @stopped_condition&.broadcast
+            end
           end
+          late_workers.each { |thread| thread.kill rescue nil }
           workers_stopped = __wait_for_worker_shutdown(:wait => context != :shutdown)
           __finalize_stop if workers_stopped
         end
@@ -1869,19 +1925,23 @@ module Lich
       private :__wait_for_worker_shutdown
 
       def __refresh_deferred_stop
-        abandoned_cleanup = lifecycle_mutex.synchronize do
-          if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
-             (!@cleanup_thread || !@cleanup_thread.alive?)
-            @cleanup_started = false
-            @cleanup_thread = nil
-            true
+        abandoned_cleanup = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
+               (!@cleanup_thread || !@cleanup_thread.alive?)
+              @cleanup_started = false
+              @cleanup_thread = nil
+              true
+            end
           end
         end
         kill(:context => :shutdown) if abandoned_cleanup
 
-        should_refresh = lifecycle_mutex.synchronize do
-          cleanup_active_elsewhere = @cleanup_thread&.alive? && @cleanup_thread != Thread.current
-          @cleanup_started && !@cleanup_complete && !@@running.include?(self) && !cleanup_active_elsewhere
+        should_refresh = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            cleanup_active_elsewhere = @cleanup_thread&.alive? && @cleanup_thread != Thread.current
+            @cleanup_started && !@cleanup_complete && !@@running.include?(self) && !cleanup_active_elsewhere
+          end
         end
         __finalize_stop if should_refresh && __wait_for_worker_shutdown(:wait => false)
       end
@@ -1901,10 +1961,12 @@ module Lich
           parent&.unregister_child(self)
           CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
         ensure
-          lifecycle_mutex.synchronize do
-            @cleanup_complete = true
-            @@stopping.delete(self)
-            @stopped_condition&.broadcast
+          Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              @cleanup_complete = true
+              @@stopping.delete(self)
+              @stopped_condition&.broadcast
+            end
           end
         end
       end
@@ -2199,12 +2261,14 @@ module Lich
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          @@name_subscript_mutex.synchronize do
-            lifecycle_mutex.synchronize do
-              num = '1'
-              num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
-              @name = "subscript#{num}"
-              @@running.push(self)
+          Script.__send__(:__registry_synchronize) do
+            @@name_subscript_mutex.synchronize do
+              lifecycle_mutex.synchronize do
+                num = '1'
+                num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
+                @name = "subscript#{num}"
+                @@running.push(self)
+              end
             end
           end
         end
@@ -2369,12 +2433,14 @@ module Lich
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          @@name_exec_mutex.synchronize do
-            lifecycle_mutex.synchronize do
-              num = '1'
-              num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
-              @name = "#{@name_prefix}#{num}"
-              @@running.push(self)
+          Script.__send__(:__registry_synchronize) do
+            @@name_exec_mutex.synchronize do
+              lifecycle_mutex.synchronize do
+                num = '1'
+                num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
+                @name = "#{@name_prefix}#{num}"
+                @@running.push(self)
+              end
             end
           end
         end

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -149,128 +149,34 @@ module Lich
                 eval('script = Script.current', script_binding, script.name)
                 Thread.current.priority = 1
                 respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
-                if trusted
-                  begin
-                    eval(script.labels[script.current_label].to_s, script_binding, script.name)
-                    script.__send__(:__record_successful_exit)
-                  rescue SystemExit => e
-                    if e.success?
-                      script.__send__(:__record_successful_exit)
+                begin
+                  Script.__send__(
+                    :__execute,
+                    script,
+                    :on_error => proc { |error| Script.__send__(:__report_script_error, script, error, :untrusted => !trusted) }
+                  ) do
+                    if trusted
+                      eval(script.labels[script.current_label].to_s, script_binding, script.name)
                     else
-                      script.__send__(:__record_exit_error, e)
+                      while (script = Script.current) and script.current_label
+                        proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
+                        Script.current.get_next_label
+                      end
                     end
-                  rescue SyntaxError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue ScriptError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue NoMemoryError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue LoadError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue SecurityError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue ThreadError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue SystemStackError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue JumpError
-                    if $! == JUMP
-                      retry if Script.current.get_next_label != JUMP_ERROR
-                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                      respond $!.backtrace.first
-                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
-                      script.__send__(:__record_exit_error, JUMP_ERROR)
-                      script.kill if script.running? && !script.stopping?
-                    else
-                      script.__send__(:__record_exit_error, $!)
-                      respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                      Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                    end
-                  rescue StandardError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  ensure
-                    script.kill if script.running? && !script.stopping?
                   end
-                else
-                  begin
-                    while (script = Script.current) and script.current_label
-                      proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
-                      Script.current.get_next_label
-                    end
-                    script.__send__(:__record_successful_exit)
-                  rescue SystemExit => e
-                    if e.success?
-                      script.__send__(:__record_successful_exit)
-                    else
-                      script.__send__(:__record_exit_error, e)
-                    end
-                  rescue SyntaxError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue ScriptError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue NoMemoryError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue LoadError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue SecurityError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    if (name = Script.current.name)
-                      respond "--- Lich: review this script (#{name}) to make sure it isn't malicious, and type #{$clean_lich_char}trust #{name}"
-                    end
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue ThreadError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue SystemStackError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  rescue JumpError
-                    if $! == JUMP
-                      retry if Script.current.get_next_label != JUMP_ERROR
-                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                      respond $!.backtrace.first
-                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
-                      script.__send__(:__record_exit_error, JUMP_ERROR)
-                      script.kill if script.running? && !script.stopping?
-                    else
-                      script.__send__(:__record_exit_error, $!)
-                      respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                      Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                    end
-                  rescue StandardError
-                    script.__send__(:__record_exit_error, $!)
-                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  ensure
-                    script.kill if script.running? && !script.stopping?
+                rescue JumpError => error
+                  if error == JUMP
+                    retry if Script.current.get_next_label != JUMP_ERROR
+                    respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
+                    respond error.backtrace.first
+                    Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{error.backtrace.join("\n\t")}"
+                    script.__send__(:__record_exit_error, JUMP_ERROR)
+                  else
+                    script.__send__(:__record_exit_error, error)
+                    Script.__send__(:__report_script_error, script, error, :untrusted => !trusted)
                   end
+                ensure
+                  script.kill if script.running? && !script.stopping?
                 end
               else
                 respond '--- error: out of cheese'
@@ -654,6 +560,58 @@ module Lich
         Lich::Messaging.msg('bold', '########################################')
       end
       private_class_method :__warn_lich_too_old
+
+      def Script.__execute(script, on_error:)
+        yield
+        script.__send__(:__record_successful_exit)
+      rescue SystemExit => error
+        if error.success?
+          script.__send__(:__record_successful_exit)
+        else
+          script.__send__(:__record_exit_error, error)
+        end
+      rescue JumpError
+        raise
+      rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => error
+        script.__send__(:__record_exit_error, error)
+        on_error.call(error)
+      end
+      private_class_method :__execute
+
+      def Script.__report_script_error(script, error, untrusted:)
+        respond "--- Lich: error: #{error}\n\t#{error.backtrace[0..1].join("\n\t")}"
+        if untrusted && error.is_a?(SecurityError)
+          respond "--- Lich: review this script (#{script.name}) to make sure it isn't malicious, and type #{$clean_lich_char}trust #{script.name}"
+        end
+        Lich.log "error: #{error}\n\t#{error.backtrace.join("\n\t")}"
+      end
+      private_class_method :__report_script_error
+
+      def Script.__report_subscript_error(error)
+        respond "--- Lich error: #{error}"
+        respond error.backtrace.first
+        Lich.log "Exception: #{error}\n\t#{error.backtrace.join("\n\t")}"
+      end
+      private_class_method :__report_subscript_error
+
+      def Script.__report_exec_error(error)
+        label =
+          case error
+          when SyntaxError then 'SyntaxError'
+          when LoadError then 'LoadError'
+          when ScriptError then 'ScriptError'
+          when NoMemoryError then 'NoMemoryError'
+          when SecurityError then 'SecurityError'
+          when ThreadError then 'ThreadError'
+          when SystemStackError then 'SystemStackError'
+          else 'Lich error'
+          end
+        log_label = label == 'Lich error' ? 'Exception' : label
+        respond "--- #{label}: #{error}"
+        respond(error.is_a?(SecurityError) ? error.backtrace[0..1] : error.backtrace.first)
+        Lich.log "#{log_label}: #{error}\n\t#{error.backtrace.join("\n\t")}"
+      end
+      private_class_method :__report_exec_error
 
       def Script.__registry_synchronize(&block)
         @@registry_mutex.synchronize(&block)
@@ -2167,19 +2125,12 @@ module Lich
                   begin
                     Thread.current.priority = 1
                     respond("--- Lich: #{script.name} active.") unless script.quiet
-                    block.call
-                    script.__send__(:__record_successful_exit)
-                  rescue SystemExit => e
-                    if e.success?
-                      script.__send__(:__record_successful_exit)
-                    else
-                      script.__send__(:__record_exit_error, e)
-                    end
-                  rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => e
-                    script.__send__(:__record_exit_error, e)
-                    respond "--- Lich error: #{e}"
-                    respond e.backtrace.first
-                    Lich.log "Exception: #{e}\n\t#{e.backtrace.join("\n\t")}"
+                    Script.__send__(
+                      :__execute,
+                      script,
+                      :on_error => proc { |error| Script.__send__(:__report_subscript_error, error) },
+                      &block
+                    )
                   ensure
                     script.kill if script.running? && !script.stopping?
                   end
@@ -2301,66 +2252,16 @@ module Lich
                 Thread.current.priority = 1
                 respond("--- Lich: #{script.name} active.") unless script.quiet
                 begin
-                  script_binding = TRUSTED_SCRIPT_BINDING.call
-                  eval('script = Script.current', script_binding, script.name.to_s)
-                  eval(cmd_data, script_binding, script.name.to_s)
-                  script.__send__(:__record_successful_exit)
-                  script.kill if script.running? && !script.stopping?
-                rescue SystemExit => e
-                  if e.success?
-                    script.__send__(:__record_successful_exit)
-                  else
-                    script.__send__(:__record_exit_error, e)
+                  Script.__send__(
+                    :__execute,
+                    script,
+                    :on_error => proc { |error| Script.__send__(:__report_exec_error, error) }
+                  ) do
+                    script_binding = TRUSTED_SCRIPT_BINDING.call
+                    eval('script = Script.current', script_binding, script.name.to_s)
+                    eval(cmd_data, script_binding, script.name.to_s)
                   end
-                  script.kill if script.running? && !script.stopping?
-                rescue SyntaxError
-                  script.__send__(:__record_exit_error, $!)
-                  respond "--- SyntaxError: #{$!}"
-                  respond $!.backtrace.first
-                  Lich.log "SyntaxError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  script.kill if script.running? && !script.stopping?
-                rescue ScriptError
-                  script.__send__(:__record_exit_error, $!)
-                  respond "--- ScriptError: #{$!}"
-                  respond $!.backtrace.first
-                  Lich.log "ScriptError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  script.kill if script.running? && !script.stopping?
-                rescue NoMemoryError
-                  script.__send__(:__record_exit_error, $!)
-                  respond "--- NoMemoryError: #{$!}"
-                  respond $!.backtrace.first
-                  Lich.log "NoMemoryError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  script.kill if script.running? && !script.stopping?
-                rescue LoadError
-                  script.__send__(:__record_exit_error, $!)
-                  respond("--- LoadError: #{$!}")
-                  respond "--- LoadError: #{$!}"
-                  respond $!.backtrace.first
-                  Lich.log "LoadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  script.kill if script.running? && !script.stopping?
-                rescue SecurityError
-                  script.__send__(:__record_exit_error, $!)
-                  respond "--- SecurityError: #{$!}"
-                  respond $!.backtrace[0..1]
-                  Lich.log "SecurityError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  script.kill if script.running? && !script.stopping?
-                rescue ThreadError
-                  script.__send__(:__record_exit_error, $!)
-                  respond "--- ThreadError: #{$!}"
-                  respond $!.backtrace.first
-                  Lich.log "ThreadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  script.kill if script.running? && !script.stopping?
-                rescue SystemStackError
-                  script.__send__(:__record_exit_error, $!)
-                  respond "--- SystemStackError: #{$!}"
-                  respond $!.backtrace.first
-                  Lich.log "SystemStackError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                  script.kill if script.running? && !script.stopping?
-                rescue StandardError
-                  script.__send__(:__record_exit_error, $!)
-                  respond "--- Lich error: #{$!}"
-                  respond $!.backtrace.first
-                  Lich.log "Exception: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                ensure
                   script.kill if script.running? && !script.stopping?
                 end
               else

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -27,8 +27,28 @@ module Lich
     class Script
       VALID_KILL_CONTEXTS = [:runtime, :shutdown].freeze
       CHILD_MUTEX_INITIALIZER = Mutex.new
+      CHILD_RELATIONSHIP_MUTEX = Mutex.new
+      LIFECYCLE_MUTEX_INITIALIZER = Mutex.new
+      CHILD_JOIN_TIMEOUT = 1.0
 
-      @@elevated_script_start = proc { |args|
+      class ThreadGroupHandle
+        def initialize(script)
+          @script = script
+        end
+
+        def add(thread)
+          accepted = @script.__send__(:__register_worker, thread)
+          raise ThreadError, 'cannot add a worker to a stopping script' unless accepted
+
+          self
+        end
+
+        def list
+          @script.__send__(:__worker_threads)
+        end
+      end
+
+      @@elevated_script_start = proc { |args, parent = nil|
         if args.empty?
           # fixme: error
           next nil
@@ -70,147 +90,211 @@ module Lich
         # Resolve via the shared resolver so script discovery stays identical
         # everywhere (custom/ root, custom/<subdir>/, then SCRIPT_DIR root).
         file_name = __find_script_file(script_name)
-        script_name = file_name.sub(/\..{1,3}$/, '') if file_name
         if file_name.nil?
           respond "--- Lich: could not find script '#{script_name}' in directory #{SCRIPT_DIR} or #{SCRIPT_DIR}/custom"
           next nil
         end
-        if (options[:force] != true) and (Script.running + Script.hidden).find { |s| s.name =~ /^#{Regexp.escape(script_name.sub(%r{/custom/([^/]+/)?}, ''))}$/i }
-          respond "--- Lich: #{script_name} is already running (use #{$clean_lich_char}force [scriptname] if desired)."
-          next nil
-        end
+        registry_name = __script_registry_name(file_name)
+        script_name = file_name.sub(/\.(?:lic|rb|cmd|wiz)(?:\.(?:gz|Z))?\z/i, '')
+        startup_reservation = Object.new
+        startup_completed = false
         begin
-          if file_name =~ /\.(?:cmd|wiz)(?:\.gz)?$/i
-            trusted = false
-            script_obj = WizardScript.new("#{SCRIPT_DIR}/#{file_name}", script_args)
-          else
-            if script_obj.labels.length > 1
-              trusted = false
-            else
-              trusted = true
-            end
-            script_obj = Script.new(:file => "#{SCRIPT_DIR}/#{file_name}", :args => script_args, :quiet => options[:quiet])
+          startup_status = __begin_start(startup_reservation, registry_name, :force => options[:force] == true)
+          if startup_status == :shutdown
+            respond "--- Lich: cannot start #{registry_name} while shutting down."
+            next nil
+          elsif startup_status == :duplicate
+            respond "--- Lich: #{script_name} is already running (use #{$clean_lich_char}force [scriptname] if desired)."
+            next nil
           end
-          if trusted
-            script_binding = TRUSTED_SCRIPT_BINDING.call
-          else
-            script_binding = Scripting.new.script
-          end
-        rescue
-          respond "--- Lich: error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-          next nil
-        end
-        unless script_obj
-          respond "--- Lich: error: failed to start script (#{script_name})"
-          next nil
-        end
-        script_obj.quiet = true if options[:quiet]
-        new_thread = Thread.new {
-          100.times { break if Script.current == script_obj; sleep 0.01 }
 
-          if (script = Script.current)
-            eval('script = Script.current', script_binding, script.name)
-            Thread.current.priority = 1
-            respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
-            if trusted
-              begin
-                eval(script.labels[script.current_label].to_s, script_binding, script.name)
-              rescue SystemExit
-                nil
-              rescue SyntaxError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ScriptError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue NoMemoryError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue LoadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SecurityError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ThreadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SystemStackError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue JumpError
-                if $! == JUMP
-                  retry if Script.current.get_next_label != JUMP_ERROR
-                  respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                  respond $!.backtrace.first
-                  Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
-                  Script.current.kill
-                else
-                  respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                  Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                end
-              rescue StandardError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              ensure
-                Script.current.kill
-              end
+          begin
+            if file_name =~ /\.(?:cmd|wiz)(?:\.gz)?$/i
+              trusted = false
+              script_obj = WizardScript.new("#{SCRIPT_DIR}/#{file_name}", script_args, false)
             else
-              begin
-                while (script = Script.current) and script.current_label
-                  proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
-                  Script.current.get_next_label
-                end
-              rescue SystemExit
-                nil
-              rescue SyntaxError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ScriptError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue NoMemoryError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue LoadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SecurityError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                if (name = Script.current.name)
-                  respond "--- Lich: review this script (#{name}) to make sure it isn't malicious, and type #{$clean_lich_char}trust #{name}"
-                end
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ThreadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SystemStackError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue JumpError
-                if $! == JUMP
-                  retry if Script.current.get_next_label != JUMP_ERROR
-                  respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                  respond $!.backtrace.first
-                  Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
-                  Script.current.kill
+              script_obj = Script.new(:file => "#{SCRIPT_DIR}/#{file_name}", :args => script_args, :quiet => options[:quiet], :publish => false)
+              trusted = script_obj.labels.length <= 1
+            end
+            if trusted
+              script_binding = TRUSTED_SCRIPT_BINDING.call
+            else
+              script_binding = Scripting.new.script
+            end
+          rescue
+            respond "--- Lich: error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+            next nil
+          end
+          unless script_obj
+            respond "--- Lich: error: failed to start script (#{script_name})"
+            next nil
+          end
+          script_obj.quiet = true if options[:quiet]
+
+          start_gate = Queue.new
+          setup_complete = false
+          worker_released = false
+          begin
+            new_thread = Thread.new {
+              next unless start_gate.pop
+
+              if (script = Script.current)
+                eval('script = Script.current', script_binding, script.name)
+                Thread.current.priority = 1
+                respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
+                if trusted
+                  begin
+                    eval(script.labels[script.current_label].to_s, script_binding, script.name)
+                    script.__send__(:__record_successful_exit)
+                  rescue SystemExit => e
+                    if e.success?
+                      script.__send__(:__record_successful_exit)
+                    else
+                      script.__send__(:__record_exit_error, e)
+                    end
+                  rescue SyntaxError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ScriptError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue NoMemoryError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue LoadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SecurityError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ThreadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SystemStackError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue JumpError
+                    if $! == JUMP
+                      retry if Script.current.get_next_label != JUMP_ERROR
+                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
+                      respond $!.backtrace.first
+                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
+                      script.__send__(:__record_exit_error, JUMP_ERROR)
+                      script.kill if script.running? && !script.stopping?
+                    else
+                      script.__send__(:__record_exit_error, $!)
+                      respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                      Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                    end
+                  rescue StandardError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  ensure
+                    script.kill if script.running? && !script.stopping?
+                  end
                 else
-                  respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                  Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  begin
+                    while (script = Script.current) and script.current_label
+                      proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
+                      Script.current.get_next_label
+                    end
+                    script.__send__(:__record_successful_exit)
+                  rescue SystemExit => e
+                    if e.success?
+                      script.__send__(:__record_successful_exit)
+                    else
+                      script.__send__(:__record_exit_error, e)
+                    end
+                  rescue SyntaxError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ScriptError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue NoMemoryError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue LoadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SecurityError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    if (name = Script.current.name)
+                      respond "--- Lich: review this script (#{name}) to make sure it isn't malicious, and type #{$clean_lich_char}trust #{name}"
+                    end
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ThreadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SystemStackError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue JumpError
+                    if $! == JUMP
+                      retry if Script.current.get_next_label != JUMP_ERROR
+                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
+                      respond $!.backtrace.first
+                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
+                      script.__send__(:__record_exit_error, JUMP_ERROR)
+                      script.kill if script.running? && !script.stopping?
+                    else
+                      script.__send__(:__record_exit_error, $!)
+                      respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                      Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                    end
+                  rescue StandardError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  ensure
+                    script.kill if script.running? && !script.stopping?
+                  end
                 end
-              rescue StandardError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              ensure
-                Script.current.kill
+              else
+                respond '--- error: out of cheese'
+              end
+            }
+            script_obj.__send__(:__attach_startup_worker, new_thread)
+            if parent && !parent.__send__(:__adopt_child_locked, script_obj)
+              new_thread&.kill
+              script_obj.__send__(:__discard_startup)
+              next nil
+            end
+            script_obj.__send__(:__publish, true)
+            setup_complete = true
+          ensure
+            begin
+              start_gate << setup_complete
+              worker_released = true
+            ensure
+              unless setup_complete && worker_released
+                new_thread&.kill
+                new_thread&.join
+                parent.__send__(:__unregister_child_locked, script_obj) if parent
+                script_obj.__send__(:__discard_startup)
               end
             end
-          else
-            respond '--- error: out of cheese'
           end
-        }
-        script_obj.thread_group.add(new_thread)
-        script_obj
+          startup_completed = true
+          script_obj
+        ensure
+          __finish_start(startup_reservation, startup_completed ? script_obj : nil)
+        end
       }
       @@elevated_exists = proc { |script_name|
         if script_name =~ /\\|\//
@@ -289,8 +373,16 @@ module Lich
         end
       }
       @@running = Array.new
+      @@stopping = Array.new
+      @@startup_mutex = Mutex.new
+      @@startup_condition = ConditionVariable.new
+      @@startup_reservations = {}
+      @@completed_named_starts = {}
+      @@shutdown_started = false
       @@library_mutex = Mutex.new
       @@loaded_libraries = Set.new
+      @@loading_libraries = {}
+      @@library_waits = {}
       @@kill_metrics_mutex = Mutex.new
       @@kill_metrics = {
         :minute            => nil,
@@ -300,7 +392,7 @@ module Lich
         :failures          => 0
       }
 
-      attr_reader :name, :vars, :safe, :file_name, :label_order, :at_exit_procs
+      attr_reader :name, :vars, :safe, :file_name, :label_order, :at_exit_procs, :exit_error
       attr_accessor :quiet, :no_echo, :jump_label, :current_label, :want_downstream, :want_downstream_xml, :want_upstream, :want_script_output, :hidden, :paused, :silent, :no_pause_all, :no_kill_all, :downstream_buffer, :upstream_buffer, :unique_buffer, :die_with, :match_stack_labels, :match_stack_strings, :watchfor, :command_line, :ignore_pause, :killed_externally, :kill_source
 
       KILL_METRICS_FEATURE_FLAG = :script_kill_metrics
@@ -349,6 +441,13 @@ module Lich
           file_list.find { |val| val =~ /^(?:\/custom\/(?:[^\/]+\/)?)?#{escaped}[^.]+\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i }
       end
       private_class_method :__find_script_file
+
+      def Script.__script_registry_name(file_name)
+        file_name
+          .sub(%r{\A/custom/(?:[^/]+/)?}, '')
+          .sub(/\.(?:lic|rb|cmd|wiz)(?:\.(?:gz|Z))?\z/i, '')
+      end
+      private_class_method :__script_registry_name
 
       # Extracts the leading header-comment lines from raw script source.
       #
@@ -552,16 +651,85 @@ module Lich
         @@running.dup
       end
 
+      def Script.shutdown_scripts
+        scripts = (@@running + @@stopping).uniq
+        scripts.each { |script| script.__send__(:__refresh_deferred_stop) }
+        (@@running + @@stopping).uniq
+      end
+
+      def Script.begin_shutdown
+        @@startup_mutex.synchronize do
+          @@shutdown_started = true
+          @@startup_condition.wait(@@startup_mutex) until @@startup_reservations.empty?
+          shutdown_scripts
+        end
+      end
+
+      def Script.__begin_start(reservation, name = nil, force: true)
+        normalized_name = name&.downcase
+        @@startup_mutex.synchronize do
+          return :shutdown if @@shutdown_started
+          if normalized_name && !force
+            running = @@running.any? { |script| script.name.casecmp?(normalized_name) }
+            starting = @@startup_reservations.value?(normalized_name)
+            return :duplicate if running || starting
+          end
+
+          @@startup_reservations[reservation] = normalized_name
+          :admitted
+        end
+      end
+      private_class_method :__begin_start
+
+      def Script.__finish_start(reservation, script = nil)
+        @@startup_mutex.synchronize do
+          name = @@startup_reservations.delete(reservation)
+          if name&.start_with?('lib')
+            @@completed_named_starts.delete(name)
+            @@completed_named_starts[name] = script if script
+          end
+          @@startup_condition.broadcast
+        end
+      end
+      private_class_method :__finish_start
+
+      def Script.__publish_to_registry(admitted:)
+        @@startup_mutex.synchronize do
+          raise ThreadError, 'cannot publish a script while shutting down' if @@shutdown_started && !admitted
+
+          yield
+        end
+      end
+      private_class_method :__publish_to_registry
+
+      def Script.__take_completed_start(name)
+        normalized_name = name.downcase
+        @@startup_mutex.synchronize do
+          while @@startup_reservations.value?(normalized_name)
+            @@startup_condition.wait(@@startup_mutex)
+          end
+          @@completed_named_starts.delete(normalized_name)
+        end
+      end
+      private_class_method :__take_completed_start
+
+      def Script.__discard_completed_start(name, script)
+        normalized_name = name.downcase
+        @@startup_mutex.synchronize do
+          @@completed_named_starts.delete(normalized_name) if @@completed_named_starts[normalized_name].equal?(script)
+        end
+      end
+      private_class_method :__discard_completed_start
+
       def Script.subscript(&block)
         SubScript.start(:parent => Script.current, :quiet => true, &block)
       end
 
       def Script.start_child(*args)
         parent = Script.current
-        child = Script.start(*args)
-        return child unless parent && child
+        return Script.start(*args) unless parent
 
-        parent.register_child(child)
+        parent.__send__(:__launch_child) { @@elevated_script_start.call(args, parent) }
       end
 
       def Script.run_child(*args)
@@ -589,11 +757,11 @@ module Lich
       end
 
       def Script.start(*args)
-        @@elevated_script_start.call(args)
+        @@elevated_script_start.call(args, nil)
       end
 
       def Script.run(*args)
-        if (s = @@elevated_script_start.call(args))
+        if (s = @@elevated_script_start.call(args, nil))
           sleep 0.1 while @@running.include?(s)
         end
       end
@@ -602,34 +770,152 @@ module Lich
         library_name = library.to_s.downcase
         library_name = "lib#{library_name}" unless library_name.start_with?('lib')
         raise ArgumentError, 'library name cannot be empty' if library_name == 'lib'
-        raise LoadError, "script library not found: #{library_name}" unless Script.exists?(library_name)
+        resolved_file = __find_script_file(library_name)
+        raise LoadError, "script library not found: #{library_name}" unless resolved_file
 
-        script = @@library_mutex.synchronize do
-          running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
-          if @@loaded_libraries.include?(library_name)
-            running
-          else
-            @@loaded_libraries.add(library_name)
-            started = running || Script.start(library_name)
-            @@loaded_libraries.delete(library_name) unless started
-            started
+        library_name = __script_registry_name(resolved_file).downcase
+
+        loading = @@library_mutex.synchronize { @@loading_libraries[library_name] }
+        if loading
+          begin
+            __join_library(library_name, loading)
+            __validate_library_completion(library_name, loading)
+            return true
+          rescue LoadError => e
+            raise if e.message.start_with?('cyclic script library dependency:')
+
+            @@library_mutex.synchronize do
+              if @@loading_libraries[library_name].equal?(loading)
+                @@loading_libraries.delete(library_name)
+                @@loaded_libraries.delete(library_name)
+              end
+            end
           end
         end
 
-        raise LoadError, "failed to start script library: #{library_name}" unless @@loaded_libraries.include?(library_name)
+        startup_reservation = Object.new
+        begin
+          startup_status = __begin_start(startup_reservation, library_name, :force => false)
+          raise LoadError, "cannot load script library during shutdown: #{library_name}" if startup_status == :shutdown
 
-        script&.join
-        true
+          completed_start = __take_completed_start(library_name) if startup_status == :duplicate
+          script, already_loaded, owns_loading, started_here = @@library_mutex.synchronize do
+            running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
+            if (loading = @@loading_libraries[library_name])
+              [loading, false, false, false]
+            elsif (candidate = completed_start || running)
+              @@loading_libraries[library_name] = candidate
+              [candidate, false, true, false]
+            elsif @@loaded_libraries.include?(library_name)
+              [nil, true, false, false]
+            else
+              started = Script.start(library_name, { :force => true })
+              raise LoadError, "failed to start script library: #{library_name}" unless started
+
+              @@loading_libraries[library_name] = started
+              [started, false, true, true]
+            end
+          end
+          __discard_completed_start(library_name, script) if started_here
+          return true if already_loaded
+
+          __finish_start(startup_reservation)
+          begin
+            __join_library(library_name, script)
+          rescue ScriptError, StandardError
+            if owns_loading
+              @@library_mutex.synchronize do
+                @@loading_libraries.delete(library_name) if @@loading_libraries[library_name].equal?(script)
+              end
+            end
+            raise
+          end
+
+          error = script.exit_error
+          completed = script.completed_successfully?
+          @@library_mutex.synchronize do
+            if @@loading_libraries[library_name].equal?(script)
+              @@loading_libraries.delete(library_name)
+              if error || !completed
+                @@loaded_libraries.delete(library_name)
+              else
+                @@loaded_libraries.add(library_name)
+              end
+            end
+          end
+          __validate_library_completion(library_name, script)
+
+          true
+        ensure
+          __finish_start(startup_reservation)
+        end
       end
 
       def Script.reloadlibs
-        @@library_mutex.synchronize { @@loaded_libraries.dup }.each { |library| Script.run(library) }
+        current_library = Script.current&.name&.downcase
+        @@library_mutex.synchronize { @@loaded_libraries.dup }.each do |library|
+          next if library == current_library
+
+          @@library_mutex.synchronize { @@loaded_libraries.delete(library) }
+          Script.loadlib(library)
+        rescue LoadError => e
+          Lich.log("error: failed to reload script library #{library}: #{e.message}")
+        end
         true
       end
 
       def Script.libs
         @@library_mutex.synchronize { @@loaded_libraries.dup }
       end
+
+      def Script.__join_library(library_name, script)
+        caller_script = Script.current
+        @@library_mutex.synchronize do
+          if caller_script
+            if __library_dependency_reaches?(script, caller_script)
+              raise LoadError, "cyclic script library dependency: #{library_name}"
+            end
+            dependencies = @@library_waits[caller_script]
+            dependencies = Set.new(Array(dependencies)) unless dependencies.is_a?(Set)
+            @@library_waits[caller_script] = dependencies
+            dependencies.add(script)
+          end
+        end
+
+        script.join
+      ensure
+        if caller_script
+          @@library_mutex.synchronize do
+            dependencies = @@library_waits[caller_script]
+            if dependencies.is_a?(Set)
+              dependencies.delete(script)
+              @@library_waits.delete(caller_script) if dependencies.empty?
+            elsif dependencies.equal?(script)
+              @@library_waits.delete(caller_script)
+            end
+          end
+        end
+      end
+      private_class_method :__join_library
+
+      def Script.__validate_library_completion(library_name, script)
+        error = script.exit_error
+        raise LoadError, "script library failed: #{library_name}: #{error.message}" if error
+        raise LoadError, "script library did not complete: #{library_name}" unless script.completed_successfully?
+      end
+      private_class_method :__validate_library_completion
+
+      def Script.__library_dependency_reaches?(start, target, visited = Set.new)
+        return true if start.equal?(target)
+        return false unless start
+        return false if visited.include?(start)
+
+        visited.add(start)
+        dependencies = @@library_waits[start]
+        dependencies = dependencies.is_a?(Set) ? dependencies : Array(dependencies)
+        dependencies.any? { |dependency| __library_dependency_reaches?(dependency, target, visited) }
+      end
+      private_class_method :__library_dependency_reaches?
 
       def Script.running?(name)
         @@running.any? { |i| (i.name =~ /^#{name}$/i) }
@@ -724,15 +1010,27 @@ module Lich
           unless script.watchfor.empty?
             script.watchfor.each_pair { |trigger, action|
               if line =~ trigger
-                new_thread = Thread.new {
-                  sleep 0.011 until Script.current
-                  begin
-                    action.call
-                  rescue
-                    echo "watchfor error: #{$!}"
+                start_gate = Queue.new
+                worker_registered = false
+                begin
+                  new_thread = Thread.new {
+                    next unless start_gate.pop
+
+                    sleep 0.011 until Script.current
+                    begin
+                      action.call
+                    rescue
+                      echo "watchfor error: #{$!}"
+                    end
+                  }
+                  worker_registered = script.__send__(:__register_worker, new_thread)
+                ensure
+                  start_gate << worker_registered
+                  unless worker_registered
+                    new_thread&.kill
+                    new_thread&.join
                   end
-                }
-                script.thread_group.add(new_thread)
+                end
               end
             }
           end
@@ -1005,6 +1303,9 @@ module Lich
         @killer_mutex = Mutex.new
         @killed_externally = false
         @kill_source = nil
+        @kill_requested = false
+        @cleanup_started = false
+        @completed_successfully = false
         @ignore_pause = false
         data = nil
         if @file_name =~ /\.gz$/i
@@ -1038,7 +1339,7 @@ module Lich
         data = nil
         @current_label = @label_order[0]
         @thread_group = ThreadGroup.new
-        @@running.push(self)
+        __publish if args.fetch(:publish, true)
         # return self
       end
 
@@ -1060,22 +1361,67 @@ module Lich
       # @param context [Symbol] :runtime for ordinary script stops, :shutdown
       #   when the owning Lich process is closing
       # @return [String] script name
-      def kill(context: :runtime)
+      def kill(context: :runtime, async: nil)
         unless VALID_KILL_CONTEXTS.include?(context)
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
-        @kill_requested = true
+        async = context != :shutdown if async.nil?
+        launch_token = Object.new
+        cleanup_thread = nil
+        cleanup_released = false
+        cleanup_owned = false
+        start_gate = Queue.new if async
         source = @kill_source || caller[0..2]
+        begin
+          start_cleanup = lifecycle_mutex.synchronize do
+            next false unless @@running.include?(self)
+            next false if @cleanup_started
 
-        if context == :shutdown
-          __run_kill_cleanup(source: source, context: context, record_metrics: false)
-        else
-          begin
-            Thread.new { __run_kill_cleanup(source: source, context: context, record_metrics: true) }
-          rescue ThreadError => e
-            __log_kill_thread_fallback(e)
+            @kill_requested = true
+            @cleanup_started = launch_token
+            @cleanup_launch_pending = true
+            @@stopping << self unless @@stopping.include?(self)
+            true
+          end
+          return @name unless start_cleanup
+
+          if async
+            cleanup_thread = Thread.new {
+              start_gate.pop
+              __run_kill_cleanup(source: source, context: context, record_metrics: true)
+            }
+            ThreadGroup::Default.add(cleanup_thread)
+            __attach_startup_worker(cleanup_thread)
+            lifecycle_mutex.synchronize { @cleanup_thread = cleanup_thread }
+            cleanup_owned = true
+            raise ThreadError, 'cleanup thread stopped before ownership transfer' unless cleanup_thread.alive?
+
+            start_gate << true
+            cleanup_released = true
+          else
+            lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
+            cleanup_owned = true
             __run_kill_cleanup(source: source, context: context, record_metrics: false)
+          end
+        rescue ThreadError => e
+          raise unless @cleanup_started.equal?(launch_token)
+
+          cleanup_thread&.kill
+          __log_kill_thread_fallback(e)
+          __run_kill_cleanup(source: source, context: context, record_metrics: false)
+        ensure
+          if async && @cleanup_started.equal?(launch_token) && !cleanup_released
+            start_gate << true
+            unless cleanup_owned && cleanup_thread&.alive?
+              cleanup_thread&.kill
+              __run_kill_cleanup(source: source, context: context, record_metrics: false)
+            end
+          end
+          if @cleanup_started.equal?(launch_token)
+            executor_abandoned = !cleanup_owned || !cleanup_thread&.alive? || cleanup_thread == Thread.current
+            __run_kill_cleanup(source: source, context: context, record_metrics: false) if running? && executor_abandoned
+            lifecycle_mutex.synchronize { @cleanup_launch_pending = false }
           end
         end
 
@@ -1090,16 +1436,28 @@ module Lich
         @kill_requested == true
       end
 
+      def completed_successfully?
+        lifecycle_mutex.synchronize { @completed_successfully == true }
+      end
+
       def join(timeout = nil)
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
-        @killer_mutex.synchronize do
-          @stopped_condition ||= ConditionVariable.new
-          while @@running.include?(self)
+        loop do
+          __refresh_deferred_stop
+          completed = lifecycle_mutex.synchronize do
+            @stopped_condition ||= ConditionVariable.new
+            running = @@running.include?(self)
+            return self if !running && Array(@stopping_threads).include?(Thread.current)
+            return self if !running && @cleanup_complete
+
             remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC) if deadline
             return nil if remaining && remaining <= 0
 
-            @stopped_condition.wait(@killer_mutex, remaining)
+            wait_for = running ? remaining : [remaining || 0.01, 0.01].min
+            @stopped_condition.wait(lifecycle_mutex, wait_for)
+            false
           end
+          break if completed
         end
         self
       end
@@ -1112,38 +1470,26 @@ module Lich
       def register_child(script)
         return nil unless script
 
-        script.hidden = true if hidden
-        script.no_kill_all = true if no_kill_all
-        script.no_pause_all = true if no_pause_all
         accepted = child_scripts_mutex.synchronize do
-          unless @child_shutdown_started
-            @child_scripts ||= []
-            @child_scripts << script unless @child_scripts.include?(script)
-            true
-          end
+          __register_child_locked(script)
         end
         unless accepted
-          script.kill_sync if script.running?
+          script.kill_sync(context: :runtime, timeout: CHILD_JOIN_TIMEOUT) if script.running?
           return nil
         end
 
-        begin
-          script.at_exit { unregister_child(script) }
-        rescue NoMethodError
-          # A short-lived child may finish before its exit handler is registered.
-        ensure
-          unregister_child(script) unless script.running?
-        end
         script
       end
 
       def unregister_child(script)
-        child_scripts_mutex.synchronize { @child_scripts&.delete(script) }
+        child_scripts_mutex.synchronize { __unregister_child_locked(script) }
         script
       end
 
       def child_scripts
-        child_scripts_mutex.synchronize { Array(@child_scripts).dup }
+        child_scripts_mutex.synchronize do
+          CHILD_RELATIONSHIP_MUTEX.synchronize { Array(@child_scripts).dup }
+        end
       end
 
       # Runs the script cleanup body used by {#kill}.
@@ -1176,23 +1522,28 @@ module Lich
         return if @killer_mutex.owned?
 
         @killer_mutex.synchronize {
+          lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
           if @@running.include?(self)
             instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
             started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
             failed = false
             begin
-              @thread_group.list.dup.each { |t|
-                unless t == Thread.current
-                  t.kill rescue nil
-                end
-              }
+              children = __begin_child_shutdown
+              stopping_threads = lifecycle_mutex.synchronize do
+                @stopping_threads = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+              end
+              stopping_threads.each { |thread| thread.kill rescue nil }
               @thread_group.add(Thread.current)
-              __stop_children(context)
+              __stop_children(children, context)
+              @thread_group.add(Thread.current)
               # Forward the kill context so die_with dependents torn down during
               # shutdown also run inline -- otherwise they route back through the
               # default :runtime path and re-spawn the thread-per-kill burst that
               # inline shutdown teardown exists to avoid.
-              @die_with.each { |script_name| Script.kill(script_name, context: context) }
+              @die_with.each do |script_name|
+                Script.kill(script_name, context: context)
+                @thread_group.add(Thread.current)
+              end
               @paused = false
               @at_exit_procs.each { |p| report_errors { p.call } }
               # Let each per-script-state subsystem (the hook registries, etc.)
@@ -1207,37 +1558,22 @@ module Lich
               # capture). The script is removed from @@running below, so they can
               # never fire again; cleared to {} rather than nil so a concurrent
               # new_downstream sweep still sees a safe, empty collection.
-              @watchfor = {}
-              # Same reasoning for the stream buffers: Script.new_downstream,
-              # new_downstream_xml and new_upstream run on the parser thread and
-              # push to these without a nil guard, and can fire in the window
-              # before the @@running.delete below. Reset to fresh empty buffers
-              # ("no pending lines") rather than nil so a concurrent push cannot
-              # raise NoMethodError. Distinct arrays - never the same object.
-              @downstream_buffer = LimitedArray.new
-              @upstream_buffer = LimitedArray.new
-              @die_with = @at_exit_procs = @match_stack_labels = @match_stack_strings = nil
-              @@running.delete(self)
-              @stopped_condition&.broadcast
-              unless @quiet
-                if @killed_externally
-                  respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
-                else
-                  respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.")
-                end
-              end
             rescue
               failed = true
               respond "--- Lich: error: #{$!}"
               Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
             ensure
-              if instrument_kill
-                finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-                Script.__send__(
-                  :__record_kill_metric,
-                  :duration_ms => (finished_at - started_at) * 1000.0,
-                  :failed      => failed
-                )
+              begin
+                if instrument_kill
+                  finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                  Script.__send__(
+                    :__record_kill_metric,
+                    :duration_ms => (finished_at - started_at) * 1000.0,
+                    :failed      => failed
+                  )
+                end
+              ensure
+                __complete_stop(source, context)
               end
             end
           end
@@ -1245,16 +1581,92 @@ module Lich
       end
       private :__run_kill_cleanup
 
-      def __stop_children(context)
-        children = child_scripts_mutex.synchronize do
-          @child_shutdown_started = true
-          current = Array(@child_scripts).dup
-          @child_scripts = []
-          current
+      def __launch_child
+        child_scripts_mutex.synchronize do
+          return nil if @child_shutdown_started
+
+          yield
         end
+      end
+      private :__launch_child
+
+      def __register_child_locked(script)
+        return nil if @child_shutdown_started
+        script.__send__(:__while_running) do
+          __adopt_child_locked(script)
+        end
+      end
+      private :__register_child_locked
+
+      def __adopt_child_locked(script)
+        return nil if @child_shutdown_started
+
+        CHILD_RELATIONSHIP_MUTEX.synchronize do
+          raise ArgumentError, 'script cannot be its own child' if script.equal?(self)
+
+          ancestor = self
+          while ancestor
+            raise ArgumentError, 'script child relationship would create a cycle' if ancestor.equal?(script)
+
+            ancestor = ancestor.__send__(:__parent_script)
+          end
+          current_parent = script.__send__(:__parent_script)
+          if current_parent && !current_parent.equal?(self)
+            raise ArgumentError, "script already belongs to parent #{current_parent.name}"
+          end
+
+          script.__send__(:__set_parent_script, self)
+          script.hidden = true if hidden
+          script.no_kill_all = true if no_kill_all
+          script.no_pause_all = true if no_pause_all
+          @child_scripts ||= []
+          @child_scripts << script unless @child_scripts.include?(script)
+        end
+        script
+      end
+      private :__adopt_child_locked
+
+      def __unregister_child_locked(script)
+        CHILD_RELATIONSHIP_MUTEX.synchronize do
+          @child_scripts&.delete(script)
+          script.__send__(:__set_parent_script, nil) if script.__send__(:__parent_script).equal?(self)
+        end
+      end
+      private :__unregister_child_locked
+
+      def __begin_child_shutdown
+        children = child_scripts_mutex.synchronize do
+          CHILD_RELATIONSHIP_MUTEX.synchronize do
+            @child_shutdown_started = true
+            Array(@child_scripts).dup
+          end
+        end
+        children
+      end
+      private :__begin_child_shutdown
+
+      def __stop_children(children, context)
+        return if children.empty?
+        # The process-wide shutdown drain already owns every running script.
+        # Recursing here would allocate one cleanup thread per child.
+        return if context == :shutdown
+
         children.each do |child|
-          child.kill(context: context) if child.running?
-          child.join
+          child.kill(context: context, async: true) if child.running?
+        rescue StandardError => e
+          Lich.log("error: failed to stop child script #{child.name}: #{e}") if defined?(Lich) && Lich.respond_to?(:log)
+        ensure
+          @thread_group.add(Thread.current)
+        end
+
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + CHILD_JOIN_TIMEOUT
+        children.each do |child|
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          break if remaining <= 0
+
+          next if child.join(remaining)
+
+          Lich.log("warning: child script #{child.name} did not stop within #{CHILD_JOIN_TIMEOUT}s") if defined?(Lich) && Lich.respond_to?(:log)
         end
       end
       private :__stop_children
@@ -1265,6 +1677,238 @@ module Lich
         CHILD_MUTEX_INITIALIZER.synchronize { @child_scripts_mutex ||= Mutex.new }
       end
       private :child_scripts_mutex
+
+      def lifecycle_mutex
+        return @lifecycle_mutex if @lifecycle_mutex
+
+        LIFECYCLE_MUTEX_INITIALIZER.synchronize { @lifecycle_mutex ||= Mutex.new }
+      end
+      private :lifecycle_mutex
+
+      def __parent_script
+        @parent_script
+      end
+      private :__parent_script
+
+      def __set_parent_script(parent)
+        @parent_script = parent
+      end
+      private :__set_parent_script
+
+      def __record_exit_error(error)
+        lifecycle_mutex.synchronize { @exit_error ||= error }
+      end
+      private :__record_exit_error
+
+      def __record_successful_exit
+        lifecycle_mutex.synchronize { @completed_successfully = true unless @exit_error }
+      end
+      private :__record_successful_exit
+
+      def __register_worker(thread)
+        registration = Object.new
+        tracked_rejection = false
+        accepted = false
+        begin
+          accepted = lifecycle_mutex.synchronize do
+            if @@running.include?(self) && !@kill_requested
+              @thread_group.add(thread)
+              true
+            else
+              @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
+              unless @worker_admission_closed
+                @worker_registrations ||= Set.new
+                @worker_registrations.add(registration)
+                tracked_rejection = true
+              end
+              false
+            end
+          end
+          unless accepted
+            thread.kill
+            thread.join unless thread == Thread.current
+          end
+          accepted
+        rescue StandardError => error
+          thread.kill
+          begin
+            thread.join unless thread == Thread.current
+          rescue StandardError
+            nil
+          end
+          raise error
+        ensure
+          unless accepted
+            thread.kill
+            begin
+              thread.join unless thread == Thread.current
+            rescue StandardError
+              nil
+            end
+          end
+          if tracked_rejection
+            lifecycle_mutex.synchronize do
+              @worker_registrations&.delete(registration)
+              @stopped_condition&.broadcast
+            end
+          end
+        end
+      end
+      private :__register_worker
+
+      def __attach_startup_worker(thread)
+        @thread_group.add(thread)
+        thread
+      end
+      private :__attach_startup_worker
+
+      def __worker_threads
+        @thread_group.list.dup
+      end
+      private :__worker_threads
+
+      def __publish(admitted = false)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+        end
+        self
+      end
+      private :__publish
+
+      def __while_running
+        lifecycle_mutex.synchronize do
+          return nil unless @@running.include?(self) && !stopping?
+
+          yield
+        end
+      end
+      private :__while_running
+
+      def __discard_startup
+        parent = nil
+        lifecycle_mutex.synchronize do
+          @@running.delete(self)
+          @@stopping.delete(self)
+          @worker_admission_closed = true
+          @cleanup_complete = true
+          CHILD_RELATIONSHIP_MUTEX.synchronize do
+            parent = @parent_script
+            @parent_script = nil
+          end
+          @stopped_condition&.broadcast
+        end
+        parent&.unregister_child(self)
+        self
+      end
+      private :__discard_startup
+
+      def __complete_stop(source, context)
+        begin
+          @watchfor = {}
+          @downstream_buffer = LimitedArray.new
+          @upstream_buffer = LimitedArray.new
+          @die_with = @at_exit_procs = @match_stack_labels = @match_stack_strings = nil
+          unless @quiet
+            if @killed_externally
+              respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
+            else
+              respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.")
+            end
+          end
+        ensure
+          lifecycle_mutex.synchronize do
+            late_workers = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+            @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
+            late_workers.each { |thread| thread.kill rescue nil }
+            @@running.delete(self)
+            @stopped_condition&.broadcast
+          end
+          workers_stopped = __wait_for_worker_shutdown(:wait => context != :shutdown)
+          __finalize_stop if workers_stopped
+        end
+      end
+      private :__complete_stop
+
+      def __wait_for_worker_shutdown(wait:)
+        loop do
+          workers = lifecycle_mutex.synchronize do
+            current_workers = @thread_group.list.dup
+            @stopping_threads = (Array(@stopping_threads) + current_workers).uniq
+            @stopping_threads.reject { |thread| thread == Thread.current || thread == @cleanup_thread || !thread.alive? }
+          end
+          if workers.empty?
+            done = lifecycle_mutex.synchronize do
+              if !@worker_registrations || @worker_registrations.empty?
+                @worker_admission_closed = true
+                true
+              elsif !wait
+                false
+              else
+                @stopped_condition ||= ConditionVariable.new
+                @stopped_condition.wait(lifecycle_mutex)
+                nil
+              end
+            end
+            return true if done
+            return false if done == false
+
+            next
+          end
+
+          workers.each { |thread| thread.kill rescue nil }
+          return false unless wait
+
+          workers.each do |thread|
+            thread.join
+          rescue StandardError => e
+            __record_exit_error(e)
+            Lich.log("error: worker shutdown failed for #{@name}: #{e.class}: #{e.message}") if defined?(Lich) && Lich.respond_to?(:log)
+          end
+        end
+      end
+      private :__wait_for_worker_shutdown
+
+      def __refresh_deferred_stop
+        abandoned_cleanup = lifecycle_mutex.synchronize do
+          if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
+             (!@cleanup_thread || !@cleanup_thread.alive?)
+            @cleanup_started = false
+            @cleanup_thread = nil
+            true
+          end
+        end
+        kill(:context => :shutdown) if abandoned_cleanup
+
+        should_refresh = lifecycle_mutex.synchronize do
+          cleanup_active_elsewhere = @cleanup_thread&.alive? && @cleanup_thread != Thread.current
+          @cleanup_started && !@cleanup_complete && !@@running.include?(self) && !cleanup_active_elsewhere
+        end
+        __finalize_stop if should_refresh && __wait_for_worker_shutdown(:wait => false)
+      end
+      private :__refresh_deferred_stop
+
+      def __finalize_stop
+        claimed = lifecycle_mutex.synchronize do
+          next false if @cleanup_complete || @finalization_started
+
+          @finalization_started = true
+        end
+        return unless claimed
+
+        parent = nil
+        begin
+          CHILD_RELATIONSHIP_MUTEX.synchronize { parent = @parent_script }
+          parent&.unregister_child(self)
+          CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
+        ensure
+          lifecycle_mutex.synchronize do
+            @cleanup_complete = true
+            @@stopping.delete(self)
+            @stopped_condition&.broadcast
+          end
+        end
+      end
+      private :__finalize_stop
 
       # Logs when {#kill} cannot allocate its normal cleanup thread.
       #
@@ -1311,7 +1955,7 @@ module Lich
       end
 
       def thread_group
-        @thread_group
+        @thread_group_handle ||= ThreadGroupHandle.new(self)
       end
 
       def has_thread?(t)
@@ -1443,38 +2087,82 @@ module Lich
       def SubScript.start(parent: Script.current, quiet: true, &block)
         raise ArgumentError, 'a block is required' unless block
 
-        new_script = SubScript.new(:quiet => quiet)
-        return false if parent && !parent.register_child(new_script)
+        startup_reservation = Object.new
+        begin
+          startup_status = Script.__send__(:__begin_start, startup_reservation)
+          return false if startup_status == :shutdown
 
-        new_thread = Thread.new {
-          100.times { break if Script.current == new_script; sleep 0.01 }
-
-          if (script = Script.current)
-            Thread.current.priority = 1
-            respond("--- Lich: #{script.name} active.") unless script.quiet
+          starter = proc do
+            new_script = SubScript.new(:quiet => quiet, :publish => false)
+            start_gate = Queue.new
+            setup_complete = false
+            worker_released = false
             begin
-              block.call
-            rescue SystemExit
-              nil
-            rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => e
-              respond "--- Lich error: #{e}"
-              respond e.backtrace.first
-              Lich.log "Exception: #{e}\n\t#{e.backtrace.join("\n\t")}"
+              new_thread = Thread.new {
+                next unless start_gate.pop
+
+                if (script = Script.current)
+                  begin
+                    Thread.current.priority = 1
+                    respond("--- Lich: #{script.name} active.") unless script.quiet
+                    block.call
+                    script.__send__(:__record_successful_exit)
+                  rescue SystemExit => e
+                    if e.success?
+                      script.__send__(:__record_successful_exit)
+                    else
+                      script.__send__(:__record_exit_error, e)
+                    end
+                  rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => e
+                    script.__send__(:__record_exit_error, e)
+                    respond "--- Lich error: #{e}"
+                    respond e.backtrace.first
+                    Lich.log "Exception: #{e}\n\t#{e.backtrace.join("\n\t")}"
+                  ensure
+                    script.kill if script.running? && !script.stopping?
+                  end
+                else
+                  respond '--- Lich: failed to start subscript'
+                end
+              }
+              new_script.__send__(:__attach_startup_worker, new_thread)
+              if parent && !parent.__send__(:__adopt_child_locked, new_script)
+                new_thread&.kill
+                new_script.__send__(:__discard_startup)
+                next false
+              end
+              new_script.__send__(:__publish, true)
+              setup_complete = true
             ensure
-              script.kill if script.running? && !script.stopping?
+              begin
+                start_gate << setup_complete
+                worker_released = true
+              ensure
+                unless setup_complete && worker_released
+                  new_thread&.kill
+                  new_thread&.join
+                  parent.__send__(:__unregister_child_locked, new_script) if parent
+                  new_script.__send__(:__discard_startup)
+                end
+              end
             end
-          else
-            respond '--- Lich: failed to start subscript'
+            new_script
           end
-        }
-        new_script.thread_group.add(new_thread)
-        new_script
+
+          if parent
+            parent.__send__(:__launch_child, &starter)
+          else
+            starter.call
+          end
+        ensure
+          Script.__send__(:__finish_start, startup_reservation)
+        end
       end
 
       # SubScript has no source file or eval string, so it initializes only the
       # runtime state shared by ordinary scripts.
       # rubocop:disable Lint/MissingSuper
-      def initialize(quiet: true)
+      def initialize(quiet: true, publish: true)
         @custom = false
         @vars = []
         @downstream_buffer = LimitedArray.new
@@ -1503,14 +2191,26 @@ module Lich
         @killed_externally = false
         @kill_source = nil
         @kill_requested = false
+        @cleanup_started = false
+        @completed_successfully = false
         @ignore_pause = false
-        @@name_subscript_mutex.synchronize do
-          num = '1'
-          num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
-          @name = "subscript#{num}"
-          @@running.push(self)
-        end
+        __publish if publish
       end
+
+      def __publish(admitted = false)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          @@name_subscript_mutex.synchronize do
+            lifecycle_mutex.synchronize do
+              num = '1'
+              num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
+              @name = "subscript#{num}"
+              @@running.push(self)
+            end
+          end
+        end
+        self
+      end
+      private :__publish
       # rubocop:enable Lint/MissingSuper
     end
 
@@ -1520,71 +2220,108 @@ module Lich
 
       def ExecScript.start(cmd_data, options = {})
         options = { :quiet => true } if options == true
-        unless (new_script = ExecScript.new(cmd_data, options))
-          respond '--- Lich: failed to start exec script'
-          return false
-        end
-        new_thread = Thread.new {
-          100.times { break if Script.current == new_script; sleep 0.01 }
+        startup_reservation = Object.new
+        begin
+          startup_status = Script.__send__(:__begin_start, startup_reservation)
+          return false if startup_status == :shutdown
 
-          if (script = Script.current)
-            Thread.current.priority = 1
-            respond("--- Lich: #{script.name} active.") unless script.quiet
+          new_script = ExecScript.new(cmd_data, options.merge(:publish => false))
+          start_gate = Queue.new
+          setup_complete = false
+          worker_released = false
+          begin
+            new_thread = Thread.new {
+              next unless start_gate.pop
+
+              if (script = Script.current)
+                Thread.current.priority = 1
+                respond("--- Lich: #{script.name} active.") unless script.quiet
+                begin
+                  script_binding = TRUSTED_SCRIPT_BINDING.call
+                  eval('script = Script.current', script_binding, script.name.to_s)
+                  eval(cmd_data, script_binding, script.name.to_s)
+                  script.__send__(:__record_successful_exit)
+                  script.kill if script.running? && !script.stopping?
+                rescue SystemExit => e
+                  if e.success?
+                    script.__send__(:__record_successful_exit)
+                  else
+                    script.__send__(:__record_exit_error, e)
+                  end
+                  script.kill if script.running? && !script.stopping?
+                rescue SyntaxError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- SyntaxError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "SyntaxError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue ScriptError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- ScriptError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "ScriptError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue NoMemoryError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- NoMemoryError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "NoMemoryError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue LoadError
+                  script.__send__(:__record_exit_error, $!)
+                  respond("--- LoadError: #{$!}")
+                  respond "--- LoadError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "LoadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue SecurityError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- SecurityError: #{$!}"
+                  respond $!.backtrace[0..1]
+                  Lich.log "SecurityError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue ThreadError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- ThreadError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "ThreadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue SystemStackError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- SystemStackError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "SystemStackError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue StandardError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- Lich error: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "Exception: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                end
+              else
+                respond 'start_exec_script screwed up...'
+              end
+            }
+            new_script.__send__(:__attach_startup_worker, new_thread)
+            new_script.__send__(:__publish, true)
+            setup_complete = true
+          ensure
             begin
-              script_binding = TRUSTED_SCRIPT_BINDING.call
-              eval('script = Script.current', script_binding, script.name.to_s)
-              eval(cmd_data, script_binding, script.name.to_s)
-              Script.current.kill
-            rescue SystemExit
-              Script.current.kill
-            rescue SyntaxError
-              respond "--- SyntaxError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "SyntaxError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue ScriptError
-              respond "--- ScriptError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "ScriptError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue NoMemoryError
-              respond "--- NoMemoryError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "NoMemoryError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue LoadError
-              respond("--- LoadError: #{$!}")
-              respond "--- LoadError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "LoadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue SecurityError
-              respond "--- SecurityError: #{$!}"
-              respond $!.backtrace[0..1]
-              Lich.log "SecurityError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue ThreadError
-              respond "--- ThreadError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "ThreadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue SystemStackError
-              respond "--- SystemStackError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "SystemStackError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue StandardError
-              respond "--- Lich error: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "Exception: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
+              start_gate << setup_complete
+              worker_released = true
+            ensure
+              unless setup_complete && worker_released
+                new_thread&.kill
+                new_thread&.join
+                new_script.__send__(:__discard_startup)
+              end
             end
-          else
-            respond 'start_exec_script screwed up...'
           end
-        }
-        new_script.thread_group.add(new_thread)
-        new_script
+          new_script
+        ensure
+          Script.__send__(:__finish_start, startup_reservation)
+        end
       end
 
       # FIXME: when modernized, ensure proper use of variables and init of parent class
@@ -1619,16 +2356,31 @@ module Lich
         @no_kill_all = false
         @match_stack_labels = Array.new
         @match_stack_strings = Array.new
-        if flags[:name].nil?
-          num = '1'; num.succ! while @@running.any? { |s| s.name == "exec#{num}" }
-          @name = "exec#{num}"
-        else
-          num = '1'; num.succ! while @@running.any? { |s| s.name == "#{flags[:name]}#{num}" }
-          @name = "#{flags[:name]}#{num}"
-        end
-        @@running.push(self)
+        @name_prefix = flags[:name] || 'exec'
+        @killed_externally = false
+        @kill_source = nil
+        @kill_requested = false
+        @cleanup_started = false
+        @completed_successfully = false
+        @ignore_pause = false
+        __publish if flags.fetch(:publish, true)
       end
       # rubocop:enable Lint/MissingSuper
+
+      def __publish(admitted = false)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          @@name_exec_mutex.synchronize do
+            lifecycle_mutex.synchronize do
+              num = '1'
+              num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
+              @name = "#{@name_prefix}#{num}"
+              @@running.push(self)
+            end
+          end
+        end
+        self
+      end
+      private :__publish
 
       def get_next_label
         echo 'goto labels are not available in exec scripts.'
@@ -1641,7 +2393,7 @@ module Lich
       # rubocop:disable Lint/MissingSuper
       # rubocop:disable Lint/UselessAssignment
       # rubocop:disable Lint/InterpolationCheck
-      def initialize(file_name, cli_vars = [])
+      def initialize(file_name, cli_vars = [], publish = true)
         @name = /.*[\/\\]+([^\.]+)\./.match(file_name).captures.first
         @file_name = file_name
         @vars = Array.new
@@ -1844,7 +2596,7 @@ module Lich
         data = nil
         @current_label = @label_order[0]
         @thread_group = ThreadGroup.new
-        @@running.push(self)
+        __publish if publish
         # return self
       end
       # rubocop:enable Lint/InterpolationCheck

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -781,13 +781,13 @@ module Lich
         end
 
         startup_reservation = Object.new
-        begin
+        prepared = begin
           startup_status = __begin_start(startup_reservation, library_name, :force => false)
           raise LoadError, "cannot load script library during shutdown: #{library_name}" if startup_status == :shutdown
 
           completed_start = __take_completed_start(library_name) if startup_status == :duplicate
-          script, already_loaded, owns_loading, started_here = @@library_mutex.synchronize do
-            running = __running_snapshot.find { |candidate| candidate.name.casecmp?(library_name) }
+          running = __running_snapshot.find { |candidate| candidate.name.casecmp?(library_name) }
+          script, already_loaded, owns_loading, start_required = @@library_mutex.synchronize do
             if (loading = @@loading_libraries[library_name])
               [loading, false, false, false]
             elsif (candidate = completed_start || running)
@@ -796,46 +796,51 @@ module Lich
             elsif @@loaded_libraries.include?(library_name)
               [nil, true, false, false]
             else
-              started = Script.start(library_name, { :force => true })
-              raise LoadError, "failed to start script library: #{library_name}" unless started
-
-              @@loading_libraries[library_name] = started
-              [started, false, true, true]
+              [nil, false, true, true]
             end
           end
-          __discard_completed_start(library_name, script) if started_here
-          return true if already_loaded
 
-          __finish_start(startup_reservation)
-          begin
-            __join_library(library_name, script)
-          rescue ScriptError, StandardError
-            if owns_loading
-              @@library_mutex.synchronize do
-                @@loading_libraries.delete(library_name) if @@loading_libraries[library_name].equal?(script)
-              end
-            end
-            raise
+          if start_required
+            script = Script.start(library_name, { :force => true })
+            raise LoadError, "failed to start script library: #{library_name}" unless script
+
+            @@library_mutex.synchronize { @@loading_libraries[library_name] = script }
+            __discard_completed_start(library_name, script)
           end
 
-          error = script.exit_error
-          completed = script.completed_successfully?
-          @@library_mutex.synchronize do
-            if @@loading_libraries[library_name].equal?(script)
-              @@loading_libraries.delete(library_name)
-              if error || !completed
-                @@loaded_libraries.delete(library_name)
-              else
-                @@loaded_libraries.add(library_name)
-              end
-            end
-          end
-          __validate_library_completion(library_name, script)
-
-          true
+          [script, already_loaded, owns_loading]
         ensure
           __finish_start(startup_reservation)
         end
+        script, already_loaded, owns_loading = prepared
+        return true if already_loaded
+
+        begin
+          __join_library(library_name, script)
+        rescue ScriptError, StandardError
+          if owns_loading
+            @@library_mutex.synchronize do
+              @@loading_libraries.delete(library_name) if @@loading_libraries[library_name].equal?(script)
+            end
+          end
+          raise
+        end
+
+        error = script.exit_error
+        completed = script.completed_successfully?
+        @@library_mutex.synchronize do
+          if @@loading_libraries[library_name].equal?(script)
+            @@loading_libraries.delete(library_name)
+            if error || !completed
+              @@loaded_libraries.delete(library_name)
+            else
+              @@loaded_libraries.add(library_name)
+            end
+          end
+        end
+        __validate_library_completion(library_name, script)
+
+        true
       end
 
       def Script.reloadlibs
@@ -869,7 +874,8 @@ module Lich
           end
         end
 
-        script.join
+        joined = script.join
+        raise LoadError, "script library teardown timed out: #{library_name}" unless joined
       ensure
         if caller_script
           @@library_mutex.synchronize do

--- a/lib/common/shutdown_script_drain.rb
+++ b/lib/common/shutdown_script_drain.rb
@@ -60,6 +60,11 @@ module Lich
 
         drain_attempts.times do
           remaining = remaining_scripts.call.uniq
+          newly_observed = remaining.reject { |script| scripts.include?(script) }
+          unless newly_observed.empty?
+            scripts.concat(newly_observed)
+            newly_observed.each { |script| kill_script(script) }
+          end
           now = clock.call
 
           scripts.each do |script|
@@ -74,8 +79,14 @@ module Lich
           sleeper.call(drain_interval)
         end
 
-        finished_at = clock.call
         remaining = remaining_scripts.call.uniq
+        newly_observed = remaining.reject { |script| scripts.include?(script) }
+        unless newly_observed.empty?
+          scripts.concat(newly_observed)
+          newly_observed.each { |script| kill_script(script) }
+          remaining = remaining_scripts.call.uniq
+        end
+        finished_at = clock.call
 
         Result.new(
           scripts_started: scripts.length,

--- a/lib/common/shutdown_script_drain.rb
+++ b/lib/common/shutdown_script_drain.rb
@@ -60,11 +60,7 @@ module Lich
 
         drain_attempts.times do
           remaining = remaining_scripts.call.uniq
-          newly_observed = remaining.reject { |script| scripts.include?(script) }
-          unless newly_observed.empty?
-            scripts.concat(newly_observed)
-            newly_observed.each { |script| kill_script(script) }
-          end
+          observe_scripts!(scripts, remaining)
           now = clock.call
 
           scripts.each do |script|
@@ -80,10 +76,8 @@ module Lich
         end
 
         remaining = remaining_scripts.call.uniq
-        newly_observed = remaining.reject { |script| scripts.include?(script) }
+        newly_observed = observe_scripts!(scripts, remaining)
         unless newly_observed.empty?
-          scripts.concat(newly_observed)
-          newly_observed.each { |script| kill_script(script) }
           remaining = remaining_scripts.call.uniq
         end
         finished_at = clock.call
@@ -96,6 +90,14 @@ module Lich
           remaining_scripts: script_names(remaining)
         )
       end
+
+      def self.observe_scripts!(scripts, observed)
+        newly_observed = observed.reject { |script| scripts.include?(script) }
+        scripts.concat(newly_observed)
+        newly_observed.each { |script| kill_script(script) }
+        newly_observed
+      end
+      private_class_method :observe_scripts!
 
       # Attempts shutdown kill for a script and logs failures without stopping
       # the remaining shutdown drain.

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -1423,9 +1423,7 @@ end
 
 def clear(_opt = 0)
   unless (script = Script.current) then respond('--- clear: Unable to identify calling script.'); return false; end
-  to_return = script.downstream_buffer.dup
-  script.downstream_buffer.clear
-  to_return
+  script.clear
 end
 
 def match(label, string)
@@ -2428,9 +2426,9 @@ def do_client(client_string)
       end
       nil
     elsif cmd =~ /^ka$|^kill\s?all$|^stop\s?all$/
-      did_something = false
-      Script.running.find_all { |s_check| not s_check.no_kill_all }.each { |s_check| s_check.kill; did_something = true }
-      respond('--- Lich: no scripts to kill') unless did_something
+      respond('--- Lich: no scripts to kill') if Script.kill_all.zero?
+    elsif cmd == 'kd'
+      respond('--- Lich: no scripts to kill') if Script.kill_all(:force => true).zero?
     elsif cmd =~ /^pa$|^pause\s?all$/
       did_something = false
       Script.running.find_all { |s_check| not s_check.paused? and not s_check.no_pause_all }.each { |s_check| s_check.pause; did_something = true }
@@ -2770,6 +2768,7 @@ def do_client(client_string)
       respond "   #{$clean_lich_char}ua                        ''"
       respond "   #{$clean_lich_char}kill all                  kill all scripts"
       respond "   #{$clean_lich_char}ka                        ''"
+      respond "   #{$clean_lich_char}kd                        kill all scripts, including protected and hidden scripts"
       respond "   #{$clean_lich_char}list all                  show all running scripts"
       respond "   #{$clean_lich_char}la                        ''"
       respond

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -83,7 +83,7 @@ reconnect_if_wanted = proc {
     Lich::Common::BestEffortShutdownCleanup.run(
       coordinator: Lich::Common::ShutdownCoordinator,
       initial_scripts: Script.begin_shutdown,
-      remaining_scripts: proc { Script.shutdown_scripts },
+      remaining_scripts: proc { Script.progress_shutdown },
       script_drain: Lich::Common::ShutdownScriptDrain,
       vars: Vars,
       active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))
@@ -921,7 +921,7 @@ reconnect_if_wanted = proc {
         scripts_at_shutdown = Script.begin_shutdown
         script_shutdown_result = Lich::Common::ShutdownScriptDrain.run(
           initial_scripts: scripts_at_shutdown,
-          remaining_scripts: proc { Script.shutdown_scripts },
+          remaining_scripts: proc { Script.progress_shutdown },
           slow_threshold: script_shutdown_slow_threshold
         )
       end

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -82,8 +82,8 @@ reconnect_if_wanted = proc {
   run_best_effort_shutdown_cleanup = proc {
     Lich::Common::BestEffortShutdownCleanup.run(
       coordinator: Lich::Common::ShutdownCoordinator,
-      initial_scripts: (Script.running + Script.hidden),
-      remaining_scripts: proc { Script.running + Script.hidden },
+      initial_scripts: Script.begin_shutdown,
+      remaining_scripts: proc { Script.shutdown_scripts },
       script_drain: Lich::Common::ShutdownScriptDrain,
       vars: Vars,
       active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))
@@ -918,9 +918,10 @@ reconnect_if_wanted = proc {
         # Individual script names are reported at 2x the step threshold so normal
         # teardown stays quiet while slow exits remain visible.
         script_shutdown_slow_threshold = shutdown_step_trace_thresholds.fetch('script shutdown', 0.75) * 2
+        scripts_at_shutdown = Script.begin_shutdown
         script_shutdown_result = Lich::Common::ShutdownScriptDrain.run(
-          initial_scripts: (Script.running + Script.hidden),
-          remaining_scripts: proc { Script.running + Script.hidden },
+          initial_scripts: scripts_at_shutdown,
+          remaining_scripts: proc { Script.shutdown_scripts },
           slow_threshold: script_shutdown_slow_threshold
         )
       end

--- a/spec/lib/common/orderly_shutdown_spec.rb
+++ b/spec/lib/common/orderly_shutdown_spec.rb
@@ -127,11 +127,35 @@ RSpec.describe Lich::Common::OrderlyShutdown do
       scripts_provider: proc { [current_script, other_script] }
     )
 
-    expect(result).to be_completed
+    expect(result).not_to be_completed
+    expect(result).not_to be_scripts_drained
     expect(coordinator.reason).to eq(:user_exit)
     expect(coordinator.current.source).to eq('script:shutdown-caller')
     expect(script_drain.calls.first[:initial_scripts]).to eq([other_script])
     expect(script_drain.calls.first[:remaining_scripts].call).to eq([other_script])
+  end
+
+  it 'closes script startup admission before the production drain snapshot' do
+    coordinator.reset!
+    current_script = Struct.new(:name).new('shutdown-caller')
+    other_script = Struct.new(:name).new('other')
+    allow(Script).to receive(:begin_shutdown).and_return([current_script, other_script])
+    allow(Script).to receive(:shutdown_scripts).and_return([current_script, other_script])
+
+    result = described_class.request_user_exit(
+      source: 'script:shutdown-caller',
+      current_script: current_script,
+      coordinator: coordinator,
+      script_drain: script_drain,
+      vars: vars,
+      game: game,
+      active_sessions_lifecycle: active_sessions_lifecycle
+    )
+
+    expect(result).not_to be_completed
+    expect(result).not_to be_scripts_drained
+    expect(Script).to have_received(:begin_shutdown).once
+    expect(script_drain.calls.first[:initial_scripts]).to eq([other_script])
   end
 
   it 'continues later cleanup steps when one step fails' do

--- a/spec/lib/common/orderly_shutdown_spec.rb
+++ b/spec/lib/common/orderly_shutdown_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Lich::Common::OrderlyShutdown do
     current_script = Struct.new(:name).new('shutdown-caller')
     other_script = Struct.new(:name).new('other')
     allow(Script).to receive(:begin_shutdown).and_return([current_script, other_script])
-    allow(Script).to receive(:shutdown_scripts).and_return([current_script, other_script])
+    allow(Script).to receive(:progress_shutdown).and_return([current_script, other_script])
 
     result = described_class.request_user_exit(
       source: 'script:shutdown-caller',

--- a/spec/lib/common/script_buffer_spec.rb
+++ b/spec/lib/common/script_buffer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Lich::Common::Script downstream buffer' do
   end
 
   after(:context) do
-    %i[ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+    %i[SubScript ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
       Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
     end
     $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -10,7 +10,7 @@ require_relative '../../../lib/common/downstreamhook'
 require_relative '../../../lib/common/upstreamhook'
 
 RSpec.describe 'Lich::Common::Script kill metrics' do
-  let(:thread_group) { instance_double(ThreadGroup, list: [], add: true) }
+  let(:thread_group) { ThreadGroup.new }
   let(:script_class) { Lich::Common::Script }
 
   before(:context) do

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
     allow(GC).to receive(:start)
+    allow_any_instance_of(script_class).to receive(:report_errors) { |_script, &block| block.call }
   end
 
   after do
@@ -135,7 +136,10 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [first, second])
       allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
       allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
+      cleanup_times = [10.0, 10.025, 20.0, 20.050]
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) do
+        Thread.current == Thread.main ? 0.0 : cleanup_times.shift
+      end
 
       first.kill
       first.join
@@ -154,7 +158,10 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [first, second])
       allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
       allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
+      cleanup_times = [10.0, 10.025, 20.0, 20.050]
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) do
+        Thread.current == Thread.main ? 0.0 : cleanup_times.shift
+      end
 
       first.kill
       first.join

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
   end
 
   after(:context) do
-    %i[ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+    %i[SubScript ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
       Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
     end
     $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../spec_helper'
+require_relative '../../../lib/common/limitedarray'
 require_relative '../../../lib/common/feature_flags'
 # Load the real hook classes so Script's kill cleanup resolves them
 # deterministically (rather than the top-level spec_helper mocks), letting us
@@ -25,6 +26,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
 
   before do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
     script_class.class_variable_set(:@@kill_metrics, {
       :minute            => nil,
       :runtime_stops     => 0,
@@ -44,12 +46,12 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
     Lich::Common::UpstreamHook.class_variable_set(:@@upstream_hook_persist, {})
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
-    allow(Thread).to receive(:new) { |&block| block.call; instance_double(Thread) }
     allow(GC).to receive(:start)
   end
 
   after do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
   end
 
   describe '#kill' do
@@ -58,6 +60,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [script])
 
       expect(script.kill).to eq('metric-target')
+      script.join
 
       expect(script_class.list).to be_empty
       expect(GC).not_to have_received(:start)
@@ -88,6 +91,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [script])
 
       script.kill
+      script.join
 
       # The dying script's hooks are gone; a hook owned by another instance survives.
       expect(Lich::Common::DownstreamHook.list).to contain_exactly('keep')
@@ -134,7 +138,9 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
 
       first.kill
+      first.join
       second.kill
+      second.join
 
       expect(Lich).to have_received(:log).with(
         'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=25.00 max_ms=25.00 failures=0'
@@ -151,7 +157,9 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
 
       first.kill
+      first.join
       second.kill
+      second.join
 
       expect(Lich).to have_received(:log).with(
         'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=25.00 max_ms=25.00 failures=1'

--- a/spec/lib/common/script_kill_shutdown_spec.rb
+++ b/spec/lib/common/script_kill_shutdown_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
   end
 
   after(:context) do
-    %i[ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+    %i[SubScript ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
       Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
     end
     $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }

--- a/spec/lib/common/script_kill_shutdown_spec.rb
+++ b/spec/lib/common/script_kill_shutdown_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
   end
 
   def build_script(name:, die_with: [])
-    thread_group = instance_double(ThreadGroup, list: [], add: true)
+    thread_group = ThreadGroup.new
     script_class.allocate.tap do |script|
       script.instance_variable_set(:@name, name)
       script.instance_variable_set(:@custom, false)

--- a/spec/lib/common/script_kill_shutdown_spec.rb
+++ b/spec/lib/common/script_kill_shutdown_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../spec_helper'
+require_relative '../../../lib/common/limitedarray'
 require_relative '../../../lib/common/feature_flags'
 # Load the real hook classes so the ScriptDeath cleanup that the kill path runs
 # resolves against real registries (matching production) rather than the
@@ -30,6 +31,7 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
 
   before do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
     # Empty hook registries so the ScriptDeath cleanup has no stale state to act
     # on and nothing leaks across examples (these are class-level).
     Lich::Common::DownstreamHook.class_variable_set(:@@downstream_hooks, {})
@@ -46,6 +48,7 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
 
   after do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
   end
 
   describe 're-entrancy guard (Fix 1)' do
@@ -80,9 +83,9 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
       script = build_script(name: 'idempotent')
       script.at_exit { cleanup_counts[:n] += 1 }
       script_class.class_variable_set(:@@running, [script])
-      allow(Thread).to receive(:new) { |&block| block.call; instance_double(Thread) }
 
       script.kill
+      expect(script.join(1)).to equal(script)
       expect(script_class.list).to be_empty
       expect(cleanup_counts[:n]).to eq(1)
 
@@ -160,9 +163,10 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
     it 'still runs cleanup asynchronously in a dedicated thread' do
       script = build_script(name: 'async-target')
       script_class.class_variable_set(:@@running, [script])
-      expect(Thread).to receive(:new) { |&block| block.call; instance_double(Thread) }
+      expect(Thread).to receive(:new).and_call_original
 
       expect(script.kill).to eq('async-target')
+      expect(script.join(1)).to equal(script)
 
       expect(script_class.list).to be_empty
     end

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -185,6 +185,22 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
+    it 'reaps a startup reservation whose owner dies before its ensure runs' do
+      reservation = Object.new
+      admitted = Queue.new
+      owner = Thread.new do
+        script_class.__send__(:__begin_start, reservation, 'libabandoned', :force => false)
+        admitted << true
+        Queue.new.pop
+      end
+      admitted.pop
+      owner.kill
+      owner.join
+
+      expect(Timeout.timeout(1) { script_class.begin_shutdown }).to be_empty
+      expect(script_class.class_variable_get(:@@startup_reservations)).to be_empty
+    end
+
     it 'uses the published name when reserving a compressed script' do
       Dir.mktmpdir('script-compressed-start') do |root|
         custom_dir = File.join(root, 'custom')
@@ -518,6 +534,23 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(child.join(1)).to equal(child)
     end
 
+    it 'kills a parent worker before waiting on its child launch reservation' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      launch_entered = Queue.new
+      launcher = Thread.new do
+        parent.__send__(:__launch_child) do
+          launch_entered << true
+          Queue.new.pop
+        end
+      end
+      parent.thread_group.add(launcher)
+      launch_entered.pop
+
+      expect(parent.kill_sync(:context => :runtime, :timeout => 1)).to equal(parent)
+      expect(launcher).not_to be_alive
+    end
+
     it 'does not publish a subscript before its worker is allocated' do
       parent = build_script('parent')
       script_class.class_variable_set(:@@running, [parent])
@@ -748,23 +781,16 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script.join(1)).to equal(script)
     end
 
-    it 'attaches an async cleanup thread to the target before cleanup starts' do
-      parent = build_script('parent')
+    it 'sets the current script identity for an async cleanup thread' do
       child = build_script('child')
-      script_class.class_variable_set(:@@running, [parent, child])
-      parent.thread_group.add(Thread.current)
+      script_class.class_variable_set(:@@running, [child])
       observed = Queue.new
-      allow(child).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
-        observed << [child.has_thread?(Thread.current), parent.has_thread?(Thread.current)]
-        method.call(**kwargs)
-      end
+      child.at_exit { observed << script_class.current }
 
       child.kill
 
-      expect(observed.pop).to eq([true, false])
+      expect(observed.pop).to equal(child)
       expect(child.join(1)).to equal(child)
-    ensure
-      ThreadGroup::Default.add(Thread.current)
     end
 
     it 'releases async cleanup when the killing caller is killed mid-transition' do
@@ -772,7 +798,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@running, [script])
       attach_entered = Queue.new
       release_attach = Queue.new
-      allow(script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+      allow(script).to receive(:__claim_cleanup_thread).and_wrap_original do |method, thread|
         attach_entered << true
         release_attach.pop
         method.call(thread)
@@ -794,7 +820,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@running, [caller_script, target_script])
       attach_entered = Queue.new
       release_attach = Queue.new
-      allow(target_script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+      allow(target_script).to receive(:__claim_cleanup_thread).and_wrap_original do |method, thread|
         attach_entered << true
         release_attach.pop
         method.call(thread)
@@ -1145,24 +1171,6 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script.join(1)).to equal(script)
     end
 
-    it 'preserves an underlying thread-group rejection when worker teardown raises' do
-      script = build_script('group-rejection')
-      script_class.class_variable_set(:@@running, [script])
-      group = instance_double(ThreadGroup, :list => [])
-      allow(group).to receive(:add).and_raise(ThreadError, 'group rejected worker')
-      script.instance_variable_set(:@thread_group, group)
-      worker = Thread.new do
-        Thread.current.report_on_exception = false
-        begin
-          Queue.new.pop
-        ensure
-          raise 'worker teardown failed'
-        end
-      end
-
-      expect { script.thread_group.add(worker) }.to raise_error(ThreadError, /group rejected worker/)
-    end
-
     it 'does not block shutdown cleanup on a worker ensure block' do
       worker_ready = Queue.new
       worker_cleanup_entered = Queue.new
@@ -1224,6 +1232,93 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       release_descendant_cleanup << true
       expect(script.join(1)).to equal(script)
+    end
+
+    it 'joins descendant workers spawned by exit callbacks' do
+      script = build_script('callback-descendant')
+      script_class.class_variable_set(:@@running, [script])
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      descendant = nil
+      script.at_exit do
+        descendant = Thread.new do
+          worker_ready << true
+          begin
+            Queue.new.pop
+          ensure
+            worker_cleanup_entered << true
+            release_worker_cleanup.pop
+          end
+        end
+        worker_ready.pop
+      end
+
+      script.kill
+      worker_cleanup_entered.pop
+      expect(script.thread_group.list).not_to include(descendant)
+      expect(descendant.group).not_to equal(script.thread_group)
+      expect(script.join(0.02)).to be_nil
+
+      release_worker_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'does not detach an inline cleanup caller when its group becomes enclosed' do
+      caller_script = build_script('caller')
+      target_script = build_script('target')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      observed = Queue.new
+      start_cleanup = Queue.new
+      descendant_ready = Queue.new
+      descendant_cleanup_entered = Queue.new
+      release_descendant_cleanup = Queue.new
+      later_descendant_ready = Queue.new
+      later_descendant_cleanup_entered = Queue.new
+      release_later_descendant_cleanup = Queue.new
+      target_script.at_exit do
+        Thread.new do
+          descendant_ready << true
+          begin
+            Queue.new.pop
+          ensure
+            descendant_cleanup_entered << true
+            release_descendant_cleanup.pop
+          end
+        end
+        descendant_ready.pop
+        caller_script.thread_group.enclose
+      end
+      caller = Thread.new do
+        start_cleanup.pop
+        target_script.kill(:context => :shutdown, :async => false)
+        Thread.new do
+          later_descendant_ready << true
+          begin
+            Queue.new.pop
+          ensure
+            later_descendant_cleanup_entered << true
+            release_later_descendant_cleanup.pop
+          end
+        end
+        later_descendant_ready.pop
+        observed << script_class.current
+      end
+      caller_script.thread_group.add(caller)
+      start_cleanup << true
+
+      descendant_cleanup_entered.pop
+      expect(target_script.join(0.02)).to be_nil
+      release_descendant_cleanup << true
+      expect(observed.pop).to equal(caller_script)
+      caller.join
+      progress_shutdown_until(target_script)
+      expect(target_script.join(1)).to equal(target_script)
+      caller_script.kill
+      later_descendant_cleanup_entered.pop
+      expect(caller_script.join(0.02)).to be_nil
+      release_later_descendant_cleanup << true
+      expect(caller_script.join(1)).to equal(caller_script)
     end
 
     it 'allows a killed worker to join its own stopping script' do
@@ -1321,6 +1416,15 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       parent_mutex&.unlock if parent_mutex&.owned?
     end
 
+    it 'prunes completed scripts from the stopping registry snapshot' do
+      script = build_script('completed-stop')
+      script.instance_variable_set(:@cleanup_complete, true)
+      script_class.class_variable_set(:@@stopping, [script])
+
+      expect(script_class.shutdown_scripts).to be_empty
+      expect(script_class.class_variable_get(:@@stopping)).to be_empty
+    end
+
     it 'holds child lifecycle state through public adoption' do
       parent = build_script('parent')
       child = build_script('child')
@@ -1346,12 +1450,50 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
     it 'preserves the standard ThreadGroup surface' do
       script = build_script('thread-group-api')
+      script_class.class_variable_set(:@@running, [script])
+      worker = Thread.new { Queue.new.pop }
 
       expect(script.thread_group).to be_a(ThreadGroup)
       expect(script.thread_group).to be_instance_of(ThreadGroup)
+      expect(script.thread_group.add(worker)).to equal(script.thread_group)
+      expect(worker.group).to equal(script.thread_group)
+      expect { script.thread_group.add(Object.new) }.to raise_error(TypeError, /expected VM\/thread/)
       expect(script.thread_group).not_to be_enclosed
       expect(script.thread_group.enclose).to equal(script.thread_group)
       expect(script.thread_group).to be_enclosed
+      other_group = ThreadGroup.new
+      expect { other_group.add(worker) }.to raise_error(ThreadError, /enclosed/)
+      expect(worker.group).to equal(script.thread_group)
+    ensure
+      worker&.kill
+      worker&.join
+    end
+
+    it 'runs teardown callbacks after the public thread group is enclosed' do
+      script = build_script('enclosed-thread-group')
+      script_class.class_variable_set(:@@running, [script])
+      callback_ran = false
+      script.at_exit { callback_ran = true }
+      script.thread_group.enclose
+
+      expect(script.kill_sync(:timeout => 1)).to equal(script)
+      expect(callback_ran).to be(true)
+      expect(script_class.class_variable_get(:@@stopping)).to be_empty
+    end
+
+    it 'kills a worker when native thread-group registration fails' do
+      script = build_script('group-rejection')
+      script_class.class_variable_set(:@@running, [script])
+      source_group = ThreadGroup.new
+      worker = Thread.new { Queue.new.pop }
+      source_group.add(worker)
+      source_group.enclose
+
+      expect { script.thread_group.add(worker) }.to raise_error(ThreadError, /enclosed/)
+      expect(worker).not_to be_alive
+    ensure
+      worker&.kill
+      worker&.join
     end
 
     it 'records cleanup callback failures in lifecycle completion' do
@@ -1415,6 +1557,21 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(script_class.libs).to include('libutil')
       expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
+    end
+
+    it 'publishes a started library before loader cancellation can take effect' do
+      allow(script_class).to receive(:start).with('libutil', { :force => true }) do
+        script_class.class_variable_set(:@@completed_named_starts, 'libutil' => library_script)
+        Thread.current.kill
+        library_script
+      end
+
+      loader = Thread.new { script_class.loadlib('util') }
+      loader.join
+
+      expect(script_class.class_variable_get(:@@loading_libraries)).to eq('libutil' => library_script)
+      expect(script_class.loadlib('util')).to be(true)
+      expect(script_class).to have_received(:start).with('libutil', { :force => true }).once
     end
 
     it 'starts a library without holding the library registry mutex' do

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/limitedarray'
+require_relative '../../../lib/common/feature_flags'
+require_relative '../../../lib/common/downstreamhook'
+require_relative '../../../lib/common/upstreamhook'
+
+RSpec.describe 'Lich::Common::Script lifecycle extensions' do
+  let(:script_class) { Lich::Common::Script }
+  let(:subscript_class) { Lich::Common::SubScript }
+
+  before(:context) do
+    require_relative '../../../lib/common/script'
+  end
+
+  after(:context) do
+    %i[SubScript ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+      Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
+    end
+    $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }
+  end
+
+  before do
+    script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@loaded_libraries, Set.new)
+    allow(Lich).to receive(:log)
+    allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
+    allow_any_instance_of(script_class).to receive(:report_errors) { |_script, &block| block.call }
+  end
+
+  after do
+    script_class.list.each { |script| script.kill(context: :shutdown) if script.running? }
+    script_class.class_variable_set(:@@running, [])
+  end
+
+  describe 'SubScript' do
+    it 'runs a block with its own Script.current identity' do
+      observed = Queue.new
+      subscript = subscript_class.start { observed << script_class.current }
+
+      expect(subscript.join(2)).to equal(subscript)
+      expect(observed.pop(true)).to equal(subscript)
+      expect(subscript).to be_a(subscript_class)
+    end
+
+    it 'unregisters itself when it exits naturally' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+
+      child = subscript_class.start(:parent => parent) {}
+      expect(child.join(2)).to equal(child)
+
+      expect(parent.child_scripts).to be_empty
+    end
+
+    it 'is stopped with the parent using the parent kill context' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      child = subscript_class.start(:parent => parent) { Queue.new.pop }
+      expect(child).to receive(:kill).with(:context => :shutdown).and_call_original
+      expect(Thread).not_to receive(:new)
+
+      parent.kill(:context => :shutdown)
+
+      expect(parent).not_to be_running
+      expect(child).not_to be_running
+    end
+
+    it 'inherits protection flags from its parent' do
+      parent = build_script('daemon-parent')
+      parent.hidden = true
+      parent.no_kill_all = true
+      parent.no_pause_all = true
+      script_class.class_variable_set(:@@running, [parent])
+      release = Queue.new
+      child = subscript_class.start(:parent => parent) { release.pop }
+
+      expect(child.hidden).to be(true)
+      expect(child.no_kill_all).to be(true)
+      expect(child.no_pause_all).to be(true)
+
+      release << true
+      child.join(2)
+    end
+
+    it 'rejects and stops a child registered after parent teardown begins' do
+      parent = build_script('stopped-parent')
+      script_class.class_variable_set(:@@running, [parent])
+      parent.kill(:context => :shutdown)
+      child = build_script('late-child')
+      script_class.class_variable_set(:@@running, [child])
+
+      expect(parent.register_child(child)).to be_nil
+      expect(child).not_to be_running
+    end
+  end
+
+  describe 'synchronous lifecycle methods' do
+    it 'waits for exit handlers in kill_sync' do
+      script = build_script('sync')
+      script_class.class_variable_set(:@@running, [script])
+      cleaned_up = false
+      script.at_exit do
+        sleep 0.02
+        cleaned_up = true
+      end
+
+      expect(script.kill_sync).to equal(script)
+      expect(cleaned_up).to be(true)
+      expect(script).not_to be_running
+    end
+
+    it 'returns nil when join times out' do
+      script = build_script('waiting')
+      script_class.class_variable_set(:@@running, [script])
+
+      expect(script.join(0.01)).to be_nil
+    end
+  end
+
+  describe 'library loading' do
+    let(:library_script) { instance_double(script_class, :name => 'libutil', :join => true) }
+
+    before do
+      allow(script_class).to receive(:exists?).and_return(true)
+    end
+
+    it 'starts a library only once across concurrent callers' do
+      allow(script_class).to receive(:start).with('libutil').and_return(library_script)
+
+      callers = Array.new(4) { Thread.new { script_class.loadlib('util') } }
+      callers.each(&:join)
+
+      expect(script_class).to have_received(:start).with('libutil').once
+      expect(script_class.libs).to eq(Set['libutil'])
+    end
+
+    it 'allows retry when startup fails' do
+      allow(script_class).to receive(:start).with('libutil').and_return(nil, library_script)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /failed to start/)
+      expect(script_class.libs).to be_empty
+      expect(script_class.loadlib('util')).to be(true)
+    end
+
+    it 'raises without recording a missing library' do
+      allow(script_class).to receive(:exists?).with('libmissing').and_return(false)
+
+      expect { script_class.loadlib('missing') }.to raise_error(LoadError, /not found/)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'reloads a stable snapshot of loaded libraries' do
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil', 'libstatus'])
+      allow(script_class).to receive(:run)
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class).to have_received(:run).with('libutil')
+      expect(script_class).to have_received(:run).with('libstatus')
+    end
+  end
+
+  describe '.kill_all' do
+    it 'preserves protected and hidden scripts unless force is requested' do
+      visible = build_script('visible')
+      protected_script = build_script('protected')
+      protected_script.no_kill_all = true
+      hidden = build_script('hidden')
+      hidden.hidden = true
+      scripts = [visible, protected_script, hidden]
+      script_class.class_variable_set(:@@running, scripts)
+      scripts.each { |script| allow(script).to receive(:kill) }
+
+      expect(script_class.kill_all).to eq(1)
+      expect(visible).to have_received(:kill).with(:context => :runtime).once
+      expect(protected_script).not_to have_received(:kill)
+      expect(hidden).not_to have_received(:kill)
+
+      expect(script_class.kill_all(:force => true)).to eq(3)
+      expect(visible).to have_received(:kill).with(:context => :runtime).twice
+      expect(protected_script).to have_received(:kill).with(:context => :runtime).once
+      expect(hidden).to have_received(:kill).with(:context => :runtime).once
+    end
+  end
+
+  def build_script(name)
+    script_class.allocate.tap do |script|
+      script.instance_variable_set(:@name, name)
+      script.instance_variable_set(:@custom, false)
+      script.instance_variable_set(:@quiet, true)
+      script.instance_variable_set(:@thread_group, ThreadGroup.new)
+      script.instance_variable_set(:@die_with, [])
+      script.instance_variable_set(:@paused, false)
+      script.instance_variable_set(:@at_exit_procs, [])
+      script.instance_variable_set(:@downstream_buffer, [])
+      script.instance_variable_set(:@upstream_buffer, [])
+      script.instance_variable_set(:@match_stack_labels, [])
+      script.instance_variable_set(:@match_stack_strings, [])
+      script.instance_variable_set(:@killer_mutex, Mutex.new)
+      script.instance_variable_set(:@killed_externally, false)
+      script.instance_variable_set(:@kill_source, nil)
+      script.instance_variable_set(:@hidden, false)
+      script.instance_variable_set(:@no_kill_all, false)
+      script.instance_variable_set(:@no_pause_all, false)
+    end
+  end
+end

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -60,6 +60,20 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
+    it 'tears down an ordinary script whose worker dies during current-script lookup' do
+      Dir.mktmpdir('script-worker-current') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        script = kill_worker_during_current { script_class.start('ordinary') }
+
+        expect(script.join(1)).to equal(script)
+        expect(script).not_to be_running
+      end
+    end
+
     it 'does not publish an ordinary script before its worker is allocated' do
       Dir.mktmpdir('script-start') do |root|
         custom_dir = File.join(root, 'custom')
@@ -307,6 +321,21 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(subscript).to be_completed_successfully
     end
 
+    it 'records JumpError raised by a subscript block' do
+      subscript = subscript_class.start(:parent => nil) { raise script_class::JUMP }
+
+      expect(subscript.join(1)).to equal(subscript)
+      expect(subscript.exit_error).to be_a(script_class::JumpError)
+      expect(subscript).not_to be_completed_successfully
+    end
+
+    it 'tears down a subscript whose worker dies during current-script lookup' do
+      script = kill_worker_during_current { subscript_class.start(:parent => nil) {} }
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
     it 'unregisters itself when it exits naturally' do
       parent = build_script('parent')
       script_class.class_variable_set(:@@running, [parent])
@@ -467,11 +496,12 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@running, [parent, child])
       launch_entered = Queue.new
       release_launch = Queue.new
+      registration_result = :pending
       launcher = Thread.new do
         parent.__send__(:__launch_child) do
           launch_entered << true
           release_launch.pop
-          parent.__send__(:__register_child_locked, child)
+          registration_result = parent.register_child(child)
         end
       end
       launch_entered.pop
@@ -484,6 +514,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       launcher.join
       killer.join
       expect(parent).not_to be_running
+      expect(registration_result).to be_nil
       expect(child.join(1)).to equal(child)
     end
 
@@ -558,6 +589,22 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(failed.join(1)).to equal(failed)
       expect(failed).not_to be_completed_successfully
       expect(failed.exit_error).to be_a(RuntimeError)
+    end
+
+    it 'records JumpError raised by exec code' do
+      allow(Lich::Common::TRUSTED_SCRIPT_BINDING).to receive(:call).and_return(Lich::Common::Scripting.new.script)
+      script = exec_script_class.start('raise Lich::Common::Script::JUMP')
+
+      expect(script.join(1)).to equal(script)
+      expect(script.exit_error).to be_a(script_class::JumpError)
+      expect(script).not_to be_completed_successfully
+    end
+
+    it 'tears down an exec script whose worker dies during current-script lookup' do
+      script = kill_worker_during_current { exec_script_class.start('nil') }
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
     end
 
     it 'preserves direct constructor publication and shutdown admission' do
@@ -807,8 +854,59 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       cleanup_thread.kill
       cleanup_thread.join
 
+      script_class.progress_shutdown
       expect(script.join(1)).to equal(script)
       expect(script).not_to be_running
+    end
+
+    it 'resumes remaining exit callbacks after cleanup executor cancellation' do
+      script = build_script('cancelled-callback')
+      script_class.class_variable_set(:@@running, [script])
+      first_callback_entered = Queue.new
+      second_callback_ran = Queue.new
+      first_callback_calls = 0
+      script.at_exit do
+        first_callback_calls += 1
+        first_callback_entered << true
+        Queue.new.pop
+      end
+      script.at_exit { second_callback_ran << true }
+
+      script.kill
+      first_callback_entered.pop
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(script, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+
+      expect(script).to be_running
+      script_class.progress_shutdown
+
+      expect(second_callback_ran.pop(true)).to be(true)
+      expect(first_callback_calls).to eq(1)
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'does not run deferred cleanup from a timeout-bounded join' do
+      script = build_script('observational-join')
+      script_class.class_variable_set(:@@running, [script])
+      script.instance_variable_set(:@kill_requested, true)
+      expect(script).not_to receive(:__refresh_deferred_stop)
+
+      expect(script.join(0.01)).to be_nil
+    end
+
+    it 'bounds shutdown kill_sync before a blocked exit callback finishes' do
+      script = build_script('bounded-shutdown-kill')
+      script_class.class_variable_set(:@@running, [script])
+      callback_entered = Queue.new
+      release_callback = Queue.new
+      script.at_exit { callback_entered << true; release_callback.pop }
+
+      expect(script.kill_sync(:context => :shutdown, :timeout => 0.02)).to be_nil
+      callback_entered.pop
+
+      release_callback << true
+      expect(script.join(1)).to equal(script)
     end
 
     it 'bounds an implicit join once teardown begins' do
@@ -1086,6 +1184,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.shutdown_scripts).to include(script)
 
       release_worker_cleanup << true
+      progress_shutdown_until(script)
       expect(script.join(1)).to equal(script)
     end
 
@@ -1175,25 +1274,97 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       child = build_script('child')
       script_class.class_variable_set(:@@running, [parent, child])
       expect(parent.register_child(child)).to equal(child)
-      launch_lock_held = Queue.new
-      release_launch_lock = Queue.new
+      parent_lock_held = Queue.new
+      release_parent_lock = Queue.new
+      parent_mutex = parent.__send__(:child_scripts_mutex)
       lock_holder = Thread.new do
-        parent.__send__(:__launch_child) do
-          launch_lock_held << true
-          release_launch_lock.pop
+        parent_mutex.synchronize do
+          parent_lock_held << true
+          release_parent_lock.pop
         end
       end
-      launch_lock_held.pop
+      parent_lock_held.pop
 
       child.kill
       expect(child.join(0.02)).to be_nil
       children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
       expect(children).to contain_exactly(child)
 
-      release_launch_lock << true
+      release_parent_lock << true
       lock_holder.join
       expect(child.join(1)).to equal(child)
       expect(parent.child_scripts).to be_empty
+    end
+
+    it 'retries parent unlinking when its finalizer is cancelled' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      expect(parent.register_child(child)).to equal(child)
+      parent_mutex = parent.__send__(:child_scripts_mutex)
+      parent_mutex.lock
+
+      child.kill
+      sleep 0.005 while child.running?
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(child, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+      children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
+      expect(Array(children)).to contain_exactly(child)
+
+      parent_mutex.unlock
+      script_class.progress_shutdown
+
+      expect(child.join(1)).to equal(child)
+      expect(parent.child_scripts).to be_empty
+    ensure
+      parent_mutex&.unlock if parent_mutex&.owned?
+    end
+
+    it 'holds child lifecycle state through public adoption' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      adoption_entered = Queue.new
+      release_adoption = Queue.new
+      allow(parent).to receive(:__adopt_child_locked).and_wrap_original do |method, adopted|
+        adoption_entered << true
+        release_adoption.pop
+        method.call(adopted)
+      end
+
+      registrar = Thread.new { parent.register_child(child) }
+      adoption_entered.pop
+      killer = Thread.new { child.kill_sync(:timeout => 1) }
+      expect(killer.join(0.02)).to be_nil
+
+      release_adoption << true
+      expect(registrar.value).to equal(child)
+      expect(killer.value).to equal(child)
+      expect(parent.child_scripts).to be_empty
+    end
+
+    it 'preserves the standard ThreadGroup surface' do
+      script = build_script('thread-group-api')
+
+      expect(script.thread_group).to be_a(ThreadGroup)
+      expect(script.thread_group).to be_instance_of(ThreadGroup)
+      expect(script.thread_group).not_to be_enclosed
+      expect(script.thread_group.enclose).to equal(script.thread_group)
+      expect(script.thread_group).to be_enclosed
+    end
+
+    it 'records cleanup callback failures in lifecycle completion' do
+      script = build_script('cleanup-error')
+      script_class.class_variable_set(:@@running, [script])
+      script.__send__(:__record_successful_exit)
+      script.at_exit { raise 'cleanup failed' }
+
+      script.kill
+
+      expect(script.join(1)).to equal(script)
+      expect(script.exit_error).to be_a(RuntimeError)
+      expect(script).not_to be_completed_successfully
     end
   end
 
@@ -1220,6 +1391,30 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(script_class).to have_received(:start).with('libutil', { :force => true }).once
       expect(script_class.libs).to eq(Set['libutil'])
+    end
+
+    it 'lets a peer commit completion when the loader owner is cancelled' do
+      owner_join_entered = Queue.new
+      join_calls = 0
+      allow(library_script).to receive(:join) do
+        join_calls += 1
+        if join_calls == 1
+          owner_join_entered << true
+          Queue.new.pop
+        else
+          true
+        end
+      end
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(library_script)
+
+      owner = Thread.new { script_class.loadlib('util') }
+      owner_join_entered.pop
+      expect(script_class.loadlib('util')).to be(true)
+      owner.kill
+      owner.join
+
+      expect(script_class.libs).to include('libutil')
+      expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
     end
 
     it 'starts a library without holding the library registry mutex' do
@@ -1519,7 +1714,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
       allow(script_class).to receive(:loadlib).with('libutil').and_raise(LoadError, 'broken reload')
 
-      expect(script_class.reloadlibs).to be(true)
+      expect(script_class.reloadlibs).to be(false)
       expect(script_class.libs).to be_empty
     end
 
@@ -1556,6 +1751,43 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(protected_script).to have_received(:kill).with(:context => :runtime).once
       expect(hidden).to have_received(:kill).with(:context => :runtime).once
     end
+  end
+
+  def progress_shutdown_until(script)
+    Timeout.timeout(1) do
+      while script_class.shutdown_scripts.include?(script)
+        script_class.progress_shutdown
+        sleep 0.005
+      end
+    end
+  rescue Timeout::Error
+    state = %i[@kill_requested @cleanup_started @cleanup_complete @cleanup_thread @stopping_threads].to_h do |name|
+      [name, Object.instance_method(:instance_variable_get).bind_call(script, name)]
+    end
+    warn "shutdown progress timed out: #{state.inspect}"
+    raise
+  end
+
+  def kill_worker_during_current
+    main_thread = Thread.current
+    lookup_entered = Queue.new
+    intercept = true
+    allow(script_class).to receive(:current).and_wrap_original do |method|
+      if Thread.current != main_thread && intercept
+        intercept = false
+        lookup_entered << true
+        Queue.new.pop
+      else
+        method.call
+      end
+    end
+
+    script = yield
+    lookup_entered.pop
+    worker = script.__send__(:__worker_threads).find(&:alive?)
+    worker.kill
+    worker.join
+    script
   end
 
   def build_script(name)

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -609,6 +609,20 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
   end
 
   describe 'synchronous lifecycle methods' do
+    it 'returns a child after run_child observes complete teardown' do
+      child = instance_double(script_class, :join => true)
+      allow(script_class).to receive(:start_child).with('worker').and_return(child)
+
+      expect(script_class.run_child('worker')).to equal(child)
+    end
+
+    it 'returns nil when run_child teardown times out' do
+      child = instance_double(script_class, :join => nil)
+      allow(script_class).to receive(:start_child).with('worker').and_return(child)
+
+      expect(script_class.run_child('worker')).to be_nil
+    end
+
     it 'waits for exit handlers in kill_sync' do
       script = build_script('sync')
       script_class.class_variable_set(:@@running, [script])

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1208,6 +1208,33 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.libs).to eq(Set['libutil'])
     end
 
+    it 'starts a library without holding the library registry mutex' do
+      library_mutex = script_class.class_variable_get(:@@library_mutex)
+      mutex_locked_during_start = nil
+      allow(script_class).to receive(:start).with('libutil', { :force => true }) do
+        mutex_locked_during_start = library_mutex.locked?
+        library_script
+      end
+
+      expect(script_class.loadlib('util')).to be(true)
+      expect(mutex_locked_during_start).to be(false)
+    end
+
+    it 'reports a library teardown timeout as a load failure' do
+      timed_out_script = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => nil,
+        :exit_error              => nil,
+        :completed_successfully? => false
+      )
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(timed_out_script)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /teardown timed out/)
+      expect(script_class.libs).to be_empty
+      expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
+    end
+
     it 'adopts an admitted plain start instead of reporting a duplicate failure' do
       admitted_script = instance_double(
         script_class,

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -797,6 +797,44 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script).not_to be_running
     end
 
+    it 'bounds an implicit join once teardown begins' do
+      stub_const('Lich::Common::Script::SCRIPT_CLEANUP_TIMEOUT', 0.03)
+      stub_const('Lich::Common::Script::JOIN_WAIT_INTERVAL', 0.005)
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+
+      script.kill
+      worker_cleanup_entered.pop
+
+      expect(script.join).to be_nil
+
+      release_worker_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'keeps shutdown snapshots free of teardown side effects' do
+      script = build_script('deferred-cleanup')
+      script_class.class_variable_set(:@@stopping, [script])
+      allow(script).to receive(:__refresh_deferred_stop)
+
+      expect(script_class.shutdown_scripts).to contain_exactly(script)
+      expect(script).not_to have_received(:__refresh_deferred_stop)
+
+      expect(script_class.progress_shutdown).to contain_exactly(script)
+      expect(script).to have_received(:__refresh_deferred_stop).once
+    end
+
     it 'finishes inline cleanup when the killing caller is cancelled' do
       script = build_script('cancelled-inline-cleanup')
       script_class.class_variable_set(:@@running, [script])

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'zlib'
+require 'timeout'
 require_relative '../../spec_helper'
 require_relative '../../../lib/common/limitedarray'
 require_relative '../../../lib/common/feature_flags'
@@ -9,6 +11,7 @@ require_relative '../../../lib/common/upstreamhook'
 RSpec.describe 'Lich::Common::Script lifecycle extensions' do
   let(:script_class) { Lich::Common::Script }
   let(:subscript_class) { Lich::Common::SubScript }
+  let(:exec_script_class) { Lich::Common::ExecScript }
 
   before(:context) do
     require_relative '../../../lib/common/script'
@@ -23,7 +26,13 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
   before do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
+    script_class.class_variable_set(:@@startup_reservations, {})
+    script_class.class_variable_set(:@@completed_named_starts, {})
+    script_class.class_variable_set(:@@shutdown_started, false)
     script_class.class_variable_set(:@@loaded_libraries, Set.new)
+    script_class.class_variable_set(:@@loading_libraries, {})
+    script_class.class_variable_set(:@@library_waits, {})
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
     allow_any_instance_of(script_class).to receive(:report_errors) { |_script, &block| block.call }
@@ -32,9 +41,262 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
   after do
     script_class.list.each { |script| script.kill(context: :shutdown) if script.running? }
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
+  end
+
+  describe '.start' do
+    it 'constructs and starts an ordinary Ruby script' do
+      Dir.mktmpdir('script-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        started = script_class.start('ordinary')
+
+        expect(started).to be_a(script_class)
+        expect(started.join(2)).to equal(started)
+        expect(started).to be_completed_successfully
+      end
+    end
+
+    it 'does not publish an ordinary script before its worker is allocated' do
+      Dir.mktmpdir('script-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        allocation_entered = Queue.new
+        release_allocation = Queue.new
+        start_launch = Queue.new
+        launcher = Thread.new do
+          start_launch.pop
+          script_class.start('ordinary')
+        end
+        first_allocation = true
+        allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+          if first_allocation
+            first_allocation = false
+            allocation_entered << true
+            release_allocation.pop
+          end
+          method.call(*args, &block)
+        end
+
+        start_launch << true
+        allocation_entered.pop
+
+        expect(script_class.list).to be_empty
+        expect(script_class.start('ordinary')).to be_nil
+
+        release_allocation << true
+        script = launcher.value
+        expect(script.join(2)).to equal(script)
+      end
+    end
+
+    it 'waits for in-flight startup before taking the shutdown snapshot' do
+      Dir.mktmpdir('script-shutdown-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nQueue.new.pop\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        allocation_entered = Queue.new
+        release_allocation = Queue.new
+        start_launch = Queue.new
+        launcher = Thread.new do
+          start_launch.pop
+          script_class.start('ordinary')
+        end
+        first_allocation = true
+        allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+          if first_allocation
+            first_allocation = false
+            allocation_entered << true
+            release_allocation.pop
+          end
+          method.call(*args, &block)
+        end
+
+        start_launch << true
+        allocation_entered.pop
+        shutdown = Thread.new { script_class.begin_shutdown }
+        expect(shutdown.join(0.02)).to be_nil
+
+        release_allocation << true
+        script = launcher.value
+        expect(shutdown.value).to contain_exactly(script)
+        expect(script_class.start('ordinary')).to be_nil
+
+        script.kill(:context => :shutdown)
+      end
+    end
+
+    it 'rejects direct constructor publication after shutdown begins' do
+      Dir.mktmpdir('script-direct-shutdown') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        file_name = File.join(custom_dir, 'direct.lic')
+        File.write(file_name, "# quiet\nnil\n")
+        script_class.begin_shutdown
+
+        expect {
+          script_class.new(:file => file_name, :args => [], :quiet => true)
+        }.to raise_error(ThreadError, /shutting down/)
+        expect(script_class.list).to be_empty
+      end
+    end
+
+    it 'releases a startup reservation when the starter is cancelled during admission' do
+      Dir.mktmpdir('script-cancelled-admission') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'cancelled.lic'), "# quiet\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        admitted = Queue.new
+        allow(script_class).to receive(:__begin_start).and_wrap_original do |method, *args, **kwargs|
+          result = method.call(*args, **kwargs)
+          admitted << true
+          Queue.new.pop
+          result
+        end
+        starter = Thread.new { script_class.start('cancelled') }
+        admitted.pop
+
+        starter.kill
+        starter.join
+
+        expect(script_class.class_variable_get(:@@startup_reservations)).to be_empty
+        expect(Thread.new { script_class.begin_shutdown }.value).to be_empty
+      end
+    end
+
+    it 'uses the published name when reserving a compressed script' do
+      Dir.mktmpdir('script-compressed-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        Zlib::GzipWriter.open(File.join(custom_dir, 'compressed.lic.gz')) do |file|
+          file.write("# quiet\nQueue.new.pop\nDone:\nnil\n")
+        end
+        stub_const('SCRIPT_DIR', root)
+
+        first = script_class.start('compressed')
+
+        expect(first.name).to eq('compressed')
+        expect(script_class.start('compressed')).to be_nil
+        first.kill(:context => :shutdown)
+      end
+    end
+
+    it 'records a missing-label jump as unsuccessful execution' do
+      Dir.mktmpdir('script-label-error') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(
+          File.join(custom_dir, 'badjump.lic'),
+          <<~RUBY
+            # quiet
+            Lich::Common::Script.current.jump_label = 'missing'
+            raise Lich::Common::Script::JUMP
+            Done:
+            nil
+          RUBY
+        )
+        stub_const('SCRIPT_DIR', root)
+
+        started = script_class.start('badjump')
+
+        expect(started.join(2)).to equal(started)
+        expect(started.exit_error).to equal(script_class::JUMP_ERROR)
+        expect(started).not_to be_completed_successfully
+      end
+    end
+
+    it 'does not publish when binding construction fails' do
+      Dir.mktmpdir('script-binding') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'binding_failure.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        allow_any_instance_of(Lich::Common::Scripting).to receive(:script).and_raise(RuntimeError, 'forced binding failure')
+
+        expect(script_class.start('binding_failure')).to be_nil
+        expect(script_class.list).to be_empty
+      end
+    end
+
+    it 'does not publish a Wizard script when binding construction fails' do
+      Dir.mktmpdir('wizard-binding') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'binding_failure.cmd'), "exit\n")
+        stub_const('SCRIPT_DIR', root)
+        allow_any_instance_of(Lich::Common::Scripting).to receive(:script).and_raise(RuntimeError, 'forced binding failure')
+
+        expect(script_class.start('binding_failure')).to be_nil
+        expect(script_class.list).to be_empty
+      end
+    end
+
+    it 'loads an ordinary library through the production startup path' do
+      Dir.mktmpdir('script-library') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'libsample.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        expect(script_class.loadlib('sample')).to be(true)
+        expect(script_class.libs).to include('libsample')
+        expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+      end
+    end
+
+    it 'executes a new generation when reloading a production library' do
+      Dir.mktmpdir('script-library-reload') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(
+          File.join(custom_dir, 'libreload.lic'),
+          "# quiet\n$script_lifecycle_reload_runs = $script_lifecycle_reload_runs.to_i + 1\nDone:\nnil\n"
+        )
+        stub_const('SCRIPT_DIR', root)
+
+        expect(script_class.loadlib('reload')).to be(true)
+        expect(script_class.list).to be_empty
+        expect(script_class.class_variable_get(:@@startup_reservations)).to be_empty
+        expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+        expect(script_class.reloadlibs).to be(true)
+        expect($script_lifecycle_reload_runs).to eq(2)
+      ensure
+        $script_lifecycle_reload_runs = nil
+      end
+    end
+
+    it 'does not load a library that exits unsuccessfully' do
+      Dir.mktmpdir('script-library-exit') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'libfailure.lic'), "# quiet\nexit(false)\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        expect { script_class.loadlib('failure') }.to raise_error(LoadError, /failed/)
+        expect(script_class.libs).not_to include('libfailure')
+      end
+    end
   end
 
   describe 'SubScript' do
+    it 'preserves direct constructor publication and shutdown admission' do
+      script = subscript_class.new
+
+      expect(script.name).to eq('subscript1')
+      expect(script).to be_running
+      script.kill(:context => :shutdown)
+
+      script_class.begin_shutdown
+      expect { subscript_class.new }.to raise_error(ThreadError, /shutting down/)
+    end
+
     it 'runs a block with its own Script.current identity' do
       observed = Queue.new
       subscript = subscript_class.start { observed << script_class.current }
@@ -42,6 +304,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(subscript.join(2)).to equal(subscript)
       expect(observed.pop(true)).to equal(subscript)
       expect(subscript).to be_a(subscript_class)
+      expect(subscript).to be_completed_successfully
     end
 
     it 'unregisters itself when it exits naturally' do
@@ -54,17 +317,30 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(parent.child_scripts).to be_empty
     end
 
-    it 'is stopped with the parent using the parent kill context' do
+    it 'is stopped with the parent during runtime teardown' do
       parent = build_script('parent')
       script_class.class_variable_set(:@@running, [parent])
       child = subscript_class.start(:parent => parent) { Queue.new.pop }
-      expect(child).to receive(:kill).with(:context => :shutdown).and_call_original
-      expect(Thread).not_to receive(:new)
+      expect(child).to receive(:kill).with(:context => :runtime, :async => true).and_call_original
+
+      expect(parent.kill_sync(:context => :runtime, :timeout => 2)).to equal(parent)
+
+      expect(parent).not_to be_running
+      expect(child).not_to be_running
+    end
+
+    it 'leaves shutdown children for the process-wide drain' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      child = subscript_class.start(:parent => parent) { Queue.new.pop }
+      allow(child).to receive(:kill).and_call_original
 
       parent.kill(:context => :shutdown)
 
       expect(parent).not_to be_running
-      expect(child).not_to be_running
+      expect(child).to be_running
+      expect(child).not_to have_received(:kill)
+      child.kill(:context => :shutdown)
     end
 
     it 'inherits protection flags from its parent' do
@@ -84,6 +360,40 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       child.join(2)
     end
 
+    it 'establishes child ownership and protection before publication' do
+      parent = build_script('daemon-parent')
+      parent.hidden = true
+      parent.no_kill_all = true
+      parent.no_pause_all = true
+      script_class.class_variable_set(:@@running, [parent])
+      publish_entered = Queue.new
+      release_publish = Queue.new
+      release_child = Queue.new
+      child_instance = nil
+      allow(subscript_class).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+        child_instance = method.call(*args, **kwargs)
+        allow(child_instance).to receive(:__publish).and_wrap_original do |publish|
+          publish_entered << true
+          release_publish.pop
+          publish.call
+        end
+        child_instance
+      end
+      launcher = Thread.new { subscript_class.start(:parent => parent) { release_child.pop } }
+      publish_entered.pop
+
+      expect(child_instance.hidden).to be(true)
+      expect(child_instance.no_kill_all).to be(true)
+      expect(child_instance.no_pause_all).to be(true)
+      expect(script_class.list).to contain_exactly(parent)
+
+      release_publish << true
+      child = launcher.value
+      expect(parent.child_scripts).to contain_exactly(child)
+      release_child << true
+      expect(child.join(2)).to equal(child)
+    end
+
     it 'rejects and stops a child registered after parent teardown begins' do
       parent = build_script('stopped-parent')
       script_class.class_variable_set(:@@running, [parent])
@@ -93,6 +403,208 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(parent.register_child(child)).to be_nil
       expect(child).not_to be_running
+    end
+
+    it 'rolls back registration when worker allocation fails' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      allow(Thread).to receive(:new).and_raise(ThreadError, 'forced allocation failure')
+
+      expect { subscript_class.start(:parent => parent) {} }.to raise_error(ThreadError, /forced/)
+
+      expect(script_class.list).to contain_exactly(parent)
+      children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
+      expect(Array(children)).to be_empty
+    end
+
+    it 'rolls back registration when worker release fails' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      start_gate = instance_double(Queue)
+      allow(start_gate).to receive(:pop) { Thread.stop }
+      allow(start_gate).to receive(:<<).with(true).and_raise(ThreadError, 'forced release failure')
+      allow(Queue).to receive(:new).and_return(start_gate)
+      rolled_back = nil
+      allow(subscript_class).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+        rolled_back = method.call(*args, **kwargs)
+      end
+
+      expect { subscript_class.start(:parent => parent) {} }.to raise_error(ThreadError, /forced/)
+
+      expect(script_class.list).to contain_exactly(parent)
+      expect(parent.child_scripts).to be_empty
+      expect(rolled_back.join(0.1)).to equal(rolled_back)
+    end
+
+    it 'preserves the parent identity for parent exit handlers' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      child_ready = Queue.new
+      child = subscript_class.start(:parent => parent) { child_ready << true; Queue.new.pop }
+      child_ready.pop
+      observed = nil
+      parent.at_exit { observed = script_class.current }
+
+      expect(parent.kill_sync(:context => :runtime, :timeout => 2)).to equal(parent)
+
+      expect(observed).to equal(parent)
+      expect(child.join(1)).to equal(child)
+    end
+
+    it 'rejects self-registration and ownership cycles' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+
+      expect { parent.register_child(parent) }.to raise_error(ArgumentError, /own child/)
+      expect(parent.register_child(child)).to equal(child)
+      expect { child.register_child(parent) }.to raise_error(ArgumentError, /cycle/)
+    end
+
+    it 'waits for an in-progress child launch before taking the teardown snapshot' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      launch_entered = Queue.new
+      release_launch = Queue.new
+      launcher = Thread.new do
+        parent.__send__(:__launch_child) do
+          launch_entered << true
+          release_launch.pop
+          parent.__send__(:__register_child_locked, child)
+        end
+      end
+      launch_entered.pop
+      killer = Thread.new { parent.kill_sync(:context => :runtime, :timeout => 2) }
+
+      sleep 0.02
+      expect(parent).to be_running
+
+      release_launch << true
+      launcher.join
+      killer.join
+      expect(parent).not_to be_running
+      expect(child.join(1)).to equal(child)
+    end
+
+    it 'does not publish a subscript before its worker is allocated' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      allocation_entered = Queue.new
+      release_allocation = Queue.new
+      start_launch = Queue.new
+      launcher = Thread.new do
+        start_launch.pop
+        subscript_class.start(:parent => parent) {}
+      end
+      first_allocation = true
+      allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+        if first_allocation
+          first_allocation = false
+          allocation_entered << true
+          release_allocation.pop
+        end
+        method.call(*args, &block)
+      end
+
+      start_launch << true
+      allocation_entered.pop
+
+      expect(script_class.list).to contain_exactly(parent)
+      expect(Array(parent.instance_variable_get(:@child_scripts))).to be_empty
+
+      release_allocation << true
+      child = launcher.value
+      expect(child.join(2)).to equal(child)
+    end
+
+    it 'rolls back subscript publication when the launcher is killed mid-transition' do
+      publish_entered = Queue.new
+      release_publish = Queue.new
+      child_instance = nil
+      allow(subscript_class).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+        child_instance = method.call(*args, **kwargs)
+        allow(child_instance).to receive(:__publish).and_wrap_original do |publish, *publish_args|
+          publish_entered << true
+          release_publish.pop
+          publish.call(*publish_args)
+        end
+        child_instance
+      end
+      launcher = Thread.new do
+        subscript_class.start(:parent => nil) { Queue.new.pop }
+      end
+      publish_entered.pop
+
+      launcher.kill
+      release_publish << true
+      launcher.join
+
+      expect(child_instance).not_to be_running
+      expect(script_class.list).to be_empty
+      expect(child_instance.__send__(:__worker_threads)).to all(satisfy { |thread| !thread.alive? })
+    end
+  end
+
+  describe 'ExecScript' do
+    it 'records successful and failed execution results' do
+      allow(Lich::Common::TRUSTED_SCRIPT_BINDING).to receive(:call).and_return(Lich::Common::Scripting.new.script)
+      successful = exec_script_class.start('nil')
+      expect(successful.join(1)).to equal(successful)
+      expect(successful).to be_completed_successfully
+      expect(successful.exit_error).to be_nil
+
+      failed = exec_script_class.start("raise 'exec failed'")
+      expect(failed.join(1)).to equal(failed)
+      expect(failed).not_to be_completed_successfully
+      expect(failed.exit_error).to be_a(RuntimeError)
+    end
+
+    it 'preserves direct constructor publication and shutdown admission' do
+      script = exec_script_class.new('nil', :quiet => true)
+
+      expect(script.name).to eq('exec1')
+      expect(script).to be_running
+      script.kill(:context => :shutdown)
+
+      script_class.begin_shutdown
+      expect { exec_script_class.new('nil') }.to raise_error(ThreadError, /shutting down/)
+    end
+
+    it 'rolls back startup when worker allocation fails' do
+      allow(Thread).to receive(:new).and_raise(ThreadError, 'forced allocation failure')
+
+      expect { exec_script_class.start('nil') }.to raise_error(ThreadError, /forced/)
+
+      expect(script_class.list).to be_empty
+    end
+
+    it 'does not publish before its worker is allocated' do
+      allocation_entered = Queue.new
+      release_allocation = Queue.new
+      start_launch = Queue.new
+      launcher = Thread.new do
+        start_launch.pop
+        exec_script_class.start('nil')
+      end
+      first_allocation = true
+      allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+        if first_allocation
+          first_allocation = false
+          allocation_entered << true
+          release_allocation.pop
+        end
+        method.call(*args, &block)
+      end
+
+      start_launch << true
+      allocation_entered.pop
+
+      expect(script_class.list).to be_empty
+
+      release_allocation << true
+      script = launcher.value
+      expect(script.join(2)).to equal(script)
     end
   end
 
@@ -117,35 +629,799 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(script.join(0.01)).to be_nil
     end
+
+    it 'honors join timeout while cleanup holds the killer mutex' do
+      script = build_script('slow-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      entered = Queue.new
+      release = Queue.new
+      script.at_exit { entered << true; release.pop }
+
+      script.kill
+      entered.pop
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      expect(script.join(0.02)).to be_nil
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).to be < 0.2
+
+      release << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'does not block a repeated shutdown kill behind active cleanup' do
+      script = build_script('slow-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      entered = Queue.new
+      release = Queue.new
+      script.at_exit { entered << true; release.pop }
+      script.kill
+      entered.pop
+
+      repeated_kill = Thread.new { script.kill(:context => :shutdown) }
+      expect(repeated_kill.join(0.1)).to equal(repeated_kill)
+
+      release << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'waits for killed worker ensure blocks to finish' do
+      ready = Queue.new
+      ensure_started = Queue.new
+      release = Queue.new
+      script = subscript_class.start(:parent => nil) do
+        ready << true
+        begin
+          Queue.new.pop
+        ensure
+          ensure_started << true
+          release.pop
+        end
+      end
+      ready.pop
+
+      script.kill
+      ensure_started.pop
+      expect(script.join(0.02)).to be_nil
+
+      release << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'attaches an async cleanup thread to the target before cleanup starts' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      parent.thread_group.add(Thread.current)
+      observed = Queue.new
+      allow(child).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        observed << [child.has_thread?(Thread.current), parent.has_thread?(Thread.current)]
+        method.call(**kwargs)
+      end
+
+      child.kill
+
+      expect(observed.pop).to eq([true, false])
+      expect(child.join(1)).to equal(child)
+    ensure
+      ThreadGroup::Default.add(Thread.current)
+    end
+
+    it 'releases async cleanup when the killing caller is killed mid-transition' do
+      script = build_script('kill-transition')
+      script_class.class_variable_set(:@@running, [script])
+      attach_entered = Queue.new
+      release_attach = Queue.new
+      allow(script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+        attach_entered << true
+        release_attach.pop
+        method.call(thread)
+      end
+      killer = Thread.new { script.kill }
+      attach_entered.pop
+
+      killer.kill
+      release_attach << true
+      killer.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'keeps target cleanup alive when the caller script is killed during handoff' do
+      caller_script = build_script('caller')
+      target_script = build_script('target')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      attach_entered = Queue.new
+      release_attach = Queue.new
+      allow(target_script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+        attach_entered << true
+        release_attach.pop
+        method.call(thread)
+      end
+      start_kill = Queue.new
+      killer = Thread.new { start_kill.pop; target_script.kill }
+      caller_script.thread_group.add(killer)
+      start_kill << true
+      attach_entered.pop
+
+      caller_script.kill
+      release_attach << true
+
+      expect(caller_script.join(1)).to equal(caller_script)
+      expect(target_script.join(1)).to equal(target_script)
+    end
+
+    it 'runs cleanup when the killing caller is cancelled before worker allocation' do
+      script = build_script('kill-allocation-transition')
+      script_class.class_variable_set(:@@running, [script])
+      start_kill = Queue.new
+      allocation_entered = Queue.new
+      killer = Thread.new { start_kill.pop; script.kill }
+      allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+        allocation_entered << true
+        Queue.new.pop
+        method.call(*args, &block)
+      end
+
+      start_kill << true
+      allocation_entered.pop
+      killer.kill
+      killer.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'recovers when an asynchronous cleanup executor is killed' do
+      script = build_script('abandoned-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      first_cleanup = true
+      allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        if first_cleanup
+          first_cleanup = false
+          cleanup_entered << true
+          Queue.new.pop
+        else
+          method.call(**kwargs)
+        end
+      end
+
+      script.kill
+      cleanup_entered.pop
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(script, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'finishes inline cleanup when the killing caller is cancelled' do
+      script = build_script('cancelled-inline-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      first_cleanup = true
+      allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        if first_cleanup
+          first_cleanup = false
+          cleanup_entered << true
+          Queue.new.pop
+        else
+          method.call(**kwargs)
+        end
+      end
+      killer = Thread.new { script.kill(:context => :shutdown) }
+      cleanup_entered.pop
+
+      killer.kill
+      killer.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'signals completion even when cleanup raises' do
+      script = build_script('bad-cleanup')
+      script.die_with << '('
+      script_class.class_variable_set(:@@running, [script])
+
+      expect(script.kill_sync(timeout: 1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'stops later children when an earlier runtime child cleanup blocks' do
+      stub_const('Lich::Common::Script::CHILD_JOIN_TIMEOUT', 0.03)
+      parent = build_script('parent')
+      blocked = build_script('blocked')
+      sibling = build_script('sibling')
+      script_class.class_variable_set(:@@running, [parent, blocked, sibling])
+      parent.register_child(blocked)
+      parent.register_child(sibling)
+      entered = Queue.new
+      release = Queue.new
+      blocked.at_exit { entered << true; release.pop }
+
+      parent.kill
+      entered.pop
+
+      expect(sibling).not_to be_running
+      expect(blocked).to be_running
+      expect(parent.join(1)).to equal(parent)
+      expect(parent.child_scripts).to contain_exactly(blocked)
+
+      release << true
+      expect(blocked.join(1)).to equal(blocked)
+      expect(parent.child_scripts).to be_empty
+    end
+
+    it 'retains a timed-out child until its worker ensure block finishes' do
+      stub_const('Lich::Common::Script::CHILD_JOIN_TIMEOUT', 0.03)
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      child = subscript_class.start(:parent => parent) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+
+      parent.kill
+      worker_cleanup_entered.pop
+      expect(parent.join(1)).to equal(parent)
+      expect(child).not_to be_running
+      expect(parent.child_scripts).to contain_exactly(child)
+      expect(script_class.shutdown_scripts).to include(child)
+
+      release_worker_cleanup << true
+      expect(child.join(1)).to equal(child)
+      expect(parent.child_scripts).to be_empty
+      expect(script_class.shutdown_scripts).to be_empty
+    end
+
+    it 'rejects workers created after teardown begins' do
+      script = build_script('late-worker')
+      script.want_downstream = false
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      release_cleanup = Queue.new
+      callback_ran = Queue.new
+      script.watchfor[/trigger/] = proc { callback_ran << true }
+      script.at_exit { cleanup_entered << true; release_cleanup.pop }
+
+      script.kill
+      cleanup_entered.pop
+      script_class.new_downstream('trigger')
+      sleep 0.02
+
+      expect { callback_ran.pop(true) }.to raise_error(ThreadError)
+
+      release_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'releases a watchfor worker when dispatch is cancelled after registration' do
+      script = build_script('cancelled-watchfor')
+      script_class.class_variable_set(:@@running, [script])
+      script.watchfor[/trigger/] = proc {}
+      registration_complete = Queue.new
+      allow(script).to receive(:__register_worker).and_wrap_original do |method, thread|
+        result = method.call(thread)
+        registration_complete << true
+        Queue.new.pop
+        result
+      end
+      dispatcher = Thread.new { script_class.new_downstream('trigger') }
+      registration_complete.pop
+
+      dispatcher.kill
+      dispatcher.join
+
+      expect(script.__send__(:__worker_threads)).to all(satisfy { |thread| !thread.alive? })
+      script.kill(:context => :shutdown)
+    end
+
+    it 'rejects and joins workers added directly during teardown' do
+      script = build_script('direct-late-worker')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      release_cleanup = Queue.new
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script.at_exit { cleanup_entered << true; release_cleanup.pop }
+
+      script.kill
+      cleanup_entered.pop
+      late_worker = Thread.new do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+      registration_error = Queue.new
+      registrar = Thread.new do
+        script.thread_group.add(late_worker)
+      rescue ThreadError => e
+        registration_error << e
+      end
+      worker_cleanup_entered.pop
+      release_cleanup << true
+      expect(script.join(0.02)).to be_nil
+
+      release_worker_cleanup << true
+      registrar.join
+      expect(registration_error.pop.message).to match(/stopping script/)
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'releases rejected worker registration when the registrar is cancelled' do
+      script = build_script('cancelled-registration')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      release_cleanup = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script.at_exit { cleanup_entered << true; release_cleanup.pop }
+      script.kill
+      cleanup_entered.pop
+      worker = Thread.new do
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      registrar = Thread.new { script.thread_group.add(worker) }
+      worker_cleanup_entered.pop
+
+      registrar.kill
+      release_worker_cleanup << true
+      registrar.join
+      release_cleanup << true
+
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'preserves an underlying thread-group rejection when worker teardown raises' do
+      script = build_script('group-rejection')
+      script_class.class_variable_set(:@@running, [script])
+      group = instance_double(ThreadGroup, :list => [])
+      allow(group).to receive(:add).and_raise(ThreadError, 'group rejected worker')
+      script.instance_variable_set(:@thread_group, group)
+      worker = Thread.new do
+        Thread.current.report_on_exception = false
+        begin
+          Queue.new.pop
+        ensure
+          raise 'worker teardown failed'
+        end
+      end
+
+      expect { script.thread_group.add(worker) }.to raise_error(ThreadError, /group rejected worker/)
+    end
+
+    it 'does not block shutdown cleanup on a worker ensure block' do
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+      shutdown_kill = Thread.new { script.kill(:context => :shutdown) }
+      worker_cleanup_entered.pop
+
+      expect(shutdown_kill.join(0.2)).to equal(shutdown_kill)
+      expect(script_class.shutdown_scripts).to include(script)
+
+      release_worker_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'joins descendant workers spawned from a killed worker ensure block' do
+      worker_ready = Queue.new
+      descendant_ready = Queue.new
+      descendant_cleanup_entered = Queue.new
+      release_descendant_cleanup = Queue.new
+      script = nil
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          descendant = Thread.new do
+            descendant_ready << true
+            begin
+              Queue.new.pop
+            ensure
+              descendant_cleanup_entered << true
+              release_descendant_cleanup.pop
+            end
+          end
+          descendant_ready.pop
+          begin
+            script.thread_group.add(descendant)
+          rescue ThreadError
+            nil
+          end
+        end
+      end
+      worker_ready.pop
+
+      script.kill
+      descendant_cleanup_entered.pop
+      expect(script.join(0.02)).to be_nil
+
+      release_descendant_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'allows a killed worker to join its own stopping script' do
+      worker_ready = Queue.new
+      worker_joined = Queue.new
+      script = nil
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_joined << script.join(1)
+        end
+      end
+      worker_ready.pop
+
+      script.kill
+
+      expect(worker_joined.pop).to equal(script)
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'finishes teardown when a killed worker ensure block raises' do
+      worker_ready = Queue.new
+      script = build_script('raising-worker')
+      script_class.class_variable_set(:@@running, [script])
+      worker = Thread.new do
+        Thread.current.report_on_exception = false
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          raise 'worker cleanup failed'
+        end
+      end
+      script.thread_group.add(worker)
+      worker_ready.pop
+
+      script.kill
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+      expect(script.exit_error).to be_a(RuntimeError)
+    end
+
+    it 'does not complete join until parent unlinking finishes' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      expect(parent.register_child(child)).to equal(child)
+      launch_lock_held = Queue.new
+      release_launch_lock = Queue.new
+      lock_holder = Thread.new do
+        parent.__send__(:__launch_child) do
+          launch_lock_held << true
+          release_launch_lock.pop
+        end
+      end
+      launch_lock_held.pop
+
+      child.kill
+      expect(child.join(0.02)).to be_nil
+      children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
+      expect(children).to contain_exactly(child)
+
+      release_launch_lock << true
+      lock_holder.join
+      expect(child.join(1)).to equal(child)
+      expect(parent.child_scripts).to be_empty
+    end
   end
 
   describe 'library loading' do
-    let(:library_script) { instance_double(script_class, :name => 'libutil', :join => true) }
+    let(:library_script) do
+      instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+    end
 
     before do
-      allow(script_class).to receive(:exists?).and_return(true)
+      allow(script_class).to receive(:__find_script_file).and_return('/custom/libutil.lic')
     end
 
     it 'starts a library only once across concurrent callers' do
-      allow(script_class).to receive(:start).with('libutil').and_return(library_script)
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(library_script)
 
       callers = Array.new(4) { Thread.new { script_class.loadlib('util') } }
       callers.each(&:join)
 
-      expect(script_class).to have_received(:start).with('libutil').once
+      expect(script_class).to have_received(:start).with('libutil', { :force => true }).once
       expect(script_class.libs).to eq(Set['libutil'])
     end
 
+    it 'adopts an admitted plain start instead of reporting a duplicate failure' do
+      admitted_script = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      startup_token = Object.new
+      script_class.__send__(:__begin_start, startup_token, 'libutil', :force => false)
+      loader = Thread.new { script_class.loadlib('util') }
+      expect(loader.join(0.02)).to be_nil
+      allow(script_class).to receive(:start)
+
+      script_class.__send__(:__finish_start, startup_token, admitted_script)
+
+      expect(loader.value).to be(true)
+      expect(script_class).not_to have_received(:start)
+      expect(script_class.libs).to include('libutil')
+    end
+
+    it 'clears an older completed generation when a newer startup fails' do
+      old_generation = instance_double(script_class)
+      script_class.class_variable_set(:@@completed_named_starts, { 'libutil' => old_generation })
+      reservation = Object.new
+      script_class.__send__(:__begin_start, reservation, 'libutil', :force => true)
+
+      script_class.__send__(:__finish_start, reservation, nil)
+
+      expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+    end
+
+    it 'adopts a completed forced generation ahead of an older running generation' do
+      old_generation = instance_double(script_class, :name => 'libutil', :running? => false)
+      allow(old_generation).to receive(:join) { raise 'older generation should not be joined' }
+      new_generation = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      script_class.class_variable_set(:@@running, [old_generation])
+      allow(script_class).to receive(:current).and_return(nil)
+      reservation = Object.new
+      script_class.__send__(:__begin_start, reservation, 'libutil', :force => true)
+      script_class.__send__(:__finish_start, reservation, new_generation)
+
+      expect(script_class.loadlib('util')).to be(true)
+      expect(old_generation).not_to have_received(:join)
+      expect(script_class.libs).to include('libutil')
+    end
+
+    it 'uses the resolved library name when adopting a prefix start' do
+      admitted_script = instance_double(
+        script_class,
+        :name                    => 'libutility',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      allow(script_class).to receive(:__find_script_file).with('libutil').and_return('/custom/libutility.lic')
+      startup_token = Object.new
+      script_class.__send__(:__begin_start, startup_token, 'libutility', :force => false)
+      loader = Thread.new { script_class.loadlib('util') }
+      expect(loader.join(0.02)).to be_nil
+      allow(script_class).to receive(:start)
+
+      script_class.__send__(:__finish_start, startup_token, admitted_script)
+
+      expect(loader.value).to be(true)
+      expect(script_class).not_to have_received(:start)
+      expect(script_class.libs).to include('libutility')
+    end
+
     it 'allows retry when startup fails' do
-      allow(script_class).to receive(:start).with('libutil').and_return(nil, library_script)
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(nil, library_script)
 
       expect { script_class.loadlib('util') }.to raise_error(LoadError, /failed to start/)
       expect(script_class.libs).to be_empty
       expect(script_class.loadlib('util')).to be(true)
     end
 
+    it 'allows retry when startup raises' do
+      attempts = 0
+      allow(script_class).to receive(:start).with('libutil', { :force => true }) do
+        attempts += 1
+        raise ThreadError, 'forced startup failure' if attempts == 1
+
+        library_script
+      end
+
+      expect { script_class.loadlib('util') }.to raise_error(ThreadError, /forced/)
+      expect(script_class.libs).to be_empty
+      expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
+      expect(script_class.loadlib('util')).to be(true)
+    end
+
+    it 'does not record a library whose execution fails' do
+      error = RuntimeError.new('broken library')
+      failed_script = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => error,
+        :completed_successfully? => false
+      )
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(failed_script)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /broken library/)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'invalidates the cache when a rerun of a loaded library fails' do
+      error = RuntimeError.new('broken rerun')
+      failed_rerun = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :exit_error              => error,
+        :completed_successfully? => false
+      )
+      allow(failed_rerun).to receive(:join) do
+        script_class.class_variable_get(:@@running).delete(failed_rerun)
+        true
+      end
+      script_class.class_variable_set(:@@running, [failed_rerun])
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      allow(script_class).to receive(:current).and_return(nil)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /broken rerun/)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'rejects cyclic library waits' do
+      caller_script = build_script('libcaller')
+      target_script = instance_double(
+        script_class,
+        :name                    => 'libtarget',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      script_class.class_variable_set(:@@running, [caller_script])
+      script_class.class_variable_set(:@@loading_libraries, { 'libtarget' => target_script })
+      script_class.class_variable_set(:@@library_waits, { target_script => caller_script })
+      allow(script_class).to receive(:current).and_return(caller_script)
+      allow(script_class).to receive(:__find_script_file).with('libtarget').and_return('/custom/team/libtarget.lic')
+
+      expect { script_class.loadlib('target') }.to raise_error(LoadError, /cyclic/)
+      expect(target_script).not_to have_received(:join)
+    end
+
+    it 'rejects a library loading itself without blocking' do
+      Dir.mktmpdir('script-library-self-cycle') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(
+          File.join(custom_dir, 'libselfcycle.lic'),
+          "# quiet\nLich::Common::Script.loadlib('selfcycle')\nDone:\nnil\n"
+        )
+        stub_const('SCRIPT_DIR', root)
+        allow(script_class).to receive(:__find_script_file).with('libselfcycle').and_return('/custom/libselfcycle.lic')
+
+        expect {
+          Timeout.timeout(1) { script_class.loadlib('selfcycle') }
+        }.to raise_error(LoadError, /cyclic script library dependency/)
+      end
+    end
+
+    it 'does not record an interrupted library as loaded' do
+      interrupted_script = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => false
+      )
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(interrupted_script)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /did not complete/)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'tracks simultaneous waits from separate threads of one script' do
+      caller_script = build_script('libcaller')
+      entered = Queue.new
+      release = Queue.new
+      target_one = instance_double(script_class, :name => 'libone')
+      target_two = instance_double(script_class, :name => 'libtwo')
+      allow(target_one).to receive(:join) { entered << true; release.pop }
+      allow(target_two).to receive(:join) { entered << true; release.pop }
+      allow(script_class).to receive(:current).and_return(caller_script)
+
+      waiters = [
+        Thread.new { script_class.__send__(:__join_library, 'libone', target_one) },
+        Thread.new { script_class.__send__(:__join_library, 'libtwo', target_two) }
+      ]
+      2.times { entered.pop }
+
+      expect(script_class.class_variable_get(:@@library_waits)[caller_script]).to eq(Set[target_one, target_two])
+
+      2.times { release << true }
+      waiters.each(&:join)
+      expect(script_class.class_variable_get(:@@library_waits)).to be_empty
+    end
+
+    it 'serializes a retry behind the failed generation' do
+      first_joined = Queue.new
+      join_mutex = Mutex.new
+      join_condition = ConditionVariable.new
+      first_released = false
+      failed_attempt = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :exit_error              => nil,
+        :completed_successfully? => false
+      )
+      successful_attempt = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      allow(failed_attempt).to receive(:join) do
+        first_joined << true
+        join_mutex.synchronize { join_condition.wait(join_mutex) until first_released }
+      end
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(failed_attempt, successful_attempt)
+
+      first_loader = Thread.new do
+        script_class.loadlib('util')
+      rescue LoadError
+        false
+      end
+      first_joined.pop
+      retry_loader = Thread.new { script_class.loadlib('util') }
+      expect(retry_loader.join(0.02)).to be_nil
+
+      join_mutex.synchronize do
+        first_released = true
+        join_condition.broadcast
+      end
+
+      expect(first_loader.value).to be(false)
+      expect(retry_loader.value).to be(true)
+      expect(script_class.libs).to include('libutil')
+      expect(script_class).to have_received(:start).with('libutil', { :force => true }).twice
+    end
+
     it 'raises without recording a missing library' do
-      allow(script_class).to receive(:exists?).with('libmissing').and_return(false)
+      allow(script_class).to receive(:__find_script_file).with('libmissing').and_return(nil)
 
       expect { script_class.loadlib('missing') }.to raise_error(LoadError, /not found/)
       expect(script_class.libs).to be_empty
@@ -153,11 +1429,30 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
     it 'reloads a stable snapshot of loaded libraries' do
       script_class.class_variable_set(:@@loaded_libraries, Set['libutil', 'libstatus'])
-      allow(script_class).to receive(:run)
+      allow(script_class).to receive(:loadlib).and_return(true)
 
       expect(script_class.reloadlibs).to be(true)
-      expect(script_class).to have_received(:run).with('libutil')
-      expect(script_class).to have_received(:run).with('libstatus')
+      expect(script_class).to have_received(:loadlib).with('libutil')
+      expect(script_class).to have_received(:loadlib).with('libstatus')
+    end
+
+    it 'invalidates a library cache entry when reload fails' do
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      allow(script_class).to receive(:loadlib).with('libutil').and_raise(LoadError, 'broken reload')
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'preserves the current library generation during reload' do
+      current_library = build_script('libutil')
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      allow(script_class).to receive(:current).and_return(current_library)
+      allow(script_class).to receive(:loadlib)
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class).not_to have_received(:loadlib)
+      expect(script_class.libs).to include('libutil')
     end
   end
 
@@ -193,6 +1488,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script.instance_variable_set(:@die_with, [])
       script.instance_variable_set(:@paused, false)
       script.instance_variable_set(:@at_exit_procs, [])
+      script.instance_variable_set(:@watchfor, {})
       script.instance_variable_set(:@downstream_buffer, [])
       script.instance_variable_set(:@upstream_buffer, [])
       script.instance_variable_set(:@match_stack_labels, [])
@@ -200,6 +1496,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script.instance_variable_set(:@killer_mutex, Mutex.new)
       script.instance_variable_set(:@killed_externally, false)
       script.instance_variable_set(:@kill_source, nil)
+      script.instance_variable_set(:@kill_requested, false)
+      script.instance_variable_set(:@cleanup_started, false)
+      script.instance_variable_set(:@completed_successfully, false)
       script.instance_variable_set(:@hidden, false)
       script.instance_variable_set(:@no_kill_all, false)
       script.instance_variable_set(:@no_pause_all, false)

--- a/spec/lib/common/script_version_gate_spec.rb
+++ b/spec/lib/common/script_version_gate_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Lich::Common::Script Lich version gating' do
   end
 
   after(:context) do
-    %i[ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+    %i[SubScript ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
       Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
     end
     $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }

--- a/spec/lib/common/shutdown_script_drain_spec.rb
+++ b/spec/lib/common/shutdown_script_drain_spec.rb
@@ -56,6 +56,82 @@ RSpec.describe Lich::Common::ShutdownScriptDrain do
     )
   end
 
+  it 'adopts and kills scripts that appear while draining' do
+    initial_script = build_script('initial')
+    late_script = build_script('late')
+    poll = 0
+
+    result = described_class.run(
+      initial_scripts: [initial_script],
+      remaining_scripts: proc {
+        poll += 1
+        poll == 1 ? [initial_script, late_script] : []
+      },
+      slow_threshold: 1.5,
+      clock: proc { 0.0 },
+      sleeper: proc { |_duration| nil }
+    )
+
+    expect(initial_script.kill_contexts).to eq([:shutdown])
+    expect(late_script.kill_contexts).to eq([:shutdown])
+    expect(result.scripts_started).to eq(2)
+    expect(result.scripts_remaining).to eq(0)
+  end
+
+  it 'kills a script first observed by the final status poll' do
+    initial_script = build_script('initial')
+    late_script = build_script('late')
+    poll = 0
+
+    result = described_class.run(
+      initial_scripts: [initial_script],
+      remaining_scripts: proc {
+        poll += 1
+        case poll
+        when 1 then []
+        when 2 then [late_script]
+        else []
+        end
+      },
+      slow_threshold: 1.5,
+      clock: proc { 0.0 },
+      sleeper: proc { |_duration| nil }
+    )
+
+    expect(late_script.kill_contexts).to eq([:shutdown])
+    expect(result.scripts_started).to eq(2)
+    expect(result.remaining_scripts).to be_empty
+  end
+
+  it 'includes a final-poll kill in slow-script timing' do
+    now = 0.0
+    late_script = Struct.new(:name) do
+      define_method(:kill) do |context:|
+        raise "unexpected context: #{context}" unless context == :shutdown
+
+        now = Thread.current[:shutdown_drain_clock]
+        Thread.current[:shutdown_drain_clock] = now + 2.0
+      end
+    end.new('late')
+    poll = 0
+    Thread.current[:shutdown_drain_clock] = now
+
+    result = described_class.run(
+      initial_scripts: [],
+      remaining_scripts: proc {
+        poll += 1
+        poll == 2 ? [late_script] : []
+      },
+      slow_threshold: 1.5,
+      clock: proc { Thread.current[:shutdown_drain_clock] },
+      sleeper: proc { |_duration| nil }
+    )
+
+    expect(result.slow_scripts).to eq(['late=2.000s'])
+  ensure
+    Thread.current[:shutdown_drain_clock] = nil
+  end
+
   it 'records a script that exits after the slow threshold' do
     script = build_script('slow-finished')
     now = 0.0

--- a/spec/lib/global_defs_spec.rb
+++ b/spec/lib/global_defs_spec.rb
@@ -393,3 +393,23 @@ RSpec.describe 'global_defs.rb sentinel constants' do
     end
   end
 end
+
+RSpec.describe 'global_defs.rb built-in script commands' do
+  let(:source) { File.read(File.join(LIB_DIR, 'global_defs.rb')) }
+
+  it 'routes kd through forced script teardown' do
+    expect(source).to match(/elsif cmd == 'kd'\s+respond\(.+Script\.kill_all\(:force => true\)/m)
+  end
+
+  it 'documents kd in built-in help' do
+    expect(source).to include("respond \"   \#{$clean_lich_char}kd")
+    expect(source).to include('including protected and hidden scripts')
+  end
+
+  it 'uses the atomic Script#clear operation' do
+    clear_definition = source[/^def clear\b.*?^end$/m]
+
+    expect(clear_definition).to include('script.clear')
+    expect(clear_definition).not_to include('downstream_buffer.dup')
+  end
+end


### PR DESCRIPTION
## Functionality

### Anonymous and child scripts

- Adds `SubScript`, which runs a Ruby block with its own `Script.current` identity, generated name, buffers, hooks, workers, exit handlers, and completion state.
- A child has one parent, inherits the parent's `hidden`, `no_kill_all`, and `no_pause_all` flags, and unregisters after teardown.
- Self-parenting, ownership cycles, and adoption by multiple parents are rejected.
- Runtime parent teardown stops owned children and waits for their bounded teardown. Process shutdown leaves child ordering to the process-wide drain.
- Script startup is reserved by canonical script name, preventing concurrent non-forced duplicate publication and rejecting new publication after shutdown admission closes.

### Lifecycle and workers

- Adds explicit running, stopping, cleanup, and completion states. Completion includes exit callbacks, descendant-worker teardown, and parent detachment.
- Runtime cleanup is asynchronous by default. The process shutdown coordinator cleans up inline to avoid a thread-allocation burst; shutdown requested from a normal script worker remains asynchronous.
- Interrupted cleanup can be reclaimed by shutdown progress instead of leaving a script permanently stopping.
- `Script#thread_group` returns the script's actual Ruby `ThreadGroup`. Native `add`, `list`, `enclose`, and `enclosed?` behavior is preserved while additions are rejected after teardown begins.
- Threads created by script workers or cleanup callbacks remain owned through teardown, including threads created during worker `ensure` blocks.
- Ordinary scripts, `SubScript`, and `ExecScript` record successful completion and their first execution or teardown error.

### Script libraries

- Library names are normalized to `lib...` names and resolved through normal script discovery.
- Concurrent callers share one library generation and wait for complete execution.
- A library is cached only after successful completion. Failed, interrupted, and timed-out generations are not cached and can be retried.
- Abandoned startup reservations are reaped by owner liveness, so shutdown and later loads cannot wait forever on a dead loader.
- Cyclic library dependencies raise `LoadError`.
- Reloading uses a stable loaded-library snapshot, skips the currently executing library, continues after individual failures, and returns aggregate success.

### Kill-all, shutdown, and buffers

- Normal kill-all preserves hidden scripts and scripts protected by `no_kill_all`; forced kill-all includes them.
- Adds the built-in `;kd` command for forced kill-all.
- Daemon setup makes the current script hidden and protects it from kill-all and pause-all.
- Shutdown closes startup admission before taking its first script snapshot and continues tracking scripts that have left the running registry but are still completing teardown.
- The shutdown drain adopts scripts first seen during polling and reports scripts that remain incomplete.
- The global `clear` helper uses the buffer's atomic clear-and-snapshot operation.
- `Script.run` now waits for full lifecycle completion rather than only running-registry removal.

## New APIs

### Class APIs

- `Script.subscript { ... }` starts a quiet `SubScript` owned by `Script.current`.
- `SubScript.start(parent: Script.current, quiet: true) { ... }` starts an anonymous script and returns its `SubScript`.
- `Script.start_child(*args)` starts a normal script owned by `Script.current`; outside a script it behaves like `Script.start`.
- `Script.run_child(*args)` starts a child, waits for complete teardown, and returns the child or `nil` if teardown does not complete.
- `Script.daemon_me` applies daemon flags to `Script.current`, returning the script or `false`.
- `Script.loadlib(library)` loads one script library and returns `true`, or raises `LoadError`.
- `Script.reloadlibs` reloads the loaded-library snapshot and returns `true` only if every attempted reload succeeds.
- `Script.libs` returns a copy of the loaded-library `Set`.
- `Script.kill_all(force: false, context: :runtime)` requests teardown for eligible scripts and returns the number selected.
- `Script.begin_shutdown` closes startup admission, waits for admitted startup transitions, and returns the shutdown snapshot.
- `Script.shutdown_scripts` returns a side-effect-free snapshot of running and still-stopping scripts.
- `Script.progress_shutdown` reclaims interrupted cleanup/finalization work and returns the remaining shutdown snapshot.

### Instance APIs

- `Script#running?` reports running-registry membership.
- `Script#stopping?` reports whether teardown has been requested.
- `Script#join(timeout = nil)` waits for complete teardown and returns the script, or `nil` on timeout.
- `Script#kill_sync(context: :runtime, timeout: nil)` requests teardown and waits for completion.
- `Script#completed_successfully?` reports successful execution with no execution or teardown error.
- `Script#exit_error` returns the first execution or teardown error, or `nil`.
- `Script#register_child(script)` adopts a running script, or stops it and returns `nil` when adoption is closed.
- `Script#unregister_child(script)` removes an owned child and returns it.
- `Script#child_scripts` returns a snapshot of currently owned children.

## Changed APIs

- `Script#kill(context: :runtime, async: nil)` adds explicit context and asynchronous-control arguments.
- `Script#thread_group` remains a native `ThreadGroup`, but worker additions are lifecycle-aware and are rejected after teardown starts.
- `Script.run` waits through exit callbacks, worker teardown, and parent detachment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `kd` command to forcibly stop all scripts, including protected and hidden scripts.
  * Improved script lifecycle handling, including startup, execution, cleanup, library loading, and worker management.

* **Bug Fixes**
  * Shutdown draining now detects and stops scripts that appear during the shutdown process.
  * Improved cleanup reliability, error reporting, and handling of asynchronous script termination.
  * The `clear` command now clears output buffers atomically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->