### PR TITLE
fix(all): Harden script lifecycle ownership (05 of 06)

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -37,10 +37,13 @@ module Lich
       RAW_THREAD_GROUP_ENCLOSED = ThreadGroup.instance_method(:enclosed?)
       JOIN_WAIT_INTERVAL = 0.05
 
-      # Lock order:
-      #   startup -> registry -> per-script lifecycle -> child ownership
-      # Library coordination never holds its mutex while starting or joining a
-      # script. No lock in this hierarchy may be held while invoking script code.
+      # Nested lock order:
+      #   parent child list -> startup -> registry -> generated name
+      #   -> per-script lifecycle -> child relationship
+      # Finalization releases the relationship lock before taking a parent's
+      # child-list lock. Library coordination releases its mutex before starting
+      # or joining a script. Registry and lifecycle locks are never held while
+      # invoking script code or cleanup callbacks.
 
       module ThreadGroupHandle
         def __attach_script(script)

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -866,8 +866,8 @@ module Lich
       private_class_method :__startup_in_progress_locked?
 
       def Script.__library_handoff_reserved_locked?(name)
-        @@startup_reservations.any? do |_reservation, (reserved_name, _owner, generation)|
-          reserved_name == name && generation.nil?
+        @@startup_reservations.any? do |_reservation, (reserved_name, owner, generation)|
+          reserved_name == name && owner == Thread.current && generation.nil?
         end
       end
       private_class_method :__library_handoff_reserved_locked?
@@ -1040,7 +1040,7 @@ module Lich
             if start_required
               script ||= __peek_completed_start(library_name)
               if script
-                @@library_mutex.synchronize { @@loading_libraries[library_name] = script }
+                @@library_mutex.synchronize { @@loading_libraries[library_name] ||= script }
               end
             end
             published_script = script || @@library_mutex.synchronize { @@loading_libraries[library_name] }
@@ -1113,8 +1113,11 @@ module Lich
             dependencies = @@library_waits[caller_script]
             dependencies = {} unless dependencies.is_a?(Hash)
             @@library_waits[caller_script] = dependencies
-            dependencies[script] ||= Set.new
-            dependencies[script].add(dependency_token)
+            if dependencies.key?(script)
+              dependencies[script].add(dependency_token)
+            else
+              dependencies[script] = Set[dependency_token]
+            end
           end
         end
 
@@ -1647,7 +1650,11 @@ module Lich
           start_cleanup = Script.__send__(:__registry_synchronize) do
             lifecycle_mutex.synchronize do
               next false unless @@running.include?(self)
-              next false if @cleanup_started
+              if @cleanup_started
+                cleanup_active = @cleanup_launch_pending ||
+                                 (@cleanup_thread&.alive? && @cleanup_thread != Thread.current)
+                next false if cleanup_active
+              end
 
               @kill_requested = true
               @cleanup_started = launch_token
@@ -1656,10 +1663,7 @@ module Lich
               true
             end
           end
