### PR TITLE
fix(all): correct path-flag aliases and document all path options

### DIFF
--- a/lib/main/argv_options.rb
+++ b/lib/main/argv_options.rb
@@ -164,11 +164,9 @@ module Lich
         end
 
         def self.handle_hosts_dir(argv_options)
-          if (arg = ARGV.find { |a| a == '--hosts-dir' })
-            i = ARGV.index(arg)
-            ARGV.delete_at(i)
-            hosts_dir = ARGV[i]
-            ARGV.delete_at(i)
+          if (arg = ARGV.find { |a| a =~ /^--hosts-dir=(.+)$/i })
+            hosts_dir = arg[/^--hosts-dir=(.+)$/i, 1]
+            ARGV.delete(arg)
             if hosts_dir && File.exist?(hosts_dir)
               hosts_dir = hosts_dir.tr('\\', '/')
               hosts_dir += '/' unless hosts_dir[-1..-1] == '/'

--- a/lib/main/help_text.rb
+++ b/lib/main/help_text.rb
@@ -190,6 +190,10 @@ module Lich
             --script-dir=PATH
             --data-dir=PATH
             --temp-dir=PATH
+            --map-dir=PATH
+            --log-dir=PATH
+            --backup-dir=PATH
+            --lib-dir=PATH
             --hosts-dir=PATH
             --hosts-file=PATH
 

--- a/lich.rbw
+++ b/lich.rbw
@@ -10,19 +10,19 @@
 for arg in ARGV
   if arg =~ /^--(?:home)=(.+)[\\\/]?$/i
     LICH_DIR = $1
-  elsif arg =~ /^--temp=(.+)[\\\/]?$/i
+  elsif arg =~ /^--(?:temp|temp-dir)=(.+)[\\\/]?$/i
     TEMP_DIR = $1
-  elsif arg =~ /^--scripts=(.+)[\\\/]?$/i
+  elsif arg =~ /^--(?:scripts|script-dir)=(.+)[\\\/]?$/i
     SCRIPT_DIR = $1
-  elsif arg =~ /^--maps=(.+)[\\\/]?$/i
+  elsif arg =~ /^--(?:maps|map-dir)=(.+)[\\\/]?$/i
     MAP_DIR = $1
-  elsif arg =~ /^--logs=(.+)[\\\/]?$/i
+  elsif arg =~ /^--(?:logs|log-dir)=(.+)[\\\/]?$/i
     LOG_DIR = $1
-  elsif arg =~ /^--backup=(.+)[\\\/]?$/i
+  elsif arg =~ /^--(?:backup|backup-dir)=(.+)[\\\/]?$/i
     BACKUP_DIR = $1
-  elsif arg =~ /^--data=(.+)[\\\/]?$/i
+  elsif arg =~ /^--(?:data|data-dir)=(.+)[\\\/]?$/i
     DATA_DIR = $1
-  elsif arg =~ /^--lib=(.+)[\\\/]?$/i
+  elsif arg =~ /^--(?:lib|lib-dir)=(.+)[\\\/]?$/i
     LIB_DIR = $1
   end
 end

