### PR TITLE
fix(all): extract game-agnostic CreatureBase into lib/common

### DIFF
--- a/lib/common/creature/creature_base.rb
+++ b/lib/common/creature/creature_base.rb
@@ -275,6 +275,11 @@ module Lich
 
         # Configures registry limits.
         #
+        # Every call resets omitted options to their defaults - max_size to 1000
+        # and auto_register to true - so calling this with no arguments restores
+        # all defaults. Facade callers (e.g. `Creature.configure(**options)`)
+        # should pass every option they mean to keep.
+        #
         # @param max_size [Integer] maximum number of retained instances.
         # @param auto_register [Boolean] whether {#register} creates instances.
         # @return [void]

--- a/lib/common/creature/creature_base.rb
+++ b/lib/common/creature/creature_base.rb
@@ -1,0 +1,518 @@
+# frozen_string_literal: true
+
+# =============================================================================
+# common/creature/creature_base.rb
+#
+# Game-agnostic core of Lich's runtime creature model, shared by the GemStone
+# and DragonRealms `Creature` implementations. Mirrors the structure of
+# common/map/map_base.rb: a single {Lich::Common::CreatureBase} mixin whose
+# `self.included` hook wires the shared {CreatureBase::ClassMethods} (id-keyed
+# registry, room roster and target queries) and {CreatureBase::InstanceMethods}
+# (transient status / classification tracking) into the including class.
+#
+# Both games receive the same structured, id-keyed creature feed:
+#
+#   <crtrStatus exist="..." hostile="1" .../>
+#
+# a full snapshot of a creature's transient combat status and classification
+# flags. The flag vocabulary is identical across the two games (see
+# {CRTR_STATUS_FLAGS} and {CRTR_CLASSIFICATION_FLAGS}), so status/flag
+# reconciliation, the registry, the room roster and target filtering all live
+# here and are mixed into each game's concrete `CreatureInstance`.
+#
+# Game-specific concerns stay out of this file:
+#   * GemStone: bestiary templates, UCS (Unarmed Combat System) tracking,
+#     HP/injury modelling and GemStone `valid_target?` exclusions
+#     (lib/gemstone/creature.rb).
+#   * DragonRealms: `assess`-stream name/position backfill and the DragonRealms
+#     `valid_target?` rule (lib/dragonrealms/creature.rb).
+#
+# Usage (see lib/gemstone/creature.rb for a worked example):
+#
+#   class CreatureInstance
+#     include Lich::Common::CreatureBase   # adds instance + class methods
+#     def initialize(id, noun, name)
+#       @id = id.to_i; @noun = noun; @name = name
+#       initialize_status_tracking
+#       # ...game-specific ivars...
+#     end
+#     def valid_target? = !crtr_flag?(:dead) # each game supplies its own rule
+#   end
+# =============================================================================
+
+module Lich
+  module Common
+    # Shared creature behaviour mixed into each game's `CreatureInstance`.
+    #
+    # Include this into a concrete creature-instance class. The `included` hook
+    # extends the class with {ClassMethods} (registry/roster/target queries) and
+    # includes {InstanceMethods} (status/flag tracking). The class must define a
+    # `new(id, noun, name)` constructor, call {InstanceMethods#initialize_status_tracking}
+    # from its own `initialize`, and expose a `valid_target?` predicate (used by
+    # {ClassMethods#targets}) plus a `created_at` reader (used by
+    # {ClassMethods#cleanup_old}).
+    module CreatureBase
+      # Wires the shared behaviour into the including class, matching the
+      # MapBase convention.
+      #
+      # @param base [Class] the including creature-instance class.
+      # @return [void]
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.include(InstanceMethods)
+      end
+
+      # Status-effect lifetimes, in seconds, used for automatic cleanup.
+      #
+      # A `nil` value means the status has a reliable server-sent removal
+      # message and therefore must not be auto-expired on a timer.
+      #
+      # @return [Hash{String=>Integer, nil}]
+      STATUS_DURATIONS = {
+        'breeze'      => 6,   # 6 seconds roundtime
+        'bind'        => 10,  # 10 seconds typical
+        'web'         => 8,   # 8 seconds typical
+        'entangle'    => 10,  # 10 seconds typical
+        'hypnotism'   => 12,  # 12 seconds typical
+        'calm'        => 15,  # 15 seconds typical
+        'mass_calm'   => 15,  # 15 seconds typical
+        'sleep'       => 8,   # 8 seconds typical (can wake early)
+        # Statuses with reliable removal messages - no duration needed.
+        'stunned'     => nil,
+        'immobilized' => nil,
+        'prone'       => nil,
+        'blind'       => nil,
+        'sunburst'    => nil,
+        'webbed'      => nil,
+        'poisoned'    => nil
+      }.freeze
+
+      # Maps `<crtrStatus>` transient XML flags to canonical status names.
+      #
+      # The XML feed and the message parser use slightly different terms for the
+      # same state (e.g. "immobile" versus "immobilized"). Keeping this mapping
+      # explicit lets XML- and message-based detection reconcile into the same
+      # status entries.
+      #
+      # @return [Hash{String=>String}]
+      CRTR_STATUS_FLAGS = {
+        'immobile'    => 'immobilized',
+        'webbed'      => 'webbed',
+        'sleeping'    => 'sleeping',
+        'disoriented' => 'disoriented',
+        'stunned'     => 'stunned',
+        'rooted'      => 'rooted',
+        'calmed'      => 'calm',
+        'kneeling'    => 'kneeling',
+        'prone'       => 'prone',
+        'sitting'     => 'sitting',
+        'flying'      => 'flying',
+        'hovering'    => 'hovering'
+      }.freeze
+
+      # Maps `<crtrStatus>` classification XML flags to predicate keys.
+      #
+      # These are relationship or classification facts rather than transient
+      # combat statuses, so they are stored separately and read via
+      # {InstanceMethods#crtr_flag?}.
+      #
+      # @return [Hash{String=>Symbol}]
+      CRTR_CLASSIFICATION_FLAGS = {
+        'hostile'       => :hostile,
+        'disengaged'    => :disengaged,
+        'dead'          => :dead,
+        'sympathetic'   => :sympathetic,
+        'ascended'      => :ascended,
+        'inferior'      => :inferior,
+        'AscensionBoss' => :ascension_boss,
+        'MiniBoss'      => :mini_boss,
+        'challenging'   => :challenging,
+        'rider'         => :rider,
+        'mount'         => :mount
+      }.freeze
+
+      # All known `<crtrStatus>` attributes keyed by XML name, for debug
+      # snapshots.
+      #
+      # @return [Hash{String=>String, Symbol}]
+      ALL_CRTR_FLAGS = CRTR_STATUS_FLAGS.merge(CRTR_CLASSIFICATION_FLAGS).freeze
+
+      # Class-level behaviour: the id-keyed instance registry, the current-room
+      # roster and the target/room queries shared by both games' `Creature`
+      # facades.
+      #
+      # State lives in per-class instance variables (`@instances`,
+      # `@current_room_ids`, ...), so each extending class keeps an independent
+      # registry - GemStone and DragonRealms never share a roster even though
+      # they share this code.
+      module ClassMethods
+        # Registers or looks up a creature instance, marking it present in the
+        # current room.
+        #
+        # Room-marking happens on every call, new instance or not, because the
+        # feed event that triggers registration (a bolded room-object name, or a
+        # `<crtrStatus>` tag) is exactly the signal that the creature is present.
+        #
+        # @param name [String, nil] display name; may be nil when the feed
+        #   supplies an id before a name (DragonRealms `<crtrStatus>`).
+        # @param id [Integer, String] server creature id.
+        # @param noun [String, nil] noun from room XML, when available.
+        # @return [Object, nil] the registered instance, or nil when
+        #   auto-registration is disabled or the registry is full.
+        def register(name, id, noun = nil)
+          return nil unless auto_register?
+
+          entered_room = mark_in_room(id)
+
+          existing = instances[id.to_i]
+          if existing
+            respond "--- #{name} (#{id}): in room" if entered_room && $creature_debug
+            return existing
+          end
+
+          if full?
+            # Progressively more aggressive: 120 minutes, then 15-minute steps.
+            [7200, 6300, 5400, 4500, 3600, 2700, 1800, 900].each do |age_threshold|
+              removed = cleanup_old(age_threshold)
+              respond "--- Auto-cleanup: removed #{removed} old creatures (threshold: #{age_threshold}s)" if removed > 0 && $creature_debug
+              break unless full?
+            end
+            return nil if full? # Still full after every cleanup attempt.
+          end
+
+          instance = new(id, noun, name)
+          instances[id.to_i] = instance
+          respond "--- #{name} (#{id}): registered" if $creature_debug
+          instance
+        end
+
+        # Marks an id present in the current-room roster.
+        #
+        # @param id [Integer, String] server creature id.
+        # @return [Boolean] true when the id was newly added.
+        def mark_in_room(id)
+          id = id.to_i
+          return false if current_room_ids.include?(id)
+
+          current_room_ids << id
+          true
+        end
+
+        # Empties the current-room roster (the persistent registry is untouched).
+        #
+        # Called from the XML parser's nav and room-object refresh hooks; the
+        # roster is then rebuilt from fresh room XML.
+        #
+        # @return [void]
+        def clear_room
+          count = current_room_ids.size
+          @current_room_ids = []
+          respond "--- room: roster cleared (#{count} creature#{'s' unless count == 1})" if $creature_debug && count > 0
+        end
+
+        # Returns the creature ids currently present in the room.
+        #
+        # @return [Array<Integer>]
+        def current_room_ids
+          @current_room_ids ||= []
+        end
+
+        # Looks up a registered instance by id.
+        #
+        # @param id [Integer, String] server creature id.
+        # @return [Object, nil]
+        def [](id)
+          instances[id.to_i]
+        end
+
+        # @return [Array<Object>] every registered instance.
+        def all
+          instances.values
+        end
+
+        # Clears all instances and the room roster (session reset).
+        #
+        # @return [void]
+        def clear
+          instances.clear
+          clear_room
+        end
+
+        # Removes instances older than the given age.
+        #
+        # @param max_age_seconds [Integer] age cutoff in seconds.
+        # @return [Integer] number of instances removed.
+        def cleanup_old(max_age_seconds = 600)
+          cutoff = Time.now - max_age_seconds
+          removed = instances.select { |_id, instance| instance.created_at < cutoff }.size
+          instances.reject! { |_id, instance| instance.created_at < cutoff }
+          removed
+        end
+
+        # Configures registry limits.
+        #
+        # @param max_size [Integer] maximum number of retained instances.
+        # @param auto_register [Boolean] whether {#register} creates instances.
+        # @return [void]
+        def configure(max_size: 1000, auto_register: true)
+          @max_size = max_size
+          @auto_register = auto_register
+        end
+
+        # @return [Boolean] whether auto-registration is enabled (default true).
+        def auto_register?
+          @auto_register = true if @auto_register.nil?
+          @auto_register
+        end
+
+        # @return [Integer] configured maximum registry size (default 1000).
+        def max_size
+          @max_size ||= 1000
+        end
+
+        # @return [Integer] current number of retained instances.
+        def size
+          instances.size
+        end
+
+        # @return [Boolean] whether the registry is at capacity.
+        def full?
+          size >= max_size
+        end
+
+        # Returns attackable hostile creatures currently in the room.
+        #
+        # Room membership comes from the creature roster (fed by XML room-object
+        # and `<crtrStatus>` events), not from any client last-selected-target
+        # control, which can go stale after movement or death. `valid_target?`
+        # (supplied by the game class) removes decoys/dead appendages and
+        # `crtr_flag?(:hostile)` supplies structured hostility.
+        #
+        # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
+        # @return [Array<Object>]
+        def targets(*filters)
+          candidates = current_room_ids
+                       .filter_map { |id| self[id] }
+                       .select { |c| c.valid_target? && c.crtr_flag?(:hostile) }
+          apply_filters(candidates, filters)
+        end
+
+        # Returns all tracked creatures currently in the room.
+        #
+        # Unlike {#targets} this requires neither hostility nor target validity,
+        # so it also serves dead creatures, looting and wound inspection.
+        # Filters are ANDed and may name a status, a classification flag, or a
+        # `not_` negation such as `:not_prone`; unknown filters match nothing.
+        #
+        # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
+        # @return [Array<Object>]
+        def in_room(*filters)
+          candidates = current_room_ids.filter_map { |id| self[id] }
+          apply_filters(candidates, filters)
+        end
+
+        # Toggles live echo of status, flag, and registration changes.
+        #
+        # @param level [Boolean, Symbol] false disables debug output; true or
+        #   `:changes` reports changes only; `:all` reports every `<crtrStatus>`
+        #   flag; `:active` reports only active `<crtrStatus>` flags.
+        # @return [Boolean, Symbol] the configured debug value.
+        def debug_on(level = :changes)
+          $creature_debug = level
+        end
+
+        private
+
+        # Applies status/classification filters to a candidate list.
+        #
+        # @param candidates [Array<Object>] initial creature list.
+        # @param filters [Array<String, Symbol>] filter names, optionally prefixed with `not_`.
+        # @return [Array<Object>]
+        def apply_filters(candidates, filters)
+          filters.each do |filter|
+            negate = filter.to_s.start_with?('not_')
+            key = negate ? filter.to_s.delete_prefix('not_') : filter.to_s
+            candidates = candidates.select { |c| c.flag_active?(key) != negate }
+          end
+          candidates
+        end
+
+        # The backing store of id => instance.
+        #
+        # @return [Hash{Integer=>Object}]
+        def instances
+          @instances ||= {}
+        end
+      end
+
+      # Per-instance transient status and classification tracking driven by the
+      # `<crtrStatus>` feed. The host class must call
+      # {#initialize_status_tracking} from its own `initialize` and expose
+      # `@name`/`@id` (used only for debug headers).
+      module InstanceMethods
+        # Initializes the tracking ivars. Call from the host class `initialize`.
+        #
+        # @return [void]
+        def initialize_status_tracking
+          @status = []
+          @status_timestamps = {}
+          @crtr_flags = {}
+        end
+
+        # Adds a status to the creature.
+        #
+        # Normalizes to String so callers can pass symbols from message-based
+        # status parsing or strings from `<crtrStatus>`; both sources then land
+        # in the same status entries and match {#has_status?}.
+        #
+        # @param status [String, Symbol] canonical status name.
+        # @param duration [Integer, nil] optional expiration duration in seconds;
+        #   falls back to {STATUS_DURATIONS} when omitted.
+        # @return [void]
+        def add_status(status, duration = nil)
+          status = status.to_s
+          return if @status.include?(status)
+
+          @status << status
+
+          duration ||= STATUS_DURATIONS[status.downcase]
+          if duration
+            @status_timestamps[status] = Time.now + duration
+            debug_log("+status: #{status} (expires in #{duration}s)")
+          else
+            debug_log("+status: #{status} (no auto-expiry)")
+          end
+        end
+
+        # Removes a status from the creature.
+        #
+        # @param status [String, Symbol] canonical status name.
+        # @return [void]
+        def remove_status(status)
+          status = status.to_s
+          @status.delete(status)
+          @status_timestamps.delete(status)
+          debug_log("-status: #{status}")
+        end
+
+        # Drops any timed statuses whose expiry has passed.
+        #
+        # @return [void]
+        def cleanup_expired_statuses
+          return unless @status_timestamps && !@status_timestamps.empty?
+
+          now = Time.now
+          @status_timestamps.select { |_status, expires_at| expires_at <= now }.keys.each do |expired_status|
+            @status.delete(expired_status)
+            @status_timestamps.delete(expired_status)
+            debug_log("~status: #{expired_status} (auto-expired)")
+          end
+        end
+
+        # Checks whether a specific status is active (after expiring stale ones).
+        #
+        # @param status [String, Symbol] canonical status name.
+        # @return [Boolean]
+        def has_status?(status)
+          cleanup_expired_statuses
+          @status.include?(status.to_s)
+        end
+
+        # Returns a copy of the currently-active statuses (after expiry).
+        #
+        # @return [Array<String>]
+        def statuses
+          cleanup_expired_statuses
+          @status.dup
+        end
+
+        # Reconciles status and classification from a `<crtrStatus>` tag.
+        #
+        # The tag is a full snapshot of what is currently active, not a delta. A
+        # missing flag, or a flag set to "0", means inactive even if it was
+        # active a moment ago, so absent known flags are cleared rather than
+        # ignored.
+        #
+        # @param attrs [Hash{String=>String}] XML attributes excluding `exist`.
+        # @return [void]
+        def sync_crtr_status(attrs)
+          CRTR_STATUS_FLAGS.each do |xml_name, status|
+            if attrs[xml_name] == '1'
+              add_status(status)
+            elsif @status.include?(status)
+              remove_status(status)
+            end
+          end
+
+          CRTR_CLASSIFICATION_FLAGS.each do |xml_name, key|
+            new_value = (attrs[xml_name] == '1')
+            debug_log("~flag: #{key}=#{new_value}") if debug_level == :changes && @crtr_flags[key] != new_value
+            @crtr_flags[key] = new_value
+          end
+
+          report_crtr_snapshot(attrs) if %i[all active].include?(debug_level)
+        end
+
+        # Checks a classification flag captured from `<crtrStatus>`.
+        #
+        # Unlike template tri-state facts, live XML flags are always-sent
+        # booleans, so an unknown or unseen flag is false, not nil.
+        #
+        # @param key [String, Symbol] classification key, e.g. `:hostile`.
+        # @return [Boolean]
+        def crtr_flag?(key)
+          @crtr_flags[key.to_sym] || false
+        end
+
+        # Checks whether a status or classification flag is active.
+        #
+        # The two vocabularies are intentionally disjoint, so callers can filter
+        # on any known flag name without caring which bucket stores it.
+        #
+        # @param key [String, Symbol] status or classification key.
+        # @return [Boolean]
+        def flag_active?(key)
+          has_status?(key) || crtr_flag?(key)
+        end
+
+        private
+
+        # Normalizes the configured creature debug level.
+        #
+        # @return [Symbol, false, nil] debug level; `true` normalizes to `:changes`.
+        def debug_level
+          $creature_debug == true ? :changes : $creature_debug
+        end
+
+        # Builds the prefix used for creature debug messages.
+        #
+        # @return [String]
+        def debug_header
+          "--- #{@name} (#{@id}):"
+        end
+
+        # Emits a creature debug message when creature debugging is enabled.
+        #
+        # @param message [String] message body.
+        # @return [void]
+        def debug_log(message)
+          respond "#{debug_header} #{message}" if $creature_debug
+        end
+
+        # Emits a debug snapshot for a `<crtrStatus>` tag.
+        #
+        # `:all` reports every known flag; `:active` reports only true flags. The
+        # snapshot reads straight from the tag attributes so it reflects exactly
+        # what the feed sent, independent of how the mutation logic applies it.
+        #
+        # @param attrs [Hash{String=>String}] XML attributes excluding `exist`.
+        # @return [void]
+        def report_crtr_snapshot(attrs)
+          flags = ALL_CRTR_FLAGS.map { |xml_name, key| [key, attrs[xml_name] == '1'] }
+          flags = flags.select { |_, active| active } if debug_level == :active
+          debug_log("crtrStatus: #{flags.map { |key, active| "#{key}=#{active}" }.join(', ')}")
+        end
+      end
+    end
+  end
+end

--- a/lib/common/creature/creature_base.rb
+++ b/lib/common/creature/creature_base.rb
@@ -137,6 +137,20 @@ module Lich
       # @return [Hash{String=>String, Symbol}]
       ALL_CRTR_FLAGS = CRTR_STATUS_FLAGS.merge(CRTR_CLASSIFICATION_FLAGS).freeze
 
+      # Every filter name {ClassMethods#targets} and {ClassMethods#in_room} can
+      # match: the canonical status vocabulary (both the `<crtrStatus>` status
+      # spellings and the timer-based message statuses in {STATUS_DURATIONS})
+      # plus the classification keys. A filter outside this set is "unknown" and,
+      # per the query contract, matches no candidates - even when negated with a
+      # `not_` prefix.
+      #
+      # @return [Array<String>]
+      KNOWN_FLAG_NAMES = (
+        CRTR_STATUS_FLAGS.values +
+        STATUS_DURATIONS.keys +
+        CRTR_CLASSIFICATION_FLAGS.values.map(&:to_s)
+      ).uniq.freeze
+
       # Class-level behaviour: the id-keyed instance registry, the current-room
       # roster and the target/room queries shared by both games' `Creature`
       # facades.
@@ -160,9 +174,14 @@ module Lich
         # @return [Object, nil] the registered instance, or nil when
         #   auto-registration is disabled or the registry is full.
         def register(name, id, noun = nil)
-          return nil unless auto_register?
-
+          # Record room presence first: the feed event that triggers this call
+          # (a bolded room-object name or a <crtrStatus> tag) is itself proof the
+          # creature is in the room, and that stays true even when
+          # auto-registration is disabled and no instance will be created. Mark
+          # before the guard so a known creature's room presence is still tracked
+          # while auto-registration is off.
           entered_room = mark_in_room(id)
+          return nil unless auto_register?
 
           existing = instances[id.to_i]
           if existing
@@ -192,9 +211,9 @@ module Lich
         # @return [Boolean] true when the id was newly added.
         def mark_in_room(id)
           id = id.to_i
-          return false if current_room_ids.include?(id)
+          return false if room_roster.include?(id)
 
-          current_room_ids << id
+          room_roster << id
           true
         end
 
@@ -205,16 +224,21 @@ module Lich
         #
         # @return [void]
         def clear_room
-          count = current_room_ids.size
+          count = room_roster.size
           @current_room_ids = []
           respond "--- room: roster cleared (#{count} creature#{'s' unless count == 1})" if $creature_debug && count > 0
         end
 
         # Returns the creature ids currently present in the room.
         #
+        # Hands back a copy, not the live roster. The internal roster is mutated
+        # in place by {#mark_in_room} / {#clear_room}, so a caller that mutated
+        # the returned array - the GemStone facade relied on this defensive copy
+        # before the extraction - would otherwise corrupt shared targeting state.
+        #
         # @return [Array<Integer>]
         def current_room_ids
-          @current_room_ids ||= []
+          room_roster.dup
         end
 
         # Looks up a registered instance by id.
@@ -291,7 +315,7 @@ module Lich
         # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
         # @return [Array<Object>]
         def targets(*filters)
-          candidates = current_room_ids
+          candidates = room_roster
                        .filter_map { |id| self[id] }
                        .select { |c| c.valid_target? && c.crtr_flag?(:hostile) }
           apply_filters(candidates, filters)
@@ -307,7 +331,7 @@ module Lich
         # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
         # @return [Array<Object>]
         def in_room(*filters)
-          candidates = current_room_ids.filter_map { |id| self[id] }
+          candidates = room_roster.filter_map { |id| self[id] }
           apply_filters(candidates, filters)
         end
 
@@ -332,9 +356,26 @@ module Lich
           filters.each do |filter|
             negate = filter.to_s.start_with?('not_')
             key = negate ? filter.to_s.delete_prefix('not_') : filter.to_s
+
+            # Unknown filters match nothing, per the documented contract. Without
+            # this guard a negated unknown filter (e.g. a typo like :not_prnoe)
+            # inverts "matches nothing" into "matches everything", silently
+            # widening a query instead of narrowing it. Filters are ANDed, so an
+            # unknown one collapses the whole result to empty.
+            return [] unless known_flag?(key)
+
             candidates = candidates.select { |c| c.flag_active?(key) != negate }
           end
           candidates
+        end
+
+        # Whether a filter name (with any `not_` prefix already removed) is part
+        # of the recognized filter vocabulary. See {CreatureBase::KNOWN_FLAG_NAMES}.
+        #
+        # @param key [String, Symbol] filter name without its `not_` prefix.
+        # @return [Boolean]
+        def known_flag?(key)
+          KNOWN_FLAG_NAMES.include?(key.to_s)
         end
 
         # The backing store of id => instance.
@@ -342,6 +383,15 @@ module Lich
         # @return [Hash{Integer=>Object}]
         def instances
           @instances ||= {}
+        end
+
+        # The live current-room roster. Mutated in place by {#mark_in_room} and
+        # replaced wholesale by {#clear_room}; {#current_room_ids} hands callers a
+        # copy so this array never escapes to be mutated from outside.
+        #
+        # @return [Array<Integer>]
+        def room_roster
+          @current_room_ids ||= []
         end
       end
 

--- a/lib/gemstone/creature.rb
+++ b/lib/gemstone/creature.rb
@@ -203,7 +203,7 @@ module Lich
     # Individual GemStone creature instance (runtime tracking with ID).
     #
     # Shares its id-keyed registry, room roster and `<crtrStatus>` status/flag
-    # handling with DragonRealms via the {Lich::Common::Creature} mixins; the
+    # handling with DragonRealms via the {Lich::Common::CreatureBase} mixin; the
     # GemStone-specific layer here adds bestiary templates, UCS (Unarmed Combat
     # System) tracking, HP/injury modelling and the GemStone `valid_target?`
     # exclusions.
@@ -456,9 +456,9 @@ module Lich
 
     # Public Creature API for GemStone runtime creature tracking.
     #
-    # Delegates registry/roster operations to {CreatureInstance} and inherits
-    # the shared `targets`/`in_room` query methods from
-    # {Lich::Common::Creature::Targeting}.
+    # A thin facade: every call delegates to {CreatureInstance}, which mixes in
+    # the shared id-keyed registry, room roster and `targets`/`in_room` query
+    # methods from {Lich::Common::CreatureBase}.
     module Creature
       # Toggles live echo of status, flag, and registration changes.
       #
@@ -523,9 +523,18 @@ module Lich
         CreatureInstance.clear
       end
 
-      # Cleanup old instances
-      def self.cleanup_old(**options)
-        CreatureInstance.cleanup_old(**options)
+      # Removes creatures older than the given age (in seconds).
+      #
+      # Positional to match {CreatureInstance#cleanup_old} (supplied by
+      # {Lich::Common::CreatureBase}) and the positional call in
+      # Combat::Tracker#cleanup_creatures. A keyword-only signature here raised
+      # ArgumentError on every scheduled tracker cleanup, which the tracker's
+      # rescue then swallowed - so registry cleanup silently never ran.
+      #
+      # @param max_age_seconds [Integer] age cutoff in seconds.
+      # @return [Integer] number of instances removed.
+      def self.cleanup_old(max_age_seconds = 600)
+        CreatureInstance.cleanup_old(max_age_seconds)
       end
 
       # Generate damage report for HP analysis

--- a/lib/gemstone/creature.rb
+++ b/lib/gemstone/creature.rb
@@ -1,5 +1,6 @@
 require 'singleton'
 require 'ostruct'
+require_relative '../common/creature/creature_base'
 
 module Lich
   module Gemstone
@@ -199,17 +200,15 @@ module Lich
       end
     end
 
-    # Individual creature instance (runtime tracking with ID)
+    # Individual GemStone creature instance (runtime tracking with ID).
+    #
+    # Shares its id-keyed registry, room roster and `<crtrStatus>` status/flag
+    # handling with DragonRealms via the {Lich::Common::Creature} mixins; the
+    # GemStone-specific layer here adds bestiary templates, UCS (Unarmed Combat
+    # System) tracking, HP/injury modelling and the GemStone `valid_target?`
+    # exclusions.
     class CreatureInstance
-      @@instances = {}
-      @@max_size = 1000
-      @@auto_register = true
-
-      # Ids currently present in the room, independent of @@instances (which
-      # deliberately keeps departed creatures around for wound reporting).
-      # Cleared and rebuilt entirely from xmlparser's own nav/room-objs hooks -
-      # not read from or written to GameObj, by design (see retirement plan).
-      @@current_room_ids = []
+      include Lich::Common::CreatureBase
 
       attr_accessor :id, :noun, :name, :status, :injuries, :health, :damage_taken, :created_at, :fatal_crit, :status_timestamps,
                     :ucs_smote, :ucs_updated
@@ -220,92 +219,20 @@ module Lich
       UCS_TTL = 120        # UCS data expires after 2 minutes
       UCS_SMITE_TTL = 15   # Smite effect expires after 15 seconds
 
-      # Status effect durations (in seconds) for auto-cleanup
-      # nil = no auto-cleanup (waits for removal message)
-      STATUS_DURATIONS = {
-        'breeze'      => 6, # 6 seconds roundtime
-        'bind'        => 10, # 10 seconds typical
-        'web'         => 8, # 8 seconds typical
-        'entangle'    => 10, # 10 seconds typical
-        'hypnotism'   => 12, # 12 seconds typical
-        'calm'        => 15, # 15 seconds typical
-        'mass_calm'   => 15, # 15 seconds typical
-        'sleep'       => 8, # 8 seconds typical (can wake early)
-        # Statuses with reliable removal messages - no duration needed
-        'stunned'     => nil, # Has removal messages
-        'immobilized' => nil, # Has removal messages
-        'prone'       => nil,         # Has removal messages
-        'blind'       => nil,         # Has removal messages
-        'sunburst'    => nil, # Has removal messages
-        'webbed'      => nil, # Has removal messages
-        'poisoned'    => nil # Has removal messages
-      }.freeze
-
-      # Maps <crtrStatus> transient XML flags to canonical status names.
-      #
-      # The XML feed and message parser use slightly different terms for the
-      # same state, e.g. "immobile" versus "immobilized". Keeping this mapping
-      # explicit lets XML and message-based detection reconcile into the same
-      # `@status` entries.
-      #
-      # @return [Hash{String=>String}]
-      CRTR_STATUS_FLAGS = {
-        'immobile'    => 'immobilized',
-        'webbed'      => 'webbed',
-        'sleeping'    => 'sleeping',
-        'disoriented' => 'disoriented',
-        'stunned'     => 'stunned',
-        'rooted'      => 'rooted',
-        'calmed'      => 'calm',
-        'kneeling'    => 'kneeling',
-        'prone'       => 'prone',
-        'sitting'     => 'sitting',
-        'flying'      => 'flying',
-        'hovering'    => 'hovering'
-      }.freeze
-
-      # Maps <crtrStatus> classification XML flags to predicate keys.
-      #
-      # These are relationship or classification facts rather than transient
-      # combat statuses, so they are stored separately from `@status` and read
-      # via {#crtr_flag?}.
-      #
-      # @return [Hash{String=>Symbol}]
-      CRTR_CLASSIFICATION_FLAGS = {
-        'hostile'       => :hostile,
-        'disengaged'    => :disengaged,
-        'dead'          => :dead,
-        'sympathetic'   => :sympathetic,
-        'ascended'      => :ascended,
-        'inferior'      => :inferior,
-        'AscensionBoss' => :ascension_boss,
-        'MiniBoss'      => :mini_boss,
-        'challenging'   => :challenging,
-        'rider'         => :rider,
-        'mount'         => :mount
-      }.freeze
-
-      # All known <crtrStatus> attributes keyed by XML name.
-      #
-      # @return [Hash{String=>String, Symbol}] canonical flag names for debug snapshots.
-      ALL_CRTR_FLAGS = CRTR_STATUS_FLAGS.merge(CRTR_CLASSIFICATION_FLAGS).freeze
-
       def initialize(id, noun, name)
         @id = id.to_i
         @noun = noun
         @name = name
-        @status = []
+        initialize_status_tracking
         @injuries = Hash.new(0)
         @health = nil
         @damage_taken = 0
         @created_at = Time.now
         @fatal_crit = false
-        @status_timestamps = {}
         @ucs_position = nil
         @ucs_tierup = nil
         @ucs_smote = nil
         @ucs_updated = nil
-        @crtr_flags = {}
       end
 
       # Get the template for this creature
@@ -316,115 +243,6 @@ module Lich
       # Check if creature has template data
       def has_template?
         !template.nil?
-      end
-
-      # Adds a status to the creature.
-      #
-      # Normalizes to String so callers can pass symbols from message-based
-      # status parsing or strings from <crtrStatus>; both sources then land in
-      # the same `@status` entries and match {#has_status?}.
-      #
-      # @param status [String, Symbol] canonical status name.
-      # @param duration [Integer, nil] optional expiration duration in seconds.
-      # @return [void]
-      def add_status(status, duration = nil)
-        status = status.to_s
-        return if @status.include?(status)
-
-        @status << status
-
-        # Set expiration timestamp for timed statuses
-        duration ||= STATUS_DURATIONS[status.downcase]
-        if duration
-          @status_timestamps[status] = Time.now + duration
-          debug_log("+status: #{status} (expires in #{duration}s)")
-        else
-          debug_log("+status: #{status} (no auto-expiry)")
-        end
-      end
-
-      # Removes a status from the creature.
-      #
-      # @param status [String, Symbol] canonical status name.
-      # @return [void]
-      def remove_status(status)
-        status = status.to_s
-        @status.delete(status)
-        @status_timestamps.delete(status)
-        debug_log("-status: #{status}")
-      end
-
-      # Clean up expired status effects
-      def cleanup_expired_statuses
-        return unless @status_timestamps && !@status_timestamps.empty?
-
-        now = Time.now
-        @status_timestamps.select { |_status, expires_at| expires_at <= now }.keys.each do |expired_status|
-          @status.delete(expired_status)
-          @status_timestamps.delete(expired_status)
-          debug_log("~status: #{expired_status} (auto-expired)")
-        end
-      end
-
-      # Check if creature has a specific status
-      def has_status?(status)
-        cleanup_expired_statuses # Clean up expired statuses first
-        @status.include?(status.to_s)
-      end
-
-      # Get all current statuses
-      def statuses
-        cleanup_expired_statuses # Clean up expired statuses first
-        @status.dup
-      end
-
-      # Reconciles status and classification from a <crtrStatus> tag.
-      #
-      # The tag is a full snapshot of what is currently active, not a delta. A
-      # missing flag, or a flag set to "0", means inactive even if it was active
-      # a moment ago, so absent known flags clear rather than being ignored.
-      #
-      # @param attrs [Hash{String=>String}] XML attributes excluding `exist`.
-      # @return [void]
-      def sync_crtr_status(attrs)
-        CRTR_STATUS_FLAGS.each do |xml_name, status|
-          if attrs[xml_name] == '1'
-            add_status(status)
-          elsif @status.include?(status)
-            remove_status(status)
-          end
-        end
-
-        CRTR_CLASSIFICATION_FLAGS.each do |xml_name, key|
-          new_value = (attrs[xml_name] == '1')
-          debug_log("~flag: #{key}=#{new_value}") if debug_level == :changes && @crtr_flags[key] != new_value
-          @crtr_flags[key] = new_value
-        end
-
-        report_crtr_snapshot(attrs) if %i[all active].include?(debug_level)
-      end
-
-      # Checks a classification flag captured from <crtrStatus>.
-      #
-      # Unlike template tri-state facts such as {CreatureTemplate#has_blood?},
-      # live XML flags are always-sent booleans. Unknown or unseen flags are
-      # therefore false, not nil.
-      #
-      # @param key [String, Symbol] classification key, such as `:hostile` or `:dead`.
-      # @return [Boolean]
-      def crtr_flag?(key)
-        @crtr_flags[key.to_sym] || false
-      end
-
-      # Checks whether a status or classification flag is active.
-      #
-      # The two vocabularies are intentionally disjoint, so callers can filter
-      # on any known flag name without caring which bucket stores it.
-      #
-      # @param key [String, Symbol] status or classification key.
-      # @return [Boolean]
-      def flag_active?(key)
-        has_status?(key) || crtr_flag?(key)
       end
 
       # UCS (Unarmed Combat System) tracking methods
@@ -634,165 +452,13 @@ module Lich
           ucs_smote: smote?
         }
       end