-          unless start_cleanup
-            __refresh_deferred_stop(:context => context)
-            return @name
-          end
+          return @name unless start_cleanup
 
           if async
             cleanup_thread = Thread.new {
@@ -1694,10 +1698,8 @@ module Lich
             end
           end
           if @cleanup_started.equal?(launch_token)
-            executor_abandoned = !cleanup_owned || !cleanup_thread&.alive? || cleanup_thread == Thread.current
-            __run_kill_cleanup(source: source, context: context, record_metrics: false) if running? && executor_abandoned
             executor_abandoned = __finish_cleanup_launch
-            __run_kill_cleanup(source: source, context: context, record_metrics: false) if running? && executor_abandoned
+            kill(:context => context, :async => true) if running? && executor_abandoned
           end
         end
 

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -1051,7 +1051,11 @@ module Lich
         @@library_mutex.synchronize { @@loaded_libraries.dup }.each do |library|
           next if library == current_library
 
-          @@library_mutex.synchronize { @@loaded_libraries.delete(library) }
+          @@library_mutex.synchronize do
+            was_loaded = @@loaded_libraries.include?(library)
+            @@loaded_libraries.delete(library)
+            @@loading_libraries.delete(library) if was_loaded
+          end
           Script.loadlib(library, :timeout => timeout)
         rescue LoadError => e
           successful = false
@@ -1069,6 +1073,7 @@ module Lich
 
       def Script.__join_library(library_name, script, timeout = nil)
         caller_script = Script.current
+        dependency_registered = false
         @@library_mutex.synchronize do
           if caller_script
             if __library_dependency_reaches?(script, caller_script)
@@ -1078,13 +1083,14 @@ module Lich
             dependencies = Hash.new(0) unless dependencies.is_a?(Hash)
             @@library_waits[caller_script] = dependencies
             dependencies[script] += 1
+            dependency_registered = true
           end
         end
 
         joined = script.join(timeout)
         raise LibraryJoinTimeout, "script library wait timed out: #{library_name}" unless joined
       ensure
-        if caller_script
+        if caller_script && dependency_registered
           @@library_mutex.synchronize do
             dependencies = @@library_waits[caller_script]
             if dependencies.is_a?(Hash)
@@ -1802,6 +1808,7 @@ module Lich
         cleanup_thread_group = __cleanup_worker_group
         previous_group_owner = nil
         moved_to_cleanup_group = false
+        cleanup_group_error = nil
         move_allowed = previous_thread_group.equal?(ThreadGroup::Default)
         if previous_cleanup_script
           previous_group_owner = previous_cleanup_script
@@ -1814,9 +1821,11 @@ module Lich
           begin
             RAW_THREAD_GROUP_ADD.bind_call(cleanup_thread_group, Thread.current)
             moved_to_cleanup_group = true
-          rescue ThreadError
+          rescue ThreadError => error
             previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
-            nil
+            cleanup_group_error = ThreadError.new(
+              "cannot establish cleanup ownership for #{@name}: #{error.message}"
+            )
           end
         end
         Thread.current.thread_variable_set(CLEANUP_SCRIPT_THREAD_KEY, self)
@@ -1829,6 +1838,8 @@ module Lich
               failed = false
               cleanup_body_complete = false
               begin
+                raise cleanup_group_error if cleanup_group_error
+
                 __close_child_launch_admission
                 stopping_threads = lifecycle_mutex.synchronize do
                   @stopping_threads = __raw_worker_threads.reject { |thread| thread == Thread.current }

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -38,12 +38,13 @@ module Lich
       JOIN_WAIT_INTERVAL = 0.05
 
       # Nested lock order:
-      #   parent child list -> startup -> registry -> generated name
-      #   -> per-script lifecycle -> child relationship
-      # Finalization releases the relationship lock before taking a parent's
-      # child-list lock. Library coordination releases its mutex before starting
-      # or joining a script. Registry and lifecycle locks are never held while
-      # invoking script code or cleanup callbacks.
+      #   startup -> registry -> per-script lifecycle -> child relationship
+      # Child adoption takes the parent's child-list lock before the child's
+      # registry/lifecycle locks. Child launch reservations avoid holding that
+      # lock across startup. Finalization releases the relationship lock before
+      # taking a parent's child-list lock. Library coordination releases its
+      # mutex before starting or joining a script. Registry and lifecycle locks
+      # are never held while invoking script code or cleanup callbacks.
 
       module ThreadGroupHandle
         def __attach_script(script)
@@ -65,6 +66,15 @@ module Lich
 
         def list
           @script.__send__(:__public_worker_threads)
+        end
+
+        def enclose
+          @script.__send__(:__enclose_worker_group)
+          self
+        end
+
+        def enclosed?
+          @script.__send__(:__worker_group_enclosed?)
         end
 
         def enclose
@@ -167,49 +177,50 @@ module Lich
             new_thread = Thread.new {
               next unless start_gate.pop
 
-              if (script = Script.current)
-                eval('script = Script.current', script_binding, script.name)
-                Thread.current.priority = 1
-                respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
-                begin
-                  Script.__send__(
-                    :__execute,
-                    script,
-                    :on_error => proc { |error| Script.__send__(:__report_script_error, script, error, :untrusted => !trusted) }
-                  ) do
-                    if trusted
-                      eval(script.labels[script.current_label].to_s, script_binding, script.name)
-                    else
-                      while (script = Script.current) and script.current_label
-                        proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
-                        Script.current.get_next_label
+              script = script_obj
+              begin
+                if Script.current
+                  eval('script = Script.current', script_binding, script.name)
+                  Thread.current.priority = 1
+                  respond("--- Lich: #{script.custom? ? 'custom/' : ''}#{script.name} active.") unless script.quiet
+                  begin
+                    Script.__send__(
+                      :__execute,
+                      script,
+                      :on_error       => proc { |error| Script.__send__(:__report_script_error, script, error, :untrusted => !trusted) },
+                      :propagate_jump => true
+                    ) do
+                      if trusted
+                        eval(script.labels[script.current_label].to_s, script_binding, script.name)
+                      else
+                        while (script = Script.current) and script.current_label
+                          proc { foo = script.labels[script.current_label]; eval(foo, script_binding, script.name, 1) }.call
+                          Script.current.get_next_label
+                        end
                       end
                     end
+                  rescue JumpError => error
+                    if error == JUMP
+                      retry if Script.current.get_next_label != JUMP_ERROR
+                      respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
+                      respond error.backtrace.first
+                      Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{error.backtrace.join("\n\t")}"
+                      script.__send__(:__record_exit_error, JUMP_ERROR)
+                    else
+                      script.__send__(:__record_exit_error, error)
+                      Script.__send__(:__report_script_error, script, error, :untrusted => !trusted)
+                    end
                   end
-                rescue JumpError => error
-                  if error == JUMP
-                    retry if Script.current.get_next_label != JUMP_ERROR
-                    respond "--- label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!"
-                    respond error.backtrace.first
-                    Lich.log "label error: `#{Script.current.jump_label}' was not found, and no `LabelError' label was found!\n\t#{error.backtrace.join("\n\t")}"
-                    script.__send__(:__record_exit_error, JUMP_ERROR)
-                  else
-                    script.__send__(:__record_exit_error, error)
-                    Script.__send__(:__report_script_error, script, error, :untrusted => !trusted)
-                  end
-                ensure
-                  script.kill if script.running? && !script.stopping?
+                else
+                  respond '--- error: out of cheese'
                 end
-              else
-                respond '--- error: out of cheese'
+              ensure
+                script.kill if script.running? && !script.stopping?
               end
             }
             script_obj.__send__(:__attach_startup_worker, new_thread)
-            if parent && !parent.__send__(:__adopt_child_locked, script_obj)
-              new_thread&.kill
-              script_obj.__send__(:__discard_startup)
-              next nil
-            end
+            next nil if parent && !parent.__send__(:__adopt_child, script_obj)
+
             script_obj.__send__(:__publish, true)
             setup_complete = true
           ensure
@@ -220,7 +231,7 @@ module Lich
               unless setup_complete && worker_released
                 new_thread&.kill
                 new_thread&.join
-                parent.__send__(:__unregister_child_locked, script_obj) if parent
+                parent.unregister_child(script_obj) if parent
                 script_obj.__send__(:__discard_startup)
               end
             end
@@ -586,7 +597,7 @@ module Lich
       end
       private_class_method :__warn_lich_too_old
 
-      def Script.__execute(script, on_error:)
+      def Script.__execute(script, on_error:, propagate_jump: false)
         yield
         script.__send__(:__record_successful_exit)
       rescue SystemExit => error
@@ -595,8 +606,11 @@ module Lich
         else
           script.__send__(:__record_exit_error, error)
         end
-      rescue JumpError
-        raise
+      rescue JumpError => error
+        raise if propagate_jump
+
+        script.__send__(:__record_exit_error, error)
+        on_error.call(error)
       rescue ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => error
         script.__send__(:__record_exit_error, error)
         on_error.call(error)
@@ -982,15 +996,17 @@ module Lich
       # @return [true]
       def Script.reloadlibs
         current_library = Script.current&.name&.downcase
+        successful = true
         @@library_mutex.synchronize { @@loaded_libraries.dup }.each do |library|
           next if library == current_library
 
           @@library_mutex.synchronize { @@loaded_libraries.delete(library) }
           Script.loadlib(library)
         rescue LoadError => e
+          successful = false
           Lich.log("error: failed to reload script library #{library}: #{e.message}")
         end
-        true
+        successful
       end
 
       # Returns a snapshot of loaded script library names.
@@ -1606,7 +1622,7 @@ module Lich
       end
 
       def completed_successfully?
-        lifecycle_mutex.synchronize { @completed_successfully == true }
+        lifecycle_mutex.synchronize { @completed_successfully == true && !@exit_error }
       end
 
       # Waits for complete script teardown.
@@ -1627,7 +1643,6 @@ module Lich
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
         loop do
-          __refresh_deferred_stop
           running, cleanup_complete, current_worker = Script.__send__(:__registry_synchronize) do
             lifecycle_mutex.synchronize do
               [
@@ -1657,7 +1672,9 @@ module Lich
       # @param timeout [Numeric, nil] maximum seconds to wait
       # @return [Script, nil] this script, or nil when the timeout expires
       def kill_sync(context: :runtime, timeout: nil)
-        kill(context: context) if running?
+        if running?
+          timeout ? kill(context: context, :async => true) : kill(context: context)
+        end
         join(timeout)
       end
 
@@ -1692,9 +1709,7 @@ module Lich
       #
       # @return [Array<Script>]
       def child_scripts
-        child_scripts_mutex.synchronize do
-          CHILD_RELATIONSHIP_MUTEX.synchronize { Array(@child_scripts).dup }
-        end
+        child_scripts_mutex.synchronize { Array(@child_scripts).dup }
       end
 
       # Runs the script cleanup body used by {#kill}.
@@ -1726,82 +1741,118 @@ module Lich
         # cleanup body twice over already-nilled state, not skip it.)
         return if @killer_mutex.owned?
 
-        @killer_mutex.synchronize {
-          lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
-          if running?
-            instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
-            started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
-            failed = false
-            begin
-              children = __begin_child_shutdown
-              stopping_threads = lifecycle_mutex.synchronize do
-                @stopping_threads = __raw_worker_threads.reject { |thread| thread == Thread.current }
-              end
-              stopping_threads.each { |thread| thread.kill rescue nil }
-              __raw_add_worker(Thread.current)
-              __stop_children(children, context)
-              __raw_add_worker(Thread.current)
-              # Forward the kill context so die_with dependents torn down during
-              # shutdown also run inline -- otherwise they route back through the
-              # default :runtime path and re-spawn the thread-per-kill burst that
-              # inline shutdown teardown exists to avoid.
-              @die_with.each do |script_name|
-                Script.kill(script_name, context: context)
-                __raw_add_worker(Thread.current)
-              end
-              @paused = false
-              @at_exit_procs.each { |p| report_errors { p.call } }
-              # Let each per-script-state subsystem (the hook registries, etc.)
-              # apply its own death policy for what this script registered.
-              # Subsystems register with ScriptDeath, so kill does not name them;
-              # cleanup keys on this instance (not its name), so a force: true
-              # sibling sharing our name is unaffected. Hooks persist by default
-              # (so register-and-exit patterns like ;alias keep working); a hook
-              # is only removed if it opted in with persist: false.
-              ScriptDeath.run(self)
-              # Release per-script watchfor procs (and the bindings they
-              # capture). The script is removed from @@running below, so they can
-              # never fire again; cleared to {} rather than nil so a concurrent
-              # new_downstream sweep still sees a safe, empty collection.
-            rescue
-              failed = true
-              respond "--- Lich: error: #{$!}"
-              Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
-            ensure
+        begin
+          @killer_mutex.synchronize do
+            lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
+            if running?
+              instrument_kill = record_metrics && (context != :shutdown) && Script.__send__(:__script_kill_metrics_enabled?)
+              started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if instrument_kill
+              failed = false
+              cleanup_body_complete = false
               begin
-                if instrument_kill
-                  finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-                  Script.__send__(
-                    :__record_kill_metric,
-                    :duration_ms => (finished_at - started_at) * 1000.0,
-                    :failed      => failed
-                  )
+                children = __begin_child_shutdown
+                stopping_threads = lifecycle_mutex.synchronize do
+                  @stopping_threads = __raw_worker_threads.reject { |thread| thread == Thread.current }
                 end
+                stopping_threads.each { |thread| thread.kill rescue nil }
+                __raw_add_worker(Thread.current)
+                __stop_children(children, context)
+                __raw_add_worker(Thread.current)
+                # Shift each callback before invoking it. If this executor is
+                # cancelled, recovery resumes with the remaining callbacks.
+                while (script_name = @die_with.shift)
+                  failed = true unless __run_cleanup_callback do
+                    Script.kill(script_name, context: context)
+                    __raw_add_worker(Thread.current)
+                  end
+                end
+                @paused = false
+                while (callback = @at_exit_procs.shift)
+                  failed = true unless __run_cleanup_callback { callback.call }
+                end
+                # ScriptDeath handlers are individually isolated by the
+                # registry and are safe to retry after executor cancellation.
+                ScriptDeath.run(self)
+                cleanup_body_complete = true
+              rescue SystemExit, ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => error
+                failed = true
+                __record_exit_error(error)
+                __report_cleanup_error(error)
+                cleanup_body_complete = true
               ensure
-                __complete_stop(source, context)
+                begin
+                  if instrument_kill && cleanup_body_complete
+                    finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+                    Script.__send__(
+                      :__record_kill_metric,
+                      :duration_ms => (finished_at - started_at) * 1000.0,
+                      :failed      => failed
+                    )
+                  end
+                ensure
+                  __complete_stop(source, context) if cleanup_body_complete
+                end
               end
             end
           end
-        }
+        ensure
+          lifecycle_mutex.synchronize do
+            @cleanup_thread = nil if @cleanup_thread == Thread.current
+            @stopped_condition&.broadcast
+          end
+        end
       end
       private :__run_kill_cleanup
 
+      def __run_cleanup_callback
+        yield
+        true
+      rescue SystemExit, ScriptError, NoMemoryError, SecurityError, SystemStackError, StandardError => error
+        __record_exit_error(error)
+        __report_cleanup_error(error)
+        false
+      end
+      private :__run_cleanup_callback
+
+      def __report_cleanup_error(error)
+        respond "--- Lich: error: #{error}"
+        Lich.log "error: #{error}\n\t#{error.backtrace.join("\n\t")}"
+      end
+      private :__report_cleanup_error
+
       def __launch_child
-        child_scripts_mutex.synchronize do
+        admitted = child_scripts_mutex.synchronize do
           return nil if @child_shutdown_started
 
+          @child_launches = @child_launches.to_i + 1
+          true
+        end
+        return nil unless admitted
+
+        begin
           yield
+        ensure
+          child_scripts_mutex.synchronize do
+            @child_launches -= 1
+            @child_launch_condition&.broadcast
+          end
         end
       end
       private :__launch_child
 
       def __register_child_locked(script)
         return nil if @child_shutdown_started
+
         script.__send__(:__while_running) do
           __adopt_child_locked(script)
         end
       end
       private :__register_child_locked
+
+      def __adopt_child(script)
+        child_scripts_mutex.synchronize { __adopt_child_locked(script) }
+      end
+      private :__adopt_child
 
       def __adopt_child_locked(script)
         return nil if @child_shutdown_started
@@ -1840,13 +1891,14 @@ module Lich
       private :__unregister_child_locked
 
       def __begin_child_shutdown
-        children = child_scripts_mutex.synchronize do
-          CHILD_RELATIONSHIP_MUTEX.synchronize do
-            @child_shutdown_started = true
-            Array(@child_scripts).dup
+        child_scripts_mutex.synchronize do
+          @child_shutdown_started = true
+          if @child_launches.to_i.positive?
+            @child_launch_condition ||= ConditionVariable.new
+            @child_launch_condition.wait(child_scripts_mutex) while @child_launches.to_i.positive?
           end
+          Array(@child_scripts).dup
         end
-        children
       end
       private :__begin_child_shutdown
 
@@ -2010,20 +2062,34 @@ module Lich
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
           Script.__send__(:__registry_synchronize) do
-            lifecycle_mutex.synchronize { @@running.push(self) unless @@running.include?(self) }
+            @@running.push(self) unless @@running.include?(self)
           end
         end
         self
       end
       private :__publish
 
-      def __while_running
-        runnable = Script.__send__(:__registry_synchronize) do
-          lifecycle_mutex.synchronize { @@running.include?(self) && !stopping? }
+      def __publish_generated(prefix, admitted)
+        Script.__send__(:__publish_to_registry, :admitted => admitted) do
+          Script.__send__(:__registry_synchronize) do
+            num = '1'
+            num.succ! while @@running.any? { |script| script.name == "#{prefix}#{num}" }
+            @name = "#{prefix}#{num}"
+            @@running.push(self)
+          end
         end
-        return nil unless runnable
+        self
+      end
+      private :__publish_generated
 
-        yield
+      def __while_running
+        Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            return nil unless @@running.include?(self) && !stopping?
+
+            yield
+          end
+        end
       end
       private :__while_running
 
@@ -2121,13 +2187,17 @@ module Lich
           lifecycle_mutex.synchronize do
             if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
                (!@cleanup_thread || !@cleanup_thread.alive?)
-              @cleanup_started = false
-              @cleanup_thread = nil
               true
             end
           end
         end
-        kill(:context => :shutdown) if abandoned_cleanup
+        if abandoned_cleanup
+          __run_kill_cleanup(
+            :source         => @kill_source || ['abandoned cleanup recovery'],
+            :context        => :shutdown,
+            :record_metrics => false
+          )
+        end
 
         should_refresh = Script.__send__(:__registry_synchronize) do
           lifecycle_mutex.synchronize do
@@ -2145,19 +2215,14 @@ module Lich
       private :__cleanup_complete?
 
       def __finalize_stop
-        claimed = lifecycle_mutex.synchronize do
-          next false if @cleanup_complete || @finalization_started
+        finalization_mutex = lifecycle_mutex.synchronize { @finalization_mutex ||= Mutex.new }
+        finalization_mutex.synchronize do
+          return if lifecycle_mutex.synchronize { @cleanup_complete }
 
-          @finalization_started = true
-        end
-        return unless claimed
-
-        parent = nil
-        begin
+          parent = nil
           CHILD_RELATIONSHIP_MUTEX.synchronize { parent = @parent_script }
           parent&.unregister_child(self)
           CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
-        ensure
           Script.__send__(:__registry_synchronize) do
             lifecycle_mutex.synchronize do
               @cleanup_complete = true
@@ -2341,8 +2406,6 @@ module Lich
     end
 
     class SubScript < Script
-      @@name_subscript_mutex = Mutex.new
-
       # Starts an anonymous script backed by a Ruby block.
       #
       # @param parent [Script, nil] owning script
@@ -2367,8 +2430,9 @@ module Lich
               new_thread = Thread.new {
                 next unless start_gate.pop
 
-                if (script = Script.current)
-                  begin
+                script = new_script
+                begin
+                  if Script.current
                     Thread.current.priority = 1
                     respond("--- Lich: #{script.name} active.") unless script.quiet
                     Script.__send__(
@@ -2377,19 +2441,16 @@ module Lich
                       :on_error => proc { |error| Script.__send__(:__report_subscript_error, error) },
                       &block
                     )
-                  ensure
-                    script.kill if script.running? && !script.stopping?
+                  else
+                    respond '--- Lich: failed to start subscript'
                   end
-                else
-                  respond '--- Lich: failed to start subscript'
+                ensure
+                  script.kill if script.running? && !script.stopping?
                 end
               }
               new_script.__send__(:__attach_startup_worker, new_thread)
-              if parent && !parent.__send__(:__adopt_child_locked, new_script)
-                new_thread&.kill
-                new_script.__send__(:__discard_startup)
-                next false
-              end
+              next false if parent && !parent.__send__(:__adopt_child, new_script)
+
               new_script.__send__(:__publish, true)
               setup_complete = true
             ensure
@@ -2400,7 +2461,7 @@ module Lich
                 unless setup_complete && worker_released
                   new_thread&.kill
                   new_thread&.join
-                  parent.__send__(:__unregister_child_locked, new_script) if parent
+                  parent.unregister_child(new_script) if parent
                   new_script.__send__(:__discard_startup)
                 end
               end
@@ -2457,26 +2518,13 @@ module Lich
       end
 
       def __publish(admitted = false)
-        Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          Script.__send__(:__registry_synchronize) do
-            @@name_subscript_mutex.synchronize do
-              lifecycle_mutex.synchronize do
-                num = '1'
-                num.succ! while @@running.any? { |script| script.name == "subscript#{num}" }
-                @name = "subscript#{num}"
-                @@running.push(self)
-              end
-            end
-          end
-        end
-        self
+        __publish_generated('subscript', admitted)
       end
       private :__publish
       # rubocop:enable Lint/MissingSuper
     end
 
     class ExecScript < Script
-      @@name_exec_mutex = Mutex.new
       attr_reader :cmd_data
 
       def ExecScript.start(cmd_data, options = {})
@@ -2494,10 +2542,11 @@ module Lich
             new_thread = Thread.new {
               next unless start_gate.pop
 
-              if (script = Script.current)
-                Thread.current.priority = 1
-                respond("--- Lich: #{script.name} active.") unless script.quiet
-                begin
+              script = new_script
+              begin
+                if Script.current
+                  Thread.current.priority = 1
+                  respond("--- Lich: #{script.name} active.") unless script.quiet
                   Script.__send__(
                     :__execute,
                     script,
@@ -2507,11 +2556,11 @@ module Lich
                     eval('script = Script.current', script_binding, script.name.to_s)
                     eval(cmd_data, script_binding, script.name.to_s)
                   end
-                ensure
-                  script.kill if script.running? && !script.stopping?
+                else
+                  respond 'start_exec_script screwed up...'
                 end
-              else
-                respond 'start_exec_script screwed up...'
+              ensure
+                script.kill if script.running? && !script.stopping?
               end
             }
             new_script.__send__(:__attach_startup_worker, new_thread)
@@ -2579,19 +2628,7 @@ module Lich
       # rubocop:enable Lint/MissingSuper
 
       def __publish(admitted = false)
-        Script.__send__(:__publish_to_registry, :admitted => admitted) do
-          Script.__send__(:__registry_synchronize) do
-            @@name_exec_mutex.synchronize do
-              lifecycle_mutex.synchronize do
-                num = '1'
-                num.succ! while @@running.any? { |script| script.name == "#{@name_prefix}#{num}" }
-                @name = "#{@name_prefix}#{num}"
-                @@running.push(self)
-              end
-            end
-          end
-        end
-        self
+        __publish_generated(@name_prefix, admitted)
       end
       private :__publish
 

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -31,6 +31,7 @@ module Lich
       CHILD_RELATIONSHIP_MUTEX = Mutex.new
       LIFECYCLE_MUTEX_INITIALIZER = Mutex.new
       CHILD_JOIN_TIMEOUT = 1.0
+      LIBRARY_RELOAD_TIMEOUT = 1.0
       RAW_THREAD_GROUP_ADD = ThreadGroup.instance_method(:add)
       RAW_THREAD_GROUP_LIST = ThreadGroup.instance_method(:list)
       RAW_THREAD_GROUP_ENCLOSE = ThreadGroup.instance_method(:enclose)
@@ -859,7 +860,7 @@ module Lich
       private_class_method :__startup_in_progress_locked?
 
       def Script.__library_handoff_reserved_locked?(name)
-        @@startup_reservations.any? do |_reservation, (reserved_name, generation)|
+        @@startup_reservations.any? do |_reservation, (reserved_name, _owner, generation)|
           reserved_name == name && generation.nil?
         end
       end
@@ -1042,15 +1043,16 @@ module Lich
 
       # Runs each loaded script library again using a stable registry snapshot.
       #
-      # @return [true]
-      def Script.reloadlibs
+      # @param timeout [Numeric, nil] maximum seconds to wait for each library
+      # @return [Boolean] whether every library completed successfully
+      def Script.reloadlibs(timeout: LIBRARY_RELOAD_TIMEOUT)
         current_library = Script.current&.name&.downcase
         successful = true
         @@library_mutex.synchronize { @@loaded_libraries.dup }.each do |library|
           next if library == current_library
 
           @@library_mutex.synchronize { @@loaded_libraries.delete(library) }
-          Script.loadlib(library)
+          Script.loadlib(library, :timeout => timeout)
         rescue LoadError => e
           successful = false
           Lich.log("error: failed to reload script library #{library}: #{e.message}")
@@ -1614,7 +1616,10 @@ module Lich
               true
             end
           end
-          return @name unless start_cleanup
+          unless start_cleanup
+            __refresh_deferred_stop(:context => context)
+            return @name
+          end
 
           if async
             cleanup_thread = Thread.new {
@@ -2326,7 +2331,7 @@ module Lich
       end
       private :__wait_for_worker_shutdown
 
-      def __refresh_deferred_stop
+      def __refresh_deferred_stop(context: :shutdown)
         abandoned_cleanup = Script.__send__(:__registry_synchronize) do
           lifecycle_mutex.synchronize do
             if @cleanup_started && !@cleanup_launch_pending && @@running.include?(self) &&
@@ -2338,7 +2343,7 @@ module Lich
         if abandoned_cleanup
           __run_kill_cleanup(
             :source         => @kill_source || ['abandoned cleanup recovery'],
-            :context        => :shutdown,
+            :context        => context,
             :record_metrics => false
           )
         end

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -702,8 +702,8 @@ module Lich
 
             @@startup_condition.wait(@@startup_mutex, JOIN_WAIT_INTERVAL)
           end
-          shutdown_scripts
         end
+        shutdown_scripts
       end
 
       def Script.__begin_start(reservation, name = nil, force: true)
@@ -1798,9 +1798,12 @@ module Lich
         previous_group_owner = nil
         moved_to_cleanup_group = false
         move_allowed = previous_thread_group.equal?(ThreadGroup::Default)
-        unless move_allowed || previous_cleanup_script
+        if previous_cleanup_script
+          previous_group_owner = previous_cleanup_script
+          move_allowed = previous_group_owner.__send__(:__borrow_worker, Thread.current)
+        elsif !move_allowed
           previous_group_owner = Script.__send__(:__script_owning_thread_group, previous_thread_group)
-          move_allowed = previous_group_owner&.__send__(:__borrow_worker, Thread.current, cleanup_thread_group)
+          move_allowed = previous_group_owner&.__send__(:__borrow_worker, Thread.current)
         end
         if move_allowed
           begin
@@ -1808,7 +1811,6 @@ module Lich
             moved_to_cleanup_group = true
           rescue ThreadError
             previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
-            previous_group_owner&.__send__(:__return_borrowed_group, cleanup_thread_group)
             nil
           end
         end
@@ -1873,12 +1875,12 @@ module Lich
             begin
               RAW_THREAD_GROUP_ADD.bind_call(previous_thread_group, Thread.current)
               previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
-              previous_group_owner&.__send__(:__return_borrowed_group, cleanup_thread_group)
             rescue ThreadError
               begin
                 borrowed_group = ThreadGroup.new
                 previous_group_owner&.__send__(:__adopt_borrowed_group, borrowed_group)
                 RAW_THREAD_GROUP_ADD.bind_call(borrowed_group, Thread.current)
+                previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
               rescue ThreadError
                 nil
               end
@@ -2069,11 +2071,13 @@ module Lich
               __raw_add_worker(thread)
               true
             else
-              @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
-              unless @worker_admission_closed
-                @worker_registrations ||= Set.new
-                @worker_registrations.add(registration)
-                tracked_rejection = true
+              unless thread == Thread.current
+                @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
+                unless @worker_admission_closed
+                  @worker_registrations ||= Set.new
+                  @worker_registrations.add(registration)
+                  tracked_rejection = true
+                end
               end
               false
             end
@@ -2082,7 +2086,7 @@ module Lich
         accepted
       ensure
         begin
-          unless accepted
+          unless accepted || thread == Thread.current
             begin
               thread.kill
               thread.join unless thread == Thread.current
@@ -2123,14 +2127,12 @@ module Lich
       end
       private :__owns_public_thread_group?
 
-      def __borrow_worker(thread, group)
+      def __borrow_worker(thread)
         lifecycle_mutex.synchronize do
-          return false if @kill_requested || @cleanup_complete
+          return false if @cleanup_complete
 
           @borrowed_workers ||= Set.new
           @borrowed_workers.add(thread)
-          @borrowed_thread_groups ||= Set.new
-          @borrowed_thread_groups.add(group)
           true
         end
       end
@@ -2152,14 +2154,6 @@ module Lich
         end
       end
       private :__adopt_borrowed_group
-
-      def __return_borrowed_group(group)
-        lifecycle_mutex.synchronize do
-          @borrowed_thread_groups&.delete(group)
-          @stopped_condition&.broadcast
-        end
-      end
-      private :__return_borrowed_group
 
       def __attach_startup_worker(thread)
         __raw_add_worker(thread)

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -36,6 +36,7 @@ module Lich
       RAW_THREAD_GROUP_ENCLOSE = ThreadGroup.instance_method(:enclose)
       RAW_THREAD_GROUP_ENCLOSED = ThreadGroup.instance_method(:enclosed?)
       JOIN_WAIT_INTERVAL = 0.05
+      CLEANUP_SCRIPT_THREAD_KEY = :lich_cleanup_script
 
       # Nested lock order:
       #   startup -> registry -> per-script lifecycle -> child relationship
@@ -66,15 +67,6 @@ module Lich
 
         def list
           @script.__send__(:__public_worker_threads)
-        end
-
-        def enclose
-          @script.__send__(:__enclose_worker_group)
-          self
-        end
-
-        def enclosed?
-          @script.__send__(:__worker_group_enclosed?)
         end
 
         def enclose
@@ -136,7 +128,6 @@ module Lich
         registry_name = __script_registry_name(file_name)
         script_name = file_name.sub(/\.(?:lic|rb|cmd|wiz)(?:\.(?:gz|Z))?\z/i, '')
         startup_reservation = Object.new
-        startup_completed = false
         begin
           startup_status = __begin_start(startup_reservation, registry_name, :force => options[:force] == true)
           if startup_status == :shutdown
@@ -175,10 +166,10 @@ module Lich
           worker_released = false
           begin
             new_thread = Thread.new {
-              next unless start_gate.pop
-
-              script = script_obj
               begin
+                next unless start_gate.pop
+
+                script = script_obj
                 if Script.current
                   eval('script = Script.current', script_binding, script.name)
                   Thread.current.priority = 1
@@ -215,7 +206,7 @@ module Lich
                   respond '--- error: out of cheese'
                 end
               ensure
-                script.kill if script.running? && !script.stopping?
+                script_obj.kill if script_obj.running? && !script_obj.stopping?
               end
             }
             script_obj.__send__(:__attach_startup_worker, new_thread)
@@ -236,10 +227,9 @@ module Lich
               end
             end
           end
-          startup_completed = true
           script_obj
         ensure
-          __finish_start(startup_reservation, startup_completed ? script_obj : nil)
+          __finish_start(startup_reservation, setup_complete ? script_obj : nil)
         end
       }
       @@elevated_exists = proc { |script_name|
@@ -662,10 +652,30 @@ module Lich
       end
       private_class_method :__running_snapshot
 
+      def Script.__script_owning_thread_group(group)
+        __running_snapshot.find { |script| script.__send__(:__owns_public_thread_group?, group) }
+      end
+      private_class_method :__script_owning_thread_group
+
       def Script.__shutdown_snapshot
-        __registry_synchronize { (@@running + @@stopping).uniq }
+        __registry_synchronize do
+          __prune_completed_stops_locked
+          (@@running + @@stopping).uniq
+        end
       end
       private_class_method :__shutdown_snapshot
+
+      def Script.__prune_completed_stops_locked
+        @@stopping.reject! { |script| script.__send__(:__cleanup_complete?) }
+      end
+      private_class_method :__prune_completed_stops_locked
+
+      def Script.__discard_completed_stop(script)
+        __registry_synchronize do
+          @@stopping.delete(script) if script.__send__(:__cleanup_complete?)
+        end
+      end
+      private_class_method :__discard_completed_stop
 
       def Script.list
         __running_snapshot
@@ -686,7 +696,12 @@ module Lich
       def Script.begin_shutdown
         @@startup_mutex.synchronize do
           @@shutdown_started = true
-          @@startup_condition.wait(@@startup_mutex) until @@startup_reservations.empty?
+          until @@startup_reservations.empty?
+            __reap_abandoned_startups_locked
+            break if @@startup_reservations.empty?
+
+            @@startup_condition.wait(@@startup_mutex, JOIN_WAIT_INTERVAL)
+          end
           shutdown_scripts
         end
       end
@@ -694,6 +709,7 @@ module Lich
       def Script.__begin_start(reservation, name = nil, force: true)
         normalized_name = name&.downcase
         @@startup_mutex.synchronize do
+          __reap_abandoned_startups_locked
           return :shutdown if @@shutdown_started
           if normalized_name && !force
             active = __active_named_script(normalized_name)
@@ -702,7 +718,12 @@ module Lich
           end
 
           @@startup_generation += 1
-          @@startup_reservations[reservation] = [normalized_name, @@startup_generation]
+          @@startup_reservations[reservation] = [
+            normalized_name,
+            Thread.current,
+            @@startup_generation,
+            nil
+          ]
           :admitted
         end
       end
@@ -711,25 +732,29 @@ module Lich
       def Script.__begin_library_start(reservation, name)
         normalized_name = name.downcase
         @@startup_mutex.synchronize do
+          __reap_abandoned_startups_locked
           return [:shutdown, nil] if @@shutdown_started
 
           unless __startup_in_progress_locked?(normalized_name)
             completed = __completed_start_value(@@completed_named_starts[normalized_name])
             active = __active_named_script(normalized_name)
             candidate = completed || active
-            @@startup_reservations[reservation] = [normalized_name, nil, candidate]
+            @@startup_reservations[reservation] = [normalized_name, Thread.current, nil, candidate]
             return [candidate ? :duplicate : :admitted, candidate]
           end
 
           @@completed_start_waiters[normalized_name] += 1
           begin
             while __startup_in_progress_locked?(normalized_name)
-              @@startup_condition.wait(@@startup_mutex)
+              __reap_abandoned_startups_locked
+              break unless __startup_in_progress_locked?(normalized_name)
+
+              @@startup_condition.wait(@@startup_mutex, JOIN_WAIT_INTERVAL)
             end
             completed = __completed_start_value(@@completed_named_starts[normalized_name])
             active = __active_named_script(normalized_name)
             candidate = completed || active
-            @@startup_reservations[reservation] = [normalized_name, nil, candidate]
+            @@startup_reservations[reservation] = [normalized_name, Thread.current, nil, candidate]
             [candidate ? :duplicate : :admitted, candidate]
           ensure
             @@completed_start_waiters[normalized_name] -= 1
@@ -754,7 +779,9 @@ module Lich
 
       def Script.__finish_start(reservation, script = nil, preserve_completed: false)
         @@startup_mutex.synchronize do
-          name, generation, = @@startup_reservations.delete(reservation)
+          entry = @@startup_reservations.delete(reservation)
+          name = entry&.first
+          generation = entry&.[](2)
           if name&.start_with?('lib')
             current_generation = __completed_start_generation(@@completed_named_starts[name])
             if !preserve_completed && generation && generation >= current_generation
@@ -774,7 +801,7 @@ module Lich
       def Script.__reserved_start_candidate(reservation)
         @@startup_mutex.synchronize do
           entry = @@startup_reservations[reservation]
-          entry&.[](2)
+          entry&.[](3)
         end
       end
       private_class_method :__reserved_start_candidate
@@ -812,8 +839,22 @@ module Lich
       end
       private_class_method :__completed_start_generation
 
+      def Script.__peek_completed_start(name)
+        @@startup_mutex.synchronize do
+          __completed_start_value(@@completed_named_starts[name.downcase])
+        end
+      end
+      private_class_method :__peek_completed_start
+
+      def Script.__reap_abandoned_startups_locked
+        previous_size = @@startup_reservations.size
+        @@startup_reservations.delete_if { |_reservation, (_name, owner)| !owner.alive? }
+        @@startup_condition.broadcast if @@startup_reservations.size < previous_size
+      end
+      private_class_method :__reap_abandoned_startups_locked
+
       def Script.__startup_in_progress_locked?(name)
-        @@startup_reservations.any? { |_reservation, (reserved_name, _generation)| reserved_name == name }
+        @@startup_reservations.any? { |_reservation, (reserved_name, _owner)| reserved_name == name }
       end
       private_class_method :__startup_in_progress_locked?
 
@@ -876,7 +917,9 @@ module Lich
       end
 
       def Script.current
-        if (script = __running_snapshot.find { |s| s.has_thread?(Thread.current) })
+        script = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
+        script ||= __running_snapshot.find { |candidate| candidate.has_thread?(Thread.current) }
+        if script
           sleep 0.2 while script.paused? and not script.ignore_pause
           script
         else
@@ -968,6 +1011,12 @@ module Lich
             end
             __finish_start(startup_reservation, nil, :preserve_completed => start_required == true)
           ensure
+            if start_required
+              script ||= __peek_completed_start(library_name)
+              if script
+                @@library_mutex.synchronize { @@loading_libraries[library_name] = script }
+              end
+            end
             published_script = script || @@library_mutex.synchronize { @@loading_libraries[library_name] }
             __discard_completed_start(library_name, published_script) if published_script
           end
@@ -1528,12 +1577,11 @@ module Lich
       # ordinary script churn.
       #
       # Runtime kills run cleanup in a dedicated thread so the caller is not
-      # blocked. Shutdown kills run cleanup inline instead: the shutdown drain
-      # (see shutdown_script_drain.rb) kills every script in a tight loop, and on
-      # long sessions spawning one cleanup thread per script there pushes the
-      # process past the OS thread ceiling ("can't alloc thread"). Inline
-      # teardown at shutdown is also the order we want -- sequential, not a
-      # concurrent burst.
+      # blocked. The process shutdown drain runs cleanup inline: spawning one
+      # cleanup thread per script in long sessions can push the process past the
+      # OS thread ceiling ("can't alloc thread"). Shutdown requested from a
+      # normal script worker remains asynchronous so callback descendants belong
+      # to the target script rather than the caller.
       #
       # @param context [Symbol] :runtime for ordinary script stops, :shutdown
       #   when the owning Lich process is closing
@@ -1543,7 +1591,10 @@ module Lich
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
-        async = context != :shutdown if async.nil?
+        if async.nil?
+          shutdown_cleanup = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
+          async = context != :shutdown || (!Thread.current.group.equal?(ThreadGroup::Default) && !shutdown_cleanup)
+        end
         launch_token = Object.new
         cleanup_thread = nil
         cleanup_released = false
@@ -1571,8 +1622,8 @@ module Lich
               __run_kill_cleanup(source: source, context: context, record_metrics: true)
             }
             ThreadGroup::Default.add(cleanup_thread)
-            __attach_startup_worker(cleanup_thread)
-            lifecycle_mutex.synchronize { @cleanup_thread = cleanup_thread }
+            __attach_cleanup_worker(cleanup_thread)
+            __claim_cleanup_thread(cleanup_thread)
             cleanup_owned = true
             raise ThreadError, 'cleanup thread stopped before ownership transfer' unless cleanup_thread.alive?
 
@@ -1741,6 +1792,27 @@ module Lich
         # cleanup body twice over already-nilled state, not skip it.)
         return if @killer_mutex.owned?
 
+        previous_cleanup_script = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
+        previous_thread_group = Thread.current.group
+        cleanup_thread_group = __cleanup_worker_group
+        previous_group_owner = nil
+        moved_to_cleanup_group = false
+        move_allowed = previous_thread_group.equal?(ThreadGroup::Default)
+        unless move_allowed || previous_cleanup_script
+          previous_group_owner = Script.__send__(:__script_owning_thread_group, previous_thread_group)
+          move_allowed = previous_group_owner&.__send__(:__borrow_worker, Thread.current, cleanup_thread_group)
+        end
+        if move_allowed
+          begin
+            RAW_THREAD_GROUP_ADD.bind_call(cleanup_thread_group, Thread.current)
+            moved_to_cleanup_group = true
+          rescue ThreadError
+            previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
+            previous_group_owner&.__send__(:__return_borrowed_group, cleanup_thread_group)
+            nil
+          end
+        end
+        Thread.current.thread_variable_set(CLEANUP_SCRIPT_THREAD_KEY, self)
         begin
           @killer_mutex.synchronize do
             lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
@@ -1750,23 +1822,23 @@ module Lich
               failed = false
               cleanup_body_complete = false
               begin
-                children = __begin_child_shutdown
+                __close_child_launch_admission
                 stopping_threads = lifecycle_mutex.synchronize do
                   @stopping_threads = __raw_worker_threads.reject { |thread| thread == Thread.current }
                 end
                 stopping_threads.each { |thread| thread.kill rescue nil }
-                __raw_add_worker(Thread.current)
+                children = __wait_for_child_launches
                 __stop_children(children, context)
-                __raw_add_worker(Thread.current)
                 # Shift each callback before invoking it. If this executor is
                 # cancelled, recovery resumes with the remaining callbacks.
+                @die_with ||= []
                 while (script_name = @die_with.shift)
                   failed = true unless __run_cleanup_callback do
                     Script.kill(script_name, context: context)
-                    __raw_add_worker(Thread.current)
                   end
                 end
                 @paused = false
+                @at_exit_procs ||= []
                 while (callback = @at_exit_procs.shift)
                   failed = true unless __run_cleanup_callback { callback.call }
                 end
@@ -1796,6 +1868,22 @@ module Lich
             end
           end
         ensure
+          Thread.current.thread_variable_set(CLEANUP_SCRIPT_THREAD_KEY, previous_cleanup_script)
+          if moved_to_cleanup_group
+            begin
+              RAW_THREAD_GROUP_ADD.bind_call(previous_thread_group, Thread.current)
+              previous_group_owner&.__send__(:__return_borrowed_worker, Thread.current)
+              previous_group_owner&.__send__(:__return_borrowed_group, cleanup_thread_group)
+            rescue ThreadError
+              begin
+                borrowed_group = ThreadGroup.new
+                previous_group_owner&.__send__(:__adopt_borrowed_group, borrowed_group)
+                RAW_THREAD_GROUP_ADD.bind_call(borrowed_group, Thread.current)
+              rescue ThreadError
+                nil
+              end
+            end
+          end
           lifecycle_mutex.synchronize do
             @cleanup_thread = nil if @cleanup_thread == Thread.current
             @stopped_condition&.broadcast
@@ -1890,9 +1978,15 @@ module Lich
       end
       private :__unregister_child_locked
 
-      def __begin_child_shutdown
+      def __close_child_launch_admission
         child_scripts_mutex.synchronize do
           @child_shutdown_started = true
+        end
+      end
+      private :__close_child_launch_admission
+
+      def __wait_for_child_launches
+        child_scripts_mutex.synchronize do
           if @child_launches.to_i.positive?
             @child_launch_condition ||= ConditionVariable.new
             @child_launch_condition.wait(child_scripts_mutex) while @child_launches.to_i.positive?
@@ -1900,7 +1994,7 @@ module Lich
           Array(@child_scripts).dup
         end
       end
-      private :__begin_child_shutdown
+      private :__wait_for_child_launches
 
       def __stop_children(children, context)
         return if children.empty?
@@ -1912,8 +2006,6 @@ module Lich
           child.kill(context: context, async: true) if child.running?
         rescue StandardError => e
           Lich.log("error: failed to stop child script #{child.name}: #{e}") if defined?(Lich) && Lich.respond_to?(:log)
-        ensure
-          __raw_add_worker(Thread.current)
         end
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + CHILD_JOIN_TIMEOUT
@@ -1962,49 +2054,43 @@ module Lich
       end
       private :__record_successful_exit
 
+      def __cleanup_complete?
+        lifecycle_mutex.synchronize { @cleanup_complete == true }
+      end
+      private :__cleanup_complete?
+
       def __register_worker(thread)
         registration = Object.new
         tracked_rejection = false
         accepted = false
-        begin
-          accepted = Script.__send__(:__registry_synchronize) do
-            lifecycle_mutex.synchronize do
-              if @@running.include?(self) && !@kill_requested
-                __raw_add_worker(thread)
-                true
-              else
-                @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
-                unless @worker_admission_closed
-                  @worker_registrations ||= Set.new
-                  @worker_registrations.add(registration)
-                  tracked_rejection = true
-                end
-                false
+        accepted = Script.__send__(:__registry_synchronize) do
+          lifecycle_mutex.synchronize do
+            if @@running.include?(self) && !@kill_requested
+              __raw_add_worker(thread)
+              true
+            else
+              @stopping_threads = (Array(@stopping_threads) + [thread]).uniq
+              unless @worker_admission_closed
+                @worker_registrations ||= Set.new
+                @worker_registrations.add(registration)
+                tracked_rejection = true
               end
+              false
             end
           end
+        end
+        accepted
+      ensure
+        begin
           unless accepted
-            thread.kill
-            thread.join unless thread == Thread.current
-          end
-          accepted
-        rescue StandardError => error
-          thread.kill
-          begin
-            thread.join unless thread == Thread.current
-          rescue StandardError
-            nil
-          end
-          raise error
-        ensure
-          unless accepted
-            thread.kill
             begin
+              thread.kill
               thread.join unless thread == Thread.current
             rescue StandardError
               nil
             end
           end
+        ensure
           if tracked_rejection
             lifecycle_mutex.synchronize do
               @worker_registrations&.delete(registration)
@@ -2015,31 +2101,93 @@ module Lich
       end
       private :__register_worker
 
-      def __attach_startup_worker(thread)
-        __raw_add_worker(thread)
-        thread
-      end
-      private :__attach_startup_worker
-
       def __raw_add_worker(thread)
         RAW_THREAD_GROUP_ADD.bind_call(@thread_group, thread)
       end
       private :__raw_add_worker
 
       def __raw_worker_threads
-        RAW_THREAD_GROUP_LIST.bind_call(@thread_group).dup
+        groups = [@thread_group, @cleanup_thread_group, *Array(@borrowed_thread_groups)].compact
+        group_threads = groups.flat_map { |group| RAW_THREAD_GROUP_LIST.bind_call(group) }
+        (group_threads + Array(@borrowed_workers)).uniq
       end
       private :__raw_worker_threads
+
+      def __public_worker_threads
+        RAW_THREAD_GROUP_LIST.bind_call(@thread_group).dup
+      end
+      private :__public_worker_threads
+
+      def __owns_public_thread_group?(group)
+        @thread_group.equal?(group)
+      end
+      private :__owns_public_thread_group?
+
+      def __borrow_worker(thread, group)
+        lifecycle_mutex.synchronize do
+          return false if @kill_requested || @cleanup_complete
+
+          @borrowed_workers ||= Set.new
+          @borrowed_workers.add(thread)
+          @borrowed_thread_groups ||= Set.new
+          @borrowed_thread_groups.add(group)
+          true
+        end
+      end
+      private :__borrow_worker
+
+      def __return_borrowed_worker(thread)
+        lifecycle_mutex.synchronize do
+          @borrowed_workers&.delete(thread)
+          @stopped_condition&.broadcast
+        end
+      end
+      private :__return_borrowed_worker
+
+      def __adopt_borrowed_group(group)
+        lifecycle_mutex.synchronize do
+          @borrowed_thread_groups ||= Set.new
+          @borrowed_thread_groups.add(group)
+          @stopped_condition&.broadcast
+        end
+      end
+      private :__adopt_borrowed_group
+
+      def __return_borrowed_group(group)
+        lifecycle_mutex.synchronize do
+          @borrowed_thread_groups&.delete(group)
+          @stopped_condition&.broadcast
+        end
+      end
+      private :__return_borrowed_group
+
+      def __attach_startup_worker(thread)
+        __raw_add_worker(thread)
+        thread
+      end
+      private :__attach_startup_worker
+
+      def __claim_cleanup_thread(thread)
+        lifecycle_mutex.synchronize { @cleanup_thread = thread }
+        thread
+      end
+      private :__claim_cleanup_thread
+
+      def __cleanup_worker_group
+        lifecycle_mutex.synchronize { @cleanup_thread_group ||= ThreadGroup.new }
+      end
+      private :__cleanup_worker_group
+
+      def __attach_cleanup_worker(thread)
+        RAW_THREAD_GROUP_ADD.bind_call(__cleanup_worker_group, thread)
+        thread
+      end
+      private :__attach_cleanup_worker
 
       def __worker_threads
         __raw_worker_threads
       end
       private :__worker_threads
-
-      def __public_worker_threads
-        __raw_worker_threads
-      end
-      private :__public_worker_threads
 
       def __enclose_worker_group
         lifecycle_mutex.synchronize { RAW_THREAD_GROUP_ENCLOSE.bind_call(@thread_group) }
@@ -2054,7 +2202,7 @@ module Lich
 
       def __managed_thread_group
         lifecycle_mutex.synchronize do
-          @thread_group.extend(ThreadGroupHandle).__send__(:__attach_script, self)
+          @thread_group_handle ||= @thread_group.extend(ThreadGroupHandle).__send__(:__attach_script, self)
         end
       end
       private :__managed_thread_group
@@ -2062,6 +2210,7 @@ module Lich
       def __publish(admitted = false)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
           Script.__send__(:__registry_synchronize) do
+            Script.__send__(:__prune_completed_stops_locked)
             @@running.push(self) unless @@running.include?(self)
           end
         end
@@ -2072,6 +2221,7 @@ module Lich
       def __publish_generated(prefix, admitted)
         Script.__send__(:__publish_to_registry, :admitted => admitted) do
           Script.__send__(:__registry_synchronize) do
+            Script.__send__(:__prune_completed_stops_locked)
             num = '1'
             num.succ! while @@running.any? { |script| script.name == "#{prefix}#{num}" }
             @name = "#{prefix}#{num}"
@@ -2118,7 +2268,7 @@ module Lich
           @watchfor = {}
           @downstream_buffer = LimitedArray.new
           @upstream_buffer = LimitedArray.new
-          @die_with = @at_exit_procs = @match_stack_labels = @match_stack_strings = nil
+          @match_stack_labels = @match_stack_strings = nil
           unless @quiet
             if @killed_externally
               respond("--- Lich: #{@custom ? 'custom/' : ''}#{@name} was killed. (#{source.first})")
@@ -2209,11 +2359,6 @@ module Lich
       end
       private :__refresh_deferred_stop
 
-      def __cleanup_complete?
-        lifecycle_mutex.synchronize { @cleanup_complete == true }
-      end
-      private :__cleanup_complete?
-
       def __finalize_stop
         finalization_mutex = lifecycle_mutex.synchronize { @finalization_mutex ||= Mutex.new }
         finalization_mutex.synchronize do
@@ -2223,13 +2368,12 @@ module Lich
           CHILD_RELATIONSHIP_MUTEX.synchronize { parent = @parent_script }
           parent&.unregister_child(self)
           CHILD_RELATIONSHIP_MUTEX.synchronize { @parent_script = nil }
-          Script.__send__(:__registry_synchronize) do
-            lifecycle_mutex.synchronize do
-              @cleanup_complete = true
-              @@stopping.delete(self)
-              @stopped_condition&.broadcast
-            end
+          lifecycle_mutex.synchronize do
+            @die_with = @at_exit_procs = nil
+            @cleanup_complete = true
+            @stopped_condition&.broadcast
           end
+          Script.__send__(:__discard_completed_stop, self)
         end
       end
       private :__finalize_stop
@@ -2428,10 +2572,10 @@ module Lich
             worker_released = false
             begin
               new_thread = Thread.new {
-                next unless start_gate.pop
-
-                script = new_script
                 begin
+                  next unless start_gate.pop
+
+                  script = new_script
                   if Script.current
                     Thread.current.priority = 1
                     respond("--- Lich: #{script.name} active.") unless script.quiet
@@ -2445,7 +2589,7 @@ module Lich
                     respond '--- Lich: failed to start subscript'
                   end
                 ensure
-                  script.kill if script.running? && !script.stopping?
+                  new_script.kill if new_script.running? && !new_script.stopping?
                 end
               }
               new_script.__send__(:__attach_startup_worker, new_thread)
@@ -2540,10 +2684,10 @@ module Lich
           worker_released = false
           begin
             new_thread = Thread.new {
-              next unless start_gate.pop
-
-              script = new_script
               begin
+                next unless start_gate.pop
+
+                script = new_script
                 if Script.current
                   Thread.current.priority = 1
                   respond("--- Lich: #{script.name} active.") unless script.quiet
@@ -2560,7 +2704,7 @@ module Lich
                   respond 'start_exec_script screwed up...'
                 end
               ensure
-                script.kill if script.running? && !script.stopping?
+                new_script.kill if new_script.running? && !new_script.stopping?
               end
             }
             new_script.__send__(:__attach_startup_worker, new_thread)

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -1809,13 +1809,19 @@ module Lich
         previous_group_owner = nil
         moved_to_cleanup_group = false
         cleanup_group_error = nil
-        move_allowed = previous_thread_group.equal?(ThreadGroup::Default)
+        move_allowed = previous_thread_group.equal?(ThreadGroup::Default) ||
+                       previous_thread_group.equal?(cleanup_thread_group)
         if previous_cleanup_script
           previous_group_owner = previous_cleanup_script
           move_allowed = previous_group_owner.__send__(:__borrow_worker, Thread.current)
         elsif !move_allowed
           previous_group_owner = Script.__send__(:__script_owning_thread_group, previous_thread_group)
           move_allowed = previous_group_owner&.__send__(:__borrow_worker, Thread.current)
+        end
+        unless move_allowed
+          cleanup_group_error = ThreadError.new(
+            "cannot establish cleanup ownership for #{@name}: source thread group is not managed"
+          )
         end
         if move_allowed
           begin

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -323,6 +323,7 @@ module Lich
       @@loaded_libraries = Set.new
       @@loaded_library_owners = {}
       @@loading_libraries = {}
+      @@reloading_libraries = Set.new
       @@library_waits = {}
       @@kill_metrics_mutex = Mutex.new
       @@kill_metrics = {
@@ -655,7 +656,12 @@ module Lich
       private_class_method :__running_snapshot
 
       def Script.__script_owning_thread_group(group)
-        __running_snapshot.find { |script| script.__send__(:__owns_public_thread_group?, group) }
+        __registry_synchronize do
+          __prune_completed_stops_locked
+          (@@running + @@stopping).uniq.find do |script|
+            script.__send__(:__owns_public_thread_group?, group)
+          end
+        end
       end
       private_class_method :__script_owning_thread_group
 
@@ -745,29 +751,33 @@ module Lich
             return [candidate ? :duplicate : :admitted, candidate]
           end
 
-          @@completed_start_waiters[normalized_name] += 1
-          begin
-            while __startup_in_progress_locked?(normalized_name)
-              __reap_abandoned_startups_locked
-              break unless __startup_in_progress_locked?(normalized_name)
+          Thread.handle_interrupt(Exception => :never) do
+            begin
+              @@completed_start_waiters[normalized_name] += 1
+              Thread.handle_interrupt(Exception => :immediate) do
+                while __startup_in_progress_locked?(normalized_name)
+                  __reap_abandoned_startups_locked
+                  break unless __startup_in_progress_locked?(normalized_name)
 
-              remaining = __remaining_library_timeout(deadline)
-              if remaining && remaining <= 0
-                raise LibraryJoinTimeout, "script library wait timed out: #{normalized_name}"
+                  remaining = __remaining_library_timeout(deadline)
+                  if remaining && remaining <= 0
+                    raise LibraryJoinTimeout, "script library wait timed out: #{normalized_name}"
+                  end
+                  wait_for = remaining ? [JOIN_WAIT_INTERVAL, remaining].min : JOIN_WAIT_INTERVAL
+                  @@startup_condition.wait(@@startup_mutex, wait_for)
+                end
               end
-              wait_for = remaining ? [JOIN_WAIT_INTERVAL, remaining].min : JOIN_WAIT_INTERVAL
-              @@startup_condition.wait(@@startup_mutex, wait_for)
-            end
-            completed = __completed_start_value(@@completed_named_starts[normalized_name])
-            active = __active_named_script(normalized_name)
-            candidate = completed || active
-            @@startup_reservations[reservation] = [normalized_name, Thread.current, nil, candidate]
-            [candidate ? :duplicate : :admitted, candidate]
-          ensure
-            @@completed_start_waiters[normalized_name] -= 1
-            if @@completed_start_waiters[normalized_name].zero?
-              @@completed_start_waiters.delete(normalized_name)
-              @@completed_named_starts.delete(normalized_name)
+              completed = __completed_start_value(@@completed_named_starts[normalized_name])
+              active = __active_named_script(normalized_name)
+              candidate = completed || active
+              @@startup_reservations[reservation] = [normalized_name, Thread.current, nil, candidate]
+              [candidate ? :duplicate : :admitted, candidate]
+            ensure
+              @@completed_start_waiters[normalized_name] -= 1
+              if @@completed_start_waiters[normalized_name].zero?
+                @@completed_start_waiters.delete(normalized_name)
+                @@completed_named_starts.delete(normalized_name)
+              end
             end
           end
         end
@@ -954,7 +964,9 @@ module Lich
       # Loads a script library once and waits for its execution to finish.
       #
       # @param library [String, Symbol] library name, with or without the lib prefix
-      # @param timeout [Numeric, nil] maximum seconds to wait, or nil to wait indefinitely
+      # @param timeout [Numeric, nil] maximum time spent waiting on startup
+      #   coordination and script completion, or nil to wait indefinitely;
+      #   synchronous script construction is not preempted
       # @return [true]
       # @raise [ArgumentError] when the library name is empty
       # @raise [LoadError] when the library cannot be found or started
@@ -1073,23 +1085,26 @@ module Lich
       def Script.reloadlibs(timeout: LIBRARY_RELOAD_TIMEOUT)
         current_library = Script.current&.name&.downcase
         successful = true
-        @@library_mutex.synchronize { @@loaded_libraries.dup }.each do |library|
+        libraries = @@library_mutex.synchronize { @@loaded_libraries | @@reloading_libraries }
+        libraries.each do |library|
           next if library == current_library
 
           @@library_mutex.synchronize do
-            if @@loaded_libraries.include?(library)
+            @@reloading_libraries.add(library)
+            if @@loaded_libraries.delete?(library)
               loaded_owner = @@loaded_library_owners[library]
               loading_script = @@loading_libraries[library]
               if loaded_owner && loading_script&.object_id == loaded_owner
                 @@loading_libraries.delete(library)
               end
               @@loaded_library_owners.delete(library)
-              @@loaded_libraries.delete(library)
             end
           end
           Script.loadlib(library, :timeout => timeout)
+          @@library_mutex.synchronize { @@reloading_libraries.delete(library) }
         rescue LoadError => e
           successful = false
+          @@library_mutex.synchronize { @@reloading_libraries.delete(library) }
           Lich.log("error: failed to reload script library #{library}: #{e.message}")
         end
         successful
@@ -1104,36 +1119,42 @@ module Lich
 
       def Script.__join_library(library_name, script, timeout = nil)
         caller_script = Script.current
-        dependency_token = Object.new
-        @@library_mutex.synchronize do
-          if caller_script
-            if __library_dependency_reaches?(script, caller_script)
-              raise LoadError, "cyclic script library dependency: #{library_name}"
+        dependency_token = [Object.new, Thread.current]
+        Thread.handle_interrupt(Exception => :never) do
+          begin
+            @@library_mutex.synchronize do
+              if caller_script
+                if __library_dependency_reaches?(script, caller_script)
+                  raise LoadError, "cyclic script library dependency: #{library_name}"
+                end
+                dependencies = @@library_waits[caller_script]
+                dependencies = {} unless dependencies.is_a?(Hash)
+                @@library_waits[caller_script] = dependencies
+                if dependencies.key?(script)
+                  dependencies[script].add(dependency_token)
+                else
+                  dependencies[script] = Set[dependency_token]
+                end
+              end
             end
-            dependencies = @@library_waits[caller_script]
-            dependencies = {} unless dependencies.is_a?(Hash)
-            @@library_waits[caller_script] = dependencies
-            if dependencies.key?(script)
-              dependencies[script].add(dependency_token)
-            else
-              dependencies[script] = Set[dependency_token]
-            end
-          end
-        end
 
-        joined = script.join(timeout)
-        raise LibraryJoinTimeout, "script library wait timed out: #{library_name}" unless joined
-      ensure
-        if caller_script
-          @@library_mutex.synchronize do
-            dependencies = @@library_waits[caller_script]
-            if dependencies.is_a?(Hash)
-              tokens = dependencies[script]
-              tokens&.delete(dependency_token)
-              dependencies.delete(script) if tokens && tokens.empty?
-              @@library_waits.delete(caller_script) if dependencies.empty?
-            elsif dependencies.equal?(script)
-              @@library_waits.delete(caller_script)
+            joined = Thread.handle_interrupt(Exception => :immediate) do
+              script.join(timeout)
+            end
+            raise LibraryJoinTimeout, "script library wait timed out: #{library_name}" unless joined
+          ensure
+            if caller_script
+              @@library_mutex.synchronize do
+                dependencies = @@library_waits[caller_script]
+                if dependencies.is_a?(Hash)
+                  tokens = dependencies[script]
+                  tokens&.delete(dependency_token)
+                  dependencies.delete(script) if tokens && tokens.empty?
+                  @@library_waits.delete(caller_script) if dependencies.empty?
+                elsif dependencies.equal?(script)
+                  @@library_waits.delete(caller_script)
+                end
+              end
             end
           end
         end
@@ -1168,6 +1189,7 @@ module Lich
       private_class_method :__validate_library_completion
 
       def Script.__library_dependency_reaches?(start, target, visited = Set.new)
+        __prune_library_waits_locked(target) if visited.empty?
         return true if start.equal?(target)
         return false unless start
         return false if visited.include?(start)
@@ -1178,6 +1200,21 @@ module Lich
         dependencies.any? { |dependency| __library_dependency_reaches?(dependency, target, visited) }
       end
       private_class_method :__library_dependency_reaches?
+
+      def Script.__prune_library_waits_locked(preserve = nil)
+        @@library_waits.delete_if do |caller, dependencies|
+          next false unless dependencies.is_a?(Hash)
+
+          dependencies.delete_if do |_target, tokens|
+            tokens.delete_if do |token|
+              token.is_a?(Array) && token.last.is_a?(Thread) && !token.last.alive?
+            end
+            tokens.empty?
+          end
+          dependencies.empty? && !caller.equal?(preserve)
+        end
+      end
+      private_class_method :__prune_library_waits_locked
 
       def Script.running?(name)
         __running_snapshot.any? { |i| (i.name =~ /^#{name}$/i) }
@@ -1890,17 +1927,15 @@ module Lich
                 __stop_children(children, context)
                 raise cleanup_group_error if cleanup_group_error
 
-                # Shift each callback before invoking it. If this executor is
-                # cancelled, recovery resumes with the remaining callbacks.
                 @die_with ||= []
-                while (script_name = @die_with.shift)
+                __run_cleanup_queue(@die_with) do |script_name|
                   failed = true unless __run_cleanup_callback do
                     Script.kill(script_name, context: context)
                   end
                 end
                 @paused = false
                 @at_exit_procs ||= []
-                while (callback = @at_exit_procs.shift)
+                __run_cleanup_queue(@at_exit_procs) do |callback|
                   failed = true unless __run_cleanup_callback { callback.call }
                 end
                 # ScriptDeath handlers are individually isolated by the
@@ -1953,6 +1988,38 @@ module Lich
       end
       private :__run_kill_cleanup
 
+      def __run_cleanup_queue(queue)
+        __restore_cleanup_queue_claim
+        loop do
+          entry = queue.first
+          break unless entry
+
+          claim = { :queue => queue, :entry => entry, :started => false }
+          @cleanup_queue_claim = claim
+          begin
+            queue.shift
+            claim[:started] = true
+            yield entry
+          ensure
+            __restore_cleanup_queue_claim
+          end
+        end
+      ensure
+        __restore_cleanup_queue_claim
+      end
+      private :__run_cleanup_queue
+
+      def __restore_cleanup_queue_claim
+        claim = @cleanup_queue_claim
+        return unless claim
+
+        unless claim[:started]
+          claim[:queue].unshift(claim[:entry]) unless claim[:queue].first.equal?(claim[:entry])
+        end
+        @cleanup_queue_claim = nil if @cleanup_queue_claim.equal?(claim)
+      end
+      private :__restore_cleanup_queue_claim
+
       def __run_cleanup_callback
         yield
         true
@@ -1970,20 +2037,21 @@ module Lich
       private :__report_cleanup_error
 
       def __launch_child
-        admitted = child_scripts_mutex.synchronize do
-          return nil if @child_shutdown_started
+        launch_token = Object.new
+        Thread.handle_interrupt(Exception => :never) do
+          begin
+            child_scripts_mutex.synchronize do
+              return nil if @child_shutdown_started
 
-          @child_launches = @child_launches.to_i + 1
-          true
-        end
-        return nil unless admitted
-
-        begin
-          yield
-        ensure
-          child_scripts_mutex.synchronize do
-            @child_launches -= 1
-            @child_launch_condition&.broadcast
+              @child_launches ||= {}
+              @child_launches[launch_token] = Thread.current
+            end
+            Thread.handle_interrupt(Exception => :immediate) { yield }
+          ensure
+            child_scripts_mutex.synchronize do
+              @child_launches&.delete(launch_token)
+              @child_launch_condition&.broadcast
+            end
           end
         end
       end
@@ -2048,9 +2116,13 @@ module Lich
 
       def __wait_for_child_launches
         child_scripts_mutex.synchronize do
-          if @child_launches.to_i.positive?
+          if @child_launches
+            @child_launches.delete_if { |_token, owner| !owner.alive? }
             @child_launch_condition ||= ConditionVariable.new
-            @child_launch_condition.wait(child_scripts_mutex) while @child_launches.to_i.positive?
+            until @child_launches.empty?
+              @child_launch_condition.wait(child_scripts_mutex, JOIN_WAIT_INTERVAL)
+              @child_launches.delete_if { |_token, owner| !owner.alive? }
+            end
           end
           Array(@child_scripts).dup
         end

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -164,11 +164,12 @@ module Lich
 
           start_gate = Queue.new
           setup_complete = false
-          worker_released = false
+          launcher_thread = Thread.current
+          gate_release_failed = false
           begin
             new_thread = Thread.new {
               begin
-                next unless start_gate.pop
+                next unless Script.__send__(:__await_thread_gate, start_gate, launcher_thread, false)
 
                 script = script_obj
                 if Script.current
@@ -216,15 +217,19 @@ module Lich
             script_obj.__send__(:__publish, true)
             setup_complete = true
           ensure
-            begin
-              start_gate << setup_complete
-              worker_released = true
-            ensure
-              unless setup_complete && worker_released
-                new_thread&.kill
-                new_thread&.join
-                parent.unregister_child(script_obj) if parent
-                script_obj.__send__(:__discard_startup)
+            Thread.handle_interrupt(Exception => :never) do
+              begin
+                start_gate << setup_complete
+              rescue Exception # rubocop:disable Lint/RescueException
+                gate_release_failed = true
+                raise
+              ensure
+                unless setup_complete && !gate_release_failed
+                  new_thread&.kill
+                  new_thread&.join
+                  parent.unregister_child(script_obj) if parent
+                  script_obj.__send__(:__discard_startup)
+                end
               end
             end
           end
@@ -317,13 +322,13 @@ module Lich
       @@startup_reservations = {}
       @@startup_generation = 0
       @@completed_named_starts = {}
-      @@completed_start_waiters = Hash.new(0)
+      @@completed_start_waiters = {}
       @@shutdown_started = false
       @@library_mutex = Mutex.new
       @@loaded_libraries = Set.new
       @@loaded_library_owners = {}
       @@loading_libraries = {}
-      @@reloading_libraries = Set.new
+      @@reloading_libraries = {}
       @@library_waits = {}
       @@kill_metrics_mutex = Mutex.new
       @@kill_metrics = {
@@ -338,6 +343,8 @@ module Lich
       attr_accessor :quiet, :no_echo, :jump_label, :current_label, :want_downstream, :want_downstream_xml, :want_upstream, :want_script_output, :hidden, :paused, :silent, :no_pause_all, :no_kill_all, :downstream_buffer, :upstream_buffer, :unique_buffer, :die_with, :match_stack_labels, :match_stack_strings, :watchfor, :command_line, :ignore_pause, :killed_externally, :kill_source
 
       KILL_METRICS_FEATURE_FLAG = :script_kill_metrics
+      CLEANUP_QUEUE_ENTRY_MARKER = Object.new.freeze
+      private_constant :CLEANUP_QUEUE_ENTRY_MARKER
 
       class JumpError < StandardError; end
       class LibraryJoinTimeout < LoadError; end
@@ -741,6 +748,7 @@ module Lich
         normalized_name = name.downcase
         @@startup_mutex.synchronize do
           __reap_abandoned_startups_locked
+          __completed_start_waiter_expected_locked?(normalized_name)
           return [:shutdown, nil] if @@shutdown_started
 
           unless __startup_in_progress_locked?(normalized_name)
@@ -751,9 +759,15 @@ module Lich
             return [candidate ? :duplicate : :admitted, candidate]
           end
 
+          waiter_token = [Object.new, Thread.current]
           Thread.handle_interrupt(Exception => :never) do
             begin
-              @@completed_start_waiters[normalized_name] += 1
+              waiters = @@completed_start_waiters[normalized_name]
+              unless waiters.is_a?(Set)
+                waiters = Set.new
+                @@completed_start_waiters[normalized_name] = waiters
+              end
+              waiters.add(waiter_token)
               Thread.handle_interrupt(Exception => :immediate) do
                 while __startup_in_progress_locked?(normalized_name)
                   __reap_abandoned_startups_locked
@@ -773,10 +787,13 @@ module Lich
               @@startup_reservations[reservation] = [normalized_name, Thread.current, nil, candidate]
               [candidate ? :duplicate : :admitted, candidate]
             ensure
-              @@completed_start_waiters[normalized_name] -= 1
-              if @@completed_start_waiters[normalized_name].zero?
-                @@completed_start_waiters.delete(normalized_name)
-                @@completed_named_starts.delete(normalized_name)
+              waiters = @@completed_start_waiters[normalized_name]
+              if waiters.is_a?(Set)
+                waiters.delete(waiter_token)
+                if waiters.empty?
+                  @@completed_start_waiters.delete(normalized_name)
+                  @@completed_named_starts.delete(normalized_name)
+                end
               end
             end
           end
@@ -803,7 +820,7 @@ module Lich
             current_generation = __completed_start_generation(@@completed_named_starts[name])
             if !preserve_completed && generation && generation >= current_generation
               @@completed_named_starts.delete(name)
-              handoff_expected = @@completed_start_waiters[name].positive? ||
+              handoff_expected = __completed_start_waiter_expected_locked?(name) ||
                                  __library_handoff_reserved_locked?(name)
               if script && handoff_expected
                 @@completed_named_starts[name] = [generation, script]
@@ -856,6 +873,23 @@ module Lich
       end
       private_class_method :__completed_start_generation
 
+      def Script.__completed_start_waiter_expected_locked?(name)
+        waiters = @@completed_start_waiters[name]
+        return (waiters || 0).to_i.positive? unless waiters.is_a?(Set)
+
+        waiters.delete_if do |token|
+          token.is_a?(Array) && token.last.is_a?(Thread) && !token.last.alive?
+        end
+        if waiters.empty?
+          @@completed_start_waiters.delete(name)
+          @@completed_named_starts.delete(name)
+          false
+        else
+          true
+        end
+      end
+      private_class_method :__completed_start_waiter_expected_locked?
+
       def Script.__peek_completed_start(name)
         @@startup_mutex.synchronize do
           __completed_start_value(@@completed_named_starts[name.downcase])
@@ -888,6 +922,23 @@ module Lich
         [deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC), 0].max
       end
       private_class_method :__remaining_library_timeout
+
+      def Script.__await_thread_gate(gate, owner, abandoned_value)
+        loop do
+          return gate.pop(true)
+        rescue ThreadError
+          unless owner.alive?
+            begin
+              return gate.pop(true)
+            rescue ThreadError
+              return abandoned_value
+            end
+          end
+
+          sleep JOIN_WAIT_INTERVAL
+        end
+      end
+      private_class_method :__await_thread_gate
 
       # Starts an anonymous child script owned by the current script.
       #
@@ -1085,12 +1136,16 @@ module Lich
       def Script.reloadlibs(timeout: LIBRARY_RELOAD_TIMEOUT)
         current_library = Script.current&.name&.downcase
         successful = true
-        libraries = @@library_mutex.synchronize { @@loaded_libraries | @@reloading_libraries }
+        libraries = @@library_mutex.synchronize do
+          @@loaded_libraries | Set.new(@@reloading_libraries.keys)
+        end
         libraries.each do |library|
           next if library == current_library
 
+          reload_token = Object.new
           @@library_mutex.synchronize do
-            @@reloading_libraries.add(library)
+            @@reloading_libraries[library] ||= Set.new
+            @@reloading_libraries[library].add(reload_token)
             if @@loaded_libraries.delete?(library)
               loaded_owner = @@loaded_library_owners[library]
               loading_script = @@loading_libraries[library]
@@ -1101,10 +1156,22 @@ module Lich
             end
           end
           Script.loadlib(library, :timeout => timeout)
-          @@library_mutex.synchronize { @@reloading_libraries.delete(library) }
+          @@library_mutex.synchronize do
+            if @@loaded_libraries.include?(library)
+              @@reloading_libraries.delete(library)
+            else
+              reloaders = @@reloading_libraries[library]
+              reloaders&.delete(reload_token)
+              @@reloading_libraries.delete(library) if reloaders&.empty?
+            end
+          end
         rescue LoadError => e
           successful = false
-          @@library_mutex.synchronize { @@reloading_libraries.delete(library) }
+          @@library_mutex.synchronize do
+            reloaders = @@reloading_libraries[library]
+            reloaders&.delete(reload_token)
+            @@reloading_libraries.delete(library) if reloaders&.empty?
+          end
           Lich.log("error: failed to reload script library #{library}: #{e.message}")
         end
         successful
@@ -1320,9 +1387,11 @@ module Lich
               if line =~ trigger
                 start_gate = Queue.new
                 worker_registered = false
+                gate_release_failed = false
+                launcher_thread = Thread.current
                 begin
                   new_thread = Thread.new {
-                    next unless start_gate.pop
+                    next unless Script.__send__(:__await_thread_gate, start_gate, launcher_thread, false)
 
                     sleep 0.011 until Script.current
                     begin
@@ -1333,10 +1402,18 @@ module Lich
                   }
                   worker_registered = script.__send__(:__register_worker, new_thread)
                 ensure
-                  start_gate << worker_registered
-                  unless worker_registered
-                    new_thread&.kill
-                    new_thread&.join
+                  Thread.handle_interrupt(Exception => :never) do
+                    begin
+                      start_gate << worker_registered
+                    rescue Exception # rubocop:disable Lint/RescueException
+                      gate_release_failed = true
+                      raise
+                    ensure
+                      unless worker_registered && !gate_release_failed
+                        new_thread&.kill
+                        new_thread&.join
+                      end
+                    end
                   end
                 end
               end
@@ -1681,62 +1758,75 @@ module Lich
         cleanup_thread = nil
         cleanup_released = false
         cleanup_owned = false
+        gate_release_failed = false
         start_gate = Queue.new if async
+        launch_owner = Thread.current
         source = @kill_source || caller[0..2]
-        begin
-          start_cleanup = Script.__send__(:__registry_synchronize) do
-            lifecycle_mutex.synchronize do
-              next false unless @@running.include?(self)
-              if @cleanup_started
-                cleanup_active = @cleanup_launch_pending ||
-                                 (@cleanup_thread&.alive? && @cleanup_thread != Thread.current)
-                next false if cleanup_active
+        Thread.handle_interrupt(Exception => :never) do
+          begin
+            start_cleanup = Script.__send__(:__registry_synchronize) do
+              lifecycle_mutex.synchronize do
+                next false unless @@running.include?(self)
+                if @cleanup_started
+                  cleanup_active = @cleanup_launch_pending ||
+                                   (@cleanup_thread&.alive? && @cleanup_thread != Thread.current)
+                  next false if cleanup_active
+                end
+
+                @kill_requested = true
+                @cleanup_started = launch_token
+                @cleanup_launch_pending = true
+                @@stopping << self unless @@stopping.include?(self)
+                true
               end
-
-              @kill_requested = true
-              @cleanup_started = launch_token
-              @cleanup_launch_pending = true
-              @@stopping << self unless @@stopping.include?(self)
-              true
             end
-          end
-          return @name unless start_cleanup
+            return @name unless start_cleanup
 
-          if async
-            cleanup_thread = Thread.new {
-              start_gate.pop
-              __run_kill_cleanup(source: source, context: context, record_metrics: true)
-            }
-            ThreadGroup::Default.add(cleanup_thread)
-            __attach_cleanup_worker(cleanup_thread)
-            __claim_cleanup_thread(cleanup_thread)
-            cleanup_owned = true
-            raise ThreadError, 'cleanup thread stopped before ownership transfer' unless cleanup_thread.alive?
+            if async
+              cleanup_thread = Thread.new {
+                Script.__send__(:__await_thread_gate, start_gate, launch_owner, true)
+                __run_kill_cleanup(source: source, context: context, record_metrics: true)
+              }
+              ThreadGroup::Default.add(cleanup_thread)
+              __attach_cleanup_worker(cleanup_thread)
+              __claim_cleanup_thread(cleanup_thread)
+              cleanup_owned = true
+              raise ThreadError, 'cleanup thread stopped before ownership transfer' unless cleanup_thread.alive?
 
-            start_gate << true
-            cleanup_released = true
-          else
-            lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
-            cleanup_owned = true
-            __run_kill_cleanup(source: source, context: context, record_metrics: false)
-          end
-        rescue ThreadError => e
-          raise unless @cleanup_started.equal?(launch_token)
-
-          cleanup_thread&.kill
-          __log_kill_thread_fallback(e)
-          __run_kill_cleanup(source: source, context: context, record_metrics: false)
-        ensure
-          if async && @cleanup_started.equal?(launch_token) && !cleanup_released
-            start_gate << true
-            unless cleanup_owned && cleanup_thread&.alive?
-              cleanup_thread&.kill
-              __run_kill_cleanup(source: source, context: context, record_metrics: false)
+              start_gate << true
+              cleanup_released = true
+            else
+              lifecycle_mutex.synchronize { @cleanup_thread = Thread.current }
+              cleanup_owned = true
+              __run_kill_cleanup_interruptibly(source: source, context: context, record_metrics: false)
             end
-          end
-          if @cleanup_started.equal?(launch_token)
-            executor_abandoned = __finish_cleanup_launch
-            kill(:context => context, :async => true) if running? && executor_abandoned
+          rescue ThreadError => e
+            raise unless @cleanup_started.equal?(launch_token)
+
+            cleanup_thread&.kill
+            __log_kill_thread_fallback(e)
+            __run_kill_cleanup_interruptibly(source: source, context: context, record_metrics: false)
+          ensure
+            begin
+              if async && @cleanup_started.equal?(launch_token) && !cleanup_released
+                begin
+                  start_gate << true
+                rescue Exception # rubocop:disable Lint/RescueException
+                  gate_release_failed = true
+                  raise
+                ensure
+                  unless !gate_release_failed && cleanup_owned && cleanup_thread&.alive?
+                    cleanup_thread&.kill
+                    __run_kill_cleanup_interruptibly(source: source, context: context, record_metrics: false)
+                  end
+                end
+              end
+            ensure
+              if @cleanup_started.equal?(launch_token)
+                executor_abandoned = __finish_cleanup_launch
+                kill(:context => context, :async => true) if running? && executor_abandoned
+              end
+            end
           end
         end
 
@@ -1865,6 +1955,13 @@ module Lich
       # @param record_metrics [Boolean] whether this cleanup can feed runtime metrics
       # @return [void]
       # @api private
+      def __run_kill_cleanup_interruptibly(**kwargs)
+        Thread.handle_interrupt(Exception => :immediate) do
+          __run_kill_cleanup(**kwargs)
+        end
+      end
+      private :__run_kill_cleanup_interruptibly
+
       def __run_kill_cleanup(source:, context:, record_metrics:)
         # Re-entrancy guard. A die_with cycle (A die_with B and B die_with A, or
         # a self-reference) reached on the inline cleanup path routes Script.kill
@@ -1991,14 +2088,33 @@ module Lich
       def __run_cleanup_queue(queue)
         __restore_cleanup_queue_claim
         loop do
-          entry = queue.first
-          break unless entry
+          queued_entry = queue.first
+          break unless queued_entry
 
-          claim = { :queue => queue, :entry => entry, :started => false }
+          entry =
+            if queued_entry.is_a?(Array) && queued_entry.first.equal?(CLEANUP_QUEUE_ENTRY_MARKER)
+              queued_entry.last
+            else
+              queued_entry
+            end
+
+          claim = {
+            :queue            => queue,
+            :entry            => entry,
+            :queued_entry     => queued_entry,
+            :marker           => Object.new,
+            :marker_installed => false,
+            :dispatched       => false,
+            :restored_entry   => [CLEANUP_QUEUE_ENTRY_MARKER, entry]
+          }
           @cleanup_queue_claim = claim
           begin
+            queue[0] = claim[:marker]
+            claim[:marker_installed] = true
             queue.shift
-            claim[:started] = true
+            # Once dispatch is claimed, the entry remains at-most-once even if
+            # the cleanup executor is cancelled inside the callback.
+            claim[:dispatched] = true
             yield entry
           ensure
             __restore_cleanup_queue_claim
@@ -2010,13 +2126,25 @@ module Lich
       private :__run_cleanup_queue
 
       def __restore_cleanup_queue_claim
-        claim = @cleanup_queue_claim
-        return unless claim
+        Thread.handle_interrupt(Exception => :never) do
+          claim = @cleanup_queue_claim
+          return unless claim
 
-        unless claim[:started]
-          claim[:queue].unshift(claim[:entry]) unless claim[:queue].first.equal?(claim[:entry])
+          unless claim[:dispatched]
+            marker_index = claim[:queue].find_index { |entry| entry.equal?(claim[:marker]) }
+            restored = claim[:restored_entry]
+            restored_index = claim[:queue].find_index { |entry| entry.equal?(restored) }
+            queued_index = claim[:queue].find_index { |entry| entry.equal?(claim[:queued_entry]) }
+            if marker_index
+              claim[:queue][marker_index] = restored
+            elsif claim[:marker_installed]
+              claim[:queue].unshift(restored) unless restored_index
+            elsif !queued_index && !claim[:queue].first.equal?(claim[:entry]) && !restored_index
+              claim[:queue].unshift(restored)
+            end
+          end
+          @cleanup_queue_claim = nil if @cleanup_queue_claim.equal?(claim)
         end
-        @cleanup_queue_claim = nil if @cleanup_queue_claim.equal?(claim)
       end
       private :__restore_cleanup_queue_claim
 
@@ -2702,11 +2830,12 @@ module Lich
             new_script = SubScript.new(:quiet => quiet, :publish => false)
             start_gate = Queue.new
             setup_complete = false
-            worker_released = false
+            launcher_thread = Thread.current
+            gate_release_failed = false
             begin
               new_thread = Thread.new {
                 begin
-                  next unless start_gate.pop
+                  next unless Script.__send__(:__await_thread_gate, start_gate, launcher_thread, false)
 
                   script = new_script
                   if Script.current
@@ -2731,15 +2860,19 @@ module Lich
               new_script.__send__(:__publish, true)
               setup_complete = true
             ensure
-              begin
-                start_gate << setup_complete
-                worker_released = true
-              ensure
-                unless setup_complete && worker_released
-                  new_thread&.kill
-                  new_thread&.join
-                  parent.unregister_child(new_script) if parent
-                  new_script.__send__(:__discard_startup)
+              Thread.handle_interrupt(Exception => :never) do
+                begin
+                  start_gate << setup_complete
+                rescue Exception # rubocop:disable Lint/RescueException
+                  gate_release_failed = true
+                  raise
+                ensure
+                  unless setup_complete && !gate_release_failed
+                    new_thread&.kill
+                    new_thread&.join
+                    parent.unregister_child(new_script) if parent
+                    new_script.__send__(:__discard_startup)
+                  end
                 end
               end
             end
@@ -2814,11 +2947,12 @@ module Lich
           new_script = ExecScript.new(cmd_data, options.merge(:publish => false))
           start_gate = Queue.new
           setup_complete = false
-          worker_released = false
+          launcher_thread = Thread.current
+          gate_release_failed = false
           begin
             new_thread = Thread.new {
               begin
-                next unless start_gate.pop
+                next unless Script.__send__(:__await_thread_gate, start_gate, launcher_thread, false)
 
                 script = new_script
                 if Script.current
@@ -2844,14 +2978,18 @@ module Lich
             new_script.__send__(:__publish, true)
             setup_complete = true
           ensure
-            begin
-              start_gate << setup_complete
-              worker_released = true
-            ensure
-              unless setup_complete && worker_released
-                new_thread&.kill
-                new_thread&.join
-                new_script.__send__(:__discard_startup)
+            Thread.handle_interrupt(Exception => :never) do
+              begin
+                start_gate << setup_complete
+              rescue Exception # rubocop:disable Lint/RescueException
+                gate_release_failed = true
+                raise
+              ensure
+                unless setup_complete && !gate_release_failed
+                  new_thread&.kill
+                  new_thread&.join
+                  new_script.__send__(:__discard_startup)
+                end
               end
             end
           end

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -321,6 +321,7 @@ module Lich
       @@shutdown_started = false
       @@library_mutex = Mutex.new
       @@loaded_libraries = Set.new
+      @@loaded_library_owners = {}
       @@loading_libraries = {}
       @@library_waits = {}
       @@kill_metrics_mutex = Mutex.new
@@ -730,7 +731,7 @@ module Lich
       end
       private_class_method :__begin_start
 
-      def Script.__begin_library_start(reservation, name)
+      def Script.__begin_library_start(reservation, name, deadline: nil)
         normalized_name = name.downcase
         @@startup_mutex.synchronize do
           __reap_abandoned_startups_locked
@@ -750,7 +751,12 @@ module Lich
               __reap_abandoned_startups_locked
               break unless __startup_in_progress_locked?(normalized_name)
 
-              @@startup_condition.wait(@@startup_mutex, JOIN_WAIT_INTERVAL)
+              remaining = __remaining_library_timeout(deadline)
+              if remaining && remaining <= 0
+                raise LibraryJoinTimeout, "script library wait timed out: #{normalized_name}"
+              end
+              wait_for = remaining ? [JOIN_WAIT_INTERVAL, remaining].min : JOIN_WAIT_INTERVAL
+              @@startup_condition.wait(@@startup_mutex, wait_for)
             end
             completed = __completed_start_value(@@completed_named_starts[normalized_name])
             active = __active_named_script(normalized_name)
@@ -866,6 +872,13 @@ module Lich
       end
       private_class_method :__library_handoff_reserved_locked?
 
+      def Script.__remaining_library_timeout(deadline)
+        return nil unless deadline
+
+        [deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC), 0].max
+      end
+      private_class_method :__remaining_library_timeout
+
       # Starts an anonymous child script owned by the current script.
       #
       # @yield required block executed by the new script
@@ -946,6 +959,9 @@ module Lich
       # @raise [ArgumentError] when the library name is empty
       # @raise [LoadError] when the library cannot be found or started
       def Script.loadlib(library, timeout: nil)
+        raise ArgumentError, 'timeout must be non-negative' if timeout && timeout.negative?
+
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout if timeout
         library_name = library.to_s.downcase
         library_name = "lib#{library_name}" unless library_name.start_with?('lib')
         raise ArgumentError, 'library name cannot be empty' if library_name == 'lib'
@@ -957,7 +973,7 @@ module Lich
         loading = @@library_mutex.synchronize { @@loading_libraries[library_name] }
         if loading
           begin
-            __join_library(library_name, loading, timeout)
+            __join_library(library_name, loading, __remaining_library_timeout(deadline))
             return __commit_library_completion(library_name, loading)
           rescue LibraryJoinTimeout
             raise
@@ -968,6 +984,7 @@ module Lich
               if @@loading_libraries[library_name].equal?(loading)
                 @@loading_libraries.delete(library_name)
                 @@loaded_libraries.delete(library_name)
+                @@loaded_library_owners.delete(library_name)
               end
             end
           end
@@ -975,7 +992,11 @@ module Lich
 
         startup_reservation = Object.new
         prepared = begin
-          startup_status, completed_start = __begin_library_start(startup_reservation, library_name)
+          startup_status, completed_start = __begin_library_start(
+            startup_reservation,
+            library_name,
+            :deadline => deadline
+          )
           raise LoadError, "cannot load script library during shutdown: #{library_name}" if startup_status == :shutdown
 
           running = __running_snapshot.find { |candidate| candidate.name.casecmp?(library_name) }
@@ -993,6 +1014,10 @@ module Lich
           end
 
           if start_required
+            remaining = __remaining_library_timeout(deadline)
+            if remaining && remaining <= 0
+              raise LibraryJoinTimeout, "script library wait timed out: #{library_name}"
+            end
             script = Script.start(library_name, { :force => true })
             raise LoadError, "failed to start script library: #{library_name}" unless script
 
@@ -1026,7 +1051,7 @@ module Lich
         return true if already_loaded
 
         begin
-          __join_library(library_name, script, timeout)
+          __join_library(library_name, script, __remaining_library_timeout(deadline))
         rescue LibraryJoinTimeout
           raise
         rescue ScriptError, StandardError
@@ -1052,9 +1077,15 @@ module Lich
           next if library == current_library
 
           @@library_mutex.synchronize do
-            was_loaded = @@loaded_libraries.include?(library)
-            @@loaded_libraries.delete(library)
-            @@loading_libraries.delete(library) if was_loaded
+            if @@loaded_libraries.include?(library)
+              loaded_owner = @@loaded_library_owners[library]
+              loading_script = @@loading_libraries[library]
+              if loaded_owner && loading_script&.object_id == loaded_owner
+                @@loading_libraries.delete(library)
+              end
+              @@loaded_library_owners.delete(library)
+              @@loaded_libraries.delete(library)
+            end
           end
           Script.loadlib(library, :timeout => timeout)
         rescue LoadError => e
@@ -1073,29 +1104,30 @@ module Lich
 
       def Script.__join_library(library_name, script, timeout = nil)
         caller_script = Script.current
-        dependency_registered = false
+        dependency_token = Object.new
         @@library_mutex.synchronize do
           if caller_script
             if __library_dependency_reaches?(script, caller_script)
               raise LoadError, "cyclic script library dependency: #{library_name}"
             end
             dependencies = @@library_waits[caller_script]
-            dependencies = Hash.new(0) unless dependencies.is_a?(Hash)
+            dependencies = {} unless dependencies.is_a?(Hash)
             @@library_waits[caller_script] = dependencies
-            dependencies[script] += 1
-            dependency_registered = true
+            dependencies[script] ||= Set.new
+            dependencies[script].add(dependency_token)
           end
         end
 
         joined = script.join(timeout)
         raise LibraryJoinTimeout, "script library wait timed out: #{library_name}" unless joined
       ensure
-        if caller_script && dependency_registered
+        if caller_script
           @@library_mutex.synchronize do
             dependencies = @@library_waits[caller_script]
             if dependencies.is_a?(Hash)
-              dependencies[script] -= 1
-              dependencies.delete(script) unless dependencies[script].positive?
+              tokens = dependencies[script]
+              tokens&.delete(dependency_token)
+              dependencies.delete(script) if tokens && tokens.empty?
               @@library_waits.delete(caller_script) if dependencies.empty?
             elsif dependencies.equal?(script)
               @@library_waits.delete(caller_script)
@@ -1112,7 +1144,9 @@ module Lich
           if @@loading_libraries[library_name].equal?(script)
             if error || !completed
               @@loaded_libraries.delete(library_name)
+              @@loaded_library_owners.delete(library_name)
             else
+              @@loaded_library_owners[library_name] = script.object_id
               @@loaded_libraries.add(library_name)
             end
             @@loading_libraries.delete(library_name)
@@ -1662,7 +1696,8 @@ module Lich
           if @cleanup_started.equal?(launch_token)
             executor_abandoned = !cleanup_owned || !cleanup_thread&.alive? || cleanup_thread == Thread.current
             __run_kill_cleanup(source: source, context: context, record_metrics: false) if running? && executor_abandoned
-            lifecycle_mutex.synchronize { @cleanup_launch_pending = false }
+            executor_abandoned = __finish_cleanup_launch
+            __run_kill_cleanup(source: source, context: context, record_metrics: false) if running? && executor_abandoned
           end
         end
 
@@ -1844,8 +1879,6 @@ module Lich
               failed = false
               cleanup_body_complete = false
               begin
-                raise cleanup_group_error if cleanup_group_error
-
                 __close_child_launch_admission
                 stopping_threads = lifecycle_mutex.synchronize do
                   @stopping_threads = __raw_worker_threads.reject { |thread| thread == Thread.current }
@@ -1853,6 +1886,8 @@ module Lich
                 stopping_threads.each { |thread| thread.kill rescue nil }
                 children = __wait_for_child_launches
                 __stop_children(children, context)
+                raise cleanup_group_error if cleanup_group_error
+
                 # Shift each callback before invoking it. If this executor is
                 # cancelled, recovery resumes with the remaining callbacks.
                 @die_with ||= []
@@ -2188,6 +2223,14 @@ module Lich
         thread
       end
       private :__claim_cleanup_thread
+
+      def __finish_cleanup_launch
+        lifecycle_mutex.synchronize do
+          @cleanup_launch_pending = false
+          !@cleanup_thread || !@cleanup_thread.alive? || @cleanup_thread == Thread.current
+        end
+      end
+      private :__finish_cleanup_launch
 
       def __cleanup_worker_group
         lifecycle_mutex.synchronize { @cleanup_thread_group ||= ThreadGroup.new }

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -148,6 +148,18 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
+    it 'releases startup coordination before taking the shutdown snapshot' do
+      startup_mutex = script_class.class_variable_get(:@@startup_mutex)
+      startup_mutex_owned = nil
+      allow(script_class).to receive(:shutdown_scripts) do
+        startup_mutex_owned = startup_mutex.owned?
+        []
+      end
+
+      expect(script_class.begin_shutdown).to be_empty
+      expect(startup_mutex_owned).to be(false)
+    end
+
     it 'rejects direct constructor publication after shutdown begins' do
       Dir.mktmpdir('script-direct-shutdown') do |root|
         custom_dir = File.join(root, 'custom')
@@ -1474,6 +1486,47 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script.join(1)).to equal(script)
     end
 
+    it 'assigns descendants from nested cleanup to the inner script' do
+      outer_script = build_script('outer-cleanup')
+      inner_script = build_script('inner-cleanup')
+      script_class.class_variable_set(:@@running, [outer_script, inner_script])
+      descendant_ready = Queue.new
+      descendant_owner = Queue.new
+      descendant_cleanup_entered = Queue.new
+      release_descendant_cleanup = Queue.new
+      inner_completed = Queue.new
+      inner_script.at_exit do
+        Thread.new do
+          descendant_owner << script_class.current
+          descendant_ready << true
+          begin
+            Queue.new.pop
+          ensure
+            descendant_cleanup_entered << true
+            release_descendant_cleanup.pop
+          end
+        end
+        descendant_ready.pop
+      end
+      outer_script.at_exit do
+        inner_script.kill(:context => :shutdown, :async => false)
+        inner_completed << inner_script.__send__(:__cleanup_complete?)
+      end
+
+      outer_script.kill(:context => :shutdown, :async => false)
+
+      expect(descendant_owner.pop).to equal(inner_script)
+      expect(inner_completed.pop).to be(false)
+      descendant_cleanup_entered.pop
+      release_descendant_cleanup << true
+      progress_shutdown_until(inner_script)
+      progress_shutdown_until(outer_script)
+      expect(inner_script.join(1)).to equal(inner_script)
+      expect(outer_script.join(1)).to equal(outer_script)
+    ensure
+      release_descendant_cleanup << true if defined?(release_descendant_cleanup) && release_descendant_cleanup
+    end
+
     it 'does not detach an inline cleanup caller when its group becomes enclosed' do
       caller_script = build_script('caller')
       target_script = build_script('target')
@@ -1677,6 +1730,17 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     ensure
       worker&.kill
       worker&.join
+    end
+
+    it 'rejects self-registration without stopping the caller' do
+      script = build_script('self-registration')
+      script_class.class_variable_set(:@@running, [script])
+      script.instance_variable_set(:@kill_requested, true)
+
+      expect { script.thread_group.add(Thread.current) }.to raise_error(ThreadError, /stopping script/)
+      expect(Thread.current).to be_alive
+      stopping_threads = Object.instance_method(:instance_variable_get).bind_call(script, :@stopping_threads)
+      expect(Array(stopping_threads)).not_to include(Thread.current)
     end
 
     it 'runs teardown callbacks after the public thread group is enclosed' do

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -781,6 +781,20 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@running, [])
     end
 
+    it 'returns a child after run_child observes complete teardown' do
+      child = instance_double(script_class, :join => true)
+      allow(script_class).to receive(:start_child).with('worker').and_return(child)
+
+      expect(script_class.run_child('worker')).to equal(child)
+    end
+
+    it 'returns nil when run_child teardown times out' do
+      child = instance_double(script_class, :join => nil)
+      allow(script_class).to receive(:start_child).with('worker').and_return(child)
+
+      expect(script_class.run_child('worker')).to be_nil
+    end
+
     it 'waits for exit handlers in kill_sync' do
       script = build_script('sync')
       script_class.class_variable_set(:@@running, [script])

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     script_class.class_variable_set(:@@startup_reservations, {})
     script_class.class_variable_set(:@@startup_generation, 0)
     script_class.class_variable_set(:@@completed_named_starts, {})
-    script_class.class_variable_set(:@@completed_start_waiters, Hash.new(0))
+    script_class.class_variable_set(:@@completed_start_waiters, {})
     script_class.class_variable_set(:@@shutdown_started, false)
     script_class.class_variable_set(:@@loaded_libraries, Set.new)
     script_class.class_variable_set(:@@loaded_library_owners, {})
     script_class.class_variable_set(:@@loading_libraries, {})
-    script_class.class_variable_set(:@@reloading_libraries, Set.new)
+    script_class.class_variable_set(:@@reloading_libraries, {})
     script_class.class_variable_set(:@@library_waits, {})
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
@@ -247,6 +247,61 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       waiter&.kill
     end
 
+    it 'does not decrement startup waiter accounting when cancelled before registration' do
+      reservation = Object.new
+      script_class.__send__(:__begin_start, reservation, 'libwaiting', :force => true)
+      interrupting_waiters = Class.new(Hash) do
+        def initialize
+          super(0)
+        end
+
+        def [](name)
+          unless defined?(@interrupted)
+            @interrupted = true
+            Thread.current.kill
+          end
+          super
+        end
+      end.new
+      script_class.class_variable_set(:@@completed_start_waiters, interrupting_waiters)
+
+      waiter = Thread.new do
+        script_class.__send__(:__begin_library_start, Object.new, 'libwaiting')
+      end
+      waiter.join
+
+      expect(script_class.class_variable_get(:@@completed_start_waiters)).to be_empty
+    ensure
+      script_class.__send__(:__finish_start, reservation) if defined?(reservation) && reservation
+      waiter&.kill
+    end
+
+    it 'consumes a gate value enqueued immediately before its owner exits' do
+      gate = Queue.new
+      release_owner = Queue.new
+      owner = Thread.new do
+        release_owner.pop
+        gate << true
+      end
+      first_pop = true
+      gate.define_singleton_method(:pop) do |non_block = false|
+        if first_pop
+          first_pop = false
+          release_owner << true
+          owner.join
+          raise ThreadError, 'simulated stale empty observation'
+        end
+        super(non_block)
+      end
+
+      result = script_class.__send__(:__await_thread_gate, gate, owner, false)
+
+      expect(result).to be(true)
+    ensure
+      release_owner << true if defined?(release_owner) && release_owner
+      owner&.kill
+    end
+
     it 'uses the published name when reserving a compressed script' do
       Dir.mktmpdir('script-compressed-start') do |root|
         custom_dir = File.join(root, 'custom')
@@ -412,6 +467,43 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
         expect(script_class.libs).not_to include('libfailure')
       end
     end
+
+    it 'does not discard a published script when gate release is interrupted' do
+      Dir.mktmpdir('script-gate-release') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'gate_release.lic'), "# quiet\nsleep 1\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        interrupt_next_queue_release(:after)
+
+        expect { script_class.start('gate_release') }.to raise_error(Timeout::Error, /gate release/)
+
+        script = script_class.list.find { |candidate| candidate.name == 'gate_release' }
+        expect(script).not_to be_nil
+        expect(script.kill_sync(:timeout => 1)).to equal(script)
+      end
+    end
+
+    it 'tears down a gated script when its launcher is killed after publication' do
+      Dir.mktmpdir('script-killed-gate-release') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'gate_release.lic'), "# quiet\nsleep 1\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+        gate_entered, release_gate = block_next_queue_release
+        launcher = Thread.new { script_class.start('gate_release') }
+        gate_entered.pop
+
+        expect(script_class.list.map(&:name)).to include('gate_release')
+        launcher.kill
+        launcher.join
+
+        Timeout.timeout(1) { sleep 0.01 until script_class.list.empty? }
+      ensure
+        release_gate << true if defined?(release_gate) && release_gate
+        launcher&.kill
+      end
+    end
   end
 
   describe 'Script facade' do
@@ -528,6 +620,18 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(subscript.join(1)).to equal(subscript)
       expect(subscript.exit_error).to be_a(script_class::JumpError)
       expect(subscript).not_to be_completed_successfully
+    end
+
+    it 'does not discard a published subscript when gate release is interrupted' do
+      interrupt_next_queue_release(:after)
+
+      expect {
+        subscript_class.start(:parent => nil) { sleep 1 }
+      }.to raise_error(Timeout::Error, /gate release/)
+
+      script = script_class.list.find { |candidate| candidate.name.start_with?('subscript') }
+      expect(script).not_to be_nil
+      expect(script.kill_sync(:timeout => 1)).to equal(script)
     end
 
     it 'tears down a subscript whose worker dies during current-script lookup' do
@@ -924,6 +1028,18 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script = launcher.value
       expect(script.join(2)).to equal(script)
     end
+
+    it 'does not discard a published exec script when gate release is interrupted' do
+      interrupt_next_queue_release(:after)
+
+      expect {
+        exec_script_class.start('sleep 1')
+      }.to raise_error(Timeout::Error, /gate release/)
+
+      script = script_class.list.find { |candidate| candidate.name.start_with?('exec') }
+      expect(script).not_to be_nil
+      expect(script.kill_sync(:timeout => 1)).to equal(script)
+    end
   end
 
   describe 'synchronous lifecycle methods' do
@@ -1193,6 +1309,18 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script).not_to be_running
     end
 
+    it 'completes cleanup when the launch-gate ensure is interrupted' do
+      script = build_script('interrupted-cleanup-gate')
+      script_class.class_variable_set(:@@running, [script])
+      interrupt_next_queue_release(:before)
+      allow(script).to receive(:__claim_cleanup_thread).and_raise(RuntimeError, 'handoff failed')
+
+      expect { script.kill }.to raise_error(Exception)
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
     it 'rechecks a dead cleanup executor after launch completion' do
       script = build_script('cleanup-launch-recheck')
       script_class.class_variable_set(:@@running, [script])
@@ -1319,18 +1447,20 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
         end
       end
       callback_calls = 0
+      callback = proc { callback_calls += 1 }
       script = build_script('cancelled-callback-dequeue')
-      script.instance_variable_set(:@at_exit_procs, interrupting_callbacks.new([proc { callback_calls += 1 }]))
+      script.instance_variable_set(:@at_exit_procs, interrupting_callbacks.new([callback, callback]))
       script_class.class_variable_set(:@@running, [script])
 
       cleanup_thread = Thread.new { script.kill(:context => :shutdown, :async => false) }
       Timeout.timeout(1) { dequeue_interrupted.pop }
+      script.at_exit { callback_calls += 10 }
       cleanup_thread.kill
       cleanup_thread.join
       script_class.progress_shutdown
 
       expect(script.join(1)).to equal(script)
-      expect(callback_calls).to eq(1)
+      expect(callback_calls).to eq(12)
     ensure
       release_dequeue << true if defined?(release_dequeue) && release_dequeue
     end
@@ -1364,6 +1494,58 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class).to have_received(:kill).once
     ensure
       release_dequeue << true if defined?(release_dequeue) && release_dequeue
+    end
+
+    it 'does not duplicate a callback when claim restoration is interrupted' do
+      interrupting_callbacks = Class.new(Array) do
+        def shift
+          entry = super()
+          unless defined?(@shift_interrupted)
+            @shift_interrupted = true
+            raise RuntimeError, 'dequeue interrupted'
+          end
+          entry
+        end
+
+        def unshift(*entries)
+          result = super
+          unless defined?(@restore_interrupted)
+            @restore_interrupted = true
+            Thread.current.kill
+          end
+          result
+        end
+
+        def []=(index, entry)
+          if @interrupt_assignment
+            @interrupt_assignment = false
+            Thread.current.kill
+          end
+          super
+        end
+      end
+      callback_calls = 0
+      callback = proc { callback_calls += 1 }
+      callbacks = interrupting_callbacks.new([callback])
+      script = build_script('interrupted-claim-restore')
+      cleanup_thread = Thread.new do
+        script.__send__(:__run_cleanup_queue, callbacks) { |entry| entry.call }
+      end
+      cleanup_thread.report_on_exception = false
+      cleanup_thread.join
+      callbacks.instance_variable_set(:@interrupt_assignment, true)
+      retry_thread = Thread.new do
+        script.__send__(:__run_cleanup_queue, callbacks) { |entry| entry.call }
+      end
+      retry_thread.report_on_exception = false
+      retry_thread.join
+      script.__send__(:__run_cleanup_queue, callbacks) { |entry| entry.call }
+
+      expect(callbacks).to be_empty
+      expect(callback_calls).to eq(1)
+    ensure
+      cleanup_thread&.kill
+      retry_thread&.kill
     end
 
     it 'does not run deferred cleanup from a timeout-bounded join' do
@@ -2144,7 +2326,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
       loaders = Array.new(2) { Thread.new { script_class.loadlib('util') } }
       waiters = script_class.class_variable_get(:@@completed_start_waiters)
-      Timeout.timeout(1) { Thread.pass until waiters['libutil'] == loaders.length }
+      Timeout.timeout(1) do
+        Thread.pass until completed_start_waiter_count(waiters, 'libutil') == loaders.length
+      end
 
       owner.kill
       owner.join
@@ -2270,7 +2454,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.__send__(:__begin_start, startup_token, 'libutil', :force => false)
       loaders = Array.new(3) { Thread.new { script_class.loadlib('util') } }
       waiters = script_class.class_variable_get(:@@completed_start_waiters)
-      Timeout.timeout(1) { Thread.pass until waiters['libutil'] == loaders.length }
+      Timeout.timeout(1) do
+        Thread.pass until completed_start_waiter_count(waiters, 'libutil') == loaders.length
+      end
       allow(script_class).to receive(:start)
 
       script_class.__send__(:__finish_start, startup_token, admitted_script)
@@ -2291,7 +2477,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
       loader = Thread.new { script_class.loadlib('util') }
       waiters = script_class.class_variable_get(:@@completed_start_waiters)
-      Timeout.timeout(1) { Thread.pass until waiters['libutil'] == 1 }
+      Timeout.timeout(1) do
+        Thread.pass until completed_start_waiter_count(waiters, 'libutil') == 1
+      end
 
       script_class.__send__(:__finish_start, startup_token, library_script)
       loader.join
@@ -2981,7 +3169,10 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
         end
       end.new(['libutil'])
       script_class.class_variable_set(:@@loaded_libraries, interrupting_libraries)
-      allow(script_class).to receive(:loadlib).with('libutil', :timeout => 1.0).and_return(true)
+      allow(script_class).to receive(:loadlib).with('libutil', :timeout => 1.0) do
+        script_class.class_variable_get(:@@loaded_libraries).add('libutil')
+        true
+      end
 
       interrupted_reload = Thread.new { script_class.reloadlibs }
       interrupted_reload.join
@@ -2992,6 +3183,99 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.class_variable_get(:@@reloading_libraries)).to be_empty
     ensure
       interrupted_reload&.kill
+    end
+
+    it 'keeps another reloader marker when an overlapping reload times out' do
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      first_reload_entered = Queue.new
+      release_first_reload = Queue.new
+      load_roles = Queue.new
+      allow(script_class).to receive(:loadlib).with('libutil', :timeout => 1.0) do
+        role = Thread.current.thread_variable_get(:reload_role)
+        load_roles << role
+        case role
+        when :first
+          first_reload_entered << true
+          release_first_reload.pop
+        when :second
+          raise script_class::LibraryJoinTimeout, 'overlapping reload timed out'
+        else
+          script_class.class_variable_get(:@@loaded_libraries).add('libutil')
+          true
+        end
+      end
+      first_reloader = Thread.new do
+        Thread.current.thread_variable_set(:reload_role, :first)
+        script_class.reloadlibs
+      end
+      first_reload_entered.pop
+      second_reloader = Thread.new do
+        Thread.current.thread_variable_set(:reload_role, :second)
+        script_class.reloadlibs
+      end
+
+      expect(second_reloader.value).to be(false)
+      expect(script_class.class_variable_get(:@@reloading_libraries).fetch('libutil').size).to eq(1)
+      first_reloader.kill
+      first_reloader.join
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(3.times.map { load_roles.pop }).to contain_exactly(:first, :second, nil)
+      expect(script_class.libs).to include('libutil')
+      expect(script_class.class_variable_get(:@@reloading_libraries)).to be_empty
+    ensure
+      release_first_reload << true if defined?(release_first_reload) && release_first_reload
+      first_reloader&.kill
+      second_reloader&.kill
+    end
+
+    it 'keeps a concurrent reloader marker after another reload succeeds' do
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      first_load_committed = Queue.new
+      release_first_reload = Queue.new
+      second_reload_entered = Queue.new
+      load_roles = Queue.new
+      allow(script_class).to receive(:loadlib).with('libutil', :timeout => 1.0) do
+        role = Thread.current.thread_variable_get(:reload_role)
+        load_roles << role
+        case role
+        when :first
+          script_class.class_variable_get(:@@loaded_libraries).add('libutil')
+          first_load_committed << true
+          release_first_reload.pop
+        when :second
+          second_reload_entered << true
+          Queue.new.pop
+        else
+          script_class.class_variable_get(:@@loaded_libraries).add('libutil')
+          true
+        end
+      end
+      first_reloader = Thread.new do
+        Thread.current.thread_variable_set(:reload_role, :first)
+        script_class.reloadlibs
+      end
+      first_load_committed.pop
+      second_reloader = Thread.new do
+        Thread.current.thread_variable_set(:reload_role, :second)
+        script_class.reloadlibs
+      end
+      second_reload_entered.pop
+      release_first_reload << true
+
+      expect(first_reloader.value).to be(true)
+      expect(script_class.class_variable_get(:@@reloading_libraries).fetch('libutil').size).to eq(1)
+      second_reloader.kill
+      second_reloader.join
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(3.times.map { load_roles.pop }).to contain_exactly(:first, :second, nil)
+      expect(script_class.libs).to include('libutil')
+      expect(script_class.class_variable_get(:@@reloading_libraries)).to be_empty
+    ensure
+      release_first_reload << true if defined?(release_first_reload) && release_first_reload
+      first_reloader&.kill
+      second_reloader&.kill
     end
 
     it 'bounds reload while another startup reservation is live' do
@@ -3047,6 +3331,47 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     end
     warn "shutdown progress timed out: #{state.inspect}"
     raise
+  end
+
+  def interrupt_next_queue_release(timing)
+    first_queue = true
+    allow(Queue).to receive(:new).and_wrap_original do |method, *args|
+      queue = method.call(*args)
+      if first_queue
+        first_queue = false
+        queue.define_singleton_method(:<<) do |value|
+          Thread.current.raise(Timeout::Error, 'gate release interrupted') if timing == :before
+          result = super(value)
+          Thread.current.raise(Timeout::Error, 'gate release interrupted') if timing == :after
+          result
+        end
+      end
+      queue
+    end
+  end
+
+  def block_next_queue_release
+    gate_entered = Queue.new
+    release_gate = Queue.new
+    first_queue = true
+    allow(Queue).to receive(:new).and_wrap_original do |method, *args|
+      queue = method.call(*args)
+      if first_queue
+        first_queue = false
+        queue.define_singleton_method(:<<) do |value|
+          gate_entered << true
+          release_gate.pop
+          super(value)
+        end
+      end
+      queue
+    end
+    [gate_entered, release_gate]
+  end
+
+  def completed_start_waiter_count(waiters, name)
+    value = waiters[name]
+    value.respond_to?(:size) ? value.size : (value || 0).to_i
   end
 
   def kill_worker_during_current

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     script_class.class_variable_set(:@@completed_start_waiters, Hash.new(0))
     script_class.class_variable_set(:@@shutdown_started, false)
     script_class.class_variable_set(:@@loaded_libraries, Set.new)
+    script_class.class_variable_set(:@@loaded_library_owners, {})
     script_class.class_variable_set(:@@loading_libraries, {})
     script_class.class_variable_set(:@@library_waits, {})
     allow(Lich).to receive(:log)
@@ -1117,6 +1118,46 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script).not_to be_running
     end
 
