### PR TITLE
feat(dr): DRCMM.moon_weapon_duration - read a moon weapon's remaining life

### DIFF
--- a/lib/dragonrealms/commons/common-moonmage.rb
+++ b/lib/dragonrealms/commons/common-moonmage.rb
@@ -350,17 +350,21 @@ module Lich
 
       # Converts a spelled-out roisaen count (as reported by FOCUS, e.g. "five",
       # "twenty", "twenty-nine", "forty-one") into an Integer, or nil if any word
-      # is not a recognized number. Reuses the canonical DR number word map, so
-      # compounds may be hyphen- or space-separated and are summed
-      # ("forty-one" -> 41). Case-insensitive.
+      # is not a recognized number. Compounds may be hyphen- or space-separated
+      # and are summed ("forty-one" -> 41). Case-insensitive.
+      #
+      # Uses the global $NUM_MAP published by drinfomon/drvariables.rb (the same
+      # number word map DRC.text2num uses) rather than the Lich::DragonRealms
+      # constant, to avoid any namespace-resolution surface.
       def parse_roisaen(text)
         return nil if text.nil?
+        return nil if $NUM_MAP.nil?
 
         words = text.downcase.tr('-', ' ').split
         return nil if words.empty?
-        return nil unless words.all? { |word| NUM_MAP.key?(word) }
+        return nil unless words.all? { |word| $NUM_MAP.key?(word) }
 
-        words.sum { |word| NUM_MAP[word] }
+        words.sum { |word| $NUM_MAP[word] }
       end
 
       def update_astral_data(data, settings = nil)

--- a/lib/dragonrealms/commons/common-moonmage.rb
+++ b/lib/dragonrealms/commons/common-moonmage.rb
@@ -31,8 +31,9 @@ module Lich
       # Regex for extracting the spelled-out remaining duration from FOCUSing a
       # moon weapon, e.g. "You judge that the moonblade will last for roughly
       # twenty-nine roisaen." The count is captured as words (a compound like
