### PR TITLE
fix(all): Synchronize script lifecycle transitions (02 of 06)

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -27,8 +27,28 @@ module Lich
     class Script
       VALID_KILL_CONTEXTS = [:runtime, :shutdown].freeze
       CHILD_MUTEX_INITIALIZER = Mutex.new
+      CHILD_RELATIONSHIP_MUTEX = Mutex.new
+      LIFECYCLE_MUTEX_INITIALIZER = Mutex.new
+      CHILD_JOIN_TIMEOUT = 1.0
 
-      @@elevated_script_start = proc { |args|
+      class ThreadGroupHandle
+        def initialize(script)
+          @script = script
+        end
+
+        def add(thread)
+          accepted = @script.__send__(:__register_worker, thread)
+          raise ThreadError, 'cannot add a worker to a stopping script' unless accepted
+
+          self
+        end
+
+        def list
+          @script.__send__(:__worker_threads)
+        end
+      end
+
+      @@elevated_script_start = proc { |args, parent = nil|
         if args.empty?
           # fixme: error
           next nil
@@ -70,147 +90,211 @@ module Lich
         # Resolve via the shared resolver so script discovery stays identical
         # everywhere (custom/ root, custom/<subdir>/, then SCRIPT_DIR root).
         file_name = __find_script_file(script_name)
-        script_name = file_name.sub(/\..{1,3}$/, '') if file_name
         if file_name.nil?
           respond "--- Lich: could not find script '#{script_name}' in directory #{SCRIPT_DIR} or #{SCRIPT_DIR}/custom"
           next nil
         end
-        if (options[:force] != true) and (Script.running + Script.hidden).find { |s| s.name =~ /^#{Regexp.escape(script_name.sub(%r{/custom/([^/]+/)?}, ''))}$/i }
-          respond "--- Lich: #{script_name} is already running (use #{$clean_lich_char}force [scriptname] if desired)."
-          next nil
-        end
+        registry_name = __script_registry_name(file_name)
+        script_name = file_name.sub(/\.(?:lic|rb|cmd|wiz)(?:\.(?:gz|Z))?\z/i, '')
+        startup_reservation = Object.new
+        startup_completed = false
         begin
-          if file_name =~ /\.(?:cmd|wiz)(?:\.gz)?$/i
-            trusted = false
-            script_obj = WizardScript.new("#{SCRIPT_DIR}/#{file_name}", script_args)
-          else
-            if script_obj.labels.length > 1
-              trusted = false
-            else
-              trusted = true
-            end
-            script_obj = Script.new(:file => "#{SCRIPT_DIR}/#{file_name}", :args => script_args, :quiet => options[:quiet])
+          startup_status = __begin_start(startup_reservation, registry_name, :force => options[:force] == true)
+          if startup_status == :shutdown
+            respond "--- Lich: cannot start #{registry_name} while shutting down."
+            next nil
+          elsif startup_status == :duplicate
+            respond "--- Lich: #{script_name} is already running (use #{$clean_lich_char}force [scriptname] if desired)."
+            next nil
           end
-          if trusted
-            script_binding = TRUSTED_SCRIPT_BINDING.call
-          else
-            script_binding = Scripting.new.script
-          end
-        rescue
-          respond "--- Lich: error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-          next nil
-        end
-        unless script_obj
-          respond "--- Lich: error: failed to start script (#{script_name})"
-          next nil
-        end
-        script_obj.quiet = true if options[:quiet]
-        new_thread = Thread.new {
-          100.times { break if Script.current == script_obj; sleep 0.01 }
 
-          if (script = Script.current)
-            eval('script = Script.current', script_binding, script.name)
-            Thread.current.priority = 1
-            respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
-            if trusted
-              begin
-                eval(script.labels[script.current_label].to_s, script_binding, script.name)
-              rescue SystemExit
-                nil
-              rescue SyntaxError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ScriptError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue NoMemoryError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue LoadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SecurityError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ThreadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SystemStackError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue JumpError
-                if $! == JUMP
-                  retry if Script.current.get_next_label != JUMP_ERROR
-                  respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                  respond $!.backtrace.first
-                  Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
-                  Script.current.kill
-                else
-                  respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                  Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-                end
-              rescue StandardError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              ensure
-                Script.current.kill
-              end
+          begin
+            if file_name =~ /\.(?:cmd|wiz)(?:\.gz)?$/i
+              trusted = false
+              script_obj = WizardScript.new("#{SCRIPT_DIR}/#{file_name}", script_args, false)
             else
-              begin
-                while (script = Script.current) and script.current_label
-                  proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
-                  Script.current.get_next_label
-                end
-              rescue SystemExit
-                nil
-              rescue SyntaxError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ScriptError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue NoMemoryError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue LoadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SecurityError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                if (name = Script.current.name)
-                  respond "--- Lich: review this script (#{name}) to make sure it isn't malicious, and type #{$clean_lich_char}trust #{name}"
-                end
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue ThreadError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue SystemStackError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              rescue JumpError
-                if $! == JUMP
-                  retry if Script.current.get_next_label != JUMP_ERROR
-                  respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                  respond $!.backtrace.first
-                  Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
-                  Script.current.kill
+              script_obj = Script.new(:file => "#{SCRIPT_DIR}/#{file_name}", :args => script_args, :quiet => options[:quiet], :publish => false)
+              trusted = script_obj.labels.length <= 1
+            end
+            if trusted
+              script_binding = TRUSTED_SCRIPT_BINDING.call
+            else
+              script_binding = Scripting.new.script
+            end
+          rescue
+            respond "--- Lich: error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+            next nil
+          end
+          unless script_obj
+            respond "--- Lich: error: failed to start script (#{script_name})"
+            next nil
+          end
+          script_obj.quiet = true if options[:quiet]
+
+          start_gate = Queue.new
+          setup_complete = false
+          worker_released = false
+          begin
+            new_thread = Thread.new {
+              next unless start_gate.pop
+
+              if (script = Script.current)
+                eval('script = Script.current', script_binding, script.name)
+                Thread.current.priority = 1
+                respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
+                if trusted
+                  begin
+                    eval(script.labels[script.current_label].to_s, script_binding, script.name)
+                    script.__send__(:__record_successful_exit)
+                  rescue SystemExit => e
+                    if e.success?
+                      script.__send__(:__record_successful_exit)
+                    else
+                      script.__send__(:__record_exit_error, e)
+                    end
+                  rescue SyntaxError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ScriptError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue NoMemoryError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue LoadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SecurityError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ThreadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SystemStackError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue JumpError
+                    if $! == JUMP
+                      retry if Script.current.get_next_label != JUMP_ERROR
+                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
+                      respond $!.backtrace.first
+                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
+                      script.__send__(:__record_exit_error, JUMP_ERROR)
+                      script.kill if script.running? && !script.stopping?
+                    else
+                      script.__send__(:__record_exit_error, $!)
+                      respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                      Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                    end
+                  rescue StandardError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  ensure
+                    script.kill if script.running? && !script.stopping?
+                  end
                 else
-                  respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                  Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  begin
+                    while (script = Script.current) and script.current_label
+                      proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
+                      Script.current.get_next_label
+                    end
+                    script.__send__(:__record_successful_exit)
+                  rescue SystemExit => e
+                    if e.success?
+                      script.__send__(:__record_successful_exit)
+                    else
+                      script.__send__(:__record_exit_error, e)
+                    end
+                  rescue SyntaxError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ScriptError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue NoMemoryError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue LoadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SecurityError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    if (name = Script.current.name)
+                      respond "--- Lich: review this script (#{name}) to make sure it isn't malicious, and type #{$clean_lich_char}trust #{name}"
+                    end
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue ThreadError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue SystemStackError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  rescue JumpError
+                    if $! == JUMP
+                      retry if Script.current.get_next_label != JUMP_ERROR
+                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
+                      respond $!.backtrace.first
+                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{$!.backtrace.join("\n\t")}"
+                      script.__send__(:__record_exit_error, JUMP_ERROR)
+                      script.kill if script.running? && !script.stopping?
+                    else
+                      script.__send__(:__record_exit_error, $!)
+                      respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                      Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                    end
+                  rescue StandardError
+                    script.__send__(:__record_exit_error, $!)
+                    respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
+                    Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  ensure
+                    script.kill if script.running? && !script.stopping?
+                  end
                 end
-              rescue StandardError
-                respond "--- Lich: error: #{$!}\n\t#{$!.backtrace[0..1].join("\n\t")}"
-                Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              ensure
-                Script.current.kill
+              else
+                respond '--- error: out of cheese'
+              end
+            }
+            script_obj.__send__(:__attach_startup_worker, new_thread)
+            if parent && !parent.__send__(:__adopt_child_locked, script_obj)
+              new_thread&.kill
+              script_obj.__send__(:__discard_startup)
+              next nil
+            end
+            script_obj.__send__(:__publish, true)
+            setup_complete = true
+          ensure
+            begin
+              start_gate << setup_complete
+              worker_released = true
+            ensure
+              unless setup_complete && worker_released
+                new_thread&.kill
+                new_thread&.join
+                parent.__send__(:__unregister_child_locked, script_obj) if parent
+                script_obj.__send__(:__discard_startup)
               end
             end
-          else
-            respond '--- error: out of cheese'
           end
-        }
-        script_obj.thread_group.add(new_thread)
-        script_obj
+          startup_completed = true
+          script_obj
+        ensure
+          __finish_start(startup_reservation, startup_completed ? script_obj : nil)
+        end
       }
       @@elevated_exists = proc { |script_name|
         if script_name =~ /\\|\//
@@ -289,8 +373,16 @@ module Lich
         end
       }
       @@running = Array.new
+      @@stopping = Array.new
+      @@startup_mutex = Mutex.new
+      @@startup_condition = ConditionVariable.new
+      @@startup_reservations = {}
+      @@completed_named_starts = {}
+      @@shutdown_started = false
       @@library_mutex = Mutex.new
       @@loaded_libraries = Set.new
+      @@loading_libraries = {}
+      @@library_waits = {}
       @@kill_metrics_mutex = Mutex.new
       @@kill_metrics = {
         :minute            => nil,
@@ -300,7 +392,7 @@ module Lich
         :failures          => 0
       }
 
-      attr_reader :name, :vars, :safe, :file_name, :label_order, :at_exit_procs
+      attr_reader :name, :vars, :safe, :file_name, :label_order, :at_exit_procs, :exit_error
       attr_accessor :quiet, :no_echo, :jump_label, :current_label, :want_downstream, :want_downstream_xml, :want_upstream, :want_script_output, :hidden, :paused, :silent, :no_pause_all, :no_kill_all, :downstream_buffer, :upstream_buffer, :unique_buffer, :die_with, :match_stack_labels, :match_stack_strings, :watchfor, :command_line, :ignore_pause, :killed_externally, :kill_source
 
       KILL_METRICS_FEATURE_FLAG = :script_kill_metrics
@@ -349,6 +441,13 @@ module Lich
           file_list.find { |val| val =~ /^(?:\/custom\/(?:[^\/]+\/)?)?#{escaped}[^.]+\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i }
       end
       private_class_method :__find_script_file
+
+      def Script.__script_registry_name(file_name)
+        file_name
+          .sub(%r{\A/custom/(?:[^/]+/)?}, '')
+          .sub(/\.(?:lic|rb|cmd|wiz)(?:\.(?:gz|Z))?\z/i, '')
+      end
+      private_class_method :__script_registry_name
 
       # Extracts the leading header-comment lines from raw script source.
       #
@@ -552,6 +651,76 @@ module Lich
         @@running.dup
       end
 
+      def Script.shutdown_scripts
+        scripts = (@@running + @@stopping).uniq
+        scripts.each { |script| script.__send__(:__refresh_deferred_stop) }
+        (@@running + @@stopping).uniq
+      end
+
+      def Script.begin_shutdown
+        @@startup_mutex.synchronize do
+          @@shutdown_started = true
+          @@startup_condition.wait(@@startup_mutex) until @@startup_reservations.empty?
+          shutdown_scripts
+        end
+      end
+
+      def Script.__begin_start(reservation, name = nil, force: true)
+        normalized_name = name&.downcase
+        @@startup_mutex.synchronize do
+          return :shutdown if @@shutdown_started
+          if normalized_name && !force
+            running = @@running.any? { |script| script.name.casecmp?(normalized_name) }
+            starting = @@startup_reservations.value?(normalized_name)
+            return :duplicate if running || starting
+          end
+
+          @@startup_reservations[reservation] = normalized_name
+          :admitted
+        end
+      end
+      private_class_method :__begin_start
+
+      def Script.__finish_start(reservation, script = nil)
+        @@startup_mutex.synchronize do
+          name = @@startup_reservations.delete(reservation)
+          if name&.start_with?('lib')
+            @@completed_named_starts.delete(name)
+            @@completed_named_starts[name] = script if script
+          end
+          @@startup_condition.broadcast
+        end
+      end
+      private_class_method :__finish_start
+
+      def Script.__publish_to_registry(admitted:)
+        @@startup_mutex.synchronize do
+          raise ThreadError, 'cannot publish a script while shutting down' if @@shutdown_started && !admitted
+
+          yield
+        end
+      end
+      private_class_method :__publish_to_registry
+
+      def Script.__take_completed_start(name)
+        normalized_name = name.downcase
+        @@startup_mutex.synchronize do
+          while @@startup_reservations.value?(normalized_name)
+            @@startup_condition.wait(@@startup_mutex)
+          end
+          @@completed_named_starts.delete(normalized_name)
+        end
+      end
+      private_class_method :__take_completed_start
+
+      def Script.__discard_completed_start(name, script)
+        normalized_name = name.downcase
+        @@startup_mutex.synchronize do
+          @@completed_named_starts.delete(normalized_name) if @@completed_named_starts[normalized_name].equal?(script)
+        end
+      end
+      private_class_method :__discard_completed_start
+
       # Starts an anonymous child script owned by the current script.
       #
       # @yield required block executed by the new script
@@ -571,10 +740,9 @@ module Lich
       # @return [Script, nil] the started script, or nil when startup fails
       def Script.start_child(*args)
         parent = Script.current
-        child = Script.start(*args)
-        return child unless parent && child
+        return Script.start(*args) unless parent
 
-        parent.register_child(child)
+        parent.__send__(:__launch_child) { @@elevated_script_start.call(args, parent) }
       end
 
       # Starts a child script and waits for it to finish.
@@ -609,11 +777,11 @@ module Lich
       end
 
       def Script.start(*args)
-        @@elevated_script_start.call(args)
+        @@elevated_script_start.call(args, nil)
       end
 
       def Script.run(*args)
-        if (s = @@elevated_script_start.call(args))
+        if (s = @@elevated_script_start.call(args, nil))
           sleep 0.1 while @@running.include?(s)
         end
       end
@@ -628,31 +796,100 @@ module Lich
         library_name = library.to_s.downcase
         library_name = "lib#{library_name}" unless library_name.start_with?('lib')
         raise ArgumentError, 'library name cannot be empty' if library_name == 'lib'
-        raise LoadError, "script library not found: #{library_name}" unless Script.exists?(library_name)
+        resolved_file = __find_script_file(library_name)
+        raise LoadError, "script library not found: #{library_name}" unless resolved_file
 
-        script = @@library_mutex.synchronize do
-          running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
-          if @@loaded_libraries.include?(library_name)
-            running
-          else
-            @@loaded_libraries.add(library_name)
-            started = running || Script.start(library_name)
-            @@loaded_libraries.delete(library_name) unless started
-            started
+        library_name = __script_registry_name(resolved_file).downcase
+
+        loading = @@library_mutex.synchronize { @@loading_libraries[library_name] }
+        if loading
+          begin
+            __join_library(library_name, loading)
+            __validate_library_completion(library_name, loading)
+            return true
+          rescue LoadError => e
+            raise if e.message.start_with?('cyclic script library dependency:')
+
+            @@library_mutex.synchronize do
+              if @@loading_libraries[library_name].equal?(loading)
+                @@loading_libraries.delete(library_name)
+                @@loaded_libraries.delete(library_name)
+              end
+            end
           end
         end
 
-        raise LoadError, "failed to start script library: #{library_name}" unless @@loaded_libraries.include?(library_name)
+        startup_reservation = Object.new
+        begin
+          startup_status = __begin_start(startup_reservation, library_name, :force => false)
+          raise LoadError, "cannot load script library during shutdown: #{library_name}" if startup_status == :shutdown
 
-        script&.join
-        true
+          completed_start = __take_completed_start(library_name) if startup_status == :duplicate
+          script, already_loaded, owns_loading, started_here = @@library_mutex.synchronize do
+            running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
+            if (loading = @@loading_libraries[library_name])
+              [loading, false, false, false]
+            elsif (candidate = completed_start || running)
+              @@loading_libraries[library_name] = candidate
+              [candidate, false, true, false]
+            elsif @@loaded_libraries.include?(library_name)
+              [nil, true, false, false]
+            else
+              started = Script.start(library_name, { :force => true })
+              raise LoadError, "failed to start script library: #{library_name}" unless started
+
+              @@loading_libraries[library_name] = started
+              [started, false, true, true]
+            end
+          end
+          __discard_completed_start(library_name, script) if started_here
+          return true if already_loaded
+
+          __finish_start(startup_reservation)
+          begin
+            __join_library(library_name, script)
+          rescue ScriptError, StandardError
+            if owns_loading
+              @@library_mutex.synchronize do
+                @@loading_libraries.delete(library_name) if @@loading_libraries[library_name].equal?(script)
+              end
+            end
+            raise
+          end
+
+          error = script.exit_error
+          completed = script.completed_successfully?
+          @@library_mutex.synchronize do
+            if @@loading_libraries[library_name].equal?(script)
+              @@loading_libraries.delete(library_name)
+              if error || !completed
+                @@loaded_libraries.delete(library_name)
+              else
+                @@loaded_libraries.add(library_name)
+              end
+            end
+          end
+          __validate_library_completion(library_name, script)
+
+          true
+        ensure
+          __finish_start(startup_reservation)
+        end
       end
 
       # Runs each loaded script library again using a stable registry snapshot.
       #
       # @return [true]
       def Script.reloadlibs
-        @@library_mutex.synchronize { @@loaded_libraries.dup }.each { |library| Script.run(library) }
+        current_library = Script.current&.name&.downcase
+        @@library_mutex.synchronize { @@loaded_libraries.dup }.each do |library|
+          next if library == current_library
+
+          @@library_mutex.synchronize { @@loaded_libraries.delete(library) }
+          Script.loadlib(library)
+        rescue LoadError => e
+          Lich.log("error: failed to reload script library #{library}: #{e.message}")
+        end
         true
       end
 
@@ -662,6 +899,55 @@ module Lich
       def Script.libs
         @@library_mutex.synchronize { @@loaded_libraries.dup }
       end
+
+      def Script.__join_library(library_name, script)
+        caller_script = Script.current
+        @@library_mutex.synchronize do
+          if caller_script
+            if __library_dependency_reaches?(script, caller_script)
+              raise LoadError, "cyclic script library dependency: #{library_name}"
+            end
+            dependencies = @@library_waits[caller_script]
+            dependencies = Set.new(Array(dependencies)) unless dependencies.is_a?(Set)
+            @@library_waits[caller_script] = dependencies
+            dependencies.add(script)
+          end
+        end
+
+        script.join
+      ensure
+        if caller_script
+          @@library_mutex.synchronize do
+            dependencies = @@library_waits[caller_script]
+            if dependencies.is_a?(Set)
+              dependencies.delete(script)
+              @@library_waits.delete(caller_script) if dependencies.empty?
+            elsif dependencies.equal?(script)
+              @@library_waits.delete(caller_script)
+            end
+          end
+        end
+      end
+      private_class_method :__join_library
+
+      def Script.__validate_library_completion(library_name, script)
+        error = script.exit_error
+        raise LoadError, "script library failed: #{library_name}: #{error.message}" if error
+        raise LoadError, "script library did not complete: #{library_name}" unless script.completed_successfully?
+      end
+      private_class_method :__validate_library_completion
+
+      def Script.__library_dependency_reaches?(start, target, visited = Set.new)
+        return true if start.equal?(target)
+        return false unless start
+        return false if visited.include?(start)
+
+        visited.add(start)
+        dependencies = @@library_waits[start]
+        dependencies = dependencies.is_a?(Set) ? dependencies : Array(dependencies)
+        dependencies.any? { |dependency| __library_dependency_reaches?(dependency, target, visited) }
+      end
+      private_class_method :__library_dependency_reaches?
 
       def Script.running?(name)
         @@running.any? { |i| (i.name =~ /^#{name}$/i) }
@@ -761,15 +1047,27 @@ module Lich
           unless script.watchfor.empty?
             script.watchfor.each_pair { |trigger, action|
               if line =~ trigger
-                new_thread = Thread.new {
-                  sleep 0.011 until Script.current
-                  begin
-                    action.call
-                  rescue
-                    echo "watchfor error: #{$!}"
+                start_gate = Queue.new
+                worker_registered = false
+                begin
+                  new_thread = Thread.new {
+                    next unless start_gate.pop
+
+                    sleep 0.011 until Script.current
+                    begin
+                      action.call
+                    rescue
+                      echo "watchfor error: #{$!}"
+                    end
+                  }
+                  worker_registered = script.__send__(:__register_worker, new_thread)
+                ensure
+                  start_gate << worker_registered
+                  unless worker_registered
+                    new_thread&.kill
+                    new_thread&.join
                   end
-                }
-                script.thread_group.add(new_thread)
+                end
               end
             }
           end
@@ -1042,6 +1340,9 @@ module Lich
         @killer_mutex = Mutex.new
         @killed_externally = false
         @kill_source = nil
+        @kill_requested = false
+        @cleanup_started = false
+        @completed_successfully = false
         @ignore_pause = false
         data = nil
         if @file_name =~ /\.gz$/i
@@ -1075,7 +1376,7 @@ module Lich
         data = nil
         @current_label = @label_order[0]
         @thread_group = ThreadGroup.new
-        @@running.push(self)
+        __publish if args.fetch(:publish, true)
         # return self
       end
 
@@ -1097,22 +1398,67 @@ module Lich
       # @param context [Symbol] :runtime for ordinary script stops, :shutdown
       #   when the owning Lich process is closing
       # @return [String] script name
-      def kill(context: :runtime)
+      def kill(context: :runtime, async: nil)
         unless VALID_KILL_CONTEXTS.include?(context)
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
-        @kill_requested = true
+        async = context != :shutdown if async.nil?
+        launch_token = Object.new
+        cleanup_thread = nil
+        cleanup_released = false
+        cleanup_owned = false
+        start_gate = Queue.new if async
         source = @kill_source || caller[0..2]
+        begin
+          start_cleanup = lifecycle_mutex.synchronize do
+            next false unless @@running.include?(self)
+            next false if @cleanup_started
 
-        if context == :shutdown
-          __run_kill_cleanup(source: source, context: context, record_metrics: false)
-        else
-          begin
-            Thread.new { __run_kill_cleanup(source: source, context: context, record_metrics: true) }
-          rescue ThreadError => e
-            __log_kill_thread_fallback(e)
+            @kill_requested = true
+            @cleanup_started = launch_token
+            @cleanup_launch_pending = true
+            @@stopping << self unless @@stopping.include?(self)
+            true
+          end
+          return @name unless start_cleanup
+
+          if async
+            cleanup_thread = Thread.new {
+              start_gate.pop
+              __run_kill_cleanup(source: source, context: context, record_metrics: true)
+            }
+            ThreadGroup::Default.add(cleanup_thread)
+            __attach_startup_worker(cleanup_thread)
+            lifecycle_mutex.synchronize { @cleanup_thread = cleanup_thread }
+            cleanup_owned = true
+            raise ThreadError, 'cleanup thread stopped before ownership transfer' unless cleanup_thread.alive?
+
+            start_gate << true
+            cleanup_released = true
+          else
+            lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
+            cleanup_owned = true
             __run_kill_cleanup(source: source, context: context, record_metrics: false)
+          end
+        rescue ThreadError => e
+          raise unless @cleanup_started.equal?(launch_token)
+
+          cleanup_thread&.kill
+          __log_kill_thread_fallback(e)
+          __run_kill_cleanup(source: source, context: context, record_metrics: false)
+        ensure
+          if async && @cleanup_started.equal?(launch_token) && !cleanup_released
+            start_gate << true
+            unless cleanup_owned && cleanup_thread&.alive?
+              cleanup_thread&.kill
+              __run_kill_cleanup(source: source, context: context, record_metrics: false)
+            end
+          end
+          if @cleanup_started.equal?(launch_token)
+            executor_abandoned = !cleanup_owned || !cleanup_thread&.alive? || cleanup_thread == Thread.current
+            __run_kill_cleanup(source: source, context: context, record_metrics: false) if running? && executor_abandoned
+            lifecycle_mutex.synchronize { @cleanup_launch_pending = false }
           end
         end
 
@@ -1133,6 +1479,10 @@ module Lich
         @kill_requested == true
       end
 
+      def completed_successfully?
+        lifecycle_mutex.synchronize { @completed_successfully == true }
+      end
+
       # Waits for complete script teardown.
       #
       # A script worker cannot join its own script because that worker must
@@ -1147,14 +1497,22 @@ module Lich
         end
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
-        @killer_mutex.synchronize do
-          @stopped_condition ||= ConditionVariable.new
-          while @@running.include?(self)
+        loop do
+          __refresh_deferred_stop
+          completed = lifecycle_mutex.synchronize do
+            @stopped_condition ||= ConditionVariable.new
+            running = @@running.include?(self)
+            return self if !running && Array(@stopping_threads).include?(Thread.current)
+            return self if !running && @cleanup_complete
+
             remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC) if deadline
             return nil if remaining && remaining <= 0
 
-            @stopped_condition.wait(@killer_mutex, remaining)
+            wait_for = running ? remaining : [remaining || 0.01, 0.01].min
+            @stopped_condition.wait(lifecycle_mutex, wait_for)
+            false
           end
+          break if completed
         end
         self
       end
@@ -1176,28 +1534,14 @@ module Lich
       def register_child(script)
         return nil unless script
 
-        script.hidden = true if hidden
-        script.no_kill_all = true if no_kill_all
-        script.no_pause_all = true if no_pause_all
         accepted = child_scripts_mutex.synchronize do
-          unless @child_shutdown_started
-            @child_scripts ||= []
-            @child_scripts << script unless @child_scripts.include?(script)
-            true
-          end
+          __register_child_locked(script)
         end
         unless accepted
-          script.kill_sync if script.running?
+          script.kill_sync(context: :runtime, timeout: CHILD_JOIN_TIMEOUT) if script.running?
           return nil
         end
 
-        begin
-          script.at_exit { unregister_child(script) }
-        rescue NoMethodError
-          # A short-lived child may finish before its exit handler is registered.
-        ensure
-          unregister_child(script) unless script.running?
-        end
         script
       end
 
@@ -1206,7 +1550,7 @@ module Lich
       # @param script [Script] child to remove
       # @return [Script] the removed child
       def unregister_child(script)
-        child_scripts_mutex.synchronize { @child_scripts&.delete(script) }
+        child_scripts_mutex.synchronize { __unregister_child_locked(script) }
         script
       end
 
@@ -1214,7 +1558,9 @@ module Lich
       #
       # @return [Array<Script>]
       def child_scripts
-        child_scripts_mutex.synchronize { Array(@child_scripts).dup }
+        child_scripts_mutex.synchronize do
+          CHILD_RELATIONSHIP_MUTEX.synchronize { Array(@child_scripts).dup }
+        end
       end
 
       # Runs the script cleanup body used by {#kill}.
@@ -1247,23 +1593,28 @@ module Lich
         return if @killer_mutex.owned?
 
         @killer_mutex.synchronize {
+          lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
           if @@running.include?(self)
             instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
             started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
             failed = false
             begin
-              @thread_group.list.dup.each { |t|
-                unless t == Thread.current
-                  t.kill rescue nil
-                end
-              }
+              children = __begin_child_shutdown
+              stopping_threads = lifecycle_mutex.synchronize do
+                @stopping_threads = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+              end
+              stopping_threads.each { |thread| thread.kill rescue nil }
               @thread_group.add(Thread.current)
-              __stop_children(context)
+              __stop_children(children, context)
+              @thread_group.add(Thread.current)
               # Forward the kill context so die_with dependents torn down during
               # shutdown also run inline -- otherwise they route back through the
               # default :runtime path and re-spawn the thread-per-kill burst that
               # inline shutdown teardown exists to avoid.
-              @die_with.each { |script_name| Script.kill(script_name, context: context) }
+              @die_with.each do |script_name|
+                Script.kill(script_name, context: context)
+                @thread_group.add(Thread.current)
+              end
               @paused = false
               @at_exit_procs.each { |p| report_errors { p.call } }
               # Let each per-script-state subsystem (the hook registries, etc.)
@@ -1278,37 +1629,22 @@ module Lich
               # capture). The script is removed from @@running below, so they can
               # never fire again; cleared to {} rather than nil so a concurrent
               # new_downstream sweep still sees a safe, empty collection.
-              @watchfor = {}
-              # Same reasoning for the stream buffers: Script.new_downstream,
-              # new_downstream_xml and new_upstream run on the parser thread and
-              # push to these without a nil guard, and can fire in the window
-              # before the @@running.delete below. Reset to fresh empty buffers
-              # ("no pending lines") rather than nil so a concurrent push cannot
-              # raise NoMethodError. Distinct arrays - never the same object.
-              @downstream_buffer = LimitedArray.new
-              @upstream_buffer = LimitedArray.new
-              @die_with = @at_exit_procs = @match_stack_labels = @match_stack_strings = nil
-              @@running.delete(self)
-              @stopped_condition&.broadcast
-              unless @quiet
-                if @killed_externally
-                  respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
-                else
-                  respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.")
-                end
-              end
             rescue
               failed = true
               respond "--- Lich: error: #{$!}"
               Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
             ensure
-              if instrument_kill
-                finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-                Script.__send__(
-                  :__record_kill_metric,
-                  :duration_ms => (finished_at - started_at) * 1000.0,
-                  :failed      => failed
-                )
+              begin
+                if instrument_kill
+                  finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                  Script.__send__(
+                    :__record_kill_metric,
+                    :duration_ms => (finished_at - started_at) * 1000.0,
+                    :failed      => failed
+                  )
+                end
+              ensure
+                __complete_stop(source, context)
               end
             end
           end
@@ -1316,16 +1652,92 @@ module Lich
       end
       private :__run_kill_cleanup
 
-      def __stop_children(context)
-        children = child_scripts_mutex.synchronize do
-          @child_shutdown_started = true
-          current = Array(@child_scripts).dup
-          @child_scripts = []
-          current
+      def __launch_child
+        child_scripts_mutex.synchronize do
+          return nil if @child_shutdown_started
+
+          yield
         end
+      end
+      private :__launch_child
+
+      def __register_child_locked(script)
+        return nil if @child_shutdown_started
+        script.__send__(:__while_running) do
+          __adopt_child_locked(script)
+        end
+      end
+      private :__register_child_locked
+
+      def __adopt_child_locked(script)
+        return nil if @child_shutdown_started
+
+        CHILD_RELATIONSHIP_MUTEX.synchronize do
+          raise ArgumentError, 'script cannot be its own child' if script.equal?(self)
+
+          ancestor = self
+          while ancestor
+            raise ArgumentError, 'script child relationship would create a cycle' if ancestor.equal?(script)
+
+            ancestor = ancestor.__send__(:__parent_script)
+          end
+          current_parent = script.__send__(:__parent_script)
+          if current_parent && !current_parent.equal?(self)
+            raise ArgumentError, "script already belongs to parent #{current_parent.name}"
+          end
+
+          script.__send__(:__set_parent_script, self)
+          script.hidden = true if hidden
+          script.no_kill_all = true if no_kill_all
+          script.no_pause_all = true if no_pause_all
+          @child_scripts ||= []
+          @child_scripts << script unless @child_scripts.include?(script)
+        end
+        script
+      end
+      private :__adopt_child_locked
+
+      def __unregister_child_locked(script)
+        CHILD_RELATIONSHIP_MUTEX.synchronize do
+          @child_scripts&.delete(script)
+          script.__send__(:__set_parent_script, nil) if script.__send__(:__parent_script).equal?(self)
+        end
+      end
+      private :__unregister_child_locked
+
+      def __begin_child_shutdown
+        children = child_scripts_mutex.synchronize do
+          CHILD_RELATIONSHIP_MUTEX.synchronize do
+            @child_shutdown_started = true
+            Array(@child_scripts).dup
+          end
+        end
+        children
+      end
+      private :__begin_child_shutdown
+
+      def __stop_children(children, context)
+        return if children.empty?
+        # The process-wide shutdown drain already owns every running script.
+        # Recursing here would allocate one cleanup thread per child.
+        return if context == :shutdown
+
         children.each do |child|
-          child.kill(context: context) if child.running?
-          child.join
+          child.kill(context: context, async: true) if child.running?
+        rescue StandardError => e
+          Lich.log("error: failed to stop child script #{child.name}: #{e}") if defined?(Lich) && Lich.respond_to?(:log)
+        ensure
+          @thread_group.add(Thread.current)
+        end
+
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + CHILD_JOIN_TIMEOUT
+        children.each do |child|
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          break if remaining <= 0
+
+          next if child.join(remaining)
+
+          Lich.log("warning: child script #{child.name} did not stop within #{CHILD_JOIN_TIMEOUT}s") if defined?(Lich) && Lich.respond_to?(:log)
         end
       end
       private :__stop_children
@@ -1336,6 +1748,238 @@ module Lich
         CHILD_MUTEX_INITIALIZER.synchronize { @child_scripts_mutex ||= Mutex.new }
       end
       private :child_scripts_mutex
+
+      def lifecycle_mutex
+        return @lifecycle_mutex if @lifecycle_mutex
+
+        LIFECYCLE_MUTEX_INITIALIZER.synchronize { @lifecycle_mutex ||= Mutex.new }
+      end
+      private :lifecycle_mutex
+
+      def __parent_script
+        @parent_script
+      end
+      private :__parent_script
+
+      def __set_parent_script(parent)
+        @parent_script = parent
+      end
+      private :__set_parent_script
+
+      def __record_exit_error(error)
+        lifecycle_mutex.synchronize { @exit_error ||= error }
+      end
+      private :__record_exit_error
+
+      def __record_successful_exit
+        lifecycle_mutex.synchronize { @completed_successfully = true unless @exit_error }
+      end
+      private :__record_successful_exit
+
+      def __register_worker(thread)
+        registration = Object.new
+        tracked_rejection = false
+        accepted = false
+        begin
+          accepted = lifecycle_mutex.synchronize do
+            if @@running.include?(self) && !@kill_requested
+              @thread_group.add(thread)
+              true
+            else
+              @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
+              unless @worker_admission_closed
+                @worker_registrations ||= Set.new
+                @worker_registrations.add(registration)
+                tracked_rejection = true
+              end
+              false
+            end
+          end
+          unless accepted
+            thread.kill
+            thread.join unless thread == Thread.current
+          end
+          accepted
+        rescue StandardError => error
+          thread.kill
+          begin
+            thread.join unless thread == Thread.current
+          rescue StandardError
+            nil
+          end
+          raise error
+        ensure
+          unless accepted
+            thread.kill
+            begin
+              thread.join unless thread == Thread.current
+            rescue StandardError
+              nil
+            end
+          end
+          if tracked_rejection
+            lifecycle_mutex.synchronize do
+              @worker_registrations&.delete(registration)
+              @stopped_condition&.broadcast
+            end
+          end
+        end
+      end
+      private :__register_worker
+
+      def __attach_startup_worker(thread)
+        @thread_group.add(thread)
+        thread
+      end
+      private :__attach_startup_worker
+
+      def __worker_threads
+        @thread_group.list.dup
+      end
+      private :__worker_threads
+
+      def __publish(admitted = false)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+        end
+        self
+      end
+      private :__publish
+
+      def __while_running
+        lifecycle_mutex.synchronize do
+          return nil unless @@running.include?(self) && !stopping?
+
+          yield
+        end
+      end
+      private :__while_running
+
+      def __discard_startup
+        parent = nil
+        lifecycle_mutex.synchronize do
+          @@running.delete(self)
+          @@stopping.delete(self)
+          @worker_admission_closed = true
+          @cleanup_complete = true
+          CHILD_RELATIONSHIP_MUTEX.synchronize do
+            parent = @parent_script
+            @parent_script = nil
+          end
+          @stopped_condition&.broadcast
+        end
+        parent&.unregister_child(self)
+        self
+      end
+      private :__discard_startup
+
+      def __complete_stop(source, context)
+        begin
+          @watchfor = {}
+          @downstream_buffer = LimitedArray.new
+          @upstream_buffer = LimitedArray.new
+          @die_with = @at_exit_procs = @match_stack_labels = @match_stack_strings = nil
+          unless @quiet
+            if @killed_externally
+              respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
+            else
+              respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} has exited.")
+            end
+          end
+        ensure
+          lifecycle_mutex.synchronize do
+            late_workers = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+            @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
+            late_workers.each { |thread| thread.kill rescue nil }
+            @@running.delete(self)
+            @stopped_condition&.broadcast
+          end
+          workers_stopped = __wait_for_worker_shutdown(:wait => context != :shutdown)
+          __finalize_stop if workers_stopped
+        end
+      end
+      private :__complete_stop
+
+      def __wait_for_worker_shutdown(wait:)
+        loop do
+          workers = lifecycle_mutex.synchronize do
+            current_workers = @thread_group.list.dup
+            @stopping_threads = (Array(@stopping_threads) + current_workers).uniq
+            @stopping_threads.reject { |thread| thread == Thread.current || thread == @cleanup_thread || !thread.alive? }
+          end
+          if workers.empty?
+            done = lifecycle_mutex.synchronize do
+              if !@worker_registrations || @worker_registrations.empty?
+                @worker_admission_closed = true
+                true
+              elsif !wait
+                false
+              else
+                @stopped_condition ||= ConditionVariable.new
+                @stopped_condition.wait(lifecycle_mutex)
+                nil
+              end
+            end
+            return true if done
+            return false if done == false
+
+            next
+          end
+
+          workers.each { |thread| thread.kill rescue nil }
+          return false unless wait
+
+          workers.each do |thread|
+            thread.join
+          rescue StandardError => e
+            __record_exit_error(e)
+            Lich.log("error: worker shutdown failed for #{@name}: #{e.class}: #{e.message}") if defined?(Lich) && Lich.respond_to?(:log)
+          end
+        end
+      end
+      private :__wait_for_worker_shutdown
+
+      def __refresh_deferred_stop
+        abandoned_cleanup = lifecycle_mutex.synchronize do
+          if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
+             (!@cleanup_thread || !@cleanup_thread.alive?)
+            @cleanup_started = false
+            @cleanup_thread = nil
+            true
+          end
+        end
+        kill(:context => :shutdown) if abandoned_cleanup
+
+        should_refresh = lifecycle_mutex.synchronize do
+          cleanup_active_elsewhere = @cleanup_thread&.alive? && @cleanup_thread != Thread.current
+          @cleanup_started && !@cleanup_complete && !@@running.include?(self) && !cleanup_active_elsewhere
+        end
+        __finalize_stop if should_refresh && __wait_for_worker_shutdown(:wait => false)
+      end
+      private :__refresh_deferred_stop
+
+      def __finalize_stop
+        claimed = lifecycle_mutex.synchronize do
+          next false if @cleanup_complete || @finalization_started
+
+          @finalization_started = true
+        end
+        return unless claimed
+
+        parent = nil
+        begin
+          CHILD_RELATIONSHIP_MUTEX.synchronize { parent = @parent_script }
+          parent&.unregister_child(self)
+          CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
+        ensure
+          lifecycle_mutex.synchronize do
+            @cleanup_complete = true
+            @@stopping.delete(self)
+            @stopped_condition&.broadcast
+          end
+        end
+      end
+      private :__finalize_stop
 
       # Logs when {#kill} cannot allocate its normal cleanup thread.
       #
@@ -1382,7 +2026,7 @@ module Lich
       end
 
       def thread_group
-        @thread_group
+        @thread_group_handle ||= ThreadGroupHandle.new(self)
       end
 
       def has_thread?(t)
@@ -1520,38 +2164,82 @@ module Lich
       def SubScript.start(parent: Script.current, quiet: true, &block)
         raise ArgumentError, 'a block is required' unless block
 
-        new_script = SubScript.new(:quiet => quiet)
-        return false if parent && !parent.register_child(new_script)
+        startup_reservation = Object.new
+        begin
+          startup_status = Script.__send__(:__begin_start, startup_reservation)
+          return false if startup_status == :shutdown
 
-        new_thread = Thread.new {
-          100.times { break if Script.current == new_script; sleep 0.01 }
-
-          if (script = Script.current)
-            Thread.current.priority = 1
-            respond("--- Lich: #{script.name} active.") unless script.quiet
+          starter = proc do
+            new_script = SubScript.new(:quiet => quiet, :publish => false)
+            start_gate = Queue.new
+            setup_complete = false
+            worker_released = false
             begin
-              block.call
-            rescue SystemExit
-              nil
-            rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => e
-              respond "--- Lich error: #{e}"
-              respond e.backtrace.first
-              Lich.log "Exception: #{e}\n\t#{e.backtrace.join("\n\t")}"
+              new_thread = Thread.new {
+                next unless start_gate.pop
+
+                if (script = Script.current)
+                  begin
+                    Thread.current.priority = 1
+                    respond("--- Lich: #{script.name} active.") unless script.quiet
+                    block.call
+                    script.__send__(:__record_successful_exit)
+                  rescue SystemExit => e
+                    if e.success?
+                      script.__send__(:__record_successful_exit)
+                    else
+                      script.__send__(:__record_exit_error, e)
+                    end
+                  rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => e
+                    script.__send__(:__record_exit_error, e)
+                    respond "--- Lich error: #{e}"
+                    respond e.backtrace.first
+                    Lich.log "Exception: #{e}\n\t#{e.backtrace.join("\n\t")}"
+                  ensure
+                    script.kill if script.running? && !script.stopping?
+                  end
+                else
+                  respond '--- Lich: failed to start subscript'
+                end
+              }
+              new_script.__send__(:__attach_startup_worker, new_thread)
+              if parent && !parent.__send__(:__adopt_child_locked, new_script)
+                new_thread&.kill
+                new_script.__send__(:__discard_startup)
+                next false
+              end
+              new_script.__send__(:__publish, true)
+              setup_complete = true
             ensure
-              script.kill if script.running? && !script.stopping?
+              begin
+                start_gate << setup_complete
+                worker_released = true
+              ensure
+                unless setup_complete && worker_released
+                  new_thread&.kill
+                  new_thread&.join
+                  parent.__send__(:__unregister_child_locked, new_script) if parent
+                  new_script.__send__(:__discard_startup)
+                end
+              end
             end
-          else
-            respond '--- Lich: failed to start subscript'
+            new_script
           end
-        }
-        new_script.thread_group.add(new_thread)
-        new_script
+
+          if parent
+            parent.__send__(:__launch_child, &starter)
+          else
+            starter.call
+          end
+        ensure
+          Script.__send__(:__finish_start, startup_reservation)
+        end
       end
 
       # SubScript has no source file or eval string, so it initializes only the
       # runtime state shared by ordinary scripts.
       # rubocop:disable Lint/MissingSuper
-      def initialize(quiet: true)
+      def initialize(quiet: true, publish: true)
         @custom = false
         @vars = []
         @downstream_buffer = LimitedArray.new
@@ -1580,14 +2268,26 @@ module Lich
         @killed_externally = false
         @kill_source = nil
         @kill_requested = false
+        @cleanup_started = false
+        @completed_successfully = false
         @ignore_pause = false
-        @@name_subscript_mutex.synchronize do
-          num = '1'
-          num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
-          @name = "subscript#{num}"
-          @@running.push(self)
-        end
+        __publish if publish
       end
+
+      def __publish(admitted = false)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          @@name_subscript_mutex.synchronize do
+            lifecycle_mutex.synchronize do
+              num = '1'
+              num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
+              @name = "subscript#{num}"
+              @@running.push(self)
+            end
+          end
+        end
+        self
+      end
+      private :__publish
       # rubocop:enable Lint/MissingSuper
     end
 
@@ -1597,71 +2297,108 @@ module Lich
 
       def ExecScript.start(cmd_data, options = {})
         options = { :quiet => true } if options == true
-        unless (new_script = ExecScript.new(cmd_data, options))
-          respond '--- Lich: failed to start exec script'
-          return false
-        end
-        new_thread = Thread.new {
-          100.times { break if Script.current == new_script; sleep 0.01 }
+        startup_reservation = Object.new
+        begin
+          startup_status = Script.__send__(:__begin_start, startup_reservation)
+          return false if startup_status == :shutdown
 
-          if (script = Script.current)
-            Thread.current.priority = 1
-            respond("--- Lich: #{script.name} active.") unless script.quiet
+          new_script = ExecScript.new(cmd_data, options.merge(:publish => false))
+          start_gate = Queue.new
+          setup_complete = false
+          worker_released = false
+          begin
+            new_thread = Thread.new {
+              next unless start_gate.pop
+
+              if (script = Script.current)
+                Thread.current.priority = 1
+                respond("--- Lich: #{script.name} active.") unless script.quiet
+                begin
+                  script_binding = TRUSTED_SCRIPT_BINDING.call
+                  eval('script = Script.current', script_binding, script.name.to_s)
+                  eval(cmd_data, script_binding, script.name.to_s)
+                  script.__send__(:__record_successful_exit)
+                  script.kill if script.running? && !script.stopping?
+                rescue SystemExit => e
+                  if e.success?
+                    script.__send__(:__record_successful_exit)
+                  else
+                    script.__send__(:__record_exit_error, e)
+                  end
+                  script.kill if script.running? && !script.stopping?
+                rescue SyntaxError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- SyntaxError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "SyntaxError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue ScriptError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- ScriptError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "ScriptError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue NoMemoryError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- NoMemoryError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "NoMemoryError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue LoadError
+                  script.__send__(:__record_exit_error, $!)
+                  respond("--- LoadError: #{$!}")
+                  respond "--- LoadError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "LoadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue SecurityError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- SecurityError: #{$!}"
+                  respond $!.backtrace[0..1]
+                  Lich.log "SecurityError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue ThreadError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- ThreadError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "ThreadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue SystemStackError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- SystemStackError: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "SystemStackError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                rescue StandardError
+                  script.__send__(:__record_exit_error, $!)
+                  respond "--- Lich error: #{$!}"
+                  respond $!.backtrace.first
+                  Lich.log "Exception: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+                  script.kill if script.running? && !script.stopping?
+                end
+              else
+                respond 'start_exec_script screwed up...'
+              end
+            }
+            new_script.__send__(:__attach_startup_worker, new_thread)
+            new_script.__send__(:__publish, true)
+            setup_complete = true
+          ensure
             begin
-              script_binding = TRUSTED_SCRIPT_BINDING.call
-              eval('script = Script.current', script_binding, script.name.to_s)
-              eval(cmd_data, script_binding, script.name.to_s)
-              Script.current.kill
-            rescue SystemExit
-              Script.current.kill
-            rescue SyntaxError
-              respond "--- SyntaxError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "SyntaxError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue ScriptError
-              respond "--- ScriptError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "ScriptError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue NoMemoryError
-              respond "--- NoMemoryError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "NoMemoryError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue LoadError
-              respond("--- LoadError: #{$!}")
-              respond "--- LoadError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "LoadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue SecurityError
-              respond "--- SecurityError: #{$!}"
-              respond $!.backtrace[0..1]
-              Lich.log "SecurityError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue ThreadError
-              respond "--- ThreadError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "ThreadError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue SystemStackError
-              respond "--- SystemStackError: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "SystemStackError: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
-            rescue StandardError
-              respond "--- Lich error: #{$!}"
-              respond $!.backtrace.first
-              Lich.log "Exception: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-              Script.current.kill
+              start_gate << setup_complete
+              worker_released = true
+            ensure
+              unless setup_complete && worker_released
+                new_thread&.kill
+                new_thread&.join
+                new_script.__send__(:__discard_startup)
+              end
             end
-          else
-            respond 'start_exec_script screwed up...'
           end
-        }
-        new_script.thread_group.add(new_thread)
-        new_script
+          new_script
+        ensure
+          Script.__send__(:__finish_start, startup_reservation)
+        end
       end
 
       # FIXME: when modernized, ensure proper use of variables and init of parent class
@@ -1696,16 +2433,31 @@ module Lich
         @no_kill_all = false
         @match_stack_labels = Array.new
         @match_stack_strings = Array.new
-        if flags[:name].nil?
-          num = '1'; num.succ! while @@running.any? { |s| s.name == "exec#{num}" }
-          @name = "exec#{num}"
-        else
-          num = '1'; num.succ! while @@running.any? { |s| s.name == "#{flags[:name]}#{num}" }
-          @name = "#{flags[:name]}#{num}"
-        end
-        @@running.push(self)
+        @name_prefix = flags[:name] || 'exec'
+        @killed_externally = false
+        @kill_source = nil
+        @kill_requested = false
+        @cleanup_started = false
+        @completed_successfully = false
+        @ignore_pause = false
+        __publish if flags.fetch(:publish, true)
       end
       # rubocop:enable Lint/MissingSuper
+
+      def __publish(admitted = false)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          @@name_exec_mutex.synchronize do
+            lifecycle_mutex.synchronize do
+              num = '1'
+              num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
+              @name = "#{@name_prefix}#{num}"
+              @@running.push(self)
+            end
+          end
+        end
+        self
+      end
+      private :__publish
 
       def get_next_label
         echo 'goto labels are not available in exec scripts.'
@@ -1718,7 +2470,7 @@ module Lich
       # rubocop:disable Lint/MissingSuper
       # rubocop:disable Lint/UselessAssignment
       # rubocop:disable Lint/InterpolationCheck
-      def initialize(file_name, cli_vars = [])
+      def initialize(file_name, cli_vars = [], publish = true)
         @name = /.*[\/\\]+([^\.]+)\./.match(file_name).captures.first
         @file_name = file_name
         @vars = Array.new
@@ -1921,7 +2673,7 @@ module Lich
         data = nil
         @current_label = @label_order[0]
         @thread_group = ThreadGroup.new
-        @@running.push(self)
+        __publish if publish
         # return self
       end
       # rubocop:enable Lint/InterpolationCheck

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -753,7 +753,7 @@ module Lich
           name, generation = @@startup_reservations.delete(reservation)
           if name&.start_with?('lib')
             current_generation = __completed_start_generation(@@completed_named_starts[name])
-            if generation.nil? || generation >= current_generation
+            if generation && generation >= current_generation
               @@completed_named_starts.delete(name)
               if script
                 completed = if @@completed_start_waiters[name].positive?
@@ -911,24 +911,24 @@ module Lich
           startup_status, completed_start = __begin_library_start(startup_reservation, library_name)
           raise LoadError, "cannot load script library during shutdown: #{library_name}" if startup_status == :shutdown
 
-          script, already_loaded, owns_loading, started_here = @@library_mutex.synchronize do
+          script, already_loaded, owns_loading = @@library_mutex.synchronize do
             running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
             if (loading = @@loading_libraries[library_name])
-              [loading, false, false, false]
+              [loading, false, false]
             elsif (candidate = completed_start || running)
               @@loading_libraries[library_name] = candidate
-              [candidate, false, true, false]
+              [candidate, false, true]
             elsif @@loaded_libraries.include?(library_name)
-              [nil, true, false, false]
+              [nil, true, false]
             else
               started = Script.start(library_name, { :force => true })
               raise LoadError, "failed to start script library: #{library_name}" unless started
 
               @@loading_libraries[library_name] = started
-              [started, false, true, true]
+              [started, false, true]
             end
           end
-          __discard_completed_start(library_name, script) if started_here
+          __discard_completed_start(library_name, script) if script
           return true if already_loaded
 
           __finish_start(startup_reservation)

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -755,13 +755,10 @@ module Lich
             current_generation = __completed_start_generation(@@completed_named_starts[name])
             if generation && generation >= current_generation
               @@completed_named_starts.delete(name)
-              if script
-                completed = if @@completed_start_waiters[name].positive?
-                              script
-                            else
-                              WeakRef.new(script)
-                            end
-                @@completed_named_starts[name] = [generation, completed]
+              handoff_expected = @@completed_start_waiters[name].positive? ||
+                                 __library_handoff_reserved_locked?(name)
+              if script && handoff_expected
+                @@completed_named_starts[name] = [generation, script]
               end
             end
           end
@@ -807,6 +804,13 @@ module Lich
         @@startup_reservations.any? { |_reservation, (reserved_name, _generation)| reserved_name == name }
       end
       private_class_method :__startup_in_progress_locked?
+
+      def Script.__library_handoff_reserved_locked?(name)
+        @@startup_reservations.any? do |_reservation, (reserved_name, generation)|
+          reserved_name == name && generation.nil?
+        end
+      end
+      private_class_method :__library_handoff_reserved_locked?
 
       # Starts an anonymous child script owned by the current script.
       #

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -7,6 +7,7 @@
 # also, don't put 'untrusted' in the name of the untrusted binding; it shows up in error messages and makes people think the error is caused by not trusting the script
 #
 
+require 'weakref'
 require_relative 'script_death'
 
 module Lich
@@ -378,6 +379,7 @@ module Lich
       @@startup_condition = ConditionVariable.new
       @@startup_reservations = {}
       @@completed_named_starts = {}
+      @@completed_start_waiters = Hash.new(0)
       @@shutdown_started = false
       @@library_mutex = Mutex.new
       @@loaded_libraries = Set.new
@@ -670,9 +672,9 @@ module Lich
         @@startup_mutex.synchronize do
           return :shutdown if @@shutdown_started
           if normalized_name && !force
-            running = @@running.any? { |script| script.name.casecmp?(normalized_name) }
+            active = (@@running + @@stopping).any? { |script| script.name.casecmp?(normalized_name) }
             starting = @@startup_reservations.value?(normalized_name)
-            return :duplicate if running || starting
+            return :duplicate if active || starting
           end
 
           @@startup_reservations[reservation] = normalized_name
@@ -686,7 +688,14 @@ module Lich
           name = @@startup_reservations.delete(reservation)
           if name&.start_with?('lib')
             @@completed_named_starts.delete(name)
-            @@completed_named_starts[name] = script if script
+            if script
+              @@completed_named_starts[name] =
+                if @@completed_start_waiters[name].positive?
+                  script
+                else
+                  WeakRef.new(script)
+                end
+            end
           end
           @@startup_condition.broadcast
         end
@@ -705,10 +714,19 @@ module Lich
       def Script.__take_completed_start(name)
         normalized_name = name.downcase
         @@startup_mutex.synchronize do
-          while @@startup_reservations.value?(normalized_name)
-            @@startup_condition.wait(@@startup_mutex)
+          @@completed_start_waiters[normalized_name] += 1
+          begin
+            while @@startup_reservations.value?(normalized_name)
+              @@startup_condition.wait(@@startup_mutex)
+            end
+            __completed_start_value(@@completed_named_starts[normalized_name])
+          ensure
+            @@completed_start_waiters[normalized_name] -= 1
+            if @@completed_start_waiters[normalized_name].zero?
+              @@completed_start_waiters.delete(normalized_name)
+              @@completed_named_starts.delete(normalized_name)
+            end
           end
-          @@completed_named_starts.delete(normalized_name)
         end
       end
       private_class_method :__take_completed_start
@@ -716,10 +734,18 @@ module Lich
       def Script.__discard_completed_start(name, script)
         normalized_name = name.downcase
         @@startup_mutex.synchronize do
-          @@completed_named_starts.delete(normalized_name) if @@completed_named_starts[normalized_name].equal?(script)
+          completed = __completed_start_value(@@completed_named_starts[normalized_name])
+          @@completed_named_starts.delete(normalized_name) if completed.equal?(script)
         end
       end
       private_class_method :__discard_completed_start
+
+      def Script.__completed_start_value(entry)
+        entry.is_a?(WeakRef) ? entry.__getobj__ : entry
+      rescue WeakRef::RefError
+        nil
+      end
+      private_class_method :__completed_start_value
 
       # Starts an anonymous child script owned by the current script.
       #

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -31,13 +31,23 @@ module Lich
       CHILD_RELATIONSHIP_MUTEX = Mutex.new
       LIFECYCLE_MUTEX_INITIALIZER = Mutex.new
       CHILD_JOIN_TIMEOUT = 1.0
+      RAW_THREAD_GROUP_ADD = ThreadGroup.instance_method(:add)
+      RAW_THREAD_GROUP_LIST = ThreadGroup.instance_method(:list)
+      RAW_THREAD_GROUP_ENCLOSE = ThreadGroup.instance_method(:enclose)
+      RAW_THREAD_GROUP_ENCLOSED = ThreadGroup.instance_method(:enclosed?)
 
-      class ThreadGroupHandle
-        def initialize(script)
+      module ThreadGroupHandle
+        def __attach_script(script)
           @script = script
+          self
         end
+        private :__attach_script
 
         def add(thread)
+          unless thread.is_a?(Thread)
+            raise TypeError, "wrong argument type #{thread.class} (expected VM/thread)"
+          end
+
           accepted = @script.__send__(:__register_worker, thread)
           raise ThreadError, 'cannot add a worker to a stopping script' unless accepted
 
@@ -45,7 +55,16 @@ module Lich
         end
 
         def list
-          @script.__send__(:__worker_threads)
+          @script.__send__(:__public_worker_threads)
+        end
+
+        def enclose
+          @script.__send__(:__enclose_worker_group)
+          self
+        end
+
+        def enclosed?
+          @script.__send__(:__worker_group_enclosed?)
         end
       end
 
@@ -672,7 +691,7 @@ module Lich
         @@startup_mutex.synchronize do
           return :shutdown if @@shutdown_started
           if normalized_name && !force
-            active = (@@running + @@stopping).any? { |script| script.name.casecmp?(normalized_name) }
+            active = __active_named_script(normalized_name)
             starting = @@startup_reservations.value?(normalized_name)
             return :duplicate if active || starting
           end
@@ -682,6 +701,50 @@ module Lich
         end
       end
       private_class_method :__begin_start
+
+      def Script.__begin_library_start(reservation, name)
+        normalized_name = name.downcase
+        @@startup_mutex.synchronize do
+          return [:shutdown, nil] if @@shutdown_started
+
+          unless @@startup_reservations.value?(normalized_name)
+            completed = __completed_start_value(@@completed_named_starts[normalized_name])
+            active = __active_named_script(normalized_name)
+            @@startup_reservations[reservation] = normalized_name
+            candidate = completed || active
+            return [candidate ? :duplicate : :admitted, candidate]
+          end
+
+          @@completed_start_waiters[normalized_name] += 1
+          begin
+            while @@startup_reservations.value?(normalized_name)
+              @@startup_condition.wait(@@startup_mutex)
+            end
+            completed = __completed_start_value(@@completed_named_starts[normalized_name])
+            active = __active_named_script(normalized_name)
+            @@startup_reservations[reservation] = normalized_name
+            candidate = completed || active
+            [candidate ? :duplicate : :admitted, candidate]
+          ensure
+            @@completed_start_waiters[normalized_name] -= 1
+            if @@completed_start_waiters[normalized_name].zero?
+              @@completed_start_waiters.delete(normalized_name)
+              @@completed_named_starts.delete(normalized_name)
+            end
+          end
+        end
+      end
+      private_class_method :__begin_library_start
+
+      def Script.__active_named_script(name)
+        running = @@running.dup.find { |script| script.name.casecmp?(name) }
+        return running if running
+
+        @@stopping.dup.find do |script|
+          script.name.casecmp?(name) && !script.__send__(:__cleanup_complete?)
+        end
+      end
+      private_class_method :__active_named_script
 
       def Script.__finish_start(reservation, script = nil)
         @@startup_mutex.synchronize do
@@ -710,26 +773,6 @@ module Lich
         end
       end
       private_class_method :__publish_to_registry
-
-      def Script.__take_completed_start(name)
-        normalized_name = name.downcase
-        @@startup_mutex.synchronize do
-          @@completed_start_waiters[normalized_name] += 1
-          begin
-            while @@startup_reservations.value?(normalized_name)
-              @@startup_condition.wait(@@startup_mutex)
-            end
-            __completed_start_value(@@completed_named_starts[normalized_name])
-          ensure
-            @@completed_start_waiters[normalized_name] -= 1
-            if @@completed_start_waiters[normalized_name].zero?
-              @@completed_start_waiters.delete(normalized_name)
-              @@completed_named_starts.delete(normalized_name)
-            end
-          end
-        end
-      end
-      private_class_method :__take_completed_start
 
       def Script.__discard_completed_start(name, script)
         normalized_name = name.downcase
@@ -847,10 +890,9 @@ module Lich
 
         startup_reservation = Object.new
         begin
-          startup_status = __begin_start(startup_reservation, library_name, :force => false)
+          startup_status, completed_start = __begin_library_start(startup_reservation, library_name)
           raise LoadError, "cannot load script library during shutdown: #{library_name}" if startup_status == :shutdown
 
-          completed_start = __take_completed_start(library_name) if startup_status == :duplicate
           script, already_loaded, owns_loading, started_here = @@library_mutex.synchronize do
             running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
             if (loading = @@loading_libraries[library_name])
@@ -1627,19 +1669,19 @@ module Lich
             begin
               children = __begin_child_shutdown
               stopping_threads = lifecycle_mutex.synchronize do
-                @stopping_threads = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+                @stopping_threads = __raw_worker_threads.reject { |thread| thread == Thread.current }
               end
               stopping_threads.each { |thread| thread.kill rescue nil }
-              @thread_group.add(Thread.current)
+              __raw_add_worker(Thread.current)
               __stop_children(children, context)
-              @thread_group.add(Thread.current)
+              __raw_add_worker(Thread.current)
               # Forward the kill context so die_with dependents torn down during
               # shutdown also run inline -- otherwise they route back through the
               # default :runtime path and re-spawn the thread-per-kill burst that
               # inline shutdown teardown exists to avoid.
               @die_with.each do |script_name|
                 Script.kill(script_name, context: context)
-                @thread_group.add(Thread.current)
+                __raw_add_worker(Thread.current)
               end
               @paused = false
               @at_exit_procs.each { |p| report_errors { p.call } }
@@ -1753,7 +1795,7 @@ module Lich
         rescue StandardError => e
           Lich.log("error: failed to stop child script #{child.name}: #{e}") if defined?(Lich) && Lich.respond_to?(:log)
         ensure
-          @thread_group.add(Thread.current)
+          __raw_add_worker(Thread.current)
         end
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + CHILD_JOIN_TIMEOUT
@@ -1809,7 +1851,7 @@ module Lich
         begin
           accepted = lifecycle_mutex.synchronize do
             if @@running.include?(self) && !@kill_requested
-              @thread_group.add(thread)
+              __raw_add_worker(thread)
               true
             else
               @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
@@ -1854,15 +1896,48 @@ module Lich
       private :__register_worker
 
       def __attach_startup_worker(thread)
-        @thread_group.add(thread)
+        __raw_add_worker(thread)
         thread
       end
       private :__attach_startup_worker
 
+      def __raw_add_worker(thread)
+        RAW_THREAD_GROUP_ADD.bind_call(@thread_group, thread)
+      end
+      private :__raw_add_worker
+
+      def __raw_worker_threads
+        RAW_THREAD_GROUP_LIST.bind_call(@thread_group).dup
+      end
+      private :__raw_worker_threads
+
       def __worker_threads
-        @thread_group.list.dup
+        __raw_worker_threads
       end
       private :__worker_threads
+
+      def __public_worker_threads
+        __raw_worker_threads
+      end
+      private :__public_worker_threads
+
+      def __enclose_worker_group
+        lifecycle_mutex.synchronize { RAW_THREAD_GROUP_ENCLOSE.bind_call(@thread_group) }
+        self
+      end
+      private :__enclose_worker_group
+
+      def __worker_group_enclosed?
+        lifecycle_mutex.synchronize { RAW_THREAD_GROUP_ENCLOSED.bind_call(@thread_group) }
+      end
+      private :__worker_group_enclosed?
+
+      def __managed_thread_group
+        lifecycle_mutex.synchronize do
+          @thread_group.extend(ThreadGroupHandle).__send__(:__attach_script, self)
+        end
+      end
+      private :__managed_thread_group
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
@@ -1914,7 +1989,7 @@ module Lich
           end
         ensure
           lifecycle_mutex.synchronize do
-            late_workers = @thread_group.list.dup.reject { |thread| thread == Thread.current }
+            late_workers = __raw_worker_threads.reject { |thread| thread == Thread.current }
             @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
             late_workers.each { |thread| thread.kill rescue nil }
             @@running.delete(self)
@@ -1929,7 +2004,7 @@ module Lich
       def __wait_for_worker_shutdown(wait:)
         loop do
           workers = lifecycle_mutex.synchronize do
-            current_workers = @thread_group.list.dup
+            current_workers = __raw_worker_threads
             @stopping_threads = (Array(@stopping_threads) + current_workers).uniq
             @stopping_threads.reject { |thread| thread == Thread.current || thread == @cleanup_thread || !thread.alive? }
           end
@@ -1983,6 +2058,11 @@ module Lich
         __finalize_stop if should_refresh && __wait_for_worker_shutdown(:wait => false)
       end
       private :__refresh_deferred_stop
+
+      def __cleanup_complete?
+        lifecycle_mutex.synchronize { @cleanup_complete == true }
+      end
+      private :__cleanup_complete?
 
       def __finalize_stop
         claimed = lifecycle_mutex.synchronize do
@@ -2052,11 +2132,11 @@ module Lich
       end
 
       def thread_group
-        @thread_group_handle ||= ThreadGroupHandle.new(self)
+        __managed_thread_group
       end
 
       def has_thread?(t)
-        @thread_group.list.include?(t)
+        __raw_worker_threads.include?(t)
       end
 
       def pause
@@ -2186,7 +2266,8 @@ module Lich
       # @param parent [Script, nil] owning script
       # @param quiet [Boolean] suppress lifecycle messages
       # @yield block executed by the new script
-      # @return [SubScript, false] the new script, or false when adoption fails
+      # @return [SubScript, false] the new script, or false when startup
+      #   admission is closed or the parent refuses adoption
       def SubScript.start(parent: Script.current, quiet: true, &block)
         raise ArgumentError, 'a block is required' unless block
 
@@ -2253,7 +2334,7 @@ module Lich
           end
 
           if parent
-            parent.__send__(:__launch_child, &starter)
+            parent.__send__(:__launch_child, &starter) || false
           else
             starter.call
           end

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -397,6 +397,7 @@ module Lich
       @@startup_mutex = Mutex.new
       @@startup_condition = ConditionVariable.new
       @@startup_reservations = {}
+      @@startup_generation = 0
       @@completed_named_starts = {}
       @@completed_start_waiters = Hash.new(0)
       @@shutdown_started = false
@@ -692,11 +693,12 @@ module Lich
           return :shutdown if @@shutdown_started
           if normalized_name && !force
             active = __active_named_script(normalized_name)
-            starting = @@startup_reservations.value?(normalized_name)
+            starting = __startup_in_progress_locked?(normalized_name)
             return :duplicate if active || starting
           end
 
-          @@startup_reservations[reservation] = normalized_name
+          @@startup_generation += 1
+          @@startup_reservations[reservation] = [normalized_name, @@startup_generation]
           :admitted
         end
       end
@@ -707,22 +709,22 @@ module Lich
         @@startup_mutex.synchronize do
           return [:shutdown, nil] if @@shutdown_started
 
-          unless @@startup_reservations.value?(normalized_name)
+          unless __startup_in_progress_locked?(normalized_name)
             completed = __completed_start_value(@@completed_named_starts[normalized_name])
             active = __active_named_script(normalized_name)
-            @@startup_reservations[reservation] = normalized_name
+            @@startup_reservations[reservation] = [normalized_name, nil]
             candidate = completed || active
             return [candidate ? :duplicate : :admitted, candidate]
           end
 
           @@completed_start_waiters[normalized_name] += 1
           begin
-            while @@startup_reservations.value?(normalized_name)
+            while __startup_in_progress_locked?(normalized_name)
               @@startup_condition.wait(@@startup_mutex)
             end
             completed = __completed_start_value(@@completed_named_starts[normalized_name])
             active = __active_named_script(normalized_name)
-            @@startup_reservations[reservation] = normalized_name
+            @@startup_reservations[reservation] = [normalized_name, nil]
             candidate = completed || active
             [candidate ? :duplicate : :admitted, candidate]
           ensure
@@ -748,16 +750,19 @@ module Lich
 
       def Script.__finish_start(reservation, script = nil)
         @@startup_mutex.synchronize do
-          name = @@startup_reservations.delete(reservation)
+          name, generation = @@startup_reservations.delete(reservation)
           if name&.start_with?('lib')
-            @@completed_named_starts.delete(name)
-            if script
-              @@completed_named_starts[name] =
-                if @@completed_start_waiters[name].positive?
-                  script
-                else
-                  WeakRef.new(script)
-                end
+            current_generation = __completed_start_generation(@@completed_named_starts[name])
+            if generation.nil? || generation >= current_generation
+              @@completed_named_starts.delete(name)
+              if script
+                completed = if @@completed_start_waiters[name].positive?
+                              script
+                            else
+                              WeakRef.new(script)
+                            end
+                @@completed_named_starts[name] = [generation, completed]
+              end
             end
           end
           @@startup_condition.broadcast
@@ -784,11 +789,24 @@ module Lich
       private_class_method :__discard_completed_start
 
       def Script.__completed_start_value(entry)
+        entry = entry[1] if entry.is_a?(Array) && entry.first.is_a?(Integer)
         entry.is_a?(WeakRef) ? entry.__getobj__ : entry
       rescue WeakRef::RefError
         nil
       end
       private_class_method :__completed_start_value
+
+      def Script.__completed_start_generation(entry)
+        return entry.first if entry.is_a?(Array) && entry.first.is_a?(Integer)
+
+        0
+      end
+      private_class_method :__completed_start_generation
+
+      def Script.__startup_in_progress_locked?(name)
+        @@startup_reservations.any? { |_reservation, (reserved_name, _generation)| reserved_name == name }
+      end
+      private_class_method :__startup_in_progress_locked?
 
       # Starts an anonymous child script owned by the current script.
       #

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -10,7 +10,7 @@ require_relative '../../../lib/common/downstreamhook'
 require_relative '../../../lib/common/upstreamhook'
 
 RSpec.describe 'Lich::Common::Script kill metrics' do
-  let(:thread_group) { instance_double(ThreadGroup, list: [], add: true) }
+  let(:thread_group) { ThreadGroup.new }
   let(:script_class) { Lich::Common::Script }
 
   before(:context) do

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../spec_helper'
+require_relative '../../../lib/common/limitedarray'
 require_relative '../../../lib/common/feature_flags'
 # Load the real hook classes so Script's kill cleanup resolves them
 # deterministically (rather than the top-level spec_helper mocks), letting us
@@ -25,6 +26,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
 
   before do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
     script_class.class_variable_set(:@@kill_metrics, {
       :minute            => nil,
       :runtime_stops     => 0,
@@ -44,12 +46,12 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
     Lich::Common::UpstreamHook.class_variable_set(:@@upstream_hook_persist, {})
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
-    allow(Thread).to receive(:new) { |&block| block.call; instance_double(Thread) }
     allow(GC).to receive(:start)
   end
 
   after do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
   end
 
   describe '#kill' do
@@ -58,6 +60,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [script])
 
       expect(script.kill).to eq('metric-target')
+      script.join
 
       expect(script_class.list).to be_empty
       expect(GC).not_to have_received(:start)
@@ -88,6 +91,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [script])
 
       script.kill
+      script.join
 
       # The dying script's hooks are gone; a hook owned by another instance survives.
       expect(Lich::Common::DownstreamHook.list).to contain_exactly('keep')
@@ -134,7 +138,9 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
 
       first.kill
+      first.join
       second.kill
+      second.join
 
       expect(Lich).to have_received(:log).with(
         'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=25.00 max_ms=25.00 failures=0'
@@ -151,7 +157,9 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
 
       first.kill
+      first.join
       second.kill
+      second.join
 
       expect(Lich).to have_received(:log).with(
         'debug: script kill metrics runtime_stops_last_minute=1 avg_ms=25.00 max_ms=25.00 failures=1'

--- a/spec/lib/common/script_kill_shutdown_spec.rb
+++ b/spec/lib/common/script_kill_shutdown_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
   end
 
   def build_script(name:, die_with: [])
-    thread_group = instance_double(ThreadGroup, list: [], add: true)
+    thread_group = ThreadGroup.new
     script_class.allocate.tap do |script|
       script.instance_variable_set(:@name, name)
       script.instance_variable_set(:@custom, false)

--- a/spec/lib/common/script_kill_shutdown_spec.rb
+++ b/spec/lib/common/script_kill_shutdown_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../spec_helper'
+require_relative '../../../lib/common/limitedarray'
 require_relative '../../../lib/common/feature_flags'
 # Load the real hook classes so the ScriptDeath cleanup that the kill path runs
 # resolves against real registries (matching production) rather than the
@@ -30,6 +31,7 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
 
   before do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
     # Empty hook registries so the ScriptDeath cleanup has no stale state to act
     # on and nothing leaks across examples (these are class-level).
     Lich::Common::DownstreamHook.class_variable_set(:@@downstream_hooks, {})
@@ -46,6 +48,7 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
 
   after do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
   end
 
   describe 're-entrancy guard (Fix 1)' do
@@ -80,9 +83,9 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
       script = build_script(name: 'idempotent')
       script.at_exit { cleanup_counts[:n] += 1 }
       script_class.class_variable_set(:@@running, [script])
-      allow(Thread).to receive(:new) { |&block| block.call; instance_double(Thread) }
 
       script.kill
+      expect(script.join(1)).to equal(script)
       expect(script_class.list).to be_empty
       expect(cleanup_counts[:n]).to eq(1)
 
@@ -160,9 +163,10 @@ RSpec.describe 'Lich::Common::Script shutdown kill path' do
     it 'still runs cleanup asynchronously in a dedicated thread' do
       script = build_script(name: 'async-target')
       script_class.class_variable_set(:@@running, [script])
-      expect(Thread).to receive(:new) { |&block| block.call; instance_double(Thread) }
+      expect(Thread).to receive(:new).and_call_original
 
       expect(script.kill).to eq('async-target')
+      expect(script.join(1)).to equal(script)
 
       expect(script_class.list).to be_empty
     end

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -222,17 +222,26 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
-    it 'retains an unclaimed completed library start only weakly' do
+    it 'does not retain an unclaimed completed library start' do
       reservation = Object.new
       library = build_script('libunused')
       script_class.__send__(:__begin_start, reservation, 'libunused', :force => true)
 
       script_class.__send__(:__finish_start, reservation, library)
 
+      expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+    end
+
+    it 'retains a completed library handoff strongly for a waiter' do
+      reservation = Object.new
+      library = build_script('libwaiting')
+      script_class.__send__(:__begin_start, reservation, 'libwaiting', :force => true)
+      script_class.class_variable_get(:@@completed_start_waiters)['libwaiting'] = 1
+
+      script_class.__send__(:__finish_start, reservation, library)
+
       completed = script_class.class_variable_get(:@@completed_named_starts)
-      completed_reference = completed.fetch('libunused').last
-      expect(completed_reference).to be_a(WeakRef)
-      expect(completed_reference.__getobj__).to equal(library)
+      expect(completed.fetch('libwaiting').last).to equal(library)
     end
 
     it 'records a missing-label jump as unsuccessful execution' do
@@ -1375,6 +1384,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       newer_reservation = Object.new
       script_class.__send__(:__begin_start, older_reservation, 'libutil', :force => true)
       script_class.__send__(:__begin_start, newer_reservation, 'libutil', :force => true)
+      script_class.class_variable_get(:@@completed_start_waiters)['libutil'] = 1
 
       script_class.__send__(:__finish_start, newer_reservation, newer_generation)
       script_class.__send__(:__finish_start, older_reservation, nil)
@@ -1390,6 +1400,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       newer_reservation = Object.new
       script_class.__send__(:__begin_start, older_reservation, 'libutil', :force => true)
       script_class.__send__(:__begin_start, newer_reservation, 'libutil', :force => true)
+      script_class.class_variable_get(:@@completed_start_waiters)['libutil'] = 1
 
       script_class.__send__(:__finish_start, newer_reservation, newer_generation)
       script_class.__send__(:__finish_start, older_reservation, older_generation)
@@ -1403,6 +1414,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       newer_generation = instance_double(script_class)
       adopted_reservation = Object.new
       script_class.__send__(:__begin_start, adopted_reservation, 'libutil', :force => true)
+      script_class.class_variable_get(:@@completed_start_waiters)['libutil'] = 1
       script_class.__send__(:__finish_start, adopted_reservation, adopted_generation)
       library_reservation = Object.new
       script_class.__send__(:__begin_library_start, library_reservation, 'libutil')
@@ -1430,7 +1442,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       allow(script_class).to receive(:current).and_return(nil)
       reservation = Object.new
       script_class.__send__(:__begin_start, reservation, 'libutil', :force => true)
+      script_class.class_variable_get(:@@completed_start_waiters)['libutil'] = 1
       script_class.__send__(:__finish_start, reservation, new_generation)
+      script_class.class_variable_get(:@@completed_start_waiters).delete('libutil')
 
       expect(script_class.loadlib('util')).to be(true)
       expect(old_generation).not_to have_received(:join)

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1398,6 +1398,24 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.__send__(:__completed_start_value, completed)).to equal(newer_generation)
     end
 
+    it 'does not let a library reservation erase a newer completion' do
+      adopted_generation = instance_double(script_class)
+      newer_generation = instance_double(script_class)
+      adopted_reservation = Object.new
+      script_class.__send__(:__begin_start, adopted_reservation, 'libutil', :force => true)
+      script_class.__send__(:__finish_start, adopted_reservation, adopted_generation)
+      library_reservation = Object.new
+      script_class.__send__(:__begin_library_start, library_reservation, 'libutil')
+      newer_reservation = Object.new
+      script_class.__send__(:__begin_start, newer_reservation, 'libutil', :force => true)
+
+      script_class.__send__(:__finish_start, newer_reservation, newer_generation)
+      script_class.__send__(:__finish_start, library_reservation, nil)
+
+      completed = script_class.class_variable_get(:@@completed_named_starts)['libutil']
+      expect(script_class.__send__(:__completed_start_value, completed)).to equal(newer_generation)
+    end
+
     it 'adopts a completed forced generation ahead of an older running generation' do
       old_generation = instance_double(script_class, :name => 'libutil', :running? => false)
       allow(old_generation).to receive(:join) { raise 'older generation should not be joined' }

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'zlib'
+require 'timeout'
 require_relative '../../spec_helper'
 require_relative '../../../lib/common/limitedarray'
 require_relative '../../../lib/common/feature_flags'
@@ -9,6 +11,7 @@ require_relative '../../../lib/common/upstreamhook'
 RSpec.describe 'Lich::Common::Script lifecycle extensions' do
   let(:script_class) { Lich::Common::Script }
   let(:subscript_class) { Lich::Common::SubScript }
+  let(:exec_script_class) { Lich::Common::ExecScript }
 
   before(:context) do
     require_relative '../../../lib/common/script'
@@ -23,7 +26,13 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
   before do
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
+    script_class.class_variable_set(:@@startup_reservations, {})
+    script_class.class_variable_set(:@@completed_named_starts, {})
+    script_class.class_variable_set(:@@shutdown_started, false)
     script_class.class_variable_set(:@@loaded_libraries, Set.new)
+    script_class.class_variable_set(:@@loading_libraries, {})
+    script_class.class_variable_set(:@@library_waits, {})
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
     allow_any_instance_of(script_class).to receive(:report_errors) { |_script, &block| block.call }
@@ -32,6 +41,248 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
   after do
     script_class.list.each { |script| script.kill(context: :shutdown) if script.running? }
     script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
+  end
+
+  describe '.start' do
+    it 'constructs and starts an ordinary Ruby script' do
+      Dir.mktmpdir('script-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        started = script_class.start('ordinary')
+
+        expect(started).to be_a(script_class)
+        expect(started.join(2)).to equal(started)
+        expect(started).to be_completed_successfully
+      end
+    end
+
+    it 'does not publish an ordinary script before its worker is allocated' do
+      Dir.mktmpdir('script-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        allocation_entered = Queue.new
+        release_allocation = Queue.new
+        start_launch = Queue.new
+        launcher = Thread.new do
+          start_launch.pop
+          script_class.start('ordinary')
+        end
+        first_allocation = true
+        allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+          if first_allocation
+            first_allocation = false
+            allocation_entered << true
+            release_allocation.pop
+          end
+          method.call(*args, &block)
+        end
+
+        start_launch << true
+        allocation_entered.pop
+
+        expect(script_class.list).to be_empty
+        expect(script_class.start('ordinary')).to be_nil
+
+        release_allocation << true
+        script = launcher.value
+        expect(script.join(2)).to equal(script)
+      end
+    end
+
+    it 'waits for in-flight startup before taking the shutdown snapshot' do
+      Dir.mktmpdir('script-shutdown-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nQueue.new.pop\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        allocation_entered = Queue.new
+        release_allocation = Queue.new
+        start_launch = Queue.new
+        launcher = Thread.new do
+          start_launch.pop
+          script_class.start('ordinary')
+        end
+        first_allocation = true
+        allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+          if first_allocation
+            first_allocation = false
+            allocation_entered << true
+            release_allocation.pop
+          end
+          method.call(*args, &block)
+        end
+
+        start_launch << true
+        allocation_entered.pop
+        shutdown = Thread.new { script_class.begin_shutdown }
+        expect(shutdown.join(0.02)).to be_nil
+
+        release_allocation << true
+        script = launcher.value
+        expect(shutdown.value).to contain_exactly(script)
+        expect(script_class.start('ordinary')).to be_nil
+
+        script.kill(:context => :shutdown)
+      end
+    end
+
+    it 'rejects direct constructor publication after shutdown begins' do
+      Dir.mktmpdir('script-direct-shutdown') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        file_name = File.join(custom_dir, 'direct.lic')
+        File.write(file_name, "# quiet\nnil\n")
+        script_class.begin_shutdown
+
+        expect {
+          script_class.new(:file => file_name, :args => [], :quiet => true)
+        }.to raise_error(ThreadError, /shutting down/)
+        expect(script_class.list).to be_empty
+      end
+    end
+
+    it 'releases a startup reservation when the starter is cancelled during admission' do
+      Dir.mktmpdir('script-cancelled-admission') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'cancelled.lic'), "# quiet\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        admitted = Queue.new
+        allow(script_class).to receive(:__begin_start).and_wrap_original do |method, *args, **kwargs|
+          result = method.call(*args, **kwargs)
+          admitted << true
+          Queue.new.pop
+          result
+        end
+        starter = Thread.new { script_class.start('cancelled') }
+        admitted.pop
+
+        starter.kill
+        starter.join
+
+        expect(script_class.class_variable_get(:@@startup_reservations)).to be_empty
+        expect(Thread.new { script_class.begin_shutdown }.value).to be_empty
+      end
+    end
+
+    it 'uses the published name when reserving a compressed script' do
+      Dir.mktmpdir('script-compressed-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        Zlib::GzipWriter.open(File.join(custom_dir, 'compressed.lic.gz')) do |file|
+          file.write("# quiet\nQueue.new.pop\nDone:\nnil\n")
+        end
+        stub_const('SCRIPT_DIR', root)
+
+        first = script_class.start('compressed')
+
+        expect(first.name).to eq('compressed')
+        expect(script_class.start('compressed')).to be_nil
+        first.kill(:context => :shutdown)
+      end
+    end
+
+    it 'records a missing-label jump as unsuccessful execution' do
+      Dir.mktmpdir('script-label-error') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(
+          File.join(custom_dir, 'badjump.lic'),
+          <<~RUBY
+            # quiet
+            Lich::Common::Script.current.jump_label = 'missing'
+            raise Lich::Common::Script::JUMP
+            Done:
+            nil
+          RUBY
+        )
+        stub_const('SCRIPT_DIR', root)
+
+        started = script_class.start('badjump')
+
+        expect(started.join(2)).to equal(started)
+        expect(started.exit_error).to equal(script_class::JUMP_ERROR)
+        expect(started).not_to be_completed_successfully
+      end
+    end
+
+    it 'does not publish when binding construction fails' do
+      Dir.mktmpdir('script-binding') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'binding_failure.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        allow_any_instance_of(Lich::Common::Scripting).to receive(:script).and_raise(RuntimeError, 'forced binding failure')
+
+        expect(script_class.start('binding_failure')).to be_nil
+        expect(script_class.list).to be_empty
+      end
+    end
+
+    it 'does not publish a Wizard script when binding construction fails' do
+      Dir.mktmpdir('wizard-binding') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'binding_failure.cmd'), "exit\n")
+        stub_const('SCRIPT_DIR', root)
+        allow_any_instance_of(Lich::Common::Scripting).to receive(:script).and_raise(RuntimeError, 'forced binding failure')
+
+        expect(script_class.start('binding_failure')).to be_nil
+        expect(script_class.list).to be_empty
+      end
+    end
+
+    it 'loads an ordinary library through the production startup path' do
+      Dir.mktmpdir('script-library') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'libsample.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        expect(script_class.loadlib('sample')).to be(true)
+        expect(script_class.libs).to include('libsample')
+        expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+      end
+    end
+
+    it 'executes a new generation when reloading a production library' do
+      Dir.mktmpdir('script-library-reload') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(
+          File.join(custom_dir, 'libreload.lic'),
+          "# quiet\n$script_lifecycle_reload_runs = $script_lifecycle_reload_runs.to_i + 1\nDone:\nnil\n"
+        )
+        stub_const('SCRIPT_DIR', root)
+
+        expect(script_class.loadlib('reload')).to be(true)
+        expect(script_class.list).to be_empty
+        expect(script_class.class_variable_get(:@@startup_reservations)).to be_empty
+        expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+        expect(script_class.reloadlibs).to be(true)
+        expect($script_lifecycle_reload_runs).to eq(2)
+      ensure
+        $script_lifecycle_reload_runs = nil
+      end
+    end
+
+    it 'does not load a library that exits unsuccessfully' do
+      Dir.mktmpdir('script-library-exit') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'libfailure.lic'), "# quiet\nexit(false)\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        expect { script_class.loadlib('failure') }.to raise_error(LoadError, /failed/)
+        expect(script_class.libs).not_to include('libfailure')
+      end
+    end
   end
 
   describe 'Script facade' do
@@ -89,6 +340,17 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
   end
 
   describe 'SubScript' do
+    it 'preserves direct constructor publication and shutdown admission' do
+      script = subscript_class.new
+
+      expect(script.name).to eq('subscript1')
+      expect(script).to be_running
+      script.kill(:context => :shutdown)
+
+      script_class.begin_shutdown
+      expect { subscript_class.new }.to raise_error(ThreadError, /shutting down/)
+    end
+
     it 'runs a block with its own Script.current identity' do
       observed = Queue.new
       subscript = subscript_class.start { observed << script_class.current }
@@ -96,6 +358,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(subscript.join(2)).to equal(subscript)
       expect(observed.pop(true)).to equal(subscript)
       expect(subscript).to be_a(subscript_class)
+      expect(subscript).to be_completed_successfully
     end
 
     it 'unregisters itself when it exits naturally' do
@@ -108,17 +371,30 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(parent.child_scripts).to be_empty
     end
 
-    it 'is stopped with the parent using the parent kill context' do
+    it 'is stopped with the parent during runtime teardown' do
       parent = build_script('parent')
       script_class.class_variable_set(:@@running, [parent])
       child = subscript_class.start(:parent => parent) { Queue.new.pop }
-      expect(child).to receive(:kill).with(:context => :shutdown).and_call_original
-      expect(Thread).not_to receive(:new)
+      expect(child).to receive(:kill).with(:context => :runtime, :async => true).and_call_original
+
+      expect(parent.kill_sync(:context => :runtime, :timeout => 2)).to equal(parent)
+
+      expect(parent).not_to be_running
+      expect(child).not_to be_running
+    end
+
+    it 'leaves shutdown children for the process-wide drain' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      child = subscript_class.start(:parent => parent) { Queue.new.pop }
+      allow(child).to receive(:kill).and_call_original
 
       parent.kill(:context => :shutdown)
 
       expect(parent).not_to be_running
-      expect(child).not_to be_running
+      expect(child).to be_running
+      expect(child).not_to have_received(:kill)
+      child.kill(:context => :shutdown)
     end
 
     it 'inherits protection flags from its parent' do
@@ -138,6 +414,40 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       child.join(2)
     end
 
+    it 'establishes child ownership and protection before publication' do
+      parent = build_script('daemon-parent')
+      parent.hidden = true
+      parent.no_kill_all = true
+      parent.no_pause_all = true
+      script_class.class_variable_set(:@@running, [parent])
+      publish_entered = Queue.new
+      release_publish = Queue.new
+      release_child = Queue.new
+      child_instance = nil
+      allow(subscript_class).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+        child_instance = method.call(*args, **kwargs)
+        allow(child_instance).to receive(:__publish).and_wrap_original do |publish|
+          publish_entered << true
+          release_publish.pop
+          publish.call
+        end
+        child_instance
+      end
+      launcher = Thread.new { subscript_class.start(:parent => parent) { release_child.pop } }
+      publish_entered.pop
+
+      expect(child_instance.hidden).to be(true)
+      expect(child_instance.no_kill_all).to be(true)
+      expect(child_instance.no_pause_all).to be(true)
+      expect(script_class.list).to contain_exactly(parent)
+
+      release_publish << true
+      child = launcher.value
+      expect(parent.child_scripts).to contain_exactly(child)
+      release_child << true
+      expect(child.join(2)).to equal(child)
+    end
+
     it 'rejects and stops a child registered after parent teardown begins' do
       parent = build_script('stopped-parent')
       script_class.class_variable_set(:@@running, [parent])
@@ -147,6 +457,208 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(parent.register_child(child)).to be_nil
       expect(child).not_to be_running
+    end
+
+    it 'rolls back registration when worker allocation fails' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      allow(Thread).to receive(:new).and_raise(ThreadError, 'forced allocation failure')
+
+      expect { subscript_class.start(:parent => parent) {} }.to raise_error(ThreadError, /forced/)
+
+      expect(script_class.list).to contain_exactly(parent)
+      children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
+      expect(Array(children)).to be_empty
+    end
+
+    it 'rolls back registration when worker release fails' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      start_gate = instance_double(Queue)
+      allow(start_gate).to receive(:pop) { Thread.stop }
+      allow(start_gate).to receive(:<<).with(true).and_raise(ThreadError, 'forced release failure')
+      allow(Queue).to receive(:new).and_return(start_gate)
+      rolled_back = nil
+      allow(subscript_class).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+        rolled_back = method.call(*args, **kwargs)
+      end
+
+      expect { subscript_class.start(:parent => parent) {} }.to raise_error(ThreadError, /forced/)
+
+      expect(script_class.list).to contain_exactly(parent)
+      expect(parent.child_scripts).to be_empty
+      expect(rolled_back.join(0.1)).to equal(rolled_back)
+    end
+
+    it 'preserves the parent identity for parent exit handlers' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      child_ready = Queue.new
+      child = subscript_class.start(:parent => parent) { child_ready << true; Queue.new.pop }
+      child_ready.pop
+      observed = nil
+      parent.at_exit { observed = script_class.current }
+
+      expect(parent.kill_sync(:context => :runtime, :timeout => 2)).to equal(parent)
+
+      expect(observed).to equal(parent)
+      expect(child.join(1)).to equal(child)
+    end
+
+    it 'rejects self-registration and ownership cycles' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+
+      expect { parent.register_child(parent) }.to raise_error(ArgumentError, /own child/)
+      expect(parent.register_child(child)).to equal(child)
+      expect { child.register_child(parent) }.to raise_error(ArgumentError, /cycle/)
+    end
+
+    it 'waits for an in-progress child launch before taking the teardown snapshot' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      launch_entered = Queue.new
+      release_launch = Queue.new
+      launcher = Thread.new do
+        parent.__send__(:__launch_child) do
+          launch_entered << true
+          release_launch.pop
+          parent.__send__(:__register_child_locked, child)
+        end
+      end
+      launch_entered.pop
+      killer = Thread.new { parent.kill_sync(:context => :runtime, :timeout => 2) }
+
+      sleep 0.02
+      expect(parent).to be_running
+
+      release_launch << true
+      launcher.join
+      killer.join
+      expect(parent).not_to be_running
+      expect(child.join(1)).to equal(child)
+    end
+
+    it 'does not publish a subscript before its worker is allocated' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      allocation_entered = Queue.new
+      release_allocation = Queue.new
+      start_launch = Queue.new
+      launcher = Thread.new do
+        start_launch.pop
+        subscript_class.start(:parent => parent) {}
+      end
+      first_allocation = true
+      allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+        if first_allocation
+          first_allocation = false
+          allocation_entered << true
+          release_allocation.pop
+        end
+        method.call(*args, &block)
+      end
+
+      start_launch << true
+      allocation_entered.pop
+
+      expect(script_class.list).to contain_exactly(parent)
+      expect(Array(parent.instance_variable_get(:@child_scripts))).to be_empty
+
+      release_allocation << true
+      child = launcher.value
+      expect(child.join(2)).to equal(child)
+    end
+
+    it 'rolls back subscript publication when the launcher is killed mid-transition' do
+      publish_entered = Queue.new
+      release_publish = Queue.new
+      child_instance = nil
+      allow(subscript_class).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+        child_instance = method.call(*args, **kwargs)
+        allow(child_instance).to receive(:__publish).and_wrap_original do |publish, *publish_args|
+          publish_entered << true
+          release_publish.pop
+          publish.call(*publish_args)
+        end
+        child_instance
+      end
+      launcher = Thread.new do
+        subscript_class.start(:parent => nil) { Queue.new.pop }
+      end
+      publish_entered.pop
+
+      launcher.kill
+      release_publish << true
+      launcher.join
+
+      expect(child_instance).not_to be_running
+      expect(script_class.list).to be_empty
+      expect(child_instance.__send__(:__worker_threads)).to all(satisfy { |thread| !thread.alive? })
+    end
+  end
+
+  describe 'ExecScript' do
+    it 'records successful and failed execution results' do
+      allow(Lich::Common::TRUSTED_SCRIPT_BINDING).to receive(:call).and_return(Lich::Common::Scripting.new.script)
+      successful = exec_script_class.start('nil')
+      expect(successful.join(1)).to equal(successful)
+      expect(successful).to be_completed_successfully
+      expect(successful.exit_error).to be_nil
+
+      failed = exec_script_class.start("raise 'exec failed'")
+      expect(failed.join(1)).to equal(failed)
+      expect(failed).not_to be_completed_successfully
+      expect(failed.exit_error).to be_a(RuntimeError)
+    end
+
+    it 'preserves direct constructor publication and shutdown admission' do
+      script = exec_script_class.new('nil', :quiet => true)
+
+      expect(script.name).to eq('exec1')
+      expect(script).to be_running
+      script.kill(:context => :shutdown)
+
+      script_class.begin_shutdown
+      expect { exec_script_class.new('nil') }.to raise_error(ThreadError, /shutting down/)
+    end
+
+    it 'rolls back startup when worker allocation fails' do
+      allow(Thread).to receive(:new).and_raise(ThreadError, 'forced allocation failure')
+
+      expect { exec_script_class.start('nil') }.to raise_error(ThreadError, /forced/)
+
+      expect(script_class.list).to be_empty
+    end
+
+    it 'does not publish before its worker is allocated' do
+      allocation_entered = Queue.new
+      release_allocation = Queue.new
+      start_launch = Queue.new
+      launcher = Thread.new do
+        start_launch.pop
+        exec_script_class.start('nil')
+      end
+      first_allocation = true
+      allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+        if first_allocation
+          first_allocation = false
+          allocation_entered << true
+          release_allocation.pop
+        end
+        method.call(*args, &block)
+      end
+
+      start_launch << true
+      allocation_entered.pop
+
+      expect(script_class.list).to be_empty
+
+      release_allocation << true
+      script = launcher.value
+      expect(script.join(2)).to equal(script)
     end
   end
 
@@ -191,35 +703,799 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(worker.join(1)).to equal(worker)
       expect(result.pop(true).message).to match(/current script/)
     end
+
+    it 'honors join timeout while cleanup holds the killer mutex' do
+      script = build_script('slow-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      entered = Queue.new
+      release = Queue.new
+      script.at_exit { entered << true; release.pop }
+
+      script.kill
+      entered.pop
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      expect(script.join(0.02)).to be_nil
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).to be < 0.2
+
+      release << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'does not block a repeated shutdown kill behind active cleanup' do
+      script = build_script('slow-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      entered = Queue.new
+      release = Queue.new
+      script.at_exit { entered << true; release.pop }
+      script.kill
+      entered.pop
+
+      repeated_kill = Thread.new { script.kill(:context => :shutdown) }
+      expect(repeated_kill.join(0.1)).to equal(repeated_kill)
+
+      release << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'waits for killed worker ensure blocks to finish' do
+      ready = Queue.new
+      ensure_started = Queue.new
+      release = Queue.new
+      script = subscript_class.start(:parent => nil) do
+        ready << true
+        begin
+          Queue.new.pop
+        ensure
+          ensure_started << true
+          release.pop
+        end
+      end
+      ready.pop
+
+      script.kill
+      ensure_started.pop
+      expect(script.join(0.02)).to be_nil
+
+      release << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'attaches an async cleanup thread to the target before cleanup starts' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      parent.thread_group.add(Thread.current)
+      observed = Queue.new
+      allow(child).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        observed << [child.has_thread?(Thread.current), parent.has_thread?(Thread.current)]
+        method.call(**kwargs)
+      end
+
+      child.kill
+
+      expect(observed.pop).to eq([true, false])
+      expect(child.join(1)).to equal(child)
+    ensure
+      ThreadGroup::Default.add(Thread.current)
+    end
+
+    it 'releases async cleanup when the killing caller is killed mid-transition' do
+      script = build_script('kill-transition')
+      script_class.class_variable_set(:@@running, [script])
+      attach_entered = Queue.new
+      release_attach = Queue.new
+      allow(script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+        attach_entered << true
+        release_attach.pop
+        method.call(thread)
+      end
+      killer = Thread.new { script.kill }
+      attach_entered.pop
+
+      killer.kill
+      release_attach << true
+      killer.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'keeps target cleanup alive when the caller script is killed during handoff' do
+      caller_script = build_script('caller')
+      target_script = build_script('target')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      attach_entered = Queue.new
+      release_attach = Queue.new
+      allow(target_script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+        attach_entered << true
+        release_attach.pop
+        method.call(thread)
+      end
+      start_kill = Queue.new
+      killer = Thread.new { start_kill.pop; target_script.kill }
+      caller_script.thread_group.add(killer)
+      start_kill << true
+      attach_entered.pop
+
+      caller_script.kill
+      release_attach << true
+
+      expect(caller_script.join(1)).to equal(caller_script)
+      expect(target_script.join(1)).to equal(target_script)
+    end
+
+    it 'runs cleanup when the killing caller is cancelled before worker allocation' do
+      script = build_script('kill-allocation-transition')
+      script_class.class_variable_set(:@@running, [script])
+      start_kill = Queue.new
+      allocation_entered = Queue.new
+      killer = Thread.new { start_kill.pop; script.kill }
+      allow(Thread).to receive(:new).and_wrap_original do |method, *args, &block|
+        allocation_entered << true
+        Queue.new.pop
+        method.call(*args, &block)
+      end
+
+      start_kill << true
+      allocation_entered.pop
+      killer.kill
+      killer.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'recovers when an asynchronous cleanup executor is killed' do
+      script = build_script('abandoned-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      first_cleanup = true
+      allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        if first_cleanup
+          first_cleanup = false
+          cleanup_entered << true
+          Queue.new.pop
+        else
+          method.call(**kwargs)
+        end
+      end
+
+      script.kill
+      cleanup_entered.pop
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(script, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'finishes inline cleanup when the killing caller is cancelled' do
+      script = build_script('cancelled-inline-cleanup')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      first_cleanup = true
+      allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        if first_cleanup
+          first_cleanup = false
+          cleanup_entered << true
+          Queue.new.pop
+        else
+          method.call(**kwargs)
+        end
+      end
+      killer = Thread.new { script.kill(:context => :shutdown) }
+      cleanup_entered.pop
+
+      killer.kill
+      killer.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'signals completion even when cleanup raises' do
+      script = build_script('bad-cleanup')
+      script.die_with << '('
+      script_class.class_variable_set(:@@running, [script])
+
+      expect(script.kill_sync(timeout: 1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
+    it 'stops later children when an earlier runtime child cleanup blocks' do
+      stub_const('Lich::Common::Script::CHILD_JOIN_TIMEOUT', 0.03)
+      parent = build_script('parent')
+      blocked = build_script('blocked')
+      sibling = build_script('sibling')
+      script_class.class_variable_set(:@@running, [parent, blocked, sibling])
+      parent.register_child(blocked)
+      parent.register_child(sibling)
+      entered = Queue.new
+      release = Queue.new
+      blocked.at_exit { entered << true; release.pop }
+
+      parent.kill
+      entered.pop
+
+      expect(sibling).not_to be_running
+      expect(blocked).to be_running
+      expect(parent.join(1)).to equal(parent)
+      expect(parent.child_scripts).to contain_exactly(blocked)
+
+      release << true
+      expect(blocked.join(1)).to equal(blocked)
+      expect(parent.child_scripts).to be_empty
+    end
+
+    it 'retains a timed-out child until its worker ensure block finishes' do
+      stub_const('Lich::Common::Script::CHILD_JOIN_TIMEOUT', 0.03)
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      child = subscript_class.start(:parent => parent) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+
+      parent.kill
+      worker_cleanup_entered.pop
+      expect(parent.join(1)).to equal(parent)
+      expect(child).not_to be_running
+      expect(parent.child_scripts).to contain_exactly(child)
+      expect(script_class.shutdown_scripts).to include(child)
+
+      release_worker_cleanup << true
+      expect(child.join(1)).to equal(child)
+      expect(parent.child_scripts).to be_empty
+      expect(script_class.shutdown_scripts).to be_empty
+    end
+
+    it 'rejects workers created after teardown begins' do
+      script = build_script('late-worker')
+      script.want_downstream = false
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      release_cleanup = Queue.new
+      callback_ran = Queue.new
+      script.watchfor[/trigger/] = proc { callback_ran << true }
+      script.at_exit { cleanup_entered << true; release_cleanup.pop }
+
+      script.kill
+      cleanup_entered.pop
+      script_class.new_downstream('trigger')
+      sleep 0.02
+
+      expect { callback_ran.pop(true) }.to raise_error(ThreadError)
+
+      release_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'releases a watchfor worker when dispatch is cancelled after registration' do
+      script = build_script('cancelled-watchfor')
+      script_class.class_variable_set(:@@running, [script])
+      script.watchfor[/trigger/] = proc {}
+      registration_complete = Queue.new
+      allow(script).to receive(:__register_worker).and_wrap_original do |method, thread|
+        result = method.call(thread)
+        registration_complete << true
+        Queue.new.pop
+        result
+      end
+      dispatcher = Thread.new { script_class.new_downstream('trigger') }
+      registration_complete.pop
+
+      dispatcher.kill
+      dispatcher.join
+
+      expect(script.__send__(:__worker_threads)).to all(satisfy { |thread| !thread.alive? })
+      script.kill(:context => :shutdown)
+    end
+
+    it 'rejects and joins workers added directly during teardown' do
+      script = build_script('direct-late-worker')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      release_cleanup = Queue.new
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script.at_exit { cleanup_entered << true; release_cleanup.pop }
+
+      script.kill
+      cleanup_entered.pop
+      late_worker = Thread.new do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+      registration_error = Queue.new
+      registrar = Thread.new do
+        script.thread_group.add(late_worker)
+      rescue ThreadError => e
+        registration_error << e
+      end
+      worker_cleanup_entered.pop
+      release_cleanup << true
+      expect(script.join(0.02)).to be_nil
+
+      release_worker_cleanup << true
+      registrar.join
+      expect(registration_error.pop.message).to match(/stopping script/)
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'releases rejected worker registration when the registrar is cancelled' do
+      script = build_script('cancelled-registration')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      release_cleanup = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script.at_exit { cleanup_entered << true; release_cleanup.pop }
+      script.kill
+      cleanup_entered.pop
+      worker = Thread.new do
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      registrar = Thread.new { script.thread_group.add(worker) }
+      worker_cleanup_entered.pop
+
+      registrar.kill
+      release_worker_cleanup << true
+      registrar.join
+      release_cleanup << true
+
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'preserves an underlying thread-group rejection when worker teardown raises' do
+      script = build_script('group-rejection')
+      script_class.class_variable_set(:@@running, [script])
+      group = instance_double(ThreadGroup, :list => [])
+      allow(group).to receive(:add).and_raise(ThreadError, 'group rejected worker')
+      script.instance_variable_set(:@thread_group, group)
+      worker = Thread.new do
+        Thread.current.report_on_exception = false
+        begin
+          Queue.new.pop
+        ensure
+          raise 'worker teardown failed'
+        end
+      end
+
+      expect { script.thread_group.add(worker) }.to raise_error(ThreadError, /group rejected worker/)
+    end
+
+    it 'does not block shutdown cleanup on a worker ensure block' do
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+      shutdown_kill = Thread.new { script.kill(:context => :shutdown) }
+      worker_cleanup_entered.pop
+
+      expect(shutdown_kill.join(0.2)).to equal(shutdown_kill)
+      expect(script_class.shutdown_scripts).to include(script)
+
+      release_worker_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'joins descendant workers spawned from a killed worker ensure block' do
+      worker_ready = Queue.new
+      descendant_ready = Queue.new
+      descendant_cleanup_entered = Queue.new
+      release_descendant_cleanup = Queue.new
+      script = nil
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          descendant = Thread.new do
+            descendant_ready << true
+            begin
+              Queue.new.pop
+            ensure
+              descendant_cleanup_entered << true
+              release_descendant_cleanup.pop
+            end
+          end
+          descendant_ready.pop
+          begin
+            script.thread_group.add(descendant)
+          rescue ThreadError
+            nil
+          end
+        end
+      end
+      worker_ready.pop
+
+      script.kill
+      descendant_cleanup_entered.pop
+      expect(script.join(0.02)).to be_nil
+
+      release_descendant_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'allows a killed worker to join its own stopping script' do
+      worker_ready = Queue.new
+      worker_joined = Queue.new
+      script = nil
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_joined << script.join(1)
+        end
+      end
+      worker_ready.pop
+
+      script.kill
+
+      expect(worker_joined.pop).to equal(script)
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'finishes teardown when a killed worker ensure block raises' do
+      worker_ready = Queue.new
+      script = build_script('raising-worker')
+      script_class.class_variable_set(:@@running, [script])
+      worker = Thread.new do
+        Thread.current.report_on_exception = false
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          raise 'worker cleanup failed'
+        end
+      end
+      script.thread_group.add(worker)
+      worker_ready.pop
+
+      script.kill
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+      expect(script.exit_error).to be_a(RuntimeError)
+    end
+
+    it 'does not complete join until parent unlinking finishes' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      expect(parent.register_child(child)).to equal(child)
+      launch_lock_held = Queue.new
+      release_launch_lock = Queue.new
+      lock_holder = Thread.new do
+        parent.__send__(:__launch_child) do
+          launch_lock_held << true
+          release_launch_lock.pop
+        end
+      end
+      launch_lock_held.pop
+
+      child.kill
+      expect(child.join(0.02)).to be_nil
+      children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
+      expect(children).to contain_exactly(child)
+
+      release_launch_lock << true
+      lock_holder.join
+      expect(child.join(1)).to equal(child)
+      expect(parent.child_scripts).to be_empty
+    end
   end
 
   describe 'library loading' do
-    let(:library_script) { instance_double(script_class, :name => 'libutil', :join => true) }
+    let(:library_script) do
+      instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+    end
 
     before do
-      allow(script_class).to receive(:exists?).and_return(true)
+      allow(script_class).to receive(:__find_script_file).and_return('/custom/libutil.lic')
     end
 
     it 'starts a library only once across concurrent callers' do
-      allow(script_class).to receive(:start).with('libutil').and_return(library_script)
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(library_script)
 
       callers = Array.new(4) { Thread.new { script_class.loadlib('util') } }
       callers.each(&:join)
 
-      expect(script_class).to have_received(:start).with('libutil').once
+      expect(script_class).to have_received(:start).with('libutil', { :force => true }).once
       expect(script_class.libs).to eq(Set['libutil'])
     end
 
+    it 'adopts an admitted plain start instead of reporting a duplicate failure' do
+      admitted_script = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      startup_token = Object.new
+      script_class.__send__(:__begin_start, startup_token, 'libutil', :force => false)
+      loader = Thread.new { script_class.loadlib('util') }
+      expect(loader.join(0.02)).to be_nil
+      allow(script_class).to receive(:start)
+
+      script_class.__send__(:__finish_start, startup_token, admitted_script)
+
+      expect(loader.value).to be(true)
+      expect(script_class).not_to have_received(:start)
+      expect(script_class.libs).to include('libutil')
+    end
+
+    it 'clears an older completed generation when a newer startup fails' do
+      old_generation = instance_double(script_class)
+      script_class.class_variable_set(:@@completed_named_starts, { 'libutil' => old_generation })
+      reservation = Object.new
+      script_class.__send__(:__begin_start, reservation, 'libutil', :force => true)
+
+      script_class.__send__(:__finish_start, reservation, nil)
+
+      expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+    end
+
+    it 'adopts a completed forced generation ahead of an older running generation' do
+      old_generation = instance_double(script_class, :name => 'libutil', :running? => false)
+      allow(old_generation).to receive(:join) { raise 'older generation should not be joined' }
+      new_generation = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      script_class.class_variable_set(:@@running, [old_generation])
+      allow(script_class).to receive(:current).and_return(nil)
+      reservation = Object.new
+      script_class.__send__(:__begin_start, reservation, 'libutil', :force => true)
+      script_class.__send__(:__finish_start, reservation, new_generation)
+
+      expect(script_class.loadlib('util')).to be(true)
+      expect(old_generation).not_to have_received(:join)
+      expect(script_class.libs).to include('libutil')
+    end
+
+    it 'uses the resolved library name when adopting a prefix start' do
+      admitted_script = instance_double(
+        script_class,
+        :name                    => 'libutility',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      allow(script_class).to receive(:__find_script_file).with('libutil').and_return('/custom/libutility.lic')
+      startup_token = Object.new
+      script_class.__send__(:__begin_start, startup_token, 'libutility', :force => false)
+      loader = Thread.new { script_class.loadlib('util') }
+      expect(loader.join(0.02)).to be_nil
+      allow(script_class).to receive(:start)
+
+      script_class.__send__(:__finish_start, startup_token, admitted_script)
+
+      expect(loader.value).to be(true)
+      expect(script_class).not_to have_received(:start)
+      expect(script_class.libs).to include('libutility')
+    end
+
     it 'allows retry when startup fails' do
-      allow(script_class).to receive(:start).with('libutil').and_return(nil, library_script)
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(nil, library_script)
 
       expect { script_class.loadlib('util') }.to raise_error(LoadError, /failed to start/)
       expect(script_class.libs).to be_empty
       expect(script_class.loadlib('util')).to be(true)
     end
 
+    it 'allows retry when startup raises' do
+      attempts = 0
+      allow(script_class).to receive(:start).with('libutil', { :force => true }) do
+        attempts += 1
+        raise ThreadError, 'forced startup failure' if attempts == 1
+
+        library_script
+      end
+
+      expect { script_class.loadlib('util') }.to raise_error(ThreadError, /forced/)
+      expect(script_class.libs).to be_empty
+      expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
+      expect(script_class.loadlib('util')).to be(true)
+    end
+
+    it 'does not record a library whose execution fails' do
+      error = RuntimeError.new('broken library')
+      failed_script = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => error,
+        :completed_successfully? => false
+      )
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(failed_script)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /broken library/)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'invalidates the cache when a rerun of a loaded library fails' do
+      error = RuntimeError.new('broken rerun')
+      failed_rerun = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :exit_error              => error,
+        :completed_successfully? => false
+      )
+      allow(failed_rerun).to receive(:join) do
+        script_class.class_variable_get(:@@running).delete(failed_rerun)
+        true
+      end
+      script_class.class_variable_set(:@@running, [failed_rerun])
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      allow(script_class).to receive(:current).and_return(nil)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /broken rerun/)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'rejects cyclic library waits' do
+      caller_script = build_script('libcaller')
+      target_script = instance_double(
+        script_class,
+        :name                    => 'libtarget',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      script_class.class_variable_set(:@@running, [caller_script])
+      script_class.class_variable_set(:@@loading_libraries, { 'libtarget' => target_script })
+      script_class.class_variable_set(:@@library_waits, { target_script => caller_script })
+      allow(script_class).to receive(:current).and_return(caller_script)
+      allow(script_class).to receive(:__find_script_file).with('libtarget').and_return('/custom/team/libtarget.lic')
+
+      expect { script_class.loadlib('target') }.to raise_error(LoadError, /cyclic/)
+      expect(target_script).not_to have_received(:join)
+    end
+
+    it 'rejects a library loading itself without blocking' do
+      Dir.mktmpdir('script-library-self-cycle') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(
+          File.join(custom_dir, 'libselfcycle.lic'),
+          "# quiet\nLich::Common::Script.loadlib('selfcycle')\nDone:\nnil\n"
+        )
+        stub_const('SCRIPT_DIR', root)
+        allow(script_class).to receive(:__find_script_file).with('libselfcycle').and_return('/custom/libselfcycle.lic')
+
+        expect {
+          Timeout.timeout(1) { script_class.loadlib('selfcycle') }
+        }.to raise_error(LoadError, /cyclic script library dependency/)
+      end
+    end
+
+    it 'does not record an interrupted library as loaded' do
+      interrupted_script = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => false
+      )
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(interrupted_script)
+
+      expect { script_class.loadlib('util') }.to raise_error(LoadError, /did not complete/)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'tracks simultaneous waits from separate threads of one script' do
+      caller_script = build_script('libcaller')
+      entered = Queue.new
+      release = Queue.new
+      target_one = instance_double(script_class, :name => 'libone')
+      target_two = instance_double(script_class, :name => 'libtwo')
+      allow(target_one).to receive(:join) { entered << true; release.pop }
+      allow(target_two).to receive(:join) { entered << true; release.pop }
+      allow(script_class).to receive(:current).and_return(caller_script)
+
+      waiters = [
+        Thread.new { script_class.__send__(:__join_library, 'libone', target_one) },
+        Thread.new { script_class.__send__(:__join_library, 'libtwo', target_two) }
+      ]
+      2.times { entered.pop }
+
+      expect(script_class.class_variable_get(:@@library_waits)[caller_script]).to eq(Set[target_one, target_two])
+
+      2.times { release << true }
+      waiters.each(&:join)
+      expect(script_class.class_variable_get(:@@library_waits)).to be_empty
+    end
+
+    it 'serializes a retry behind the failed generation' do
+      first_joined = Queue.new
+      join_mutex = Mutex.new
+      join_condition = ConditionVariable.new
+      first_released = false
+      failed_attempt = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :exit_error              => nil,
+        :completed_successfully? => false
+      )
+      successful_attempt = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      allow(failed_attempt).to receive(:join) do
+        first_joined << true
+        join_mutex.synchronize { join_condition.wait(join_mutex) until first_released }
+      end
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(failed_attempt, successful_attempt)
+
+      first_loader = Thread.new do
+        script_class.loadlib('util')
+      rescue LoadError
+        false
+      end
+      first_joined.pop
+      retry_loader = Thread.new { script_class.loadlib('util') }
+      expect(retry_loader.join(0.02)).to be_nil
+
+      join_mutex.synchronize do
+        first_released = true
+        join_condition.broadcast
+      end
+
+      expect(first_loader.value).to be(false)
+      expect(retry_loader.value).to be(true)
+      expect(script_class.libs).to include('libutil')
+      expect(script_class).to have_received(:start).with('libutil', { :force => true }).twice
+    end
+
     it 'raises without recording a missing library' do
-      allow(script_class).to receive(:exists?).with('libmissing').and_return(false)
+      allow(script_class).to receive(:__find_script_file).with('libmissing').and_return(nil)
 
       expect { script_class.loadlib('missing') }.to raise_error(LoadError, /not found/)
       expect(script_class.libs).to be_empty
@@ -227,11 +1503,30 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
     it 'reloads a stable snapshot of loaded libraries' do
       script_class.class_variable_set(:@@loaded_libraries, Set['libutil', 'libstatus'])
-      allow(script_class).to receive(:run)
+      allow(script_class).to receive(:loadlib).and_return(true)
 
       expect(script_class.reloadlibs).to be(true)
-      expect(script_class).to have_received(:run).with('libutil')
-      expect(script_class).to have_received(:run).with('libstatus')
+      expect(script_class).to have_received(:loadlib).with('libutil')
+      expect(script_class).to have_received(:loadlib).with('libstatus')
+    end
+
+    it 'invalidates a library cache entry when reload fails' do
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      allow(script_class).to receive(:loadlib).with('libutil').and_raise(LoadError, 'broken reload')
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class.libs).to be_empty
+    end
+
+    it 'preserves the current library generation during reload' do
+      current_library = build_script('libutil')
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      allow(script_class).to receive(:current).and_return(current_library)
+      allow(script_class).to receive(:loadlib)
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class).not_to have_received(:loadlib)
+      expect(script_class.libs).to include('libutil')
     end
   end
 
@@ -267,6 +1562,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script.instance_variable_set(:@die_with, [])
       script.instance_variable_set(:@paused, false)
       script.instance_variable_set(:@at_exit_procs, [])
+      script.instance_variable_set(:@watchfor, {})
       script.instance_variable_set(:@downstream_buffer, [])
       script.instance_variable_set(:@upstream_buffer, [])
       script.instance_variable_set(:@match_stack_labels, [])
@@ -274,6 +1570,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script.instance_variable_set(:@killer_mutex, Mutex.new)
       script.instance_variable_set(:@killed_externally, false)
       script.instance_variable_set(:@kill_source, nil)
+      script.instance_variable_set(:@kill_requested, false)
+      script.instance_variable_set(:@cleanup_started, false)
+      script.instance_variable_set(:@completed_successfully, false)
       script.instance_variable_set(:@hidden, false)
       script.instance_variable_set(:@no_kill_all, false)
       script.instance_variable_set(:@no_pause_all, false)

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     script_class.class_variable_set(:@@stopping, [])
     script_class.class_variable_set(:@@startup_reservations, {})
     script_class.class_variable_set(:@@completed_named_starts, {})
+    script_class.class_variable_set(:@@completed_start_waiters, Hash.new(0))
     script_class.class_variable_set(:@@shutdown_started, false)
     script_class.class_variable_set(:@@loaded_libraries, Set.new)
     script_class.class_variable_set(:@@loading_libraries, {})
@@ -188,6 +189,32 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
+    it 'rejects a non-forced start while the same name is still stopping' do
+      Dir.mktmpdir('script-stopping-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        stopping = build_script('ordinary')
+        script_class.class_variable_set(:@@stopping, [stopping])
+
+        expect(script_class.start('ordinary')).to be_nil
+        expect(script_class.list).to be_empty
+      end
+    end
+
+    it 'retains an unclaimed completed library start only weakly' do
+      reservation = Object.new
+      library = build_script('libunused')
+      script_class.__send__(:__begin_start, reservation, 'libunused', :force => true)
+
+      script_class.__send__(:__finish_start, reservation, library)
+
+      completed = script_class.class_variable_get(:@@completed_named_starts)
+      expect(completed.fetch('libunused')).to be_a(WeakRef)
+      expect(completed.fetch('libunused').__getobj__).to equal(library)
+    end
+
     it 'records a missing-label jump as unsuccessful execution' do
       Dir.mktmpdir('script-label-error') do |root|
         custom_dir = File.join(root, 'custom')
@@ -311,13 +338,26 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     end
 
     it 'registers a named child through Script.start_child' do
-      parent = build_script('parent')
-      child = build_script('child')
-      allow(script_class).to receive(:current).and_return(parent)
-      allow(script_class).to receive(:start).with('child').and_return(child)
-      expect(parent).to receive(:register_child).with(child).and_return(child)
+      Dir.mktmpdir('script-facade-child') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'child.lic'), "# quiet\nSCRIPT_FACADE_RELEASE.pop\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        stub_const('SCRIPT_FACADE_RELEASE', Queue.new)
+        parent = build_script('parent')
+        script_class.class_variable_set(:@@running, [parent])
+        parent.thread_group.add(Thread.current)
 
-      expect(script_class.start_child('child')).to equal(child)
+        child = script_class.start_child('child')
+        ThreadGroup::Default.add(Thread.current)
+
+        expect(parent.child_scripts).to contain_exactly(child)
+        SCRIPT_FACADE_RELEASE << true
+        expect(child.join(1)).to equal(child)
+        expect(parent.child_scripts).to be_empty
+      ensure
+        ThreadGroup::Default.add(Thread.current)
+      end
     end
 
     it 'waits for a child through Script.run_child' do

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -643,7 +643,8 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       allocation_entered.pop
 
       expect(script_class.list).to contain_exactly(parent)
-      expect(Array(parent.instance_variable_get(:@child_scripts))).to be_empty
+      children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
+      expect(Array(children)).to be_empty
 
       release_allocation << true
       child = launcher.value

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -203,6 +203,24 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
+    it 'allows a non-forced restart after a completed stopping entry is stranded' do
+      Dir.mktmpdir('script-completed-stopper-start') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        stopping = build_script('ordinary')
+        stopping.instance_variable_set(:@cleanup_complete, true)
+        script_class.class_variable_set(:@@stopping, [stopping])
+
+        restarted = script_class.start('ordinary')
+
+        expect(restarted).to be_a(script_class)
+        expect(restarted.join(2)).to equal(restarted)
+        expect(script_class.class_variable_get(:@@stopping)).to contain_exactly(stopping)
+      end
+    end
+
     it 'retains an unclaimed completed library start only weakly' do
       reservation = Object.new
       library = build_script('libunused')
@@ -326,7 +344,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     end
 
     it 'raises when anonymous child startup is rejected' do
-      allow(subscript_class).to receive(:start).and_return(false)
+      parent = build_script('stopping-parent')
+      parent.__send__(:__begin_child_shutdown)
+      allow(script_class).to receive(:current).and_return(parent)
 
       expect {
         script_class.subscript {}
@@ -497,6 +517,13 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(parent.register_child(child)).to be_nil
       expect(child).not_to be_running
+    end
+
+    it 'returns false when parent teardown rejects subscript startup' do
+      parent = build_script('stopping-parent')
+      parent.__send__(:__begin_child_shutdown)
+
+      expect(subscript_class.start(:parent => parent) {}).to be(false)
     end
 
     it 'rolls back registration when worker allocation fails' do
@@ -703,6 +730,29 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
   end
 
   describe 'synchronous lifecycle methods' do
+    it 'preserves the standard ThreadGroup surface' do
+      script = build_script('thread-group-api')
+      script_class.class_variable_set(:@@running, [script])
+      worker = Thread.new { Queue.new.pop }
+      group = script.thread_group
+
+      expect(group).to be_a(ThreadGroup)
+      expect(group).to be_instance_of(ThreadGroup)
+      expect(group.add(worker)).to equal(group)
+      expect(worker.group).to equal(group)
+      expect { group.add(Object.new) }.to raise_error(TypeError, /expected VM\/thread/)
+      expect(group).not_to be_enclosed
+      expect(group.enclose).to equal(group)
+      expect(group).to be_enclosed
+      other_group = ThreadGroup.new
+      expect { other_group.add(worker) }.to raise_error(ThreadError, /enclosed/)
+      expect(worker.group).to equal(group)
+    ensure
+      worker&.kill
+      worker&.join
+      script_class.class_variable_set(:@@running, [])
+    end
+
     it 'waits for exit handlers in kill_sync' do
       script = build_script('sync')
       script_class.class_variable_set(:@@running, [script])
@@ -1112,9 +1162,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     it 'preserves an underlying thread-group rejection when worker teardown raises' do
       script = build_script('group-rejection')
       script_class.class_variable_set(:@@running, [script])
-      group = instance_double(ThreadGroup, :list => [])
-      allow(group).to receive(:add).and_raise(ThreadError, 'group rejected worker')
-      script.instance_variable_set(:@thread_group, group)
+      source_group = ThreadGroup.new
       worker = Thread.new do
         Thread.current.report_on_exception = false
         begin
@@ -1123,8 +1171,10 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
           raise 'worker teardown failed'
         end
       end
+      source_group.add(worker)
+      source_group.enclose
 
-      expect { script.thread_group.add(worker) }.to raise_error(ThreadError, /group rejected worker/)
+      expect { script.thread_group.add(worker) }.to raise_error(ThreadError, /enclosed/)
     end
 
     it 'does not block shutdown cleanup on a worker ensure block' do
@@ -1284,7 +1334,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.libs).to eq(Set['libutil'])
     end
 
-    it 'adopts an admitted plain start instead of reporting a duplicate failure' do
+    it 'adopts an admitted plain start across concurrent duplicate callers' do
       admitted_script = instance_double(
         script_class,
         :name                    => 'libutil',
@@ -1294,13 +1344,14 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       )
       startup_token = Object.new
       script_class.__send__(:__begin_start, startup_token, 'libutil', :force => false)
-      loader = Thread.new { script_class.loadlib('util') }
-      expect(loader.join(0.02)).to be_nil
+      loaders = Array.new(3) { Thread.new { script_class.loadlib('util') } }
+      waiters = script_class.class_variable_get(:@@completed_start_waiters)
+      Timeout.timeout(1) { Thread.pass until waiters['libutil'] == loaders.length }
       allow(script_class).to receive(:start)
 
       script_class.__send__(:__finish_start, startup_token, admitted_script)
 
-      expect(loader.value).to be(true)
+      expect(loaders.map(&:value)).to all be(true)
       expect(script_class).not_to have_received(:start)
       expect(script_class.libs).to include('libutil')
     end
@@ -1335,6 +1386,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.loadlib('util')).to be(true)
       expect(old_generation).not_to have_received(:join)
       expect(script_class.libs).to include('libutil')
+      expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
     end
 
     it 'uses the resolved library name when adopting a prefix start' do

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     script_class.class_variable_set(:@@running, [])
     script_class.class_variable_set(:@@stopping, [])
     script_class.class_variable_set(:@@startup_reservations, {})
+    script_class.class_variable_set(:@@startup_generation, 0)
     script_class.class_variable_set(:@@completed_named_starts, {})
     script_class.class_variable_set(:@@completed_start_waiters, Hash.new(0))
     script_class.class_variable_set(:@@shutdown_started, false)
@@ -229,8 +230,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.__send__(:__finish_start, reservation, library)
 
       completed = script_class.class_variable_get(:@@completed_named_starts)
-      expect(completed.fetch('libunused')).to be_a(WeakRef)
-      expect(completed.fetch('libunused').__getobj__).to equal(library)
+      completed_reference = completed.fetch('libunused').last
+      expect(completed_reference).to be_a(WeakRef)
+      expect(completed_reference.__getobj__).to equal(library)
     end
 
     it 'records a missing-label jump as unsuccessful execution' do
@@ -1365,6 +1367,35 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.__send__(:__finish_start, reservation, nil)
 
       expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+    end
+
+    it 'does not let an older failed start erase a newer completion' do
+      newer_generation = instance_double(script_class)
+      older_reservation = Object.new
+      newer_reservation = Object.new
+      script_class.__send__(:__begin_start, older_reservation, 'libutil', :force => true)
+      script_class.__send__(:__begin_start, newer_reservation, 'libutil', :force => true)
+
+      script_class.__send__(:__finish_start, newer_reservation, newer_generation)
+      script_class.__send__(:__finish_start, older_reservation, nil)
+
+      completed = script_class.class_variable_get(:@@completed_named_starts)['libutil']
+      expect(script_class.__send__(:__completed_start_value, completed)).to equal(newer_generation)
+    end
+
+    it 'does not let an older completion replace a newer completion' do
+      older_generation = instance_double(script_class)
+      newer_generation = instance_double(script_class)
+      older_reservation = Object.new
+      newer_reservation = Object.new
+      script_class.__send__(:__begin_start, older_reservation, 'libutil', :force => true)
+      script_class.__send__(:__begin_start, newer_reservation, 'libutil', :force => true)
+
+      script_class.__send__(:__finish_start, newer_reservation, newer_generation)
+      script_class.__send__(:__finish_start, older_reservation, older_generation)
+
+      completed = script_class.class_variable_get(:@@completed_named_starts)['libutil']
+      expect(script_class.__send__(:__completed_start_value, completed)).to equal(newer_generation)
     end
 
     it 'adopts a completed forced generation ahead of an older running generation' do


### PR DESCRIPTION
## Summary

Synchronizes concurrent script startup, execution, ownership, and teardown:

- Reserves startup names before publication and treats running and stopping generations as occupied names.
- Publishes generation-specific startup results to exact registered waiters, retaining completed scripts only while live callers can consume them.
- Prunes dead startup waiters and completed stopping entries so abandoned callers cannot leak state or permanently reject a restart.
- Keeps forced and ordinary generations distinct, preventing stale completions from satisfying a newer caller.
- Tracks running and stopping scripts through complete teardown.
- Makes parent adoption and child launch ordering atomic.
- Adds lifecycle-aware worker registration and completion accounting.
- Coordinates concurrent library loads, shares one startup generation, and rejects cyclic library dependencies.

## Validation

Full stack head: 5,094 examples, 0 failures. RuboCop: 1,031 files inspected, no offenses.

## Stack

2 of 6. Depends on the supervised child script API PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous script termination support.
  * Added a way to check whether a script completed successfully and inspect exit errors.
  * Improved script and child-script startup, registration, and shutdown coordination.
  * Enhanced library loading and reloading, including safer handling of concurrent operations and cyclic dependencies.

* **Bug Fixes**
  * Improved cleanup reliability, preventing scripts or workers from being left running during shutdown.
  * Improved lifecycle behavior when scripts are restarted, interrupted, or stopped simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->