+    it 'rechecks a dead cleanup executor after launch completion' do
+      script = build_script('cleanup-launch-recheck')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      finish_entered = Queue.new
+      release_finish = Queue.new
+      first_cleanup = true
+      allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        if first_cleanup
+          first_cleanup = false
+          cleanup_entered << true
+          Queue.new.pop
+        else
+          method.call(**kwargs)
+        end
+      end
+      allow(script).to receive(:__finish_cleanup_launch).and_wrap_original do |method|
+        finish_entered << true
+        release_finish.pop
+        method.call
+      end
+
+      first_killer = Thread.new { script.kill }
+      cleanup_entered.pop
+      finish_entered.pop
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(script, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+
+      expect(Thread.new { script.kill }.value).to eq(script.name)
+      release_finish << true
+      first_killer.join
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    ensure
+      release_finish << true if defined?(release_finish) && release_finish
+      first_killer&.kill
+    end
+
     it 'resumes remaining exit callbacks after cleanup executor cancellation' do
       script = build_script('cancelled-callback')
       script_class.class_variable_set(:@@running, [script])
@@ -1557,12 +1598,14 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     it 'does not run callbacks when cleanup ownership cannot move from an enclosed group' do
       caller_script = build_script('enclosed-caller')
       target_script = build_script('ownership-target')
-      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      child_script = build_script('ownership-child')
+      script_class.class_variable_set(:@@running, [caller_script, target_script, child_script])
+      target_script.register_child(child_script)
       callback_ran = false
       target_script.at_exit { callback_ran = true }
       result = Queue.new
       caller = Thread.new do
-        target_script.kill(:context => :shutdown, :async => false)
+        target_script.kill(:context => :runtime, :async => false)
         result << script_class.current
       end
       caller_script.thread_group.add(caller)
@@ -1572,6 +1615,8 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(result.pop).to equal(caller_script)
       expect(target_script.join(1)).to equal(target_script)
+      expect(child_script.join(1)).to equal(child_script)
+      expect(target_script.child_scripts).to be_empty
       expect(callback_ran).to be(false)
       expect(target_script.exit_error).to be_a(ThreadError)
       expect(target_script.exit_error.message).to match(/cannot establish cleanup ownership/)
@@ -1973,7 +2018,11 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
         :exit_error              => nil,
         :completed_successfully? => true
       )
