### PR TITLE
fix(all): Coordinate script shutdown draining (03 of 06)

### DIFF
--- a/lib/common/orderly_shutdown.rb
+++ b/lib/common/orderly_shutdown.rb
@@ -43,12 +43,18 @@ module Lich
           ShutdownLog.begin_user_exit_summary!
           coordinator.request(reason: :user_exit, source: source)
 
-          scripts_provider ||= proc { Script.running + Script.hidden }
+          initial_scripts =
+            if scripts_provider
+              scripts_provider.call
+            else
+              Script.begin_shutdown
+            end
+          scripts_provider ||= proc { Script.shutdown_scripts }
           remaining_scripts = proc { scripts_provider.call.reject { |script| script.equal?(current_script) } }
 
-          run(
+          result = run(
             coordinator: coordinator,
-            initial_scripts: remaining_scripts.call,
+            initial_scripts: initial_scripts.reject { |script| script.equal?(current_script) },
             remaining_scripts: remaining_scripts,
             script_drain: script_drain,
             vars: vars,
@@ -56,6 +62,11 @@ module Lich
             active_sessions_lifecycle: active_sessions_lifecycle,
             slow_threshold: slow_threshold
           )
+          if current_script && initial_scripts.include?(current_script)
+            result.scripts_drained = false
+            result.completed = false
+          end
+          result
         end
 
         # Executes orderly user shutdown once.

--- a/lib/common/orderly_shutdown.rb
+++ b/lib/common/orderly_shutdown.rb
@@ -49,7 +49,7 @@ module Lich
             else
               Script.begin_shutdown
             end
-          scripts_provider ||= proc { Script.shutdown_scripts }
+          scripts_provider ||= proc { Script.progress_shutdown }
           remaining_scripts = proc { scripts_provider.call.reject { |script| script.equal?(current_script) } }
 
           result = run(

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -868,7 +868,10 @@ module Lich
       #
       # @param timeout [Numeric, nil] maximum seconds to wait, or nil to wait indefinitely
       # @return [Script, nil] the completed child, or nil on startup failure or timeout
+      # @raise [ArgumentError] when the timeout is negative, before the child starts
       def Script.run_child(*args, timeout: nil)
+        raise ArgumentError, 'timeout must be non-negative' if timeout && timeout.negative?
+
         child = Script.start_child(*args)
         return nil unless child
 

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -35,6 +35,13 @@ module Lich
       RAW_THREAD_GROUP_LIST = ThreadGroup.instance_method(:list)
       RAW_THREAD_GROUP_ENCLOSE = ThreadGroup.instance_method(:enclose)
       RAW_THREAD_GROUP_ENCLOSED = ThreadGroup.instance_method(:enclosed?)
+      SCRIPT_CLEANUP_TIMEOUT = 1.0
+      JOIN_WAIT_INTERVAL = 0.05
+
+      # Lock order:
+      #   startup -> registry -> per-script lifecycle -> child ownership
+      # Library coordination never holds its mutex while starting or joining a
+      # script. No lock in this hierarchy may be held while invoking script code.
 
       module ThreadGroupHandle
         def __attach_script(script)
@@ -396,6 +403,7 @@ module Lich
       @@stopping = Array.new
       @@startup_mutex = Mutex.new
       @@startup_condition = ConditionVariable.new
+      @@registry_mutex = Mutex.new
       @@startup_reservations = {}
       @@startup_generation = 0
       @@completed_named_starts = {}
@@ -669,14 +677,35 @@ module Lich
       end
       private_class_method :__warn_lich_too_old
 
+      def Script.__registry_synchronize(&block)
+        @@registry_mutex.synchronize(&block)
+      end
+      private_class_method :__registry_synchronize
+
+      def Script.__running_snapshot
+        __registry_synchronize { @@running.dup }
+      end
+      private_class_method :__running_snapshot
+
+      def Script.__shutdown_snapshot
+        __registry_synchronize { (@@running + @@stopping).uniq }
+      end
+      private_class_method :__shutdown_snapshot
+
       def Script.list
-        @@running.dup
+        __running_snapshot
       end
 
       def Script.shutdown_scripts
-        scripts = (@@running + @@stopping).uniq
+        __shutdown_snapshot
+      end
+
+      # Advances teardown that lost its cleanup executor, then returns the
+      # scripts still participating in shutdown.
+      def Script.progress_shutdown
+        scripts = __shutdown_snapshot
         scripts.each { |script| script.__send__(:__refresh_deferred_stop) }
-        (@@running + @@stopping).uniq
+        __shutdown_snapshot
       end
 
       def Script.begin_shutdown
@@ -739,11 +768,11 @@ module Lich
       private_class_method :__begin_library_start
 
       def Script.__active_named_script(name)
-        running = @@running.dup.find { |script| script.name.casecmp?(name) }
-        return running if running
-
-        @@stopping.dup.find do |script|
-          script.name.casecmp?(name) && !script.__send__(:__cleanup_complete?)
+        __registry_synchronize do
+          running = @@running.find { |script| script.name.casecmp?(name) }
+          running || @@stopping.find do |script|
+            script.name.casecmp?(name) && !script.__send__(:__cleanup_complete?)
+          end
         end
       end
       private_class_method :__active_named_script
@@ -859,7 +888,7 @@ module Lich
       end
 
       def Script.current
-        if (script = @@running.find { |s| s.has_thread?(Thread.current) })
+        if (script = __running_snapshot.find { |s| s.has_thread?(Thread.current) })
           sleep 0.2 while script.paused? and not script.ignore_pause
           script
         else
@@ -873,7 +902,7 @@ module Lich
 
       def Script.run(*args)
         if (s = @@elevated_script_start.call(args, nil))
-          sleep 0.1 while @@running.include?(s)
+          s.join
         end
       end
 
@@ -916,7 +945,7 @@ module Lich
           raise LoadError, "cannot load script library during shutdown: #{library_name}" if startup_status == :shutdown
 
           script, already_loaded, owns_loading = @@library_mutex.synchronize do
-            running = @@running.find { |candidate| candidate.name.casecmp?(library_name) }
+            running = __running_snapshot.find { |candidate| candidate.name.casecmp?(library_name) }
             if (loading = @@loading_libraries[library_name])
               [loading, false, false]
             elsif (candidate = completed_start || running)
@@ -1040,7 +1069,7 @@ module Lich
       private_class_method :__library_dependency_reaches?
 
       def Script.running?(name)
-        @@running.any? { |i| (i.name =~ /^#{name}$/i) }
+        __running_snapshot.any? { |i| (i.name =~ /^#{name}$/i) }
       end
 
       def Script.pause(name = nil)
@@ -1048,7 +1077,8 @@ module Lich
           Script.current.pause
           Script.current
         else
-          if (s = (@@running.find { |i| (i.name == name) and not i.paused? }) || (@@running.find { |i| (i.name =~ /^#{name}$/i) and not i.paused? }))
+          running = __running_snapshot
+          if (s = (running.find { |i| (i.name == name) and not i.paused? }) || (running.find { |i| (i.name =~ /^#{name}$/i) and not i.paused? }))
             s.pause
             true
           else
@@ -1058,7 +1088,8 @@ module Lich
       end
 
       def Script.unpause(name)
-        if (s = (@@running.find { |i| (i.name == name) and i.paused? }) || (@@running.find { |i| (i.name =~ /^#{name}$/i) and i.paused? }))
+        running = __running_snapshot
+        if (s = (running.find { |i| (i.name == name) and i.paused? }) || (running.find { |i| (i.name =~ /^#{name}$/i) and i.paused? }))
           s.unpause
           true
         else
@@ -1082,7 +1113,8 @@ module Lich
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
-        if (s = (@@running.find { |i| i.name == name }) || (@@running.find { |i| i.name =~ /^#{name}$/i }))
+        running = __running_snapshot
+        if (s = (running.find { |i| i.name == name }) || (running.find { |i| i.name =~ /^#{name}$/i }))
           s.killed_externally = true
           s.kill_source = caller[0..2]
           s.kill(context: context)
@@ -1108,7 +1140,8 @@ module Lich
       end
 
       def Script.paused?(name)
-        if (s = (@@running.find { |i| i.name == name }) || (@@running.find { |i| i.name =~ /^#{name}$/i }))
+        running = __running_snapshot
+        if (s = (running.find { |i| i.name == name }) || (running.find { |i| i.name =~ /^#{name}$/i }))
           s.paused?
         else
           nil
@@ -1120,19 +1153,19 @@ module Lich
       end
 
       def Script.new_downstream_xml(line)
-        for script in @@running
+        for script in __running_snapshot
           script.downstream_buffer.push(line.chomp) if script.want_downstream_xml
         end
       end
 
       def Script.new_upstream(line)
-        for script in @@running
+        for script in __running_snapshot
           script.upstream_buffer.push(line.chomp) if script.want_upstream
         end
       end
 
       def Script.new_downstream(line)
-        @@running.each { |script|
+        __running_snapshot.each { |script|
           script.downstream_buffer.push(line.chomp) if script.want_downstream
           unless script.watchfor.empty?
             script.watchfor.each_pair { |trigger, action|
@@ -1165,7 +1198,7 @@ module Lich
       end
 
       def Script.new_script_output(line)
-        for script in @@running
+        for script in __running_snapshot
           script.downstream_buffer.push(line.chomp) if script.want_script_output
         end
       end
@@ -1216,7 +1249,7 @@ module Lich
 
       def Script.running
         list = Array.new
-        for script in @@running
+        for script in __running_snapshot
           list.push(script) unless script.hidden
         end
         return list
@@ -1228,7 +1261,7 @@ module Lich
 
       def Script.hidden
         list = Array.new
-        for script in @@running
+        for script in __running_snapshot
           list.push(script) if script.hidden
         end
         return list
@@ -1501,15 +1534,17 @@ module Lich
         start_gate = Queue.new if async
         source = @kill_source || caller[0..2]
         begin
-          start_cleanup = lifecycle_mutex.synchronize do
-            next false unless @@running.include?(self)
-            next false if @cleanup_started
+          start_cleanup = Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              next false unless @@running.include?(self)
+              next false if @cleanup_started
 
-            @kill_requested = true
-            @cleanup_started = launch_token
-            @cleanup_launch_pending = true
-            @@stopping << self unless @@stopping.include?(self)
-            true
+              @kill_requested = true
+              @cleanup_started = launch_token
+              @cleanup_launch_pending = true
+              @@stopping << self unless @@stopping.include?(self)
+              true
+            end
           end
           return @name unless start_cleanup
 
@@ -1559,7 +1594,7 @@ module Lich
       #
       # @return [Boolean]
       def running?
-        @@running.include?(self)
+        Script.__send__(:__registry_synchronize) { @@running.include?(self) }
       end
 
       # Reports whether teardown has been requested.
@@ -1582,29 +1617,39 @@ module Lich
       # @return [Script, nil] this script, or nil when the timeout expires
       # @raise [ThreadError] when called by one of this script's workers
       def join(timeout = nil)
+        raise ArgumentError, 'timeout must be non-negative' if timeout && timeout.negative?
         if running? && has_thread?(Thread.current)
           raise ThreadError, 'cannot join the current script from one of its workers'
         end
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
+        cleanup_deadline = nil
         loop do
           __refresh_deferred_stop
-          completed = lifecycle_mutex.synchronize do
-            @stopped_condition ||= ConditionVariable.new
-            running = @@running.include?(self)
-            return self if !running && Array(@stopping_threads).include?(Thread.current)
-            return self if !running && @cleanup_complete
-
-            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC) if deadline
-            return nil if remaining && remaining <= 0
-
-            wait_for = running ? remaining : [remaining || 0.01, 0.01].min
-            @stopped_condition.wait(lifecycle_mutex, wait_for)
-            false
+          running, stopping, cleanup_complete, current_worker = Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              [
+                @@running.include?(self),
+                @kill_requested == true,
+                @cleanup_complete == true,
+                Array(@stopping_threads).include?(Thread.current)
+              ]
+            end
           end
-          break if completed
+          return self if !running && (cleanup_complete || current_worker)
+
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          cleanup_deadline ||= now + SCRIPT_CLEANUP_TIMEOUT if stopping
+          effective_deadline = [deadline, cleanup_deadline].compact.min
+          remaining = effective_deadline - now if effective_deadline
+          return nil if remaining && remaining <= 0
+
+          wait_for = remaining ? [remaining, JOIN_WAIT_INTERVAL].min : JOIN_WAIT_INTERVAL
+          lifecycle_mutex.synchronize do
+            @stopped_condition ||= ConditionVariable.new
+            @stopped_condition.wait(lifecycle_mutex, wait_for)
+          end
         end
-        self
       end
 
       # Requests teardown and waits for completion.
@@ -1684,7 +1729,7 @@ module Lich
 
         @killer_mutex.synchronize {
           lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
-          if @@running.include?(self)
+          if running?
             instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
             started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
             failed = false
@@ -1871,18 +1916,20 @@ module Lich
         tracked_rejection = false
         accepted = false
         begin
-          accepted = lifecycle_mutex.synchronize do
-            if @@running.include?(self) && !@kill_requested
-              __raw_add_worker(thread)
-              true
-            else
-              @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
-              unless @worker_admission_closed
-                @worker_registrations ||= Set.new
-                @worker_registrations.add(registration)
-                tracked_rejection = true
+          accepted = Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              if @@running.include?(self) && !@kill_requested
+                __raw_add_worker(thread)
+                true
+              else
+                @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
+                unless @worker_admission_closed
+                  @worker_registrations ||= Set.new
+                  @worker_registrations.add(registration)
+                  tracked_rejection = true
+                end
+                false
               end
-              false
             end
           end
           unless accepted
@@ -1963,33 +2010,38 @@ module Lich
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+          Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+          end
         end
         self
       end
       private :__publish
 
       def __while_running
-        lifecycle_mutex.synchronize do
-          return nil unless @@running.include?(self) && !stopping?
-
-          yield
+        runnable = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize { @@running.include?(self) && !stopping? }
         end
+        return nil unless runnable
+
+        yield
       end
       private :__while_running
 
       def __discard_startup
         parent = nil
-        lifecycle_mutex.synchronize do
-          @@running.delete(self)
-          @@stopping.delete(self)
-          @worker_admission_closed = true
-          @cleanup_complete = true
-          CHILD_RELATIONSHIP_MUTEX.synchronize do
-            parent = @parent_script
-            @parent_script = nil
+        Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            @@running.delete(self)
+            @@stopping.delete(self)
+            @worker_admission_closed = true
+            @cleanup_complete = true
+            CHILD_RELATIONSHIP_MUTEX.synchronize do
+              parent = @parent_script
+              @parent_script = nil
+            end
+            @stopped_condition&.broadcast
           end
-          @stopped_condition&.broadcast
         end
         parent&.unregister_child(self)
         self
@@ -2010,13 +2062,16 @@ module Lich
             end
           end
         ensure
-          lifecycle_mutex.synchronize do
-            late_workers = __raw_worker_threads.reject { |thread| thread == Thread.current }
-            @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
-            late_workers.each { |thread| thread.kill rescue nil }
-            @@running.delete(self)
-            @stopped_condition&.broadcast
+          late_workers = nil
+          Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              late_workers = __raw_worker_threads.reject { |thread| thread == Thread.current }
+              @stopping_threads = (Array(@stopping_threads) + late_workers).uniq
+              @@running.delete(self)
+              @stopped_condition&.broadcast
+            end
           end
+          late_workers.each { |thread| thread.kill rescue nil }
           workers_stopped = __wait_for_worker_shutdown(:wait => context != :shutdown)
           __finalize_stop if workers_stopped
         end
@@ -2063,19 +2118,23 @@ module Lich
       private :__wait_for_worker_shutdown
 
       def __refresh_deferred_stop
-        abandoned_cleanup = lifecycle_mutex.synchronize do
-          if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
-             (!@cleanup_thread || !@cleanup_thread.alive?)
-            @cleanup_started = false
-            @cleanup_thread = nil
-            true
+        abandoned_cleanup = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
+               (!@cleanup_thread || !@cleanup_thread.alive?)
+              @cleanup_started = false
+              @cleanup_thread = nil
+              true
+            end
           end
         end
         kill(:context => :shutdown) if abandoned_cleanup
 
-        should_refresh = lifecycle_mutex.synchronize do
-          cleanup_active_elsewhere = @cleanup_thread&.alive? && @cleanup_thread != Thread.current
-          @cleanup_started && !@cleanup_complete && !@@running.include?(self) && !cleanup_active_elsewhere
+        should_refresh = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            cleanup_active_elsewhere = @cleanup_thread&.alive? && @cleanup_thread != Thread.current
+            @cleanup_started && !@cleanup_complete && !@@running.include?(self) && !cleanup_active_elsewhere
+          end
         end
         __finalize_stop if should_refresh && __wait_for_worker_shutdown(:wait => false)
       end
@@ -2100,10 +2159,12 @@ module Lich
           parent&.unregister_child(self)
           CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
         ensure
-          lifecycle_mutex.synchronize do
-            @cleanup_complete = true
-            @@stopping.delete(self)
-            @stopped_condition&.broadcast
+          Script.__send__(:__registry_synchronize) do
+            lifecycle_mutex.synchronize do
+              @cleanup_complete = true
+              @@stopping.delete(self)
+              @stopped_condition&.broadcast
+            end
           end
         end
       end
@@ -2405,12 +2466,14 @@ module Lich
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          @@name_subscript_mutex.synchronize do
-            lifecycle_mutex.synchronize do
-              num = '1'
-              num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
-              @name = "subscript#{num}"
-              @@running.push(self)
+          Script.__send__(:__registry_synchronize) do
+            @@name_subscript_mutex.synchronize do
+              lifecycle_mutex.synchronize do
+                num = '1'
+                num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
+                @name = "subscript#{num}"
+                @@running.push(self)
+              end
             end
           end
         end
@@ -2575,12 +2638,14 @@ module Lich
 
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          @@name_exec_mutex.synchronize do
-            lifecycle_mutex.synchronize do
-              num = '1'
-              num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
-              @name = "#{@name_prefix}#{num}"
-              @@running.push(self)
+          Script.__send__(:__registry_synchronize) do
+            @@name_exec_mutex.synchronize do
+              lifecycle_mutex.synchronize do
+                num = '1'
+                num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
+                @name = "#{@name_prefix}#{num}"
+                @@running.push(self)
+              end
             end
           end
         end

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -35,7 +35,6 @@ module Lich
       RAW_THREAD_GROUP_LIST = ThreadGroup.instance_method(:list)
       RAW_THREAD_GROUP_ENCLOSE = ThreadGroup.instance_method(:enclose)
       RAW_THREAD_GROUP_ENCLOSED = ThreadGroup.instance_method(:enclosed?)
-      SCRIPT_CLEANUP_TIMEOUT = 1.0
       JOIN_WAIT_INTERVAL = 0.05
 
       # Lock order:
@@ -867,11 +866,13 @@ module Lich
 
       # Starts a child script and waits for it to finish.
       #
-      # @return [Script, nil] the completed child, or nil when startup fails
-      def Script.run_child(*args)
+      # @param timeout [Numeric, nil] maximum seconds to wait, or nil to wait indefinitely
+      # @return [Script, nil] the completed child, or nil on startup failure or timeout
+      def Script.run_child(*args, timeout: nil)
         child = Script.start_child(*args)
-        child&.join
-        child
+        return nil unless child
+
+        child.join(timeout) ? child : nil
       end
 
       # Marks the current script as hidden and protected from kill-all and
@@ -1613,7 +1614,9 @@ module Lich
       # A script worker cannot join its own script because that worker must
       # return before the script can complete.
       #
-      # @param timeout [Numeric, nil] maximum seconds to wait
+      # Without a timeout, this method waits indefinitely.
+      #
+      # @param timeout [Numeric, nil] maximum seconds to wait, or nil to wait indefinitely
       # @return [Script, nil] this script, or nil when the timeout expires
       # @raise [ThreadError] when called by one of this script's workers
       def join(timeout = nil)
@@ -1623,14 +1626,12 @@ module Lich
         end
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
-        cleanup_deadline = nil
         loop do
           __refresh_deferred_stop
-          running, stopping, cleanup_complete, current_worker = Script.__send__(:__registry_synchronize) do
+          running, cleanup_complete, current_worker = Script.__send__(:__registry_synchronize) do
             lifecycle_mutex.synchronize do
               [
                 @@running.include?(self),
-                @kill_requested == true,
                 @cleanup_complete == true,
                 Array(@stopping_threads).include?(Thread.current)
               ]
@@ -1639,9 +1640,7 @@ module Lich
           return self if !running && (cleanup_complete || current_worker)
 
           now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          cleanup_deadline ||= now + SCRIPT_CLEANUP_TIMEOUT if stopping
-          effective_deadline = [deadline, cleanup_deadline].compact.min
-          remaining = effective_deadline - now if effective_deadline
+          remaining = deadline - now if deadline
           return nil if remaining && remaining <= 0
 
           wait_for = remaining ? [remaining, JOIN_WAIT_INTERVAL].min : JOIN_WAIT_INTERVAL

--- a/lib/common/shutdown_script_drain.rb
+++ b/lib/common/shutdown_script_drain.rb
@@ -60,6 +60,11 @@ module Lich
 
         drain_attempts.times do
           remaining = remaining_scripts.call.uniq
+          newly_observed = remaining.reject { |script| scripts.include?(script) }
+          unless newly_observed.empty?
+            scripts.concat(newly_observed)
+            newly_observed.each { |script| kill_script(script) }
+          end
           now = clock.call
 
           scripts.each do |script|
@@ -74,8 +79,14 @@ module Lich
           sleeper.call(drain_interval)
         end
 
-        finished_at = clock.call
         remaining = remaining_scripts.call.uniq
+        newly_observed = remaining.reject { |script| scripts.include?(script) }
+        unless newly_observed.empty?
+          scripts.concat(newly_observed)
+          newly_observed.each { |script| kill_script(script) }
+          remaining = remaining_scripts.call.uniq
+        end
+        finished_at = clock.call
 
         Result.new(
           scripts_started: scripts.length,

--- a/lib/common/shutdown_script_drain.rb
+++ b/lib/common/shutdown_script_drain.rb
@@ -60,11 +60,7 @@ module Lich
 
         drain_attempts.times do
           remaining = remaining_scripts.call.uniq
-          newly_observed = remaining.reject { |script| scripts.include?(script) }
-          unless newly_observed.empty?
-            scripts.concat(newly_observed)
-            newly_observed.each { |script| kill_script(script) }
-          end
+          observe_scripts!(scripts, remaining)
           now = clock.call
 
           scripts.each do |script|
@@ -80,10 +76,8 @@ module Lich
         end
 
         remaining = remaining_scripts.call.uniq
-        newly_observed = remaining.reject { |script| scripts.include?(script) }
+        newly_observed = observe_scripts!(scripts, remaining)
         unless newly_observed.empty?
-          scripts.concat(newly_observed)
-          newly_observed.each { |script| kill_script(script) }
           remaining = remaining_scripts.call.uniq
         end
         finished_at = clock.call
@@ -96,6 +90,14 @@ module Lich
           remaining_scripts: script_names(remaining)
         )
       end
+
+      def self.observe_scripts!(scripts, observed)
+        newly_observed = observed.reject { |script| scripts.include?(script) }
+        scripts.concat(newly_observed)
+        newly_observed.each { |script| kill_script(script) }
+        newly_observed
+      end
+      private_class_method :observe_scripts!
 
       # Attempts shutdown kill for a script and logs failures without stopping
       # the remaining shutdown drain.

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -80,7 +80,7 @@ reconnect_if_wanted = proc {
     Lich::Common::BestEffortShutdownCleanup.run(
       coordinator: Lich::Common::ShutdownCoordinator,
       initial_scripts: Script.begin_shutdown,
-      remaining_scripts: proc { Script.shutdown_scripts },
+      remaining_scripts: proc { Script.progress_shutdown },
       script_drain: Lich::Common::ShutdownScriptDrain,
       vars: Vars,
       active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))
@@ -918,7 +918,7 @@ reconnect_if_wanted = proc {
         scripts_at_shutdown = Script.begin_shutdown
         script_shutdown_result = Lich::Common::ShutdownScriptDrain.run(
           initial_scripts: scripts_at_shutdown,
-          remaining_scripts: proc { Script.shutdown_scripts },
+          remaining_scripts: proc { Script.progress_shutdown },
           slow_threshold: script_shutdown_slow_threshold
         )
       end

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -79,8 +79,8 @@ reconnect_if_wanted = proc {
   run_best_effort_shutdown_cleanup = proc {
     Lich::Common::BestEffortShutdownCleanup.run(
       coordinator: Lich::Common::ShutdownCoordinator,
-      initial_scripts: (Script.running + Script.hidden),
-      remaining_scripts: proc { Script.running + Script.hidden },
+      initial_scripts: Script.begin_shutdown,
+      remaining_scripts: proc { Script.shutdown_scripts },
       script_drain: Lich::Common::ShutdownScriptDrain,
       vars: Vars,
       active_sessions_lifecycle: (Lich::InternalAPI::ActiveSessions::Lifecycle if defined?(Lich::InternalAPI::ActiveSessions::Lifecycle))
@@ -915,9 +915,10 @@ reconnect_if_wanted = proc {
         # Individual script names are reported at 2x the step threshold so normal
         # teardown stays quiet while slow exits remain visible.
         script_shutdown_slow_threshold = shutdown_step_trace_thresholds.fetch('script shutdown', 0.75) * 2
+        scripts_at_shutdown = Script.begin_shutdown
         script_shutdown_result = Lich::Common::ShutdownScriptDrain.run(
-          initial_scripts: (Script.running + Script.hidden),
-          remaining_scripts: proc { Script.running + Script.hidden },
+          initial_scripts: scripts_at_shutdown,
+          remaining_scripts: proc { Script.shutdown_scripts },
           slow_threshold: script_shutdown_slow_threshold
         )
       end

--- a/spec/lib/common/orderly_shutdown_spec.rb
+++ b/spec/lib/common/orderly_shutdown_spec.rb
@@ -127,11 +127,35 @@ RSpec.describe Lich::Common::OrderlyShutdown do
       scripts_provider: proc { [current_script, other_script] }
     )
 
-    expect(result).to be_completed
+    expect(result).not_to be_completed
+    expect(result).not_to be_scripts_drained
     expect(coordinator.reason).to eq(:user_exit)
     expect(coordinator.current.source).to eq('script:shutdown-caller')
     expect(script_drain.calls.first[:initial_scripts]).to eq([other_script])
     expect(script_drain.calls.first[:remaining_scripts].call).to eq([other_script])
+  end
+
+  it 'closes script startup admission before the production drain snapshot' do
+    coordinator.reset!
+    current_script = Struct.new(:name).new('shutdown-caller')
+    other_script = Struct.new(:name).new('other')
+    allow(Script).to receive(:begin_shutdown).and_return([current_script, other_script])
+    allow(Script).to receive(:shutdown_scripts).and_return([current_script, other_script])
+
+    result = described_class.request_user_exit(
+      source: 'script:shutdown-caller',
+      current_script: current_script,
+      coordinator: coordinator,
+      script_drain: script_drain,
+      vars: vars,
+      game: game,
+      active_sessions_lifecycle: active_sessions_lifecycle
+    )
+
+    expect(result).not_to be_completed
+    expect(result).not_to be_scripts_drained
+    expect(Script).to have_received(:begin_shutdown).once
+    expect(script_drain.calls.first[:initial_scripts]).to eq([other_script])
   end
 
   it 'continues later cleanup steps when one step fails' do

--- a/spec/lib/common/orderly_shutdown_spec.rb
+++ b/spec/lib/common/orderly_shutdown_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Lich::Common::OrderlyShutdown do
     current_script = Struct.new(:name).new('shutdown-caller')
     other_script = Struct.new(:name).new('other')
     allow(Script).to receive(:begin_shutdown).and_return([current_script, other_script])
-    allow(Script).to receive(:shutdown_scripts).and_return([current_script, other_script])
+    allow(Script).to receive(:progress_shutdown).and_return([current_script, other_script])
 
     result = described_class.request_user_exit(
       source: 'script:shutdown-caller',

--- a/spec/lib/common/script_kill_metrics_spec.rb
+++ b/spec/lib/common/script_kill_metrics_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
     allow(GC).to receive(:start)
+    allow_any_instance_of(script_class).to receive(:report_errors) { |_script, &block| block.call }
   end
 
   after do
@@ -135,7 +136,10 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [first, second])
       allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
       allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
+      cleanup_times = [10.0, 10.025, 20.0, 20.050]
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) do
+        Thread.current == Thread.main ? 0.0 : cleanup_times.shift
+      end
 
       first.kill
       first.join
@@ -154,7 +158,10 @@ RSpec.describe 'Lich::Common::Script kill metrics' do
       script_class.class_variable_set(:@@running, [first, second])
       allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(true)
       allow(Time).to receive(:now).and_return(Time.at(60), Time.at(120))
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 10.025, 20.0, 20.050)
+      cleanup_times = [10.0, 10.025, 20.0, 20.050]
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) do
+        Thread.current == Thread.main ? 0.0 : cleanup_times.shift
+      end
 
       first.kill
       first.join

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -407,6 +407,14 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.run_child('child', :timeout => 0.25)).to be_nil
     end
 
+    it 'rejects a negative Script.run_child timeout before starting the child' do
+      expect(script_class).not_to receive(:start_child)
+
+      expect {
+        script_class.run_child('child', :timeout => -1)
+      }.to raise_error(ArgumentError, /non-negative/)
+    end
+
     it 'marks the current script as a daemon' do
       script = build_script('daemon')
       allow(script_class).to receive(:current).and_return(script)

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -394,9 +394,17 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     it 'waits for a child through Script.run_child' do
       child = build_script('child')
       allow(script_class).to receive(:start_child).with('child').and_return(child)
-      expect(child).to receive(:join).and_return(child)
+      expect(child).to receive(:join).with(nil).and_return(child)
 
       expect(script_class.run_child('child')).to equal(child)
+    end
+
+    it 'applies an explicit Script.run_child timeout' do
+      child = build_script('child')
+      allow(script_class).to receive(:start_child).with('child').and_return(child)
+      expect(child).to receive(:join).with(0.25).and_return(nil)
+
+      expect(script_class.run_child('child', :timeout => 0.25)).to be_nil
     end
 
     it 'marks the current script as a daemon' do
@@ -973,9 +981,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script).not_to be_running
     end
 
-    it 'bounds an implicit join once teardown begins' do
-      stub_const('Lich::Common::Script::SCRIPT_CLEANUP_TIMEOUT', 0.03)
-      stub_const('Lich::Common::Script::JOIN_WAIT_INTERVAL', 0.005)
+    it 'waits indefinitely for teardown when no timeout is given' do
       worker_ready = Queue.new
       worker_cleanup_entered = Queue.new
       release_worker_cleanup = Queue.new
@@ -992,11 +998,12 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       script.kill
       worker_cleanup_entered.pop
+      waiter = Thread.new { script.join }
 
-      expect(script.join).to be_nil
+      expect(waiter.join(0.05)).to be_nil
 
       release_worker_cleanup << true
-      expect(script.join(1)).to equal(script)
+      expect(waiter.value).to equal(script)
     end
 
     it 'keeps shutdown snapshots free of teardown side effects' do

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -973,6 +973,44 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script).not_to be_running
     end
 
+    it 'bounds an implicit join once teardown begins' do
+      stub_const('Lich::Common::Script::SCRIPT_CLEANUP_TIMEOUT', 0.03)
+      stub_const('Lich::Common::Script::JOIN_WAIT_INTERVAL', 0.005)
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      script = subscript_class.start(:parent => nil) do
+        worker_ready << true
+        begin
+          Queue.new.pop
+        ensure
+          worker_cleanup_entered << true
+          release_worker_cleanup.pop
+        end
+      end
+      worker_ready.pop
+
+      script.kill
+      worker_cleanup_entered.pop
+
+      expect(script.join).to be_nil
+
+      release_worker_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'keeps shutdown snapshots free of teardown side effects' do
+      script = build_script('deferred-cleanup')
+      script_class.class_variable_set(:@@stopping, [script])
+      allow(script).to receive(:__refresh_deferred_stop)
+
+      expect(script_class.shutdown_scripts).to contain_exactly(script)
+      expect(script).not_to have_received(:__refresh_deferred_stop)
+
+      expect(script_class.progress_shutdown).to contain_exactly(script)
+      expect(script).to have_received(:__refresh_deferred_stop).once
+    end
+
     it 'finishes inline cleanup when the killing caller is cancelled' do
       script = build_script('cancelled-inline-cleanup')
       script_class.class_variable_set(:@@running, [script])

--- a/spec/lib/common/shutdown_script_drain_spec.rb
+++ b/spec/lib/common/shutdown_script_drain_spec.rb
@@ -56,6 +56,82 @@ RSpec.describe Lich::Common::ShutdownScriptDrain do
     )
   end
 
+  it 'adopts and kills scripts that appear while draining' do
+    initial_script = build_script('initial')
+    late_script = build_script('late')
+    poll = 0
+
+    result = described_class.run(
+      initial_scripts: [initial_script],
+      remaining_scripts: proc {
+        poll += 1
+        poll == 1 ? [initial_script, late_script] : []
+      },
+      slow_threshold: 1.5,
+      clock: proc { 0.0 },
+      sleeper: proc { |_duration| nil }
+    )
+
+    expect(initial_script.kill_contexts).to eq([:shutdown])
+    expect(late_script.kill_contexts).to eq([:shutdown])
+    expect(result.scripts_started).to eq(2)
+    expect(result.scripts_remaining).to eq(0)
+  end
+
+  it 'kills a script first observed by the final status poll' do
+    initial_script = build_script('initial')
+    late_script = build_script('late')
+    poll = 0
+
+    result = described_class.run(
+      initial_scripts: [initial_script],
+      remaining_scripts: proc {
+        poll += 1
+        case poll
+        when 1 then []
+        when 2 then [late_script]
+        else []
+        end
+      },
+      slow_threshold: 1.5,
+      clock: proc { 0.0 },
+      sleeper: proc { |_duration| nil }
+    )
+
+    expect(late_script.kill_contexts).to eq([:shutdown])
+    expect(result.scripts_started).to eq(2)
+    expect(result.remaining_scripts).to be_empty
+  end
+
+  it 'includes a final-poll kill in slow-script timing' do
+    now = 0.0
+    late_script = Struct.new(:name) do
+      define_method(:kill) do |context:|
+        raise "unexpected context: #{context}" unless context == :shutdown
+
+        now = Thread.current[:shutdown_drain_clock]
+        Thread.current[:shutdown_drain_clock] = now + 2.0
+      end
+    end.new('late')
+    poll = 0
+    Thread.current[:shutdown_drain_clock] = now
+
+    result = described_class.run(
+      initial_scripts: [],
+      remaining_scripts: proc {
+        poll += 1
+        poll == 2 ? [late_script] : []
+      },
+      slow_threshold: 1.5,
+      clock: proc { Thread.current[:shutdown_drain_clock] },
+      sleeper: proc { |_duration| nil }
+    )
+
+    expect(result.slow_scripts).to eq(['late=2.000s'])
+  ensure
+    Thread.current[:shutdown_drain_clock] = nil
+  end
+
   it 'records a script that exits after the slow threshold' do
     script = build_script('slow-finished')
     now = 0.0


### PR DESCRIPTION
## Summary

Connects lifecycle state to process shutdown and makes wait bounds explicit:

- Closes startup admission before the initial shutdown snapshot.
- Tracks scripts through stopping and cleanup rather than only registry removal.
- Reclaims deferred teardown and discovers scripts first observed during drain polling.
- Reports incomplete teardown when the current script remains in the shutdown set.
- Makes `Script#join(timeout = nil)` wait indefinitely unless the caller supplies a timeout.
- Adds `Script.run_child(*args, timeout: nil)`; a timeout returns `nil` if complete teardown does not finish in time.
- Keeps process shutdown bounded at the `ShutdownScriptDrain` call site instead of imposing a global timeout on every join.

## Validation

Full stack head: 5,094 examples, 0 failures. RuboCop: 1,031 files inspected, no offenses.

## Stack

3 of 6. Depends on synchronized lifecycle transitions.