-
-      private
-
-      # Normalizes the configured creature debug level.
-      #
-      # @return [Symbol, false, nil] debug level; true is normalized to `:changes`.
-      def debug_level
-        $creature_debug == true ? :changes : $creature_debug
-      end
-
-      # Builds the prefix used for creature debug messages.
-      #
-      # @return [String]
-      def debug_header
-        "--- #{@name} (#{@id}):"
-      end
-
-      # Emits a creature debug message when creature debugging is enabled.
-      #
-      # @param message [String] message body.
-      # @return [void]
-      def debug_log(message)
-        respond "#{debug_header} #{message}" if $creature_debug
-      end
-
-      # Emits a debug snapshot for a <crtrStatus> tag.
-      #
-      # `:all` reports every known flag; `:active` reports only true flags. The
-      # snapshot reads straight from the tag attributes so it reflects exactly
-      # what the feed sent, independent of how the mutation logic applies it.
-      #
-      # @param attrs [Hash{String=>String}] XML attributes excluding `exist`.
-      # @return [void]
-      def report_crtr_snapshot(attrs)
-        flags = ALL_CRTR_FLAGS.map { |xml_name, key| [key, attrs[xml_name] == '1'] }
-        flags = flags.select { |_, active| active } if debug_level == :active
-        debug_log("crtrStatus: #{flags.map { |key, active| "#{key}=#{active}" }.join(', ')}")
-      end
-
-      # Class methods for registry management
-      class << self
-        # Configure registry
-        def configure(max_size: 1000, auto_register: true)
-          @@max_size = max_size
-          @@auto_register = auto_register
-        end
-
-        # Check if auto-registration is enabled
-        def auto_register?
-          @@auto_register
-        end
-
-        # Get current registry size
-        def size
-          @@instances.size
-        end
-
-        # Check if registry is full
-        def full?
-          size >= @@max_size
-        end
-
-        # Registers or looks up a creature instance.
-        #
-        # Also marks the id as present in the room. The parser calls this every
-        # time a bolded room-object name is seen, which is the feed event that
-        # means the creature is present whether or not the instance is new.
-        #
-        # @param name [String] display name from room XML.
-        # @param id [Integer, String] server creature id.
-        # @param noun [String, nil] noun from room XML.
-        # @return [CreatureInstance, nil] registered instance, or nil when disabled/full.
-        def register(name, id, noun = nil)
-          return nil unless auto_register?
-
-          entered_room = mark_in_room(id)
-
-          existing = @@instances[id.to_i]
-          if existing
-            respond "--- #{name} (#{id}): in room" if entered_room && $creature_debug
-            return existing
-          end
-
-          # Auto-cleanup old instances if registry is full - get progressively more aggressive
-          if full?
-            # Try 120 minutes, then 15 minute intervals.
-            [7200, 6300, 5400, 4500, 3600, 2700, 1800, 900].each do |age_threshold|
-              removed = cleanup_old(age_threshold)
-              respond "--- Auto-cleanup: removed #{removed} old creatures (threshold: #{age_threshold}s)" if removed > 0 && $creature_debug
-              break unless full?
-            end
-            return nil if full? # Still full after all cleanup attempts
-          end
-
-          instance = new(id, noun, name)
-          @@instances[id.to_i] = instance
-          respond "--- #{name} (#{id}): registered" if $creature_debug
-          instance
-        end
-
-        # Marks an id present in the current room roster.
-        #
-        # @param id [Integer, String] server creature id.
-        # @return [Boolean] true when the id was newly added.
-        def mark_in_room(id)
-          id = id.to_i
-          return false if @@current_room_ids.include?(id)
-
-          @@current_room_ids << id
-          true
-        end
-
-        # Empties the current room roster.
-        #
-        # Called from XML parser nav and room-object refresh hooks. The roster
-        # is rebuilt from fresh room XML, mirroring `GameObj.npcs` accuracy
-        # without reading from or mutating GameObj itself.
-        #
-        # @return [void]
-        def clear_room
-          count = @@current_room_ids.size
-          @@current_room_ids = []
-          respond "--- room: roster cleared (#{count} creature#{'s' unless count == 1})" if $creature_debug && count > 0
-        end
-
-        # Returns the creature ids currently present in the room.
-        #
-        # @return [Array<Integer>]
-        def current_room_ids
-          @@current_room_ids.dup
-        end
-
-        # Lookup creature by ID
-        def [](id)
-          @@instances[id.to_i]
-        end
-
-        # Get all registered instances
-        def all
-          @@instances.values
-        end
-
-        # Clear all instances (session reset)
-        def clear
-          @@instances.clear
-          clear_room
-        end
-
-        # Remove old instances (cleanup)
-        def cleanup_old(max_age_seconds = 600)
-          cutoff = Time.now - max_age_seconds
-          removed = @@instances.select { |_id, instance| instance.created_at < cutoff }.size
-          @@instances.reject! { |_id, instance| instance.created_at < cutoff }
-          removed
-        end
-      end
     end
 
     # Public Creature API for GemStone runtime creature tracking.
+    #
+    # Delegates registry/roster operations to {CreatureInstance} and inherits
+    # the shared `targets`/`in_room` query methods from
+    # {Lich::Common::Creature::Targeting}.
     module Creature
       # Toggles live echo of status, flag, and registration changes.
       #
@@ -811,51 +477,19 @@ module Lich
 
       # Returns attackable hostile creatures currently in the room.
       #
-      # This deliberately uses Creature's own room roster instead of
-      # `GameObj.targets` or `XMLData.current_target_ids`. The target id list is
-      # the client's last-selected-target control, not authoritative room
-      # membership, so it can remain stale after movement or death. The roster
-      # is fed directly by XML room-object events, `valid_target?` removes
-      # decoys/dead appendages, and `crtr_flag?(:hostile)` supplies structured
-      # hostility.
-      #
       # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
       # @return [Array<CreatureInstance>]
       def self.targets(*filters)
-        candidates = CreatureInstance.current_room_ids
-                                     .filter_map { |id| CreatureInstance[id] }
-                                     .select { |c| c.valid_target? && c.crtr_flag?(:hostile) }
-        apply_filters(candidates, filters)
+        CreatureInstance.targets(*filters)
       end
 
       # Returns all tracked creatures currently in the room.
       #
-      # Unlike {.targets}, this does not require hostility or target validity,
-      # so it can be used for dead creatures, looting, or wound inspection.
-      # Filters are ANDed and may name a known status, a classification flag, or
-      # a `not_` negation such as `:not_prone`; unknown filters match nothing.
-      #
       # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
       # @return [Array<CreatureInstance>]
       def self.in_room(*filters)
-        candidates = CreatureInstance.current_room_ids.filter_map { |id| CreatureInstance[id] }
-        apply_filters(candidates, filters)
+        CreatureInstance.in_room(*filters)
       end
-
-      # Applies Creature status/classification filters to a candidate list.
-      #
-      # @param candidates [Array<CreatureInstance>] initial creature list.
-      # @param filters [Array<String, Symbol>] filter names, optionally prefixed with `not_`.
-      # @return [Array<CreatureInstance>]
-      def self.apply_filters(candidates, filters)
-        filters.each do |filter|
-          negate = filter.to_s.start_with?('not_')
-          key = negate ? filter.to_s.delete_prefix('not_') : filter.to_s
-          candidates = candidates.select { |c| c.flag_active?(key) != negate }
-        end
-        candidates
-      end
-      private_class_method :apply_filters
 
       # Empties the current room roster.
       #
@@ -879,7 +513,7 @@ module Lich
         {
           instances: CreatureInstance.size,
           templates: CreatureTemplate.all.size,
-          max_size: CreatureInstance.class_variable_get(:@@max_size),
+          max_size: CreatureInstance.max_size,
           auto_register: CreatureInstance.auto_register?
         }
       end

--- a/spec/lib/common/creature/creature_base_spec.rb
+++ b/spec/lib/common/creature/creature_base_spec.rb
@@ -91,8 +91,10 @@ RSpec.describe Lich::Common::CreatureBase do
       creature.add_status('web', 5) # 5-second lifetime
       expect(creature.has_status?('web')).to be true
 
-      # Fast-forward past the expiry rather than sleeping.
-      allow(Time).to receive(:now).and_return(Time.now + 6)
+      # Fast-forward past the expiry rather than sleeping. Compute the target
+      # time before stubbing so it never reads back through the stub.
+      later = Time.now + 6
+      allow(Time).to receive(:now).and_return(later)
       expect(creature.has_status?('web')).to be false
     end
 
@@ -151,7 +153,7 @@ RSpec.describe Lich::Common::CreatureBase do
   end
 
   describe '#flag_active?' do
-    it 'matches a status, a classification flag, or a not_ negation' do
+    it 'matches either a status or a classification flag' do
       creature = SampleCreature.register('kobold', 1)
       creature.sync_crtr_status('hostile' => '1', 'prone' => '1')
 

--- a/spec/lib/common/creature/creature_base_spec.rb
+++ b/spec/lib/common/creature/creature_base_spec.rb
@@ -38,9 +38,40 @@ class SampleCreature
   def self.respond(*); end
 end
 
+# A second, unrelated host class. Proves each including class gets its own
+# registry, roster and configuration: GemStone and DragonRealms must never share
+# creature state even though they share this code. Kept at file scope for the
+# same reason SampleCreature is - a normal constant, not a constant-in-a-block.
+class OtherSampleCreature
+  include Lich::Common::CreatureBase
+
+  attr_reader :id, :noun, :name, :created_at
+
+  def initialize(id, noun, name)
+    @id = id.to_i
+    @noun = noun
+    @name = name
+    @created_at = Time.now
+    initialize_status_tracking
+  end
+
+  def valid_target?
+    !crtr_flag?(:dead)
+  end
+
+  def respond(*); end
+  def self.respond(*); end
+end
+
 RSpec.describe Lich::Common::CreatureBase do
   before do
     SampleCreature.clear
+    OtherSampleCreature.clear
+    # Reset configuration to defaults. #configure mutates per-class instance vars
+    # that would otherwise leak across examples under random ordering; calling it
+    # with no arguments restores the documented defaults.
+    SampleCreature.configure
+    OtherSampleCreature.configure
     $creature_debug = nil
   end
 
@@ -250,6 +281,202 @@ RSpec.describe Lich::Common::CreatureBase do
 
       expect(SampleCreature.targets).to eq([])
       expect(SampleCreature.in_room).to eq([])
+    end
+  end
+
+  describe 'unknown filters (F3)' do
+    before do
+      hostile = SampleCreature.register('kobold', 1)
+      hostile.sync_crtr_status('hostile' => '1', 'prone' => '1')
+    end
+
+    it 'treats a positive unknown filter as matching nothing' do
+      expect(SampleCreature.in_room(:bogus)).to eq([])
+      expect(SampleCreature.targets(:bogus)).to eq([])
+    end
+
+    it 'treats a negated unknown filter as matching nothing, not everything' do
+      # Regression: `:not_prnoe` (a typo of :not_prone) used to invert
+      # "unknown matches nothing" into "matches everything", silently widening
+      # the query to every candidate in the room.
+      expect(SampleCreature.in_room(:not_prnoe)).to eq([])
+      expect(SampleCreature.targets(:not_prnoe)).to eq([])
+    end
+
+    it 'lets an unknown filter anywhere in an AND chain collapse the whole result' do
+      # :prone alone would match the kobold; because filters are ANDed, the
+      # unknown filter must still zero the result regardless of position.
+      expect(SampleCreature.in_room(:prone, :not_bogus)).to eq([])
+      expect(SampleCreature.in_room(:not_bogus, :prone)).to eq([])
+    end
+
+    it 'still returns empty for a known filter that no candidate has' do
+      # A known-but-absent filter and an unknown filter both yield empty; only
+      # the reason differs. This pins the known path so the F3 fix cannot
+      # accidentally start rejecting legitimate filters.
+      expect(SampleCreature.in_room(:webbed)).to eq([])
+    end
+
+    it 'still honours a known negation alongside real matches' do
+      standing = SampleCreature.register('goblin', 2)
+      standing.sync_crtr_status('hostile' => '1')
+
+      expect(SampleCreature.in_room(:not_prone).map(&:id)).to eq([2])
+    end
+  end
+
+  describe 'defensive copy of the room roster (F1)' do
+    it 'hands back a copy so external mutation cannot corrupt the live roster' do
+      SampleCreature.register('kobold', 1)
+
+      snapshot = SampleCreature.current_room_ids
+      snapshot << 999
+      snapshot.clear
+
+      expect(SampleCreature.current_room_ids).to eq([1])
+    end
+
+    it 'returns a fresh array on each call' do
+      SampleCreature.register('kobold', 1)
+
+      expect(SampleCreature.current_room_ids).not_to equal(SampleCreature.current_room_ids)
+    end
+
+    it 'keeps target/in_room queries intact after a returned copy is mutated' do
+      hostile = SampleCreature.register('kobold', 1)
+      hostile.sync_crtr_status('hostile' => '1')
+
+      SampleCreature.current_room_ids.clear # must not touch the live roster
+
+      expect(SampleCreature.targets.map(&:id)).to eq([1])
+      expect(SampleCreature.in_room.map(&:id)).to eq([1])
+    end
+  end
+
+  describe 'auto-registration toggle (F2)' do
+    it 'creates no instance when auto-registration is disabled' do
+      SampleCreature.configure(auto_register: false)
+
+      expect(SampleCreature.register('kobold', 1)).to be_nil
+      expect(SampleCreature[1]).to be_nil
+      expect(SampleCreature.size).to eq(0)
+    end
+
+    it 'still records room presence with auto-registration off' do
+      SampleCreature.configure(auto_register: false)
+
+      SampleCreature.register('kobold', 42)
+
+      expect(SampleCreature.current_room_ids).to eq([42])
+    end
+
+    it 're-marks an already-known creature into the room while auto-registration is off' do
+      known = SampleCreature.register('kobold', 42) # registered while enabled (default)
+      SampleCreature.clear_room                     # e.g. a nav / room-objs refresh
+      SampleCreature.configure(auto_register: false)
+
+      SampleCreature.register('kobold', 42)         # reappears; no new instance created
+
+      expect(SampleCreature.current_room_ids).to eq([42])
+      expect(SampleCreature[42]).to equal(known)    # same instance, not duplicated
+      expect(SampleCreature.size).to eq(1)
+    end
+  end
+
+  describe 'capacity and configuration boundaries' do
+    it 'exposes lazy defaults on a freshly-including class before any configure' do
+      klass = Class.new { include Lich::Common::CreatureBase }
+
+      expect(klass.max_size).to eq(1000)
+      expect(klass.auto_register?).to be true
+      expect(klass.size).to eq(0)
+      expect(klass.full?).to be false
+      expect(klass.current_room_ids).to eq([])
+    end
+
+    it 'reports full? exactly at the configured capacity' do
+      SampleCreature.configure(max_size: 2)
+      expect(SampleCreature.full?).to be false
+
+      SampleCreature.register('a', 1)
+      expect(SampleCreature.full?).to be false
+
+      SampleCreature.register('b', 2)
+      expect(SampleCreature.full?).to be true
+    end
+
+    it 'refuses a newcomer when full and nothing is old enough to evict' do
+      SampleCreature.configure(max_size: 2)
+      SampleCreature.register('a', 1)
+      SampleCreature.register('b', 2)
+
+      overflow = SampleCreature.register('c', 3)
+
+      expect(overflow).to be_nil
+      expect(SampleCreature.size).to eq(2)
+      expect(SampleCreature[3]).to be_nil
+    end
+
+    it 'evicts an aged creature to make room, then registers the newcomer' do
+      SampleCreature.configure(max_size: 2)
+      old = SampleCreature.register('old', 1)
+      old.instance_variable_set(:@created_at, Time.now - 10_800) # 3 hours old
+      SampleCreature.register('fresh', 2)
+      expect(SampleCreature.full?).to be true
+
+      newcomer = SampleCreature.register('new', 3)
+
+      expect(newcomer).not_to be_nil
+      expect(SampleCreature[1]).to be_nil # aged one evicted
+      expect(SampleCreature[3]).to equal(newcomer)
+      expect(SampleCreature.size).to eq(2)
+    end
+
+    it 'defaults cleanup_old to a 600s cutoff when called with no argument' do
+      old = SampleCreature.register('old', 1)
+      old.instance_variable_set(:@created_at, Time.now - 601)
+      SampleCreature.register('fresh', 2)
+
+      expect(SampleCreature.cleanup_old).to eq(1)
+      expect(SampleCreature[1]).to be_nil
+      expect(SampleCreature[2]).not_to be_nil
+    end
+  end
+
+  describe 'per-class isolation across including classes' do
+    it 'keeps registries independent' do
+      SampleCreature.register('kobold', 1)
+      OtherSampleCreature.register('spider', 1)
+      OtherSampleCreature.register('spider', 2)
+
+      expect(SampleCreature.all.map(&:id)).to eq([1])
+      expect(OtherSampleCreature.all.map(&:id)).to contain_exactly(1, 2)
+      expect(SampleCreature[2]).to be_nil
+    end
+
+    it 'keeps room rosters independent' do
+      SampleCreature.register('kobold', 1)
+      OtherSampleCreature.register('spider', 9)
+
+      expect(SampleCreature.current_room_ids).to eq([1])
+      expect(OtherSampleCreature.current_room_ids).to eq([9])
+    end
+
+    it 'keeps configuration independent' do
+      SampleCreature.configure(max_size: 5, auto_register: false)
+
+      expect(OtherSampleCreature.max_size).to eq(1000)
+      expect(OtherSampleCreature.auto_register?).to be true
+    end
+
+    it 'clearing one class leaves the other untouched' do
+      SampleCreature.register('kobold', 1)
+      OtherSampleCreature.register('spider', 1)
+
+      SampleCreature.clear
+
+      expect(SampleCreature.all).to be_empty
+      expect(OtherSampleCreature.all.map(&:id)).to eq([1])
     end
   end
 end

--- a/spec/lib/common/creature/creature_base_spec.rb
+++ b/spec/lib/common/creature/creature_base_spec.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require 'common/creature/creature_base'
+
+# Exercises the game-agnostic Lich::Common::CreatureBase mixin directly, through
+# a minimal host class that stands in for a real game's CreatureInstance. The
+# host supplies only what the base documents as required: a
+# `new(id, noun, name)` constructor, a `created_at` reader, and a
+# `valid_target?` predicate. Everything else under test comes from the mixin.
+#
+# GemStone- and DragonRealms-specific behaviour is covered by their own specs;
+# these examples pin down only the shared contract.
+
+# A deliberately tiny stand-in creature. `valid_target?` mirrors the simplest
+# real rule (alive), so the shared target queries have something to call. Kept
+# at file scope so it is a normal constant, not a constant-in-a-block.
+class SampleCreature
+  include Lich::Common::CreatureBase
+
+  attr_reader :id, :noun, :name, :created_at
+
+  def initialize(id, noun, name)
+    @id = id.to_i
+    @noun = noun
+    @name = name
+    @created_at = Time.now
+    initialize_status_tracking
+  end
+
+  # Alive == attackable, for the purposes of the shared #targets query.
+  def valid_target?
+    !crtr_flag?(:dead)
+  end
+
+  # No-op debug sink so debug-guarded code paths never raise in isolation.
+  def respond(*); end
+  def self.respond(*); end
+end
+
+RSpec.describe Lich::Common::CreatureBase do
+  before do
+    SampleCreature.clear
+    $creature_debug = nil
+  end
+
+  describe 'instance status tracking' do
+    it 'stores symbol and string statuses as the same canonical entry' do
+      creature = SampleCreature.register('kobold', 1)
+
+      creature.add_status(:stunned)
+
+      expect(creature.has_status?('stunned')).to be true
+      expect(creature.has_status?(:stunned)).to be true
+    end
+
+    it 'auto-expires a timed status once its duration has elapsed' do
+      creature = SampleCreature.register('kobold', 1)
+
+      creature.add_status('web', 5) # 5-second lifetime
+      expect(creature.has_status?('web')).to be true
+
+      # Fast-forward past the expiry rather than sleeping.
+      allow(Time).to receive(:now).and_return(Time.now + 6)
+      expect(creature.has_status?('web')).to be false
+    end
+
+    it 'keeps a status with no configured duration until it is removed explicitly' do
+      creature = SampleCreature.register('kobold', 1)
+
+      creature.add_status('stunned') # nil duration in STATUS_DURATIONS
+      expect(creature.has_status?('stunned')).to be true
+
+      creature.remove_status('stunned')
+      expect(creature.has_status?('stunned')).to be false
+    end
+  end
+
+  describe '#sync_crtr_status' do
+    it 'maps XML flag spellings onto the canonical status vocabulary' do
+      creature = SampleCreature.register('kobold', 1)
+
+      creature.sync_crtr_status('immobile' => '1', 'calmed' => '1')
+
+      expect(creature.has_status?('immobilized')).to be true
+      expect(creature.has_status?('calm')).to be true
+    end
+
+    it 'reads classification flags, including mixed-case XML names, as booleans' do
+      creature = SampleCreature.register('kobold', 1)
+
+      creature.sync_crtr_status('hostile' => '1', 'AscensionBoss' => '1', 'MiniBoss' => '0')
+
+      expect(creature.crtr_flag?(:hostile)).to be true
+      expect(creature.crtr_flag?(:ascension_boss)).to be true
+      expect(creature.crtr_flag?(:mini_boss)).to be false
+      expect(creature.crtr_flag?(:never_sent)).to be false
+    end
+
+    it 'treats each tag as a full snapshot: a flag absent from a later tag clears' do
+      creature = SampleCreature.register('kobold', 1)
+      creature.sync_crtr_status('hostile' => '1', 'stunned' => '1')
+      expect(creature.has_status?('stunned')).to be true
+
+      creature.sync_crtr_status('hostile' => '1', 'dead' => '1')
+
+      expect(creature.has_status?('stunned')).to be false
+      expect(creature.crtr_flag?(:dead)).to be true
+      expect(creature.crtr_flag?(:hostile)).to be true
+    end
+
+    it 'leaves statuses outside its own vocabulary untouched' do
+      creature = SampleCreature.register('kobold', 1)
+      creature.add_status('bind') # not a crtrStatus-managed status
+
+      creature.sync_crtr_status('hostile' => '1')
+
+      expect(creature.has_status?('bind')).to be true
+    end
+  end
+
+  describe '#flag_active?' do
+    it 'matches a status, a classification flag, or a not_ negation' do
+      creature = SampleCreature.register('kobold', 1)
+      creature.sync_crtr_status('hostile' => '1', 'prone' => '1')
+
+      expect(creature.flag_active?(:prone)).to be true
+      expect(creature.flag_active?('hostile')).to be true
+      expect(creature.flag_active?(:dead)).to be false
+    end
+  end
+
+  describe 'the id-keyed registry' do
+    it 'registers a creature under its integer id and looks it back up' do
+      registered = SampleCreature.register('kobold', 42, 'kobold')
+
+      expect(SampleCreature[42]).to equal(registered)
+      expect(registered.name).to eq('kobold')
+      expect(registered.noun).to eq('kobold')
+    end
+
+    it 'accepts a nil name so an id-first feed can backfill the name later' do
+      registered = SampleCreature.register(nil, 42)
+      expect(registered.name).to be_nil
+
+      # A later feed learns the name for the same id.
+      registered.instance_variable_set(:@name, 'jeol moradu')
+      expect(SampleCreature[42].name).to eq('jeol moradu')
+    end
+
+    it 'returns the existing instance instead of duplicating a known id' do
+      first = SampleCreature.register('kobold', 42)
+      second = SampleCreature.register('kobold', 42)
+
+      expect(second).to equal(first)
+      expect(SampleCreature.all.size).to eq(1)
+    end
+
+    it 'clears every instance and the room roster on #clear' do
+      SampleCreature.register('kobold', 42)
+
+      SampleCreature.clear
+
+      expect(SampleCreature.all).to be_empty
+      expect(SampleCreature.current_room_ids).to be_empty
+    end
+
+    it 'removes only instances older than the cleanup cutoff' do
+      old = SampleCreature.register('old kobold', 1)
+      old.instance_variable_set(:@created_at, Time.now - 3600)
+      SampleCreature.register('fresh kobold', 2)
+
+      removed = SampleCreature.cleanup_old(600)
+
+      expect(removed).to eq(1)
+      expect(SampleCreature[1]).to be_nil
+      expect(SampleCreature[2]).not_to be_nil
+    end
+  end
+
+  describe 'the current-room roster' do
+    it 'marks a creature into the room on registration' do
+      SampleCreature.register('kobold', 42)
+      expect(SampleCreature.current_room_ids).to eq([42])
+    end
+
+    it 'clears the roster without evicting the persistent registry' do
+      SampleCreature.register('kobold', 42)
+
+      SampleCreature.clear_room
+
+      expect(SampleCreature.current_room_ids).to be_empty
+      expect(SampleCreature[42]).not_to be_nil
+    end
+
+    it 're-marks a known creature into the roster when it reappears after a clear' do
+      SampleCreature.register('kobold', 42)
+      SampleCreature.clear_room
+
+      SampleCreature.register('kobold', 42)
+
+      expect(SampleCreature.current_room_ids).to eq([42])
+    end
+  end
+
+  describe '.targets and .in_room' do
+    it 'targets only hostile, valid creatures present in the room' do
+      hostile = SampleCreature.register('kobold', 1)
+      hostile.sync_crtr_status('hostile' => '1')
+      SampleCreature.register('rabbit', 2).sync_crtr_status('hostile' => '0')
+
+      expect(SampleCreature.targets.map(&:id)).to eq([1])
+    end
+
+    it 'excludes dead creatures from targets even when they are hostile' do
+      dead = SampleCreature.register('kobold', 1)
+      dead.sync_crtr_status('hostile' => '1', 'dead' => '1')
+
+      expect(SampleCreature.targets).to eq([])
+    end
+
+    it 'AND-filters targets on a named flag, honouring not_ negation' do
+      prone = SampleCreature.register('kobold', 1)
+      prone.sync_crtr_status('hostile' => '1', 'prone' => '1')
+      standing = SampleCreature.register('goblin', 2)
+      standing.sync_crtr_status('hostile' => '1')
+
+      expect(SampleCreature.targets(:prone).map(&:id)).to eq([1])
+      expect(SampleCreature.targets(:not_prone).map(&:id)).to eq([2])
+    end
+
+    it 'in_room returns everyone in the roster, including non-hostile and dead' do
+      SampleCreature.register('kobold', 1).sync_crtr_status('hostile' => '1')
+      SampleCreature.register('rabbit', 2).sync_crtr_status('hostile' => '0')
+      SampleCreature.register('corpse', 3).sync_crtr_status('hostile' => '1', 'dead' => '1')
+
+      expect(SampleCreature.in_room.map(&:id)).to contain_exactly(1, 2, 3)
+    end
+
+    it 'in_room can find dead creatures that targets deliberately hides' do
+      SampleCreature.register('corpse', 1).sync_crtr_status('hostile' => '1', 'dead' => '1')
+
+      expect(SampleCreature.in_room(:dead).map(&:id)).to eq([1])
+    end
+
+    it 'sources room membership from the roster, not the registry alone' do
+      registered = SampleCreature.register('kobold', 1)
+      registered.sync_crtr_status('hostile' => '1')
+      SampleCreature.clear_room # still registered, but no longer present
+
+      expect(SampleCreature.targets).to eq([])
+      expect(SampleCreature.in_room).to eq([])
+    end
+  end
+end

--- a/spec/lib/gemstone/creature_spec.rb
+++ b/spec/lib/gemstone/creature_spec.rb
@@ -467,10 +467,12 @@ RSpec.describe Lich::Gemstone::Creature do
       # room changes and a zone change. Anything sourced from it alone (not
       # also in the room roster) must not leak into an "authoritative"
       # in-room list.
-      stale = Lich::Gemstone::CreatureInstance.new(9, 'thing', 'departed thing')
+      stale = Lich::Gemstone::CreatureInstance.register('departed thing', 9)
       stale.sync_crtr_status('hostile' => '1')
-      Lich::Gemstone::CreatureInstance.class_variable_get(:@@instances)[9] = stale
-      XMLData.current_target_ids = ['9'] # registered, hostile, but never marked into the room roster
+      # Registered and hostile, but no longer in the room roster (e.g. it left
+      # or died and the room refreshed) - only the sticky dropdown still names it.
+      Lich::Gemstone::CreatureInstance.clear_room
+      XMLData.current_target_ids = ['9']
 
       expect(described_class.targets.map(&:id)).to eq([])
     end
@@ -516,8 +518,8 @@ RSpec.describe Lich::Gemstone::Creature do
     end
 
     it 'also ignores current_target_ids, same as .targets' do
-      stale = Lich::Gemstone::CreatureInstance.new(9, 'thing', 'departed thing')
-      Lich::Gemstone::CreatureInstance.class_variable_get(:@@instances)[9] = stale
+      Lich::Gemstone::CreatureInstance.register('departed thing', 9)
+      Lich::Gemstone::CreatureInstance.clear_room # registered, but not in the room roster
       XMLData.current_target_ids = ['9']
 
       expect(described_class.in_room.map(&:id)).to eq([])

--- a/spec/lib/gemstone/creature_spec.rb
+++ b/spec/lib/gemstone/creature_spec.rb
@@ -526,3 +526,115 @@ RSpec.describe Lich::Gemstone::Creature do
     end
   end
 end
+
+RSpec.describe Lich::Gemstone::CreatureInstance, 'roster defensive copy (F1)' do
+  before { described_class.clear }
+
+  it 'returns a copy of current_room_ids so callers cannot corrupt the live roster' do
+    hostile = described_class.register('sea nymph', 1)
+    hostile.sync_crtr_status('hostile' => '1')
+
+    described_class.current_room_ids << 999 # a stray external append
+    described_class.current_room_ids.clear  # and an external clear
+
+    expect(described_class.current_room_ids).to eq([1])
+    expect(Lich::Gemstone::Creature.targets.map(&:id)).to eq([1])
+  end
+
+  it 'returns a fresh array on each call' do
+    described_class.register('sea nymph', 1)
+
+    expect(described_class.current_room_ids).not_to equal(described_class.current_room_ids)
+  end
+end
+
+RSpec.describe Lich::Gemstone::Creature, 'facade delegation and cleanup_old (F4)' do
+  let(:instance_class) { Lich::Gemstone::CreatureInstance }
+
+  before do
+    instance_class.clear
+    instance_class.configure # reset to documented defaults
+  end
+
+  # #configure mutates per-class state on CreatureInstance; restore defaults so a
+  # disabled-auto_register or shrunken max_size never leaks into another example.
+  after { instance_class.configure }
+
+  describe '.cleanup_old' do
+    it 'accepts a positional age - the exact form Combat::Tracker#cleanup_creatures passes' do
+      old = described_class.register('old thing', 1)
+      old.created_at = Time.now - 10_800 # 3 hours old
+      described_class.register('fresh thing', 2)
+
+      # Mirrors tracker.rb: `removed = Creature.cleanup_old(max_age)`. Before the
+      # F4 fix the keyword-only facade raised ArgumentError here, which the
+      # tracker's rescue swallowed - so registry cleanup silently never ran.
+      removed = nil
+      expect { removed = described_class.cleanup_old(600) }.not_to raise_error
+
+      expect(removed).to eq(1)
+      expect(described_class[1]).to be_nil
+      expect(described_class[2]).not_to be_nil
+    end
+
+    it 'defaults to a 600s cutoff when called with no argument' do
+      old = described_class.register('old thing', 1)
+      old.created_at = Time.now - 601
+      described_class.register('fresh thing', 2)
+
+      expect(described_class.cleanup_old).to eq(1)
+    end
+
+    it 'removes nothing when everything is newer than the cutoff' do
+      described_class.register('fresh thing', 1)
+
+      expect(described_class.cleanup_old(600)).to eq(0)
+      expect(described_class[1]).not_to be_nil
+    end
+  end
+
+  describe 'delegation to CreatureInstance' do
+    it 'registers through the facade into the shared registry' do
+      registered = described_class.register('sea nymph', 42, 'nymph')
+
+      expect(instance_class[42]).to equal(registered)
+      expect(described_class[42]).to equal(registered)
+    end
+
+    it 'clears every instance and the roster via .clear' do
+      described_class.register('sea nymph', 1)
+
+      described_class.clear
+
+      expect(instance_class.all).to be_empty
+      expect(described_class.in_room).to be_empty
+    end
+
+    it 'clears only the roster via .clear_room, keeping the registry' do
+      described_class.register('sea nymph', 1)
+
+      described_class.clear_room
+
+      expect(instance_class[1]).not_to be_nil
+      expect(described_class.in_room).to be_empty
+    end
+
+    it 'forwards configure(**options) to the shared registry' do
+      described_class.configure(max_size: 3, auto_register: false)
+
+      expect(instance_class.max_size).to eq(3)
+      expect(instance_class.auto_register?).to be false
+    end
+
+    it 'reports registry stats sourced from the shared registry' do
+      described_class.register('sea nymph', 1)
+
+      stats = described_class.stats
+
+      expect(stats[:instances]).to eq(1)
+      expect(stats[:max_size]).to eq(1000)
+      expect(stats[:auto_register]).to be true
+      expect(stats).to have_key(:templates)
+    end
+  end
+end


### PR DESCRIPTION
## What

Extracts the game-agnostic core of the GemStone creature model out of `lib/gemstone/creature.rb` into a new shared `lib/common/creature/creature_base.rb`, following the `common/map/map_base.rb` convention: a `Lich::Common::CreatureBase` mixin whose `self.included` hook wires `ClassMethods` (id-keyed registry, current-room roster, target/room queries) and `InstanceMethods` (`<crtrStatus>` status/classification flag tracking) into the host class.

## Why

DragonRealms now emits the same `<crtrStatus exist=... hostile=1 .../>` feed GemStone gets, with an identical flag vocabulary. The registry, roster, `sync_crtr_status` reconciliation and target filtering are all game-neutral and belong in `lib/common`. This PR is the safe, behavior-preserving first step; a follow-up will add the DragonRealms `Creature` layer on top of this base.

## Scope / safety

- **Behavior-preserving.** No public API changes, no new runtime behavior.
- `Lich::Gemstone::CreatureInstance` / `Creature` keep their exact signatures (`register(name, id, noun)`, `new(id, noun, name)`), so the combat tracker/processor and every other consumer are untouched. GemStone-only concerns (bestiary templates, UCS tracking, HP/injury modelling, GemStone `valid_target?` exclusions) stay in `lib/gemstone/creature.rb`, which now just `include`s the base.
- Each extending class gets an independent registry (per-class instance-var storage), so GemStone and DragonRealms never share a roster.

## Tests

- New DAMP spec `spec/lib/common/creature/creature_base_spec.rb` exercises the shared base directly through a minimal stand-in creature class (22 examples).
- Two existing GemStone spec cases that reached into the private `@@instances` class variable now use the equivalent public API (`register` + `clear_room`), which is less brittle and matches the new per-class storage.
- Full suite green (no new failures); touched files are rubocop-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared creature tracking across game environments.
  * Added creature registry and room roster management.
  * Added status, classification, expiration, and filtering support.
  * Added configurable automatic registration, capacity limits, cleanup, and debug controls.
  * Improved target and in-room queries, including negated and unknown-filter handling.

* **Bug Fixes**
  * Improved room roster isolation and protection against unintended changes.
  * Corrected cleanup behavior and facade delegation for creature management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->