-      allow(timed_out_script).to receive(:join).with(0.01).and_return(nil, timed_out_script)
+      join_calls = 0
+      allow(timed_out_script).to receive(:join) do
+        join_calls += 1
+        join_calls == 1 ? nil : timed_out_script
+      end
       allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(timed_out_script)
 
       expect {
@@ -1989,7 +2038,11 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     end
 
     it 'keeps a fast-path timeout as the single-flight owner for retry' do
-      allow(library_script).to receive(:join).with(0.01).and_return(nil, library_script)
+      join_calls = 0
+      allow(library_script).to receive(:join) do
+        join_calls += 1
+        join_calls == 1 ? nil : library_script
+      end
       script_class.class_variable_set(:@@loading_libraries, 'libutil' => library_script)
 
       expect {
@@ -2028,8 +2081,8 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       startup_token = Object.new
       script_class.__send__(:__begin_start, startup_token, 'libutil', :force => false)
       original_begin = script_class.method(:__begin_library_start)
-      allow(script_class).to receive(:__begin_library_start) do |*args|
-        result = original_begin.call(*args)
+      allow(script_class).to receive(:__begin_library_start) do |*args, **kwargs|
+        result = original_begin.call(*args, **kwargs)
         Thread.current.kill
         result
       end
@@ -2225,7 +2278,10 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       )
       script_class.class_variable_set(:@@running, [caller_script])
       script_class.class_variable_set(:@@loading_libraries, { 'libtarget' => target_script })
-      script_class.class_variable_set(:@@library_waits, { target_script => { caller_script => 1 } })
+      script_class.class_variable_set(
+        :@@library_waits,
+        target_script => { caller_script => Set[Object.new] }
+      )
       allow(script_class).to receive(:current).and_return(caller_script)
       allow(script_class).to receive(:__find_script_file).with('libtarget').and_return('/custom/team/libtarget.lic')
 
@@ -2280,10 +2336,9 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       ]
       2.times { entered.pop }
 