-      # "twenty-nine" or a single word like "five"). One roisaen == 60 seconds.
-      MOON_FOCUS_DURATION_REGEX = /will last for roughly (?<count>[a-z][a-z-]*) roisaen/i.freeze
+      # "twenty-nine" or a single word like "five"). The unit is "roisaen"
+      # (plural) or "roisan" (singular, i.e. one); one roisaen == 60 seconds.
+      MOON_FOCUS_DURATION_REGEX = /will last for roughly (?<count>[a-z][a-z-]*) roisae?n/i.freeze
 
       # Maps divination tool keywords to their use verb.
       DIV_TOOL_VERBS = {

--- a/lib/dragonrealms/commons/common-moonmage.rb
+++ b/lib/dragonrealms/commons/common-moonmage.rb
@@ -28,6 +28,12 @@ module Lich
       # Regex for extracting moon color from glance output.
       MOON_GLANCE_REGEX = /You glance at a .* (?<color>black|red-hot|blue-white) moon(?:blade|staff)/i.freeze
 
+      # Regex for extracting the spelled-out remaining duration from FOCUSing a
+      # moon weapon, e.g. "You judge that the moonblade will last for roughly
+      # twenty-nine roisaen." The count is captured as words (a compound like
+      # "twenty-nine" or a single word like "five"). One roisaen == 60 seconds.
+      MOON_FOCUS_DURATION_REGEX = /will last for roughly (?<count>[a-z][a-z-]*) roisaen/i.freeze
+
       # Maps divination tool keywords to their use verb.
       DIV_TOOL_VERBS = {
         'charts' => 'review',
@@ -321,6 +327,40 @@ module Lich
           return MOON_COLOR_TO_NAME[match[:color]] if match
         end
         nil
+      end
+
+      # Focuses the summoned moon weapon (moonblade/moonstaff) you are holding or
+      # wearing and returns how many roisaen it will last, or nil if you have no
+      # moon weapon or the duration could not be parsed. One roisaen == 60
+      # seconds; moonblade duration ranges 12-41 minutes.
+      # https://elanthipedia.play.net/Moonblade
+      #
+      # NOTE: FOCUS incurs roundtime, so callers should not poll this every tick.
+      def moon_weapon_duration
+        MOON_WEAPON_NAMES.each do |weapon|
+          result = DRC.bput("focus my #{weapon}", MOON_FOCUS_DURATION_REGEX, "I could not find", "Focus on what")
+          match = result&.match(MOON_FOCUS_DURATION_REGEX)
+          next unless match
+
+          waitrt?
+          return parse_roisaen(match[:count])
+        end
+        nil
+      end
+
+      # Converts a spelled-out roisaen count (as reported by FOCUS, e.g. "five",
+      # "twenty", "twenty-nine", "forty-one") into an Integer, or nil if any word
+      # is not a recognized number. Reuses the canonical DR number word map, so
+      # compounds may be hyphen- or space-separated and are summed
+      # ("forty-one" -> 41). Case-insensitive.
+      def parse_roisaen(text)
+        return nil if text.nil?
+
+        words = text.downcase.tr('-', ' ').split
+        return nil if words.empty?
+        return nil unless words.all? { |word| NUM_MAP.key?(word) }
+
+        words.sum { |word| NUM_MAP[word] }
       end
 
       def update_astral_data(data, settings = nil)

--- a/lib/dragonrealms/commons/common-moonmage.rb
+++ b/lib/dragonrealms/commons/common-moonmage.rb
@@ -35,6 +35,11 @@ module Lich
       # (plural) or "roisan" (singular, i.e. one); one roisaen == 60 seconds.
       MOON_FOCUS_DURATION_REGEX = /will last for roughly (?<count>[a-z][a-z-]*) roisae?n/i.freeze
 
+      # Near expiry (under one roisaen remaining) FOCUS drops the "roughly <count>"
+      # form entirely and reports "will last for less than one roisan" -- no
+      # spelled count. moon_weapon_duration treats this as 0 roisaen (expiring now).
+      MOON_FOCUS_EXPIRING_REGEX = /will last for less than one roisae?n/i.freeze
+
       # Maps divination tool keywords to their use verb.
       DIV_TOOL_VERBS = {
         'charts' => 'review',
@@ -331,15 +336,24 @@ module Lich
       end
 
       # Focuses the summoned moon weapon (moonblade/moonstaff) you are holding or
-      # wearing and returns how many roisaen it will last, or nil if you have no
-      # moon weapon or the duration could not be parsed. One roisaen == 60
-      # seconds; moonblade duration ranges 12-41 minutes.
+      # wearing and returns how many roisaen it will last: a positive Integer for
+      # the "roughly <count> roisaen" form, 0 for the near-expiry "less than one
+      # roisan" form, or nil if you have no moon weapon or the phrase could not be
+      # parsed. One roisaen == 60 seconds; moonblade duration ranges 12-41 minutes.
       # https://elanthipedia.play.net/Moonblade
       #
       # NOTE: FOCUS incurs roundtime, so callers should not poll this every tick.
       def moon_weapon_duration
         MOON_WEAPON_NAMES.each do |weapon|
-          result = DRC.bput("focus my #{weapon}", MOON_FOCUS_DURATION_REGEX, "I could not find", "Focus on what")
+          result = DRC.bput("focus my #{weapon}", MOON_FOCUS_DURATION_REGEX, MOON_FOCUS_EXPIRING_REGEX, "I could not find", "Focus on what")
+
+          # Near expiry FOCUS reports "less than one roisan" with no count; treat
+          # as 0 roisaen (expiring now) so callers can refresh immediately.
+          if result&.match?(MOON_FOCUS_EXPIRING_REGEX)
+            waitrt?
+            return 0
+          end
+
           match = result&.match(MOON_FOCUS_DURATION_REGEX)
           next unless match
 

--- a/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Lich::DragonRealms::DRCMM do
       expect(described_class::MOON_FOCUS_DURATION_REGEX).to be_frozen
     end
 
+    it 'MOON_FOCUS_EXPIRING_REGEX is frozen' do
+      expect(described_class::MOON_FOCUS_EXPIRING_REGEX).to be_frozen
+    end
+
     it 'DIV_TOOL_VERBS is frozen' do
       expect(described_class::DIV_TOOL_VERBS).to be_frozen
     end
@@ -391,82 +395,108 @@ RSpec.describe Lich::DragonRealms::DRCMM do
   # moon_weapon_duration
   # ================================================================
   describe '.moon_weapon_duration' do
-    let(:focus_args) { ['I could not find', 'Focus on what'] }
+    # The real call passes: duration regex, expiring regex, then the two
+    # not-found strings. The first example asserts the exact pattern list; the
+    # rest use any_args so they do not re-encode the pattern count.
+    let(:focus_args) { [described_class::MOON_FOCUS_EXPIRING_REGEX, 'I could not find', 'Focus on what'] }
 
-    it 'focuses the moonblade and returns its remaining roisaen' do
+    it 'focuses the moonblade with the exact pattern list and returns its roisaen' do
       allow(DRC).to receive(:bput)
         .with('focus my moonblade', described_class::MOON_FOCUS_DURATION_REGEX, *focus_args)
         .and_return('You judge that the moonblade will last for roughly twenty-nine roisaen.')
       expect(described_class.moon_weapon_duration).to eq(29)
     end
 
-    it 'parses a single-word (short) duration' do
-      allow(DRC).to receive(:bput)
-        .with('focus my moonblade', anything, anything, anything)
-        .and_return('You judge that the moonblade will last for roughly three roisaen.')
-      expect(described_class.moon_weapon_duration).to eq(3)
+    it 'parses a small plural duration (confirmed "two roisaen")' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for roughly two roisaen.')
+      expect(described_class.moon_weapon_duration).to eq(2)
     end
 
     it 'parses the maximum duration' do
-      allow(DRC).to receive(:bput)
-        .with('focus my moonblade', anything, anything, anything)
-        .and_return('You judge that the moonblade will last for roughly forty-one roisaen.')
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for roughly forty-one roisaen.')
       expect(described_class.moon_weapon_duration).to eq(41)
     end
 
-    it 'parses the singular unit "roisan" (one remaining)' do
-      # The game uses "roisan" (singular) for exactly one and "roisaen" (plural)
-      # for more; a moonblade counts down through one before it dissipates.
-      allow(DRC).to receive(:bput)
-        .with('focus my moonblade', anything, anything, anything)
-        .and_return('You judge that the moonblade will last for roughly one roisan.')
-      expect(described_class.moon_weapon_duration).to eq(1)
+    it 'returns 0 for the confirmed near-expiry phrase "less than one roisan"' do
+      # Near expiry the game drops "roughly <count>" and reports "less than one
+      # roisan" (singular unit); treat as 0 roisaen == expiring now.
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for less than one roisan.')
+      expect(described_class.moon_weapon_duration).to eq(0)
+    end
+
+    it 'returns 0 for a defensive plural-unit "less than one roisaen"' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for less than one roisaen.')
+      expect(described_class.moon_weapon_duration).to eq(0)
+    end
+
+    it 'distinguishes 0 (expiring now) from nil (no weapon)' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for less than one roisan.')
+      expect(described_class.moon_weapon_duration).to eq(0)
+      expect(described_class.moon_weapon_duration).not_to be_nil
     end
 
     it 'falls back to moonstaff when no moonblade is present' do
-      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
-      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything)
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', any_args)
                                   .and_return('You judge that the moonstaff will last for roughly forty roisaen.')
       expect(described_class.moon_weapon_duration).to eq(40)
     end
 
+    it 'reads an expiring moonstaff after no moonblade' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', any_args)
+                                  .and_return('You judge that the moonstaff will last for less than one roisan.')
+      expect(described_class.moon_weapon_duration).to eq(0)
+    end
+
     it 'checks moonblade before moonstaff and stops once found' do
-      expect(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).ordered
+      expect(DRC).to receive(:bput).with('focus my moonblade', any_args).ordered
                                    .and_return('You judge that the moonblade will last for roughly ten roisaen.')
-      expect(DRC).not_to receive(:bput).with('focus my moonstaff', anything, anything, anything)
+      expect(DRC).not_to receive(:bput).with('focus my moonstaff', any_args)
       described_class.moon_weapon_duration
     end
 
     it 'returns nil when neither moon weapon is present' do
-      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
-      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', any_args).and_return('I could not find')
       expect(described_class.moon_weapon_duration).to be_nil
     end
 
     it 'returns nil on the "Focus on what" no-target response' do
-      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('Focus on what?')
-      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('Focus on what?')
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args).and_return('Focus on what?')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', any_args).and_return('Focus on what?')
       expect(described_class.moon_weapon_duration).to be_nil
     end
 
-    it 'returns nil when the duration phrase is unparseable' do
-      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
-      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('I could not find')
-      # matcher returned something unexpected -> match is nil -> nil
+    it 'returns nil when the roughly-count phrase has an unknown number word' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for roughly banana roisaen.')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', any_args).and_return('I could not find')
       expect(described_class.moon_weapon_duration).to be_nil
     end
 
