### PR TITLE
fix(all): deflake PasswordCipher wrong-key specs

### DIFF
--- a/spec/lib/common/gui/password_cipher_spec.rb
+++ b/spec/lib/common/gui/password_cipher_spec.rb
@@ -29,11 +29,18 @@ RSpec.describe Lich::Common::GUI::PasswordCipher do
         expect(described_class.decrypt(encrypted2, mode: :standard, account_name: account_name)).to eq(password)
       end
 
-      it 'fails to decrypt with wrong account name' do
+      it 'never recovers the password with wrong account name' do
         encrypted = described_class.encrypt(password, mode: :standard, account_name: account_name)
-        expect do
-          described_class.decrypt(encrypted, mode: :standard, account_name: 'WrongAccount')
-        end.to raise_error(Lich::Common::GUI::PasswordCipher::DecryptionError)
+        # AES-CBC with the wrong key usually raises on invalid padding, but
+        # roughly 1 in 256 garbage plaintexts carries coincidentally valid
+        # padding and decrypts without error. The cipher only guarantees the
+        # original password never comes back, so accept either outcome.
+        begin
+          result = described_class.decrypt(encrypted, mode: :standard, account_name: 'WrongAccount')
+          expect(result).not_to eq(password)
+        rescue Lich::Common::GUI::PasswordCipher::DecryptionError
+          # the overwhelmingly common outcome
+        end
       end
     end
 
@@ -57,11 +64,15 @@ RSpec.describe Lich::Common::GUI::PasswordCipher do
         expect(described_class.decrypt(encrypted2, mode: :enhanced, master_password: master_password)).to eq(password)
       end
 
-      it 'fails to decrypt with wrong master password' do
+      it 'never recovers the password with wrong master password' do
         encrypted = described_class.encrypt(password, mode: :enhanced, master_password: master_password)
-        expect do
-          described_class.decrypt(encrypted, mode: :enhanced, master_password: 'WrongMasterPass')
-        end.to raise_error(Lich::Common::GUI::PasswordCipher::DecryptionError)
+        # Same 1-in-256 valid-padding caveat as the wrong-account-name example.
+        begin
+          result = described_class.decrypt(encrypted, mode: :enhanced, master_password: 'WrongMasterPass')
+          expect(result).not_to eq(password)
+        rescue Lich::Common::GUI::PasswordCipher::DecryptionError
+          # the overwhelmingly common outcome
+        end
       end
     end
 


### PR DESCRIPTION
## Problem

`spec/lib/common/gui/password_cipher_spec.rb` has two intermittently failing examples ("fails to decrypt with wrong account name" / "wrong master password"). They expect `DecryptionError` on every wrong-key decrypt, but AES-256-CBC only raises when the final block's PKCS#7 padding is invalid — about 1 in 256 wrong-key decryptions yields garbage ending in `0x01` (valid one-byte padding), which OpenSSL returns without error.

Measured locally: **9 non-raises in 2000 wrong-key decrypts** (~1/256, as predicted). With two such examples in the suite, roughly 0.8% of CI runs fail here at random — it just hit PR #1480 on a change nowhere near this code.

## Fix

Assert the property the cipher actually guarantees: the original password is never recovered with a wrong key. Each example now accepts either `DecryptionError` (the overwhelmingly common outcome) or a plaintext that does not match the original password.

The neighboring corrupted/truncated-data examples are deterministic (invalid strict Base64) and unchanged, and the `validate_master_password`/`validate_current_password` specs already compare round-tripped plaintext, so they were never affected.

## Testing

- `bundle exec rspec spec/lib/common/gui/password_cipher_spec.rb` — 18 examples, 0 failures
- `bundle exec rubocop spec/lib/common/gui/password_cipher_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)