-      expect(script_class.class_variable_get(:@@library_waits)[caller_script]).to eq(
-        target_one => 1,
-        target_two => 1
-      )
+      dependencies = script_class.class_variable_get(:@@library_waits)[caller_script]
+      expect(dependencies.keys).to contain_exactly(target_one, target_two)
+      expect(dependencies.values.map(&:size)).to contain_exactly(1, 1)
 
       2.times { release << true }
       waiters.each(&:join)
@@ -2302,12 +2357,14 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
         Thread.new { script_class.__send__(:__join_library, 'libtarget', target_script) }
       end
       2.times { entered.pop }
-      expect(script_class.class_variable_get(:@@library_waits)[caller_script]).to eq(target_script => 2)
+      dependencies = script_class.class_variable_get(:@@library_waits)[caller_script]
+      expect(dependencies.fetch(target_script).size).to eq(2)
 
       waiters.first.kill
       waiters.first.join
 
-      expect(script_class.class_variable_get(:@@library_waits)[caller_script]).to eq(target_script => 1)
+      dependencies = script_class.class_variable_get(:@@library_waits)[caller_script]
+      expect(dependencies.fetch(target_script).size).to eq(1)
       expect(
         script_class.__send__(:__library_dependency_reaches?, caller_script, target_script)
       ).to be(true)
