### PR TITLE
fix(all): surface the underlying LoadError in dependency alerts

### DIFF
--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -282,7 +282,7 @@ module Lich
 
     # @param missing [Array<String>] gem names identified by our detector
     # @param groups [Array<Symbol>] groups being verified
-    # @param error [Exception, nil] the Bundler exception, if any
+    # @param error [Exception, nil] the Bundler or require exception, if any
     # @return [void]
     def alert(missing: [], groups: [:default], error: nil)
       write_log(missing: missing, groups: groups, error: error)
@@ -302,9 +302,11 @@ module Lich
       end
     end
 
-    # Composes the alert dialog body: platform message + either a bulleted
-    # list of detected missing gems, or the raw Bundler error if our
-    # detector came up empty.
+    # Composes the alert dialog body: platform message + a bulleted list of
+    # detected missing gems, plus the underlying error when one was captured.
+    # The error is always shown when present: a failed `require 'gtk3'` may
+    # mean a native DLL failed to load even though every gem is installed, so
+    # hiding the message behind the missing-gems list misdiagnoses the fault.
     # @param missing [Array<String>]
     # @param error [Exception, nil]
     # @return [String]
@@ -312,8 +314,9 @@ module Lich
       parts = [message]
       if missing.any?
         parts << "Missing gems:\n  - #{missing.join("\n  - ")}"
-      elsif error
-        parts << "Bundler reported:\n  #{error.message.lines.first.to_s.strip}"
+      end
+      if error
+        parts << "Underlying error:\n  #{error.message.lines.first.to_s.strip}"
       end
       parts << "See #{File.join(TEMP_DIR, LOG_FILENAME)} for details." if defined?(TEMP_DIR)
       parts.join("\n\n")

--- a/lib/init.rb
+++ b/lib/init.rb
@@ -448,12 +448,12 @@ end
 
 begin
   require 'sqlite3'
-rescue LoadError
+rescue LoadError => sqlite_load_error
   # sqlite3 is a required dependency. It is restored only from an approved,
   # hash-verified Ruby4Lich5 manifest unit; this never falls back to `gem
   # install` or a user GEM_HOME.
   unless Lich::GemCheck.self_healing_supported?
-    Lich::GemCheck.alert(missing: ['sqlite3'], groups: [:default])
+    Lich::GemCheck.alert(missing: ['sqlite3'], groups: [:default], error: sqlite_load_error)
     exit 1
   end
 
@@ -481,7 +481,7 @@ unless ARGV.any? { |arg| arg.match?(/^--no-(?:gtk|gui)$/i) }
   begin
     require 'gtk3'
     HAVE_GTK = true
-  rescue LoadError
+  rescue LoadError => gtk_load_error
     # gtk3 stands for the whole GTK runtime unit in the manifest. A missing
     # native dependency therefore restores the complete, ordered closure.
     if Lich::GemCheck.self_healing_supported?
@@ -507,7 +507,7 @@ unless ARGV.any? { |arg| arg.match?(/^--no-(?:gtk|gui)$/i) }
     else
       # GTK is required unless the user explicitly selected a headless launch.
       # Do not infer that choice from DISPLAY, TTY, or cron environment state.
-      Lich::GemCheck.alert(missing: ['gtk3'], groups: [:gtk])
+      Lich::GemCheck.alert(missing: ['gtk3'], groups: [:gtk], error: gtk_load_error)
       exit 1
     end
   end

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -533,7 +533,7 @@ RSpec.describe Lich::GemCheck do
       body = described_class.build_alert_body([], nil)
       expect(body).to include(described_class::UNIX_MESSAGE)
       expect(body).not_to include('Missing gems:')
-      expect(body).not_to include('Bundler reported:')
+      expect(body).not_to include('Underlying error:')
     end
 
     it 'appends a bulleted list when gems are provided' do
@@ -543,18 +543,19 @@ RSpec.describe Lich::GemCheck do
       expect(body).to include('- sqlite3')
     end
 
-    it 'falls back to the Bundler error when no gems were detected' do
+    it 'shows the underlying error when no gems were detected' do
       error = double('error', message: "Could not find gem 'transitive' in locally installed gems.")
       body = described_class.build_alert_body([], error)
-      expect(body).to include('Bundler reported:')
+      expect(body).to include('Underlying error:')
       expect(body).to include("Could not find gem 'transitive'")
     end
 
-    it 'prefers the detected list over the Bundler error when both are present' do
-      error = double('error', message: 'some bundler message')
-      body = described_class.build_alert_body(['ox'], error)
+    it 'shows both the detected list and the underlying error when both are present' do
+      error = double('error', message: 'cannot load such file -- glib2.so')
+      body = described_class.build_alert_body(['gtk3'], error)
       expect(body).to include('Missing gems:')
-      expect(body).not_to include('Bundler reported:')
+      expect(body).to include('Underlying error:')
+      expect(body).to include('cannot load such file -- glib2.so')
     end
 
     it 'points at the log file when TEMP_DIR is defined' do


### PR DESCRIPTION
## Problem

When `require 'gtk3'` (or `require 'sqlite3'`) fails at startup, the alert dialog always blames a "missing gem" and never shows why the require actually failed:

- `lib/init.rb` discarded the exception on two paths: the initial `rescue LoadError` didn't capture it, and the no-self-healing branch called `GemCheck.alert` without `error:`.
- `GemCheck.build_alert_body` only rendered the error when the missing-gems list was empty — which it never is, because init.rb always passes the gem name literally.

So a user whose gems are all installed but whose native DLL failed to load (transient LoadLibrary failure, broken dependency deep in the gtk3 require chain, etc.) gets told "gtk3 is not installed" with no way to diagnose the real fault after the fact — nothing is on screen and the debug log isn't open yet at that point in startup.

## Fix

- Capture the original `LoadError` in both rescues and pass it through to `alert` on the paths that previously dropped it.
- `build_alert_body` now always appends `Underlying error: <first line of message>` when an error is present, alongside the missing-gems list instead of hidden behind it. (`write_log` already recorded the full class + message whenever the error was provided; now it is provided on every failure path.)

## Testing

- `bundle exec rspec spec/lib/gemcheck_spec.rb` — 82 examples, 0 failures (updated the three `build_alert_body` examples that codified the old either/or behavior)
- `bundle exec rubocop lib/gemcheck.rb lib/init.rb spec/lib/gemcheck_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)