### PR TITLE
ci(all): de-flake PasswordCipher wrong-key decrypt specs

### DIFF
--- a/spec/lib/common/gui/password_cipher_spec.rb
+++ b/spec/lib/common/gui/password_cipher_spec.rb
@@ -29,11 +29,19 @@ RSpec.describe Lich::Common::GUI::PasswordCipher do
         expect(described_class.decrypt(encrypted2, mode: :standard, account_name: account_name)).to eq(password)
       end
 
-      it 'fails to decrypt with wrong account name' do
+      it 'does not recover the password with a wrong account name' do
         encrypted = described_class.encrypt(password, mode: :standard, account_name: account_name)
-        expect do
-          described_class.decrypt(encrypted, mode: :standard, account_name: 'WrongAccount')
-        end.to raise_error(Lich::Common::GUI::PasswordCipher::DecryptionError)
+
+        # AES-256-CBC is unauthenticated: a wrong key usually raises on invalid
+        # PKCS7 padding, but ~1/256 of the time it yields garbage instead of
+        # raising. Both outcomes are acceptable; recovering the real password is
+        # not. Asserting "always raises" makes this test flaky.
+        begin
+          result = described_class.decrypt(encrypted, mode: :standard, account_name: 'WrongAccount')
+          expect(result).not_to eq(password)
+        rescue Lich::Common::GUI::PasswordCipher::DecryptionError
+          # expected the vast majority of the time
+        end
       end
     end
 
@@ -57,11 +65,17 @@ RSpec.describe Lich::Common::GUI::PasswordCipher do
         expect(described_class.decrypt(encrypted2, mode: :enhanced, master_password: master_password)).to eq(password)
       end
 
-      it 'fails to decrypt with wrong master password' do
+      it 'does not recover the password with a wrong master password' do
         encrypted = described_class.encrypt(password, mode: :enhanced, master_password: master_password)
-        expect do
-          described_class.decrypt(encrypted, mode: :enhanced, master_password: 'WrongMasterPass')
-        end.to raise_error(Lich::Common::GUI::PasswordCipher::DecryptionError)
+
+        # See note above: AES-256-CBC decrypt with a wrong key does not
+        # deterministically raise, so assert the recoverability property instead.
+        begin
+          result = described_class.decrypt(encrypted, mode: :enhanced, master_password: 'WrongMasterPass')
+          expect(result).not_to eq(password)
+        rescue Lich::Common::GUI::PasswordCipher::DecryptionError
+          # expected the vast majority of the time
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Two examples in `spec/lib/common/gui/password_cipher_spec.rb` assert that decrypting with the wrong key *always* raises `DecryptionError`. The cipher is AES-256-CBC (`lib/common/gui/password_cipher.rb:26`), which is unauthenticated, so a wrong key does not deterministically raise -- it only raises when the resulting PKCS7 padding is invalid (~255/256 of the time). Roughly 1 run in ~256 the padding validates by chance, decrypt returns garbage instead of raising, and the example fails with:

    expected Lich::Common::GUI::PasswordCipher::DecryptionError but nothing was raised

Measured non-raise rate over 20,000 standalone trials: 0.47% (~1/212), matching the ~1/256 first-principles estimate. The flake is intrinsic to the cipher and the assertion -- independent of RSpec seed, example order, and unrelated spec files. (The IV comes from OpenSSL's CSPRNG, which RSpec's seeded `Kernel.srand` does not affect, so re-running the same `--seed` will not reliably reproduce it.)

## Change

Test-only. The two affected examples now assert the property that actually holds -- a wrong key must not recover the original plaintext -- and accept either failure shape (a raise, or a non-matching return):

- standard-mode "wrong account name" (`password_cipher_spec.rb`, ~line 32)
- enhanced-mode "wrong master password" (`password_cipher_spec.rb`, ~line 60)

No production code changes.

## Deliberately out of scope

- `lib/common/gui/password_cipher.rb` is untouched.
- The deterministic `DecryptionError` tests -- corrupted data (~line 87) and truncated data (~line 93) -- feed malformed input that fails before padding is reached, so they are not flaky and are left unchanged.
- Making wrong-key decryption raise *deterministically* would require an authenticated cipher (AES-256-GCM), which changes the stored ciphertext format and needs a migration path for existing credentials. Tracked separately.

## Testing

- Full suite green.
- Stability: ran the affected spec 500+ times with no failures (`for i in $(seq 1 500); do rspec spec/lib/common/gui/password_cipher_spec.rb --seed $i || break; done`). Previously failed roughly 1 in ~200 runs.
- RuboCop clean; source ASCII-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of password decryption when incorrect credentials are provided.
  * Coverage now accounts for expected variations in failure behavior while ensuring the original password is not returned.
  * Added consistent checks across standard and enhanced encryption modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->