@@ -2324,9 +2381,10 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       caller_script = build_script('libcaller')
       target_script = instance_double(script_class, :name => 'libtarget')
       library_mutex = script_class.class_variable_get(:@@library_mutex)
+      existing_token = Object.new
       script_class.class_variable_set(
         :@@library_waits,
-        caller_script => { target_script => 1 }
+        caller_script => { target_script => Set[existing_token] }
       )
       allow(script_class).to receive(:current).and_return(caller_script)
       library_mutex.lock
@@ -2339,7 +2397,8 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       library_mutex.unlock
       waiter.join
 
-      expect(script_class.class_variable_get(:@@library_waits)[caller_script]).to eq(target_script => 1)
+      dependencies = script_class.class_variable_get(:@@library_waits)[caller_script]
+      expect(dependencies.fetch(target_script)).to eq(Set[existing_token])
     ensure
       library_mutex&.unlock if library_mutex&.owned?
       waiter&.kill
@@ -2469,6 +2528,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
         :completed_successfully? => true
       )
       script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      script_class.class_variable_set(:@@loaded_library_owners, 'libutil' => library_script.object_id)
       script_class.class_variable_set(:@@loading_libraries, 'libutil' => library_script)
       allow(script_class).to receive(:start)
         .with('libutil', { :force => true })
@@ -2478,6 +2538,78 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class).to have_received(:start).once
       expect(script_class.libs).to include('libutil')
       expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
+    end
+
+    it 'does not evict a newer active owner while reloading an older generation' do
+      newer_generation = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      script_class.class_variable_set(:@@loaded_library_owners, 'libutil' => library_script.object_id)
+      script_class.class_variable_set(:@@loading_libraries, 'libutil' => newer_generation)
+      allow(script_class).to receive(:start)
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class).not_to have_received(:start)
+      expect(script_class.class_variable_get(:@@loaded_library_owners)).to eq(
+        'libutil' => newer_generation.object_id
+      )
+    end
+
+    it 'completes stale-owner removal after a concurrent reload is interrupted' do
+      interrupting_owners = Class.new(Hash) do
+        def delete(key)
+          value = super
+          unless defined?(@interrupted)
+            @interrupted = true
+            Thread.current.kill
+          end
+          value
+        end
+      end.new
+      interrupting_owners['libutil'] = library_script.object_id
+      replacement = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      script_class.class_variable_set(:@@loaded_library_owners, interrupting_owners)
+      script_class.class_variable_set(:@@loading_libraries, 'libutil' => library_script)
+      allow(script_class).to receive(:start)
+        .with('libutil', { :force => true })
+        .and_return(replacement)
+
+      interrupted_reload = Thread.new { script_class.reloadlibs }
+      interrupted_reload.join
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class).to have_received(:start).once
+      expect(script_class.libs).to include('libutil')
+    ensure
+      interrupted_reload&.kill
+    end
+
+    it 'bounds reload while another startup reservation is live' do
+      reservation = Object.new
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      script_class.__send__(:__begin_start, reservation, 'libutil', :force => true)
+      allow(script_class).to receive(:start)
+
+      reload = Thread.new { script_class.reloadlibs(:timeout => 0.01) }
+
+      expect(reload.join(0.2)).to equal(reload)
+      expect(reload.value).to be(false)
+      expect(script_class).not_to have_received(:start)
+    ensure
+      script_class.__send__(:__finish_start, reservation, nil) if defined?(reservation) && reservation
+      reload&.kill
     end
   end
 

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1090,6 +1090,33 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script).not_to be_running
     end
 
+    it 'recovers a dead cleanup executor when explicitly killed again' do
+      script = build_script('runtime-cleanup-retry')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      first_cleanup = true
+      allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        if first_cleanup
+          first_cleanup = false
+          cleanup_entered << true
+          Queue.new.pop
+        else
+          method.call(**kwargs)
+        end
+      end
+
+      script.kill
+      cleanup_entered.pop
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(script, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+
+      script.kill
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
     it 'resumes remaining exit callbacks after cleanup executor cancellation' do
       script = build_script('cancelled-callback')
       script_class.class_variable_set(:@@running, [script])
@@ -1919,6 +1946,20 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.libs).to include('libutil')
     end
 
+    it 'keeps a fast-path timeout as the single-flight owner for retry' do
+      allow(library_script).to receive(:join).with(0.01).and_return(nil, library_script)
+      script_class.class_variable_set(:@@loading_libraries, 'libutil' => library_script)
+
+      expect {
+        script_class.loadlib('util', :timeout => 0.01)
+      }.to raise_error(script_class::LibraryJoinTimeout, /wait timed out/)
+      expect(script_class.class_variable_get(:@@loading_libraries)).to eq('libutil' => library_script)
+
+      expect(script_class.loadlib('util', :timeout => 0.01)).to be(true)
+      expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
+      expect(script_class.libs).to include('libutil')
+    end
+
     it 'adopts an admitted plain start across concurrent duplicate callers' do
       admitted_script = instance_double(
         script_class,
@@ -2319,13 +2360,13 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       allow(script_class).to receive(:loadlib).and_return(true)
 
       expect(script_class.reloadlibs).to be(true)
-      expect(script_class).to have_received(:loadlib).with('libutil')
-      expect(script_class).to have_received(:loadlib).with('libstatus')
+      expect(script_class).to have_received(:loadlib).with('libutil', :timeout => 1.0)
+      expect(script_class).to have_received(:loadlib).with('libstatus', :timeout => 1.0)
     end
 
     it 'invalidates a library cache entry when reload fails' do
       script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
-      allow(script_class).to receive(:loadlib).with('libutil').and_raise(LoadError, 'broken reload')
+      allow(script_class).to receive(:loadlib).with('libutil', :timeout => 1.0).and_raise(LoadError, 'broken reload')
 
       expect(script_class.reloadlibs).to be(false)
       expect(script_class.libs).to be_empty
@@ -2340,6 +2381,16 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.reloadlibs).to be(true)
       expect(script_class).not_to have_received(:loadlib)
       expect(script_class.libs).to include('libutil')
+    end
+
+    it 'bounds reload waits for a still-running library' do
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      allow(script_class).to receive(:loadlib)
+        .with('libutil', :timeout => 0.01)
+        .and_raise(script_class::LibraryJoinTimeout, 'still running')
+
+      expect(script_class.reloadlibs(:timeout => 0.01)).to be(false)
+      expect(script_class.libs).to be_empty
     end
   end
 

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1577,6 +1577,25 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(target_script.exit_error.message).to match(/cannot establish cleanup ownership/)
     end
 
+    it 'does not run callbacks from an unmanaged non-default thread group' do
+      target_script = build_script('unmanaged-ownership-target')
+      script_class.class_variable_set(:@@running, [target_script])
+      callback_ran = false
+      target_script.at_exit { callback_ran = true }
+      source_group = ThreadGroup.new
+      caller = Thread.new do
+        target_script.kill(:context => :shutdown, :async => false)
+      end
+      source_group.add(caller)
+
+      caller.join
+
+      expect(target_script.join(1)).to equal(target_script)
+      expect(callback_ran).to be(false)
+      expect(target_script.exit_error).to be_a(ThreadError)
+      expect(target_script.exit_error.message).to match(/source thread group is not managed/)
+    end
+
     it 'does not detach an inline cleanup caller when its group becomes enclosed' do
       caller_script = build_script('caller')
       target_script = build_script('target')

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1554,6 +1554,29 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       release_descendant_cleanup << true if defined?(release_descendant_cleanup) && release_descendant_cleanup
     end
 