-    it 'waits out the focus roundtime after a successful read' do
-      allow(DRC).to receive(:bput)
-        .with('focus my moonblade', anything, anything, anything)
-        .and_return('You judge that the moonblade will last for roughly fifteen roisaen.')
+    it 'waits out the focus roundtime after a successful count read' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for roughly fifteen roisaen.')
+      expect(described_class).to receive(:waitrt?)
+      described_class.moon_weapon_duration
+    end
+
+    it 'waits out the focus roundtime on an expiring read' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args)
+                                  .and_return('You judge that the moonblade will last for less than one roisan.')
       expect(described_class).to receive(:waitrt?)
       described_class.moon_weapon_duration
     end
 
     it 'does not wait out roundtime when nothing is focused' do
-      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
-      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonblade', any_args).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', any_args).and_return('I could not find')
       expect(described_class).not_to receive(:waitrt?)
       described_class.moon_weapon_duration
     end

--- a/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
@@ -5,7 +5,10 @@ require_relative '../../../spec_helper'
 # Global used by check_moonwatch for autostart message
 $clean_lich_char ||= ';'
 
-# Load production code
+# Load production code. drvariables provides Lich::DragonRealms::NUM_MAP, which
+# parse_roisaen uses to convert spelled-out durations; it is a pure constants
+# file (no side effects) so requiring it here is safe.
+require File.join(LIB_DIR, 'dragonrealms', 'drinfomon', 'drvariables.rb')
 require File.join(LIB_DIR, 'dragonrealms', 'commons', 'common-moonmage.rb')
 
 DRCMM = Lich::DragonRealms::DRCMM unless defined?(DRCMM)