--- a/spec/lib/main/argv_options_spec.rb
+++ b/spec/lib/main/argv_options_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'tmpdir'
+
+# lib/main/argv_options.rb pulls a heavy require chain and auto-executes
+# ArgvOptions.process_argv at load time, so it cannot be required in isolation.
+# To exercise SideEffects.handle_hosts_dir without booting the whole ARGV
+# pipeline, lift the real method body out of the source file and eval it into a
+# lightweight harness. Extracting from source (rather than duplicating the
+# logic here) keeps this spec bound to the shipping code and guards drift.
+RSpec.describe 'Lich::Main::ArgvOptions::SideEffects.handle_hosts_dir' do
+  source_path = File.expand_path('../../../lib/main/argv_options.rb', __dir__)
+
+  harness_class = Class.new do
+    source = File.read(source_path)
+    method_body = source[/^(?<ind>[ \t]*)def self\.handle_hosts_dir\(argv_options\).*?^\k<ind>end$/m]
+    raise 'could not extract handle_hosts_dir from argv_options.rb' unless method_body
+
+    # Rebind as an instance method on the harness (drop the `self.`).
+    module_eval(method_body.sub('def self.handle_hosts_dir', 'def handle_hosts_dir'))
+  end
+
+  let(:harness) { harness_class.new }
+  let(:argv_options) { {} }
+
+  around do |example|
+    original_argv = ARGV.dup
+    begin
+      example.run
+    ensure
+      ARGV.replace(original_argv)
+    end
+  end
+
+  def set_argv(*args)
+    ARGV.replace(args)
+  end
+
+  it 'parses the equals form and records a normalized directory' do
+    Dir.mktmpdir do |dir|
+      set_argv("--hosts-dir=#{dir}")
+
+      harness.handle_hosts_dir(argv_options)
+
+      expect(argv_options[:hosts_dir]).to eq("#{dir}/")
+      expect(ARGV).not_to include("--hosts-dir=#{dir}")
+    end
+  end
+
+  it 'does not append a second trailing slash when one is already present' do
+    Dir.mktmpdir do |dir|
+      set_argv("--hosts-dir=#{dir}/")
+
+      harness.handle_hosts_dir(argv_options)
+
+      expect(argv_options[:hosts_dir]).to eq("#{dir}/")
+    end
+  end
+
+  it 'warns and records nothing when the directory does not exist' do
+    missing = File.join(Dir.tmpdir, "lich-missing-hosts-#{Process.pid}")
+    set_argv("--hosts-dir=#{missing}")
+
+    expect { harness.handle_hosts_dir(argv_options) }
+      .to output(/does not exist: #{Regexp.escape(missing)}/).to_stdout
+
+    expect(argv_options).not_to have_key(:hosts_dir)
+    expect(ARGV).not_to include("--hosts-dir=#{missing}")
+  end
+
+  it 'ignores the legacy space-separated form (regression guard for the equals switch)' do
+    Dir.mktmpdir do |dir|
+      set_argv('--hosts-dir', dir)
+
+      harness.handle_hosts_dir(argv_options)
+
+      expect(argv_options).not_to have_key(:hosts_dir)
+      # Neither token matches the equals form, so ARGV is left untouched.
+      expect(ARGV).to eq(['--hosts-dir', dir])
+    end
+  end
+end

--- a/spec/lib/main/help_text_spec.rb
+++ b/spec/lib/main/help_text_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe Lich::Main::HelpText do
       expect(output).to include('Multiple frontends may attach to one detachable port.')
       expect(output).to include('commands from all attached frontends are processed serially')
     end
+
+    it 'lists every supported path option' do
+      output = described_class.render('paths')
+
+      expect(output).to include('--home=PATH')
+      expect(output).to include('--script-dir=PATH')
+      expect(output).to include('--data-dir=PATH')
+      expect(output).to include('--temp-dir=PATH')
+      expect(output).to include('--map-dir=PATH')
+      expect(output).to include('--log-dir=PATH')
+      expect(output).to include('--backup-dir=PATH')
+      expect(output).to include('--lib-dir=PATH')
+      expect(output).to include('--hosts-dir=PATH')
+      expect(output).to include('--hosts-file=PATH')
+    end
   end
 
   describe '.topic_from_argv' do


### PR DESCRIPTION
## Summary

Fixes problem 1 & 2 of #1471 and aligns the CLI path-flag interface with its own documentation. Lich exposes two independent argument subsystems:

- the early constant loop in `lich.rbw` (runs before `constants.rb`) seeds the directory constants `LICH_DIR`, `SCRIPT_DIR`, `DATA_DIR`, `TEMP_DIR`, `MAP_DIR`, `LOG_DIR`, `BACKUP_DIR`, `LIB_DIR`;
- `lib/main/argv_options.rb` builds the runtime `@argv_options` (including `--hosts-file` and `--hosts-dir`).

The two had drifted: `--help paths` documents `--script-dir` / `--data-dir` / `--temp-dir`, but the loop only recognized the legacy `--scripts` / `--data` / `--temp` short forms, so following the help text produced flags that were silently ignored (the constant fell back to its default). This PR makes the loop accept both spellings, documents the full set of path options, and fixes a separate `--hosts-dir` parsing mismatch.

## Changes

### `lich.rbw` — accept `-dir` aliases (backward compatible)

Each directory flag now accepts both its legacy short form and a canonical `-dir` form (alias = constant name, lowercased, `_` -> `-`):

| Constant     | Accepted flags            |
| ------------ | ------------------------- |
| `TEMP_DIR`   | `--temp`, `--temp-dir`     |
| `SCRIPT_DIR` | `--scripts`, `--script-dir`|
| `MAP_DIR`    | `--maps`, `--map-dir`      |
| `LOG_DIR`    | `--logs`, `--log-dir`      |
| `BACKUP_DIR` | `--backup`, `--backup-dir` |
| `DATA_DIR`   | `--data`, `--data-dir`     |
| `LIB_DIR`    | `--lib`, `--lib-dir`       |

`--home` (-> `LICH_DIR`) is unchanged. Implemented by widening the existing `(?:home)` non-capturing-group pattern already used on the first branch; no other change to the loop. Every previously accepted flag still works.

### `lib/main/help_text.rb` — document all path options

`paths_help` now lists `--map-dir`, `--log-dir`, `--backup-dir`, and `--lib-dir` alongside the existing entries. These four supported directories were previously undocumented. The help shows the canonical `-dir` spelling (matching how `--script-dir` etc. are already presented); the legacy short forms remain accepted but intentionally undocumented.

### `lib/main/argv_options.rb` — parse `--hosts-dir` with `=`

`handle_hosts_dir` previously matched a bare `--hosts-dir` token and consumed the *next* argv element as its value (`--hosts-dir /path`), while the help text and its sibling `--hosts-file` both use the `=` form. It now parses `--hosts-dir=PATH`, consistent with `--hosts-file=PATH` and the documentation. The existence check, backslash normalization, trailing-slash handling, and warning message are unchanged.

> Behavioral note: the previously-working `--hosts-dir <path>` space form is no
> longer accepted. Use the documented `--hosts-dir=<path>`.

## Testing

- `spec/lib/main/help_text_spec.rb`: new example asserting `--help paths` renders all ten path options.
- `spec/lib/main/argv_options_spec.rb` (new): covers `handle_hosts_dir` — equals-form parse + normalization, trailing-slash idempotence, the missing-directory warning, and a regression guard that the legacy space-separated form is now ignored. `argv_options.rb` auto-runs `process_argv` at load and can't be required standalone, so the spec lifts the real method body from source rather than duplicating logic (keeps it bound to shipping code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for directory-specific command-line aliases, including `--temp-dir`, `--script-dir`, `--maps-dir`, `--logs-dir`, `--backup-dir`, and `--data-dir`.
  * Expanded path-related help output to document available directory options.

* **Bug Fixes**
  * Standardized `--hosts-dir` usage to the `--hosts-dir=PATH` format.
  * Normalized trailing slashes in valid hosts directory paths and preserved invalid arguments for correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->