+    it 'does not run callbacks when cleanup ownership cannot move from an enclosed group' do
+      caller_script = build_script('enclosed-caller')
+      target_script = build_script('ownership-target')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      callback_ran = false
+      target_script.at_exit { callback_ran = true }
+      result = Queue.new
+      caller = Thread.new do
+        target_script.kill(:context => :shutdown, :async => false)
+        result << script_class.current
+      end
+      caller_script.thread_group.add(caller)
+      caller_script.thread_group.enclose
+
+      caller.join
+
+      expect(result.pop).to equal(caller_script)
+      expect(target_script.join(1)).to equal(target_script)
+      expect(callback_ran).to be(false)
+      expect(target_script.exit_error).to be_a(ThreadError)
+      expect(target_script.exit_error.message).to match(/cannot establish cleanup ownership/)
+    end
+
     it 'does not detach an inline cleanup caller when its group becomes enclosed' do
       caller_script = build_script('caller')
       target_script = build_script('target')
@@ -2278,6 +2301,31 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       release << true if defined?(release) && release
     end
 
+    it 'does not remove another waiter edge when cancelled before registration' do
+      caller_script = build_script('libcaller')
+      target_script = instance_double(script_class, :name => 'libtarget')
+      library_mutex = script_class.class_variable_get(:@@library_mutex)
+      script_class.class_variable_set(
+        :@@library_waits,
+        caller_script => { target_script => 1 }
+      )
+      allow(script_class).to receive(:current).and_return(caller_script)
+      library_mutex.lock
+
+      waiter = Thread.new do
+        script_class.__send__(:__join_library, 'libtarget', target_script)
+      end
+      Timeout.timeout(1) { Thread.pass until waiter.status == 'sleep' }
+      waiter.kill
+      library_mutex.unlock
+      waiter.join
+
+      expect(script_class.class_variable_get(:@@library_waits)[caller_script]).to eq(target_script => 1)
+    ensure
+      library_mutex&.unlock if library_mutex&.owned?
+      waiter&.kill
+    end
+
     it 'keeps a completed marker until loaded state is published' do
       interrupting_set = Class.new(Set) do
         def add(value)
@@ -2391,6 +2439,26 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(script_class.reloadlibs(:timeout => 0.01)).to be(false)
       expect(script_class.libs).to be_empty
+    end
+
+    it 'starts a replacement when reload consumes an interrupted completion marker' do
+      replacement = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
+      script_class.class_variable_set(:@@loading_libraries, 'libutil' => library_script)
+      allow(script_class).to receive(:start)
+        .with('libutil', { :force => true })
+        .and_return(replacement)
+
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class).to have_received(:start).once
+      expect(script_class.libs).to include('libutil')
+      expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
     end
   end
 

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -187,6 +187,22 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
+    it 'reaps a startup reservation whose owner dies before its ensure runs' do
+      reservation = Object.new
+      admitted = Queue.new
+      owner = Thread.new do
+        script_class.__send__(:__begin_start, reservation, 'libabandoned', :force => false)
+        admitted << true
+        Queue.new.pop
+      end
+      admitted.pop
+      owner.kill
+      owner.join
+
+      expect(Timeout.timeout(1) { script_class.begin_shutdown }).to be_empty
+      expect(script_class.class_variable_get(:@@startup_reservations)).to be_empty
+    end
+
     it 'uses the published name when reserving a compressed script' do
       Dir.mktmpdir('script-compressed-start') do |root|
         custom_dir = File.join(root, 'custom')
@@ -232,7 +248,6 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
         expect(restarted).to be_a(script_class)
         expect(restarted.join(2)).to equal(restarted)
-        expect(script_class.class_variable_get(:@@stopping)).to contain_exactly(stopping)
       end
     end
 
@@ -370,7 +385,8 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
     it 'raises when anonymous child startup is rejected' do
       parent = build_script('stopping-parent')
-      parent.__send__(:__begin_child_shutdown)
+      script_class.class_variable_set(:@@running, [parent])
+      parent.kill(:context => :shutdown)
       allow(script_class).to receive(:current).and_return(parent)
 
       expect {
@@ -577,7 +593,8 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
     it 'returns false when parent teardown rejects subscript startup' do
       parent = build_script('stopping-parent')
-      parent.__send__(:__begin_child_shutdown)
+      script_class.class_variable_set(:@@running, [parent])
+      parent.kill(:context => :shutdown)
 
       expect(subscript_class.start(:parent => parent) {}).to be(false)
     end
@@ -664,6 +681,23 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(parent).not_to be_running
       expect(registration_result).to be_nil
       expect(child.join(1)).to equal(child)
+    end
+
+    it 'kills a parent worker before waiting on its child launch reservation' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      launch_entered = Queue.new
+      launcher = Thread.new do
+        parent.__send__(:__launch_child) do
+          launch_entered << true
+          Queue.new.pop
+        end
+      end
+      parent.thread_group.add(launcher)
+      launch_entered.pop
+
+      expect(parent.kill_sync(:context => :runtime, :timeout => 1)).to equal(parent)
+      expect(launcher).not_to be_alive
     end
 
     it 'does not publish a subscript before its worker is allocated' do
@@ -940,23 +974,16 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script.join(1)).to equal(script)
     end
 
-    it 'attaches an async cleanup thread to the target before cleanup starts' do
-      parent = build_script('parent')
+    it 'sets the current script identity for an async cleanup thread' do
       child = build_script('child')
-      script_class.class_variable_set(:@@running, [parent, child])
-      parent.thread_group.add(Thread.current)
+      script_class.class_variable_set(:@@running, [child])
       observed = Queue.new
-      allow(child).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
-        observed << [child.has_thread?(Thread.current), parent.has_thread?(Thread.current)]
-        method.call(**kwargs)
-      end
+      child.at_exit { observed << script_class.current }
 
       child.kill
 
-      expect(observed.pop).to eq([true, false])
+      expect(observed.pop).to equal(child)
       expect(child.join(1)).to equal(child)
-    ensure
-      ThreadGroup::Default.add(Thread.current)
     end
 
     it 'releases async cleanup when the killing caller is killed mid-transition' do
@@ -964,7 +991,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@running, [script])
       attach_entered = Queue.new
       release_attach = Queue.new
-      allow(script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+      allow(script).to receive(:__claim_cleanup_thread).and_wrap_original do |method, thread|
         attach_entered << true
         release_attach.pop
         method.call(thread)
@@ -986,7 +1013,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@running, [caller_script, target_script])
       attach_entered = Queue.new
       release_attach = Queue.new
-      allow(target_script).to receive(:__attach_startup_worker).and_wrap_original do |method, thread|
+      allow(target_script).to receive(:__claim_cleanup_thread).and_wrap_original do |method, thread|
         attach_entered << true
         release_attach.pop
         method.call(thread)
@@ -1417,6 +1444,93 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script.join(1)).to equal(script)
     end
 
+    it 'joins descendant workers spawned by exit callbacks' do
+      script = build_script('callback-descendant')
+      script_class.class_variable_set(:@@running, [script])
+      worker_ready = Queue.new
+      worker_cleanup_entered = Queue.new
+      release_worker_cleanup = Queue.new
+      descendant = nil
+      script.at_exit do
+        descendant = Thread.new do
+          worker_ready << true
+          begin
+            Queue.new.pop
+          ensure
+            worker_cleanup_entered << true
+            release_worker_cleanup.pop
+          end
+        end
+        worker_ready.pop
+      end
+
+      script.kill
+      worker_cleanup_entered.pop
+      expect(script.thread_group.list).not_to include(descendant)
+      expect(descendant.group).not_to equal(script.thread_group)
+      expect(script.join(0.02)).to be_nil
+
+      release_worker_cleanup << true
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'does not detach an inline cleanup caller when its group becomes enclosed' do
+      caller_script = build_script('caller')
+      target_script = build_script('target')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      observed = Queue.new
+      start_cleanup = Queue.new
+      descendant_ready = Queue.new
+      descendant_cleanup_entered = Queue.new
+      release_descendant_cleanup = Queue.new
+      later_descendant_ready = Queue.new
+      later_descendant_cleanup_entered = Queue.new
+      release_later_descendant_cleanup = Queue.new
+      target_script.at_exit do
+        Thread.new do
+          descendant_ready << true
+          begin
+            Queue.new.pop
+          ensure
+            descendant_cleanup_entered << true
+            release_descendant_cleanup.pop
+          end
+        end
+        descendant_ready.pop
+        caller_script.thread_group.enclose
+      end
+      caller = Thread.new do
+        start_cleanup.pop
+        target_script.kill(:context => :shutdown, :async => false)
+        Thread.new do
+          later_descendant_ready << true
+          begin
+            Queue.new.pop
+          ensure
+            later_descendant_cleanup_entered << true
+            release_later_descendant_cleanup.pop
+          end
+        end
+        later_descendant_ready.pop
+        observed << script_class.current
+      end
+      caller_script.thread_group.add(caller)
+      start_cleanup << true
+
+      descendant_cleanup_entered.pop
+      expect(target_script.join(0.02)).to be_nil
+      release_descendant_cleanup << true
+      expect(observed.pop).to equal(caller_script)
+      caller.join
+      progress_shutdown_until(target_script)
+      expect(target_script.join(1)).to equal(target_script)
+      caller_script.kill
+      later_descendant_cleanup_entered.pop
+      expect(caller_script.join(0.02)).to be_nil
+      release_later_descendant_cleanup << true
+      expect(caller_script.join(1)).to equal(caller_script)
+    end
+
     it 'allows a killed worker to join its own stopping script' do
       worker_ready = Queue.new
       worker_joined = Queue.new
@@ -1512,6 +1626,15 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       parent_mutex&.unlock if parent_mutex&.owned?
     end
 
+    it 'prunes completed scripts from the stopping registry snapshot' do
+      script = build_script('completed-stop')
+      script.instance_variable_set(:@cleanup_complete, true)
+      script_class.class_variable_set(:@@stopping, [script])
+
+      expect(script_class.shutdown_scripts).to be_empty
+      expect(script_class.class_variable_get(:@@stopping)).to be_empty
+    end
+
     it 'holds child lifecycle state through public adoption' do
       parent = build_script('parent')
       child = build_script('child')
@@ -1537,12 +1660,50 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
     it 'preserves the standard ThreadGroup surface' do
       script = build_script('thread-group-api')
+      script_class.class_variable_set(:@@running, [script])
+      worker = Thread.new { Queue.new.pop }
 
       expect(script.thread_group).to be_a(ThreadGroup)
       expect(script.thread_group).to be_instance_of(ThreadGroup)
+      expect(script.thread_group.add(worker)).to equal(script.thread_group)
+      expect(worker.group).to equal(script.thread_group)
+      expect { script.thread_group.add(Object.new) }.to raise_error(TypeError, /expected VM\/thread/)
       expect(script.thread_group).not_to be_enclosed
       expect(script.thread_group.enclose).to equal(script.thread_group)
       expect(script.thread_group).to be_enclosed
+      other_group = ThreadGroup.new
+      expect { other_group.add(worker) }.to raise_error(ThreadError, /enclosed/)
+      expect(worker.group).to equal(script.thread_group)
+    ensure
+      worker&.kill
+      worker&.join
+    end
+
+    it 'runs teardown callbacks after the public thread group is enclosed' do
+      script = build_script('enclosed-thread-group')
+      script_class.class_variable_set(:@@running, [script])
+      callback_ran = false
+      script.at_exit { callback_ran = true }
+      script.thread_group.enclose
+
+      expect(script.kill_sync(:timeout => 1)).to equal(script)
+      expect(callback_ran).to be(true)
+      expect(script_class.class_variable_get(:@@stopping)).to be_empty
+    end
+
+    it 'kills a worker when native thread-group registration fails' do
+      script = build_script('group-rejection')
+      script_class.class_variable_set(:@@running, [script])
+      source_group = ThreadGroup.new
+      worker = Thread.new { Queue.new.pop }
+      source_group.add(worker)
+      source_group.enclose
+
+      expect { script.thread_group.add(worker) }.to raise_error(ThreadError, /enclosed/)
+      expect(worker).not_to be_alive
+    ensure
+      worker&.kill
+      worker&.join
     end
 
     it 'records cleanup callback failures in lifecycle completion' do
@@ -1584,6 +1745,43 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.libs).to eq(Set['libutil'])
     end
 
+    it 'elects one replacement when a reserved library startup is abandoned' do
+      startup_token = Object.new
+      admitted = Queue.new
+      owner = Thread.new do
+        script_class.__send__(:__begin_start, startup_token, 'libutil', :force => false)
+        admitted << true
+        Queue.new.pop
+      end
+      admitted.pop
+      start_entered = Queue.new
+      release_start = Queue.new
+      allow(script_class).to receive(:start).with('libutil', { :force => true }) do
+        start_entered << true
+        release_start.pop
+        library_script
+      end
+      loaders = Array.new(2) { Thread.new { script_class.loadlib('util') } }
+      waiters = script_class.class_variable_get(:@@completed_start_waiters)
+      Timeout.timeout(1) { Thread.pass until waiters['libutil'] == loaders.length }
+
+      owner.kill
+      owner.join
+      Timeout.timeout(1) { start_entered.pop }
+
+      reservations = script_class.class_variable_get(:@@startup_reservations)
+      expect(reservations.values.map(&:first)).to include('libutil')
+      expect(script_class).to have_received(:start).once
+
+      release_start << true
+      expect(loaders.map(&:value)).to all be(true)
+      expect(script_class).to have_received(:start).once
+    ensure
+      owner&.kill
+      release_start << true if defined?(release_start) && release_start
+      loaders&.each(&:kill)
+    end
+
     it 'lets a peer commit completion when the loader owner is cancelled' do
       owner_join_entered = Queue.new
       join_calls = 0
@@ -1606,6 +1804,21 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(script_class.libs).to include('libutil')
       expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
+    end
+
+    it 'publishes a started library before loader cancellation can take effect' do
+      allow(script_class).to receive(:start).with('libutil', { :force => true }) do
+        script_class.class_variable_set(:@@completed_named_starts, 'libutil' => library_script)
+        Thread.current.kill
+        library_script
+      end
+
+      loader = Thread.new { script_class.loadlib('util') }
+      loader.join
+
+      expect(script_class.class_variable_get(:@@loading_libraries)).to eq('libutil' => library_script)
+      expect(script_class.loadlib('util')).to be(true)
+      expect(script_class).to have_received(:start).with('libutil', { :force => true }).once
     end
 
     it 'starts a library without holding the library registry mutex' do

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -1125,6 +1125,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       finish_entered = Queue.new
       release_finish = Queue.new
       first_cleanup = true
+      finish_blocked = false
       allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
         if first_cleanup
           first_cleanup = false
@@ -1135,8 +1136,11 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
         end
       end
       allow(script).to receive(:__finish_cleanup_launch).and_wrap_original do |method|
-        finish_entered << true
-        release_finish.pop
+        unless finish_blocked
+          finish_blocked = true
+          finish_entered << true
+          release_finish.pop
+        end
         method.call
       end
 
@@ -1156,6 +1160,46 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     ensure
       release_finish << true if defined?(release_finish) && release_finish
       first_killer&.kill
+    end
+
+    it 'does not run abandoned cleanup recovery on a target worker' do
+      script = build_script('worker-cleanup-retry')
+      script_class.class_variable_set(:@@running, [script])
+      cleanup_entered = Queue.new
+      retry_kill = Queue.new
+      cleanup_executors = Queue.new
+      first_cleanup = true
+      allow(script).to receive(:__run_kill_cleanup).and_wrap_original do |method, **kwargs|
+        if first_cleanup
+          first_cleanup = false
+          cleanup_entered << true
+          Queue.new.pop
+        else
+          cleanup_executors << Thread.current
+          method.call(**kwargs)
+        end
+      end
+      worker = Thread.new do
+        retry_kill.pop
+        script.kill
+      end
+      script.thread_group.add(worker)
+
+      script.kill
+      cleanup_entered.pop
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(script, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+      retry_kill << true
+
+      expect(cleanup_executors.pop).not_to equal(worker)
+      expect(script.join(1)).to equal(script)
+      expect(worker).not_to be_alive
+      expect(script).not_to be_running
+    ensure
+      retry_kill << true if defined?(retry_kill) && retry_kill
+      worker&.kill
+      worker&.join
     end
 
     it 'resumes remaining exit callbacks after cleanup executor cancellation' do
@@ -2163,6 +2207,24 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.__send__(:__completed_start_value, completed)).to equal(newer_generation)
     end
 
+    it 'does not retain a forced completion for another thread library reservation' do
+      library_reservation = Object.new
+      script_class.__send__(:__begin_library_start, library_reservation, 'libutil')
+      completed_generation = instance_double(script_class)
+
+      Thread.new do
+        forced_reservation = Object.new
+        script_class.__send__(:__begin_start, forced_reservation, 'libutil', :force => true)
+        script_class.__send__(:__finish_start, forced_reservation, completed_generation)
+      end.join
+
+      expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+    ensure
+      if defined?(library_reservation) && library_reservation
+        script_class.__send__(:__finish_start, library_reservation)
+      end
+    end
+
     it 'adopts a completed forced generation ahead of an older running generation' do
       old_generation = instance_double(script_class, :name => 'libutil', :running? => false)
       allow(old_generation).to receive(:join) { raise 'older generation should not be joined' }
@@ -2404,6 +2466,34 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       waiter&.kill
     end
 
+    it 'publishes a dependency token atomically with its target edge' do
+      caller_script = build_script('libcaller')
+      target_script = instance_double(script_class, :name => 'libtarget')
+      assignment_entered = Queue.new
+      blocking_dependencies = Class.new(Hash) do
+        define_method(:[]=) do |key, value|
+          super(key, value)
+          assignment_entered << true
+          Queue.new.pop
+        end
+      end.new
+      script_class.class_variable_set(:@@library_waits, caller_script => blocking_dependencies)
+      allow(script_class).to receive(:current).and_return(caller_script)
+
+      waiter = Thread.new do
+        script_class.__send__(:__join_library, 'libtarget', target_script)
+      end
+      assignment_entered.pop
+
+      expect(blocking_dependencies.fetch(target_script).size).to eq(1)
+
+      waiter.kill
+      waiter.join
+      expect(script_class.class_variable_get(:@@library_waits)).to be_empty
+    ensure
+      waiter&.kill
+    end
+
     it 'keeps a completed marker until loaded state is published' do
       interrupting_set = Class.new(Set) do
         def add(value)
@@ -2472,6 +2562,68 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(retry_loader.value).to be(true)
       expect(script_class.libs).to include('libutil')
       expect(script_class).to have_received(:start).with('libutil', { :force => true }).twice
+    end
+
+    it 'does not republish a failed generation over a replacement loader' do
+      failed_attempt = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :join                    => true,
+        :exit_error              => RuntimeError.new('failed generation'),
+        :completed_successfully? => false
+      )
+      replacement_joined = Queue.new
+      release_replacement = Queue.new
+      successful_attempt = instance_double(
+        script_class,
+        :name                    => 'libutil',
+        :exit_error              => nil,
+        :completed_successfully? => true
+      )
+      allow(successful_attempt).to receive(:join) do
+        replacement_joined << true
+        release_replacement.pop
+        successful_attempt
+      end
+      allow(script_class).to receive(:start)
+        .with('libutil', { :force => true })
+        .and_return(failed_attempt, successful_attempt)
+      first_finish_entered = Queue.new
+      release_first_finish = Queue.new
+      allow(script_class).to receive(:__finish_start).and_wrap_original do |method, *args, **kwargs|
+        result = method.call(*args, **kwargs)
+        if Thread.current.thread_variable_get(:pause_library_finish) && kwargs[:preserve_completed]
+          first_finish_entered << true
+          release_first_finish.pop
+        end
+        result
+      end
+
+      first_loader = Thread.new do
+        Thread.current.thread_variable_set(:pause_library_finish, true)
+        script_class.loadlib('util')
+      rescue LoadError
+        false
+      end
+      first_finish_entered.pop
+      replacement_loader = Thread.new { script_class.loadlib('util') }
+      replacement_joined.pop
+
+      release_first_finish << true
+      expect(first_loader.value).to be(false)
+      expect(script_class.class_variable_get(:@@loading_libraries)).to eq(
+        'libutil' => successful_attempt
+      )
+
+      release_replacement << true
+      expect(replacement_loader.value).to be(true)
+      expect(script_class.libs).to include('libutil')
+      expect(script_class).to have_received(:start).twice
+    ensure
+      release_first_finish << true if defined?(release_first_finish) && release_first_finish
+      release_replacement << true if defined?(release_replacement) && release_replacement
+      first_loader&.kill
+      replacement_loader&.kill
     end
 
     it 'raises without recording a missing library' do

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       end
     end
 
+    it 'tears down an ordinary script whose worker dies during current-script lookup' do
+      Dir.mktmpdir('script-worker-current') do |root|
+        custom_dir = File.join(root, 'custom')
+        FileUtils.mkdir_p(custom_dir)
+        File.write(File.join(custom_dir, 'ordinary.lic'), "# quiet\nnil\nDone:\nnil\n")
+        stub_const('SCRIPT_DIR', root)
+
+        script = kill_worker_during_current { script_class.start('ordinary') }
+
+        expect(script.join(1)).to equal(script)
+        expect(script).not_to be_running
+      end
+    end
+
     it 'does not publish an ordinary script before its worker is allocated' do
       Dir.mktmpdir('script-start') do |root|
         custom_dir = File.join(root, 'custom')
@@ -448,6 +462,21 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(subscript).to be_completed_successfully
     end
 
+    it 'records JumpError raised by a subscript block' do
+      subscript = subscript_class.start(:parent => nil) { raise script_class::JUMP }
+
+      expect(subscript.join(1)).to equal(subscript)
+      expect(subscript.exit_error).to be_a(script_class::JumpError)
+      expect(subscript).not_to be_completed_successfully
+    end
+
+    it 'tears down a subscript whose worker dies during current-script lookup' do
+      script = kill_worker_during_current { subscript_class.start(:parent => nil) {} }
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
+    end
+
     it 'unregisters itself when it exits naturally' do
       parent = build_script('parent')
       script_class.class_variable_set(:@@running, [parent])