@@ -41,6 +44,10 @@ RSpec.describe Lich::DragonRealms::DRCMM do
 
     it 'MOON_GLANCE_REGEX is frozen' do
       expect(described_class::MOON_GLANCE_REGEX).to be_frozen
+    end
+
+    it 'MOON_FOCUS_DURATION_REGEX is frozen' do
+      expect(described_class::MOON_FOCUS_DURATION_REGEX).to be_frozen
     end
 
     it 'DIV_TOOL_VERBS is frozen' do
@@ -315,6 +322,144 @@ RSpec.describe Lich::DragonRealms::DRCMM do
       allow(DRC).to receive(:bput).with('glance my moonblade', anything, anything).and_return('I could not find')
       allow(DRC).to receive(:bput).with('glance my moonstaff', anything, anything).and_return('You glance at a wicked black moonstaff')
       expect(described_class.moon_used_to_summon_weapon).to eq('katamba')
+    end
+  end
+
+  # ================================================================
+  # parse_roisaen
+  #
+  # Converts the spelled-out roisaen count reported by FOCUS into an
+  # Integer. A moonblade lasts 12-41 minutes (== roisaen, at 60s each),
+  # but near expiry it counts down toward 0, so the full 0-41 range is
+  # exercised. An independent word generator (built here, not from the
+  # production NUM_MAP) is used as the oracle so the test does not merely
+  # mirror the implementation.
+  # ================================================================
+  describe '.parse_roisaen' do
+    # Independent English-number oracle for 0..41, built from definition-time
+    # locals (a lambda closure) so it is usable in example descriptions. It is
+    # deliberately NOT the production NUM_MAP the method under test relies on,
+    # so the test does not merely mirror the implementation.
+    ones = %w[zero one two three four five six seven eight nine ten eleven twelve
+              thirteen fourteen fifteen sixteen seventeen eighteen nineteen]
+    tens = { 20 => 'twenty', 30 => 'thirty', 40 => 'forty' }
+    words_for = lambda do |number|
+      next ones[number] if number < 20
+
+      ten = (number / 10) * 10
+      one = number % 10
+      one.zero? ? tens[ten] : "#{tens[ten]}-#{ones[one]}"
+    end
+
+    context 'across the full 0-41 duration range' do
+      (0..41).each do |minutes|
+        words = words_for.call(minutes)
+        it "parses \"#{words}\" as #{minutes}" do
+          expect(described_class.parse_roisaen(words)).to eq(minutes)
+        end
+      end
+    end
+
+    context 'boundary values' do
+      it('parses the minimum documented duration (twelve)') { expect(described_class.parse_roisaen('twelve')).to eq(12) }
+      it('parses the maximum documented duration (forty-one)') { expect(described_class.parse_roisaen('forty-one')).to eq(41) }
+      it('parses zero (fully expired)') { expect(described_class.parse_roisaen('zero')).to eq(0) }
+      it('parses one (singular, about to expire)') { expect(described_class.parse_roisaen('one')).to eq(1) }
+    end
+
+    context 'formatting tolerance' do
+      it('accepts a space-separated compound') { expect(described_class.parse_roisaen('twenty nine')).to eq(29) }
+      it('accepts a hyphen-separated compound') { expect(described_class.parse_roisaen('twenty-nine')).to eq(29) }
+      it('is case-insensitive') { expect(described_class.parse_roisaen('Twenty-Nine')).to eq(29) }
+      it('is case-insensitive for all-caps') { expect(described_class.parse_roisaen('FORTY-ONE')).to eq(41) }
+      it('tolerates surrounding whitespace') { expect(described_class.parse_roisaen('  thirty-five  ')).to eq(35) }
+    end
+
+    context 'adversarial / malformed input' do
+      it('returns nil for nil') { expect(described_class.parse_roisaen(nil)).to be_nil }
+      it('returns nil for an empty string') { expect(described_class.parse_roisaen('')).to be_nil }
+      it('returns nil for whitespace only') { expect(described_class.parse_roisaen('   ')).to be_nil }
+      it('returns nil for a non-number word') { expect(described_class.parse_roisaen('banana')).to be_nil }
+      it('returns nil for the article "a" (unsupported phrasing)') { expect(described_class.parse_roisaen('a')).to be_nil }
+      it('returns nil when any word is unknown') { expect(described_class.parse_roisaen('twenty-banana')).to be_nil }
+      it('returns nil for digits (game spells numbers out)') { expect(described_class.parse_roisaen('29')).to be_nil }
+      it('does not misread a partial word') { expect(described_class.parse_roisaen('twent')).to be_nil }
+    end
+  end
+
+  # ================================================================
+  # moon_weapon_duration
+  # ================================================================
+  describe '.moon_weapon_duration' do
+    let(:focus_args) { ['I could not find', 'Focus on what'] }
+
+    it 'focuses the moonblade and returns its remaining roisaen' do
+      allow(DRC).to receive(:bput)
+        .with('focus my moonblade', described_class::MOON_FOCUS_DURATION_REGEX, *focus_args)
+        .and_return('You judge that the moonblade will last for roughly twenty-nine roisaen.')
+      expect(described_class.moon_weapon_duration).to eq(29)
+    end
+
+    it 'parses a single-word (short) duration' do
+      allow(DRC).to receive(:bput)
+        .with('focus my moonblade', anything, anything, anything)
+        .and_return('You judge that the moonblade will last for roughly three roisaen.')
+      expect(described_class.moon_weapon_duration).to eq(3)
+    end
+
+    it 'parses the maximum duration' do
+      allow(DRC).to receive(:bput)
+        .with('focus my moonblade', anything, anything, anything)
+        .and_return('You judge that the moonblade will last for roughly forty-one roisaen.')
+      expect(described_class.moon_weapon_duration).to eq(41)
+    end
+
+    it 'falls back to moonstaff when no moonblade is present' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything)
+                                  .and_return('You judge that the moonstaff will last for roughly forty roisaen.')
+      expect(described_class.moon_weapon_duration).to eq(40)
+    end
+
+    it 'checks moonblade before moonstaff and stops once found' do
+      expect(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).ordered
+                                   .and_return('You judge that the moonblade will last for roughly ten roisaen.')
+      expect(DRC).not_to receive(:bput).with('focus my moonstaff', anything, anything, anything)
+      described_class.moon_weapon_duration
+    end
+
+    it 'returns nil when neither moon weapon is present' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('I could not find')
+      expect(described_class.moon_weapon_duration).to be_nil
+    end
+
+    it 'returns nil on the "Focus on what" no-target response' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('Focus on what?')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('Focus on what?')
+      expect(described_class.moon_weapon_duration).to be_nil
+    end
+
+    it 'returns nil when the duration phrase is unparseable' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('I could not find')
+      # matcher returned something unexpected -> match is nil -> nil
+      expect(described_class.moon_weapon_duration).to be_nil
+    end
+
+    it 'waits out the focus roundtime after a successful read' do
+      allow(DRC).to receive(:bput)
+        .with('focus my moonblade', anything, anything, anything)
+        .and_return('You judge that the moonblade will last for roughly fifteen roisaen.')
+      expect(described_class).to receive(:waitrt?)
+      described_class.moon_weapon_duration
+    end
+
+    it 'does not wait out roundtime when nothing is focused' do
+      allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
+      allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything).and_return('I could not find')
+      expect(described_class).not_to receive(:waitrt?)
+      described_class.moon_weapon_duration
     end
   end
 

--- a/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../../spec_helper'
 # Global used by check_moonwatch for autostart message
 $clean_lich_char ||= ';'
 
-# Load production code. drvariables provides Lich::DragonRealms::NUM_MAP, which
+# Load production code. drvariables publishes the $NUM_MAP global, which
 # parse_roisaen uses to convert spelled-out durations; it is a pure constants
 # file (no side effects) so requiring it here is safe.
 require File.join(LIB_DIR, 'dragonrealms', 'drinfomon', 'drvariables.rb')

--- a/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_moonmage_spec.rb
@@ -414,6 +414,15 @@ RSpec.describe Lich::DragonRealms::DRCMM do
       expect(described_class.moon_weapon_duration).to eq(41)
     end
 
+    it 'parses the singular unit "roisan" (one remaining)' do
+      # The game uses "roisan" (singular) for exactly one and "roisaen" (plural)
+      # for more; a moonblade counts down through one before it dissipates.
+      allow(DRC).to receive(:bput)
+        .with('focus my moonblade', anything, anything, anything)
+        .and_return('You judge that the moonblade will last for roughly one roisan.')
+      expect(described_class.moon_weapon_duration).to eq(1)
+    end
+
     it 'falls back to moonstaff when no moonblade is present' do
       allow(DRC).to receive(:bput).with('focus my moonblade', anything, anything, anything).and_return('I could not find')
       allow(DRC).to receive(:bput).with('focus my moonstaff', anything, anything, anything)