@@ -615,11 +644,12 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@running, [parent, child])
       launch_entered = Queue.new
       release_launch = Queue.new
+      registration_result = :pending
       launcher = Thread.new do
         parent.__send__(:__launch_child) do
           launch_entered << true
           release_launch.pop
-          parent.__send__(:__register_child_locked, child)
+          registration_result = parent.register_child(child)
         end
       end
       launch_entered.pop
@@ -632,6 +662,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       launcher.join
       killer.join
       expect(parent).not_to be_running
+      expect(registration_result).to be_nil
       expect(child.join(1)).to equal(child)
     end
 
@@ -707,6 +738,22 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(failed.join(1)).to equal(failed)
       expect(failed).not_to be_completed_successfully
       expect(failed.exit_error).to be_a(RuntimeError)
+    end
+
+    it 'records JumpError raised by exec code' do
+      allow(Lich::Common::TRUSTED_SCRIPT_BINDING).to receive(:call).and_return(Lich::Common::Scripting.new.script)
+      script = exec_script_class.start('raise Lich::Common::Script::JUMP')
+
+      expect(script.join(1)).to equal(script)
+      expect(script.exit_error).to be_a(script_class::JumpError)
+      expect(script).not_to be_completed_successfully
+    end
+
+    it 'tears down an exec script whose worker dies during current-script lookup' do
+      script = kill_worker_during_current { exec_script_class.start('nil') }
+
+      expect(script.join(1)).to equal(script)
+      expect(script).not_to be_running
     end
 
     it 'preserves direct constructor publication and shutdown admission' do
@@ -999,8 +1046,59 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       cleanup_thread.kill
       cleanup_thread.join
 
+      script_class.progress_shutdown
       expect(script.join(1)).to equal(script)
       expect(script).not_to be_running
+    end
+
+    it 'resumes remaining exit callbacks after cleanup executor cancellation' do
+      script = build_script('cancelled-callback')
+      script_class.class_variable_set(:@@running, [script])
+      first_callback_entered = Queue.new
+      second_callback_ran = Queue.new
+      first_callback_calls = 0
+      script.at_exit do
+        first_callback_calls += 1
+        first_callback_entered << true
+        Queue.new.pop
+      end
+      script.at_exit { second_callback_ran << true }
+
+      script.kill
+      first_callback_entered.pop
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(script, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+
+      expect(script).to be_running
+      script_class.progress_shutdown
+
+      expect(second_callback_ran.pop(true)).to be(true)
+      expect(first_callback_calls).to eq(1)
+      expect(script.join(1)).to equal(script)
+    end
+
+    it 'does not run deferred cleanup from a timeout-bounded join' do
+      script = build_script('observational-join')
+      script_class.class_variable_set(:@@running, [script])
+      script.instance_variable_set(:@kill_requested, true)
+      expect(script).not_to receive(:__refresh_deferred_stop)
+
+      expect(script.join(0.01)).to be_nil
+    end
+
+    it 'bounds shutdown kill_sync before a blocked exit callback finishes' do
+      script = build_script('bounded-shutdown-kill')
+      script_class.class_variable_set(:@@running, [script])
+      callback_entered = Queue.new
+      release_callback = Queue.new
+      script.at_exit { callback_entered << true; release_callback.pop }
+
+      expect(script.kill_sync(:context => :shutdown, :timeout => 0.02)).to be_nil
+      callback_entered.pop
+
+      release_callback << true
+      expect(script.join(1)).to equal(script)
     end
 
     it 'waits indefinitely for teardown when no timeout is given' do
@@ -1277,6 +1375,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.shutdown_scripts).to include(script)
 
       release_worker_cleanup << true
+      progress_shutdown_until(script)
       expect(script.join(1)).to equal(script)
     end
 
@@ -1366,25 +1465,97 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       child = build_script('child')
       script_class.class_variable_set(:@@running, [parent, child])
       expect(parent.register_child(child)).to equal(child)
-      launch_lock_held = Queue.new
-      release_launch_lock = Queue.new
+      parent_lock_held = Queue.new
+      release_parent_lock = Queue.new
+      parent_mutex = parent.__send__(:child_scripts_mutex)
       lock_holder = Thread.new do
-        parent.__send__(:__launch_child) do
-          launch_lock_held << true
-          release_launch_lock.pop
+        parent_mutex.synchronize do
+          parent_lock_held << true
+          release_parent_lock.pop
         end
       end
-      launch_lock_held.pop
+      parent_lock_held.pop
 
       child.kill
       expect(child.join(0.02)).to be_nil
       children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
       expect(children).to contain_exactly(child)
 
-      release_launch_lock << true
+      release_parent_lock << true
       lock_holder.join
       expect(child.join(1)).to equal(child)
       expect(parent.child_scripts).to be_empty
+    end
+
+    it 'retries parent unlinking when its finalizer is cancelled' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      expect(parent.register_child(child)).to equal(child)
+      parent_mutex = parent.__send__(:child_scripts_mutex)
+      parent_mutex.lock
+
+      child.kill
+      sleep 0.005 while child.running?
+      cleanup_thread = Object.instance_method(:instance_variable_get).bind_call(child, :@cleanup_thread)
+      cleanup_thread.kill
+      cleanup_thread.join
+      children = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_scripts)
+      expect(Array(children)).to contain_exactly(child)
+
+      parent_mutex.unlock
+      script_class.progress_shutdown
+
+      expect(child.join(1)).to equal(child)
+      expect(parent.child_scripts).to be_empty
+    ensure
+      parent_mutex&.unlock if parent_mutex&.owned?
+    end
+
+    it 'holds child lifecycle state through public adoption' do
+      parent = build_script('parent')
+      child = build_script('child')
+      script_class.class_variable_set(:@@running, [parent, child])
+      adoption_entered = Queue.new
+      release_adoption = Queue.new
+      allow(parent).to receive(:__adopt_child_locked).and_wrap_original do |method, adopted|
+        adoption_entered << true
+        release_adoption.pop
+        method.call(adopted)
+      end
+
+      registrar = Thread.new { parent.register_child(child) }
+      adoption_entered.pop
+      killer = Thread.new { child.kill_sync(:timeout => 1) }
+      expect(killer.join(0.02)).to be_nil
+
+      release_adoption << true
+      expect(registrar.value).to equal(child)
+      expect(killer.value).to equal(child)
+      expect(parent.child_scripts).to be_empty
+    end
+
+    it 'preserves the standard ThreadGroup surface' do
+      script = build_script('thread-group-api')
+
+      expect(script.thread_group).to be_a(ThreadGroup)
+      expect(script.thread_group).to be_instance_of(ThreadGroup)
+      expect(script.thread_group).not_to be_enclosed
+      expect(script.thread_group.enclose).to equal(script.thread_group)
+      expect(script.thread_group).to be_enclosed
+    end
+
+    it 'records cleanup callback failures in lifecycle completion' do
+      script = build_script('cleanup-error')
+      script_class.class_variable_set(:@@running, [script])
+      script.__send__(:__record_successful_exit)
+      script.at_exit { raise 'cleanup failed' }
+
+      script.kill
+
+      expect(script.join(1)).to equal(script)
+      expect(script.exit_error).to be_a(RuntimeError)
+      expect(script).not_to be_completed_successfully
     end
   end
 
@@ -1411,6 +1582,30 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(script_class).to have_received(:start).with('libutil', { :force => true }).once
       expect(script_class.libs).to eq(Set['libutil'])
+    end
+
+    it 'lets a peer commit completion when the loader owner is cancelled' do
+      owner_join_entered = Queue.new
+      join_calls = 0
+      allow(library_script).to receive(:join) do
+        join_calls += 1
+        if join_calls == 1
+          owner_join_entered << true
+          Queue.new.pop
+        else
+          true
+        end
+      end
+      allow(script_class).to receive(:start).with('libutil', { :force => true }).and_return(library_script)
+
+      owner = Thread.new { script_class.loadlib('util') }
+      owner_join_entered.pop
+      expect(script_class.loadlib('util')).to be(true)
+      owner.kill
+      owner.join
+
+      expect(script_class.libs).to include('libutil')
+      expect(script_class.class_variable_get(:@@loading_libraries)).to be_empty
     end
 
     it 'starts a library without holding the library registry mutex' do
@@ -1855,7 +2050,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       script_class.class_variable_set(:@@loaded_libraries, Set['libutil'])
       allow(script_class).to receive(:loadlib).with('libutil').and_raise(LoadError, 'broken reload')
 
-      expect(script_class.reloadlibs).to be(true)
+      expect(script_class.reloadlibs).to be(false)
       expect(script_class.libs).to be_empty
     end
 
@@ -1892,6 +2087,43 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(protected_script).to have_received(:kill).with(:context => :runtime).once
       expect(hidden).to have_received(:kill).with(:context => :runtime).once
     end
+  end
+
+  def progress_shutdown_until(script)
+    Timeout.timeout(1) do
+      while script_class.shutdown_scripts.include?(script)
+        script_class.progress_shutdown
+        sleep 0.005
+      end
+    end
+  rescue Timeout::Error
+    state = %i[@kill_requested @cleanup_started @cleanup_complete @cleanup_thread @stopping_threads].to_h do |name|
+      [name, Object.instance_method(:instance_variable_get).bind_call(script, name)]
+    end
+    warn "shutdown progress timed out: #{state.inspect}"
+    raise
+  end
+
+  def kill_worker_during_current
+    main_thread = Thread.current
+    lookup_entered = Queue.new
+    intercept = true
+    allow(script_class).to receive(:current).and_wrap_original do |method|
+      if Thread.current != main_thread && intercept
+        intercept = false
+        lookup_entered << true
+        Queue.new.pop
+      else
+        method.call
+      end
+    end
+
+    script = yield
+    lookup_entered.pop
+    worker = script.__send__(:__worker_threads).find(&:alive?)
+    worker.kill
+    worker.join
+    script
   end
 
   def build_script(name)

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
     script_class.class_variable_set(:@@loaded_libraries, Set.new)
     script_class.class_variable_set(:@@loaded_library_owners, {})
     script_class.class_variable_set(:@@loading_libraries, {})
+    script_class.class_variable_set(:@@reloading_libraries, Set.new)
     script_class.class_variable_set(:@@library_waits, {})
     allow(Lich).to receive(:log)
     allow(Lich::Common::FeatureFlags).to receive(:enabled?).with(:script_kill_metrics).and_return(false)
@@ -214,6 +215,36 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(Timeout.timeout(1) { script_class.begin_shutdown }).to be_empty
       expect(script_class.class_variable_get(:@@startup_reservations)).to be_empty
+    end
+
+    it 'releases startup waiter accounting when cancelled after registration' do
+      reservation = Object.new
+      script_class.__send__(:__begin_start, reservation, 'libwaiting', :force => true)
+      interrupting_waiters = Class.new(Hash) do
+        def initialize
+          super(0)
+        end
+
+        def []=(name, count)
+          super
+          unless defined?(@interrupted)
+            @interrupted = true
+            Thread.current.kill
+          end
+        end
+      end.new
+      script_class.class_variable_set(:@@completed_start_waiters, interrupting_waiters)
+
+      waiter = Thread.new do
+        script_class.__send__(:__begin_library_start, Object.new, 'libwaiting')
+      end
+      waiter.join
+
+      expect(script_class.class_variable_get(:@@completed_start_waiters)).to be_empty
+      expect(script_class.class_variable_get(:@@completed_named_starts)).to be_empty
+    ensure
+      script_class.__send__(:__finish_start, reservation) if defined?(reservation) && reservation
+      waiter&.kill
     end
 
     it 'uses the published name when reserving a compressed script' do
@@ -711,6 +742,50 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
 
       expect(parent.kill_sync(:context => :runtime, :timeout => 1)).to equal(parent)
       expect(launcher).not_to be_alive
+    end
+
+    it 'releases a child launch reservation when cancelled after admission' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      original_mutex = parent.__send__(:child_scripts_mutex)
+      interrupting_mutex = Object.new
+      first_synchronize = true
+      interrupting_mutex.define_singleton_method(:synchronize) do |&block|
+        result = original_mutex.synchronize(&block)
+        if first_synchronize
+          first_synchronize = false
+          Thread.current.kill
+        end
+        result
+      end
+      parent.instance_variable_set(:@child_scripts_mutex, interrupting_mutex)
+
+      launcher = Thread.new { parent.__send__(:__launch_child) { raise 'unreachable' } }
+      launcher.join
+
+      launches = Object.instance_method(:instance_variable_get).bind_call(parent, :@child_launches)
+      expect(launches.nil? || launches.empty?).to be(true)
+      expect(parent.kill_sync(:context => :runtime, :timeout => 1)).to equal(parent)
+    ensure
+      launcher&.kill
+    end
+
+    it 'reaps a child launch reservation when its owner dies without signaling' do
+      parent = build_script('parent')
+      script_class.class_variable_set(:@@running, [parent])
+      launch_owner = Thread.new { Queue.new.pop }
+      parent.instance_variable_set(:@child_launches, Object.new => launch_owner)
+      killer = Thread.new { parent.kill_sync(:context => :runtime, :timeout => 1) }
+      sleep 0.02
+
+      launch_owner.kill
+      launch_owner.join
+
+      expect(killer.value).to equal(parent)
+      expect(parent).not_to be_running
+    ensure
+      launch_owner&.kill
+      killer&.kill
     end
 
     it 'does not publish a subscript before its worker is allocated' do
@@ -1229,6 +1304,68 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script.join(1)).to equal(script)
     end
 
+    it 'retries an exit callback when cancellation interrupts its dequeue' do
+      dequeue_interrupted = Queue.new
+      release_dequeue = Queue.new
+      interrupting_callbacks = Class.new(Array) do
+        define_method(:shift) do
+          entry = super()
+          unless defined?(@interrupted)
+            @interrupted = true
+            dequeue_interrupted << true
+            release_dequeue.pop
+          end
+          entry
+        end
+      end
+      callback_calls = 0
+      script = build_script('cancelled-callback-dequeue')
+      script.instance_variable_set(:@at_exit_procs, interrupting_callbacks.new([proc { callback_calls += 1 }]))
+      script_class.class_variable_set(:@@running, [script])
+
+      cleanup_thread = Thread.new { script.kill(:context => :shutdown, :async => false) }
+      Timeout.timeout(1) { dequeue_interrupted.pop }
+      cleanup_thread.kill
+      cleanup_thread.join
+      script_class.progress_shutdown
+
+      expect(script.join(1)).to equal(script)
+      expect(callback_calls).to eq(1)
+    ensure
+      release_dequeue << true if defined?(release_dequeue) && release_dequeue
+    end
+
+    it 'retries a die-with callback when cancellation interrupts its dequeue' do
+      dequeue_interrupted = Queue.new
+      release_dequeue = Queue.new
+      interrupting_callbacks = Class.new(Array) do
+        define_method(:shift) do
+          entry = super()
+          unless defined?(@interrupted)
+            @interrupted = true
+            dequeue_interrupted << true
+            release_dequeue.pop
+          end
+          entry
+        end
+      end
+      script = build_script('cancelled-die-with-dequeue')
+      script.instance_variable_set(:@die_with, interrupting_callbacks.new(['target']))
+      script_class.class_variable_set(:@@running, [script])
+      allow(script_class).to receive(:kill).with('target', hash_including(:context)).and_return(true)
+
+      cleanup_thread = Thread.new { script.kill(:context => :shutdown, :async => false) }
+      Timeout.timeout(1) { dequeue_interrupted.pop }
+      cleanup_thread.kill
+      cleanup_thread.join
+      script_class.progress_shutdown
+
+      expect(script.join(1)).to equal(script)
+      expect(script_class).to have_received(:kill).once
+    ensure
+      release_dequeue << true if defined?(release_dequeue) && release_dequeue
+    end
+
     it 'does not run deferred cleanup from a timeout-bounded join' do
       script = build_script('observational-join')
       script_class.class_variable_set(:@@running, [script])
@@ -1683,6 +1820,28 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(callback_ran).to be(false)
       expect(target_script.exit_error).to be_a(ThreadError)
       expect(target_script.exit_error.message).to match(/source thread group is not managed/)
+    end
+
+    it 'recognizes cleanup ownership from a script already in the stopping registry' do
+      caller_script = build_script('stopping-owner')
+      target_script = build_script('stopping-owner-target')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      callback_ran = false
+      target_script.at_exit { callback_ran = true }
+      caller = Thread.new do
+        target_script.kill(:context => :shutdown, :async => false)
+      end
+      caller_script.thread_group.add(caller)
+      script_class.class_variable_set(:@@running, [target_script])
+      script_class.class_variable_set(:@@stopping, [caller_script])
+
+      caller.join
+
+      expect(target_script.join(1)).to equal(target_script)
+      expect(callback_ran).to be(true)
+      expect(target_script.exit_error).to be_nil
+    ensure
+      caller&.kill
     end
 
     it 'does not detach an inline cleanup caller when its group becomes enclosed' do
@@ -2466,6 +2625,68 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       waiter&.kill
     end
 
+    it 'completes dependency cleanup after repeated cancellation' do
+      caller_script = build_script('libcaller')
+      target_script = instance_double(script_class, :name => 'libtarget')
+      join_entered = Queue.new
+      join_unwinding = Queue.new
+      allow(target_script).to receive(:join) do
+        join_entered << true
+        begin
+          Queue.new.pop
+        ensure
+          join_unwinding << true
+        end
+      end
+      allow(script_class).to receive(:current).and_return(caller_script)
+      library_mutex = script_class.class_variable_get(:@@library_mutex)
+      waiter = Thread.new do
+        script_class.__send__(:__join_library, 'libtarget', target_script)
+      end
+      join_entered.pop
+      library_mutex.lock
+
+      waiter.kill
+      join_unwinding.pop
+      waiter.kill
+      library_mutex.unlock
+      waiter.join
+
+      expect(script_class.class_variable_get(:@@library_waits)).to be_empty
+    ensure
+      library_mutex&.unlock if library_mutex&.owned?
+      waiter&.kill
+    end
+
+    it 'prunes a dead waiter when cancellation interrupts dependency cleanup' do
+      caller_script = build_script('libcaller')
+      target_script = instance_double(script_class, :name => 'libtarget', :join => true)
+      allow(script_class).to receive(:current).and_return(caller_script)
+      original_mutex = script_class.class_variable_get(:@@library_mutex)
+      interrupting_mutex = Object.new
+      synchronize_calls = 0
+      interrupting_mutex.define_singleton_method(:synchronize) do |&block|
+        synchronize_calls += 1
+        Thread.current.kill if synchronize_calls == 2
+        original_mutex.synchronize(&block)
+      end
+      script_class.class_variable_set(:@@library_mutex, interrupting_mutex)
+
+      waiter = Thread.new do
+        script_class.__send__(:__join_library, 'libtarget', target_script)
+      end
+      waiter.join
+      script_class.class_variable_set(:@@library_mutex, original_mutex)
+
+      expect(
+        script_class.__send__(:__library_dependency_reaches?, caller_script, target_script)
+      ).to be(false)
+      expect(script_class.class_variable_get(:@@library_waits)).to be_empty
+    ensure
+      script_class.class_variable_set(:@@library_mutex, original_mutex) if defined?(original_mutex)
+      waiter&.kill
+    end
+
     it 'publishes a dependency token atomically with its target edge' do
       caller_script = build_script('libcaller')
       target_script = instance_double(script_class, :name => 'libtarget')
@@ -2744,6 +2965,31 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.reloadlibs).to be(true)
       expect(script_class).to have_received(:start).once
       expect(script_class.libs).to include('libutil')
+    ensure
+      interrupted_reload&.kill
+    end
+
+    it 'retries a reload interrupted after removing its loaded marker' do
+      interrupting_libraries = Class.new(Set) do
+        def delete?(library)
+          removed = super
+          unless defined?(@interrupted)
+            @interrupted = true
+            Thread.current.kill
+          end
+          removed
+        end
+      end.new(['libutil'])
+      script_class.class_variable_set(:@@loaded_libraries, interrupting_libraries)
+      allow(script_class).to receive(:loadlib).with('libutil', :timeout => 1.0).and_return(true)
+
+      interrupted_reload = Thread.new { script_class.reloadlibs }
+      interrupted_reload.join
+
+      expect(script_class.libs).to be_empty
+      expect(script_class.reloadlibs).to be(true)
+      expect(script_class).to have_received(:loadlib).once
+      expect(script_class.class_variable_get(:@@reloading_libraries)).to be_empty
     ensure
       interrupted_reload&.kill
     end


### PR DESCRIPTION
## Summary

Hardens lifecycle ownership and interruption handling under concurrent starts, stops, child launches, callbacks, and library operations:

- Preserves native `ThreadGroup` behavior while registering script workers with lifecycle ownership.
- Tracks callback and worker descendants until cleanup completes, including cleanup invoked from another script group.
- Uses interruption-safe launch gates for ordinary scripts, `ExecScript`, `SubScript`, watch callbacks, and asynchronous cleanup.
- Recovers abandoned startup, child-launch, cleanup, and library bookkeeping when an owning thread exits at any handoff point.
- Prevents ownership cycles, cross-parent adoption races, overlapping same-name generations, stale loader publication, and dependency records owned by dead waiters.
- Restores an at-exit callback to its exact queue position when cleanup is interrupted before dispatch; dispatched callbacks retain at-most-once semantics.
- Tracks concurrent reload attempts with independent tokens so one timeout or completion cannot erase another active invalidation.
- Adds `Script.reloadlibs(timeout: 1.0)`; the timeout applies per library and the return value reports whether every reload succeeded.
- Bounds child cleanup at ownership call sites, isolates kill metric timing, documents lock ordering, and prunes completed lifecycle records.

## Validation

Focused lifecycle suite: 159 examples, 0 failures under six deterministic seeds. Branch suite: 5,091 examples, 0 failures.

RuboCop: 1,031 files inspected, no offenses. Ruby syntax validation and `git diff --check` pass.

## Stack

5 of 6. Depends on unified execution and library loading.