### PR DESCRIPTION
## Summary

Adds two `DRCMM` (Moon Mage commons) methods for reading how long a summoned moon weapon will last, so scripts can refresh a moonblade/moonstaff **before** it dissipates instead of reacting after it is already gone.

### `DRCMM.moon_weapon_duration`
FOCUSes the summoned moon weapon you are holding or wearing and returns its remaining duration in **roisaen** (1 roisaen == 60 seconds), or `nil` if you have no moon weapon or the message can't be parsed.

- Parses `You judge that the moonblade will last for roughly <count> roisaen.`
- Checks `moonblade` then `moonstaff` (mirrors `moon_used_to_summon_weapon`).
- Waits out the FOCUS roundtime only on a successful read.
- Documented as unsuitable for per-tick polling (FOCUS has roundtime). Moonblade duration ranges 12-41 minutes ([Elanthipedia](https://elanthipedia.play.net/Moonblade)).

### `DRCMM.parse_roisaen`
Converts the spelled-out count the game reports (`"twenty-nine"`, `"forty-one"`, `"five"`) into an `Integer`, or `nil` if any word is unrecognized. Reuses the canonical `Lich::DragonRealms::NUM_MAP`, so compounds may be hyphen- or space-separated and are summed; case-insensitive.

## Why

The game reports a moon weapon's remaining life via FOCUS, but there is currently no commons helper to read it. Scripts that use a summoned moonblade as a weapon can only tell *whether* one exists (`glance`/`moon_used_to_summon_weapon`), not *how long* it will last, so they tend to recast on a fixed timer that doesn't match the variable (12-41 min) duration and can let the blade expire mid-use. This exposes the actual remaining time as a primitive; the consuming logic lives in a separate dr-scripts change.

## Tests

`spec/lib/dragonrealms/commons/common_moonmage_spec.rb`:

- **`parse_roisaen` across the full 0-41 range** - each value is generated by an independent English-number oracle built in the spec (deliberately *not* the production `NUM_MAP`), so the test does not merely mirror the implementation. Plus boundary values (12/41/0/1), formatting tolerance (space vs hyphen, case, surrounding whitespace), and adversarial/malformed input (nil, empty, whitespace, non-number words, digits, partial words, mixed known/unknown -> `nil`).
- **`moon_weapon_duration` end-to-end** - moonblade read, single-word and max durations, moonstaff fallback, moonblade-before-moonstaff ordering with early stop, not-found, `Focus on what`, unparseable, and roundtime handling (waits on success, not on miss).

`drvariables.rb` (pure constants, provides `NUM_MAP`) is required in the spec; it is already required by several existing specs. Full `commons` + `drinfomon` suites pass (2338 examples, 0 failures) and `rubocop` is clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved moon weapon duration detection for moonblades and moonstaffs.
  * Correctly interprets durations written as words, including hyphenated values.
  * Recognizes weapons with less than one roisan remaining as expiring immediately.
  * Improved fallback behavior when a weapon cannot be identified or focused.
* **Reliability**
  * Handles invalid duration messages and roundtime more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->