### PR TITLE
feat(dr): id-based creature tracking from crtrStatus + assess

### DIFF
--- a/lib/common/creature/creature_base.rb
+++ b/lib/common/creature/creature_base.rb
@@ -84,7 +84,8 @@ module Lich
         'blind'       => nil,
         'sunburst'    => nil,
         'webbed'      => nil,
-        'poisoned'    => nil
+        'poisoned'    => nil,
+        'hidden'      => nil
       }.freeze
 
       # Maps `<crtrStatus>` transient XML flags to canonical status names.
@@ -107,7 +108,8 @@ module Lich
         'prone'       => 'prone',
         'sitting'     => 'sitting',
         'flying'      => 'flying',
-        'hovering'    => 'hovering'
+        'hovering'    => 'hovering',
+        'hidden'      => 'hidden'
       }.freeze
 
       # Maps `<crtrStatus>` classification XML flags to predicate keys.

--- a/lib/common/gameloader.rb
+++ b/lib/common/gameloader.rb
@@ -58,6 +58,7 @@ module Lich
         require File.join(LIB_DIR, 'dragonrealms', 'dependency', 'settings_config.rb')
         require File.join(LIB_DIR, 'dragonrealms', 'drinfomon.rb')
         require File.join(LIB_DIR, 'dragonrealms', 'commons.rb')
+        require File.join(LIB_DIR, 'dragonrealms', 'creature.rb')
         DRInfomon.watch!
         self.common_after
       end

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -378,8 +378,10 @@ module Lich
             GameObj.clear_pcs
             GameObj.clear_room_desc
             # Creature tracks its own room roster independently of GameObj
-            # (see lib/gemstone/creature.rb) - not loaded for DR sessions.
+            # (see lib/gemstone/creature.rb / lib/dragonrealms/creature.rb).
+            # Only one game's Creature is ever loaded per session.
             Lich::Gemstone::Creature.clear_room if defined?(Lich::Gemstone::Creature)
+            Lich::DragonRealms::Creature.clear_room if defined?(Lich::DragonRealms::Creature)
             # Any <crtrStatus> cached for the room being left is scoped to
             # that room - don't let it survive to misapply if the id gets
             # reused elsewhere.
@@ -417,6 +419,9 @@ module Lich
             if attributes['id'] == 'room objs'
               GameObj.begin_room_objs
               Lich::Gemstone::Creature.clear_room if defined?(Lich::Gemstone::Creature)
+              # DR rebuilds the roster from the <crtrStatus> batch that follows
+              # this component; clearing here gives that batch a clean snapshot.
+              Lich::DragonRealms::Creature.clear_room if defined?(Lich::DragonRealms::Creature)
               @pending_crtr_status.clear
             elsif attributes['id'] == 'room players'
               GameObj.begin_room_players
@@ -445,8 +450,22 @@ module Lich
             # reappear in Creature.targets/.in_room. Deferring to the text()
             # handler keeps registration/room-marking and flag application on
             # the same path for both new and already-known creatures.
+            #
+            # DragonRealms differs: its room-objs carry no per-creature <a exist>
+            # tag, so there is no text() path to defer to. Its <crtrStatus> tags
+            # arrive batched after the room-objs component and carry their own
+            # id, so they are applied immediately, id-first (name-less; the name
+            # is backfilled later from the assess stream - see
+            # lib/dragonrealms/creature.rb).
             crtr_id = attributes['exist']
-            @pending_crtr_status[crtr_id] = attributes.reject { |k, _| k == 'exist' } if crtr_id
+            if crtr_id
+              crtr_flags = attributes.reject { |k, _| k == 'exist' }
+              if XMLData.game =~ /^DR/
+                Lich::DragonRealms::Creature.sync(crtr_id, crtr_flags) if defined?(Lich::DragonRealms::Creature)
+              else
+                @pending_crtr_status[crtr_id] = crtr_flags
+              end
+            end
           end
           if name == 'inv'
             if attributes['id'] == 'stow'
@@ -498,7 +517,15 @@ module Lich
           if name == 'popStream'
             if @current_stream == 'assess' && @assess_buffer
               entry = parse_assess_line(@assess_buffer, @assess_ids)
-              @assess << entry if entry
+              if entry
+                @assess << entry
+                # The assess stream is DragonRealms' only tie between an exist id
+                # and a creature name/position, so it backfills the id-first
+                # instances created from <crtrStatus>. Self and PCs are skipped.
+                if XMLData.game =~ /^DR/ && !entry[:self] && !entry[:pc] && defined?(Lich::DragonRealms::Creature)
+                  Lich::DragonRealms::Creature.feed_assess(entry)
+                end
+              end
               @assess_buffer = nil
             end
             if attributes['id'] == 'room'

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -66,12 +66,13 @@ module Lich
         @next_level_text = String.new
         @current_target_ids = Array.new
         @pending_crtr_status = Hash.new
-        # DragonRealms stream-order name backfill: bold room-objs names captured
-        # in order, then paired index-for-index with the <crtrStatus> batch that
-        # follows (see the room-objs and crtrStatus handlers). DR-only; unused by
+        # DragonRealms stream-order name backfill: bold room-objs names and the
+        # <crtrStatus> batch ids are both captured in order, then paired at the
+        # following <prompt> - but only when their counts match exactly (an
+        # all-or-nothing gate; see the prompt handler). DR-only; unused by
         # GemStone, which carries the name inline on the bold <a> tag.
         @dr_room_npc_names = []
-        @dr_crtr_index = 0
+        @dr_crtr_ids = []
 
         @room_count = 0
         @room_title = String.new
@@ -206,9 +207,9 @@ module Lich
         # exist id (ids are recycled - see Creature.targets' notes).
         @pending_crtr_status.clear
         # A reset mid-fragment invalidates the room-objs<->crtrStatus pairing, so
-        # drop any captured names and restart the batch index.
+        # drop any captured names and collected ids.
         @dr_room_npc_names = []
-        @dr_crtr_index = 0
+        @dr_crtr_ids = []
       end
 
       def safe_to_respond?
@@ -434,10 +435,10 @@ module Lich
               Lich::DragonRealms::Creature.clear_room if defined?(Lich::DragonRealms::Creature)
               @pending_crtr_status.clear
               # Start a fresh room-objs<->crtrStatus pairing for this refresh: the
-              # bold names captured below are zipped, in order, to the crtrStatus
-              # batch that follows this component.
+              # bold names captured below and the crtrStatus ids that follow are
+              # zipped at the next <prompt>, gated on equal counts.
               @dr_room_npc_names = []
-              @dr_crtr_index = 0
+              @dr_crtr_ids = []
             elsif attributes['id'] == 'room players'
               GameObj.begin_room_players
             elsif attributes['id'] == 'room exits'
@@ -468,21 +469,21 @@ module Lich
             #
             # DragonRealms differs: its room-objs carry no per-creature <a exist>
             # tag, so there is no text() path to defer to. Its <crtrStatus> tags
-            # arrive batched after the room-objs component and carry their own
-            # id, so they are applied immediately, id-first. The name is
-            # backfilled two ways: the stream-order pairing here (the Nth bold
-            # room-objs name captured above -> the Nth crtrStatus in this batch),
-            # and, authoritatively, later from the assess stream (see
+            # arrive batched after the room-objs component and carry their own id,
+            # so flags are applied immediately, id-first. The name is backfilled
+            # two ways: the stream-order pairing (bold room-objs names zipped to
+            # this batch's ids at the next <prompt>, gated on equal counts) and,
+            # authoritatively, later from the assess stream (see
             # lib/dragonrealms/creature.rb).
             crtr_id = attributes['exist']
             if crtr_id
               crtr_flags = attributes.reject { |k, _| k == 'exist' }
               if XMLData.game =~ /^DR/
-                # Bounds-checked: more crtrStatus than captured names yields nil
-                # (the count-guard), never a mis-paired earlier slot.
-                positional_name = @dr_room_npc_names[@dr_crtr_index]
-                @dr_crtr_index += 1
-                Lich::DragonRealms::Creature.sync(crtr_id, crtr_flags, positional_name) if defined?(Lich::DragonRealms::Creature)
+                # Apply flags now (id-first, name-less); collect the id in arrival
+                # order so the prompt handler can pair it to a bold name only if
+                # the counts match for this refresh.
+                Lich::DragonRealms::Creature.sync(crtr_id, crtr_flags) if defined?(Lich::DragonRealms::Creature)
+                @dr_crtr_ids << crtr_id
               else
                 @pending_crtr_status[crtr_id] = crtr_flags
               end
@@ -620,6 +621,24 @@ module Lich
               @dr_active_spells_tmp = {}
             elsif @dr_active_spells_clear
               @dr_active_spells = {}
+            end
+
+            # DragonRealms stream-order name backfill, applied as an
+            # all-or-nothing batch at the end of the room-objs + crtrStatus
+            # sequence. Only when the captured bold-name count exactly matches
+            # this batch's crtrStatus id count do we pair them by position; on any
+            # mismatch (e.g. a bold room entity that emits no crtrStatus) we skip
+            # naming rather than risk a shifted mis-pair - assess still backfills
+            # names by id. Reset after every prompt so a later lone crtrStatus
+            # batch can't reuse a previous refresh's names.
+            if XMLData.game =~ /^DR/ && defined?(Lich::DragonRealms::Creature)
+              if !@dr_crtr_ids.empty? && @dr_crtr_ids.length == @dr_room_npc_names.length
+                @dr_crtr_ids.each_with_index do |id, i|
+                  Lich::DragonRealms::Creature[id]&.apply_room_name(@dr_room_npc_names[i])
+                end
+              end
+              @dr_room_npc_names = []
+              @dr_crtr_ids = []
             end
           end
 

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -66,6 +66,12 @@ module Lich
         @next_level_text = String.new
         @current_target_ids = Array.new
         @pending_crtr_status = Hash.new
+        # DragonRealms stream-order name backfill: bold room-objs names captured
+        # in order, then paired index-for-index with the <crtrStatus> batch that
+        # follows (see the room-objs and crtrStatus handlers). DR-only; unused by
+        # GemStone, which carries the name inline on the bold <a> tag.
+        @dr_room_npc_names = []
+        @dr_crtr_index = 0
 
         @room_count = 0
         @room_title = String.new
@@ -199,6 +205,10 @@ module Lich
         # could misapply to an unrelated creature that later reuses the same
         # exist id (ids are recycled - see Creature.targets' notes).
         @pending_crtr_status.clear
+        # A reset mid-fragment invalidates the room-objs<->crtrStatus pairing, so
+        # drop any captured names and restart the batch index.
+        @dr_room_npc_names = []
+        @dr_crtr_index = 0
       end
 
       def safe_to_respond?
@@ -423,6 +433,11 @@ module Lich
               # this component; clearing here gives that batch a clean snapshot.
               Lich::DragonRealms::Creature.clear_room if defined?(Lich::DragonRealms::Creature)
               @pending_crtr_status.clear
+              # Start a fresh room-objs<->crtrStatus pairing for this refresh: the
+              # bold names captured below are zipped, in order, to the crtrStatus
+              # batch that follows this component.
+              @dr_room_npc_names = []
+              @dr_crtr_index = 0
             elsif attributes['id'] == 'room players'
               GameObj.begin_room_players
             elsif attributes['id'] == 'room exits'
@@ -454,14 +469,20 @@ module Lich
             # DragonRealms differs: its room-objs carry no per-creature <a exist>
             # tag, so there is no text() path to defer to. Its <crtrStatus> tags
             # arrive batched after the room-objs component and carry their own
-            # id, so they are applied immediately, id-first (name-less; the name
-            # is backfilled later from the assess stream - see
+            # id, so they are applied immediately, id-first. The name is
+            # backfilled two ways: the stream-order pairing here (the Nth bold
+            # room-objs name captured above -> the Nth crtrStatus in this batch),
+            # and, authoritatively, later from the assess stream (see
             # lib/dragonrealms/creature.rb).
             crtr_id = attributes['exist']
             if crtr_id
               crtr_flags = attributes.reject { |k, _| k == 'exist' }
               if XMLData.game =~ /^DR/
-                Lich::DragonRealms::Creature.sync(crtr_id, crtr_flags) if defined?(Lich::DragonRealms::Creature)
+                # Bounds-checked: more crtrStatus than captured names yields nil
+                # (the count-guard), never a mis-paired earlier slot.
+                positional_name = @dr_room_npc_names[@dr_crtr_index]
+                @dr_crtr_index += 1
+                Lich::DragonRealms::Creature.sync(crtr_id, crtr_flags, positional_name) if defined?(Lich::DragonRealms::Creature)
               else
                 @pending_crtr_status[crtr_id] = crtr_flags
               end
@@ -971,7 +992,19 @@ module Lich
               if @active_tags.include?('a')
                 if @bold
                   @last_npc = GameObj.new_npc(@obj_exist, @obj_noun, text_string)
-                  if XMLData.current_target_ids.include?(@obj_exist) || @pending_crtr_status.key?(@obj_exist)
+                  if XMLData.game =~ /^DR/
+                    # Future-proofing: DragonRealms room-objs creatures currently
+                    # carry no <a> tag, but if that ever changes to GemStone's
+                    # <a exist noun> shape, register id-first with the inline
+                    # name/noun via DR's own Creature (never the unqualified
+                    # Gemstone Creature below, which is not loaded in DR). With an
+                    # <a> present the stream-order capture branch is skipped, so
+                    # this becomes the sole name source - no double-set.
+                    if @obj_exist && defined?(Lich::DragonRealms::Creature)
+                      dr_creature = Lich::DragonRealms::Creature.register(text_string, @obj_exist, @obj_noun)
+                      dr_creature&.apply_room_name(text_string)
+                    end
+                  elsif XMLData.current_target_ids.include?(@obj_exist) || @pending_crtr_status.key?(@obj_exist)
                     creature = Creature.register(text_string, @obj_exist, @obj_noun)
                     if creature && (pending_flags = @pending_crtr_status.delete(@obj_exist))
                       creature.sync_crtr_status(pending_flags)
@@ -980,7 +1013,18 @@ module Lich
                 else
                   GameObj.new_loot(@obj_exist, @obj_noun, text_string)
                 end
+              elsif @bold && XMLData.game =~ /^DR/
+                # DragonRealms room-objs bold NPC names carry no <a> tag. Capture
+                # them in stream order so the <crtrStatus> batch that follows can
+                # pair the Nth name to the Nth id (see the crtrStatus handler).
+                # Only bold runs are names; the non-bold "(dead)"/"(immobile)"
+                # status runs fall through to the annotation branch below.
+                @dr_room_npc_names << text_string
               elsif (text_string =~ /that (?:is|appears) ([\w\s]+)(?:,| and|\.)/) or (text_string =~ / \(([^\(]+)\)/)
+                # @last_npc is nil in DragonRealms here (DR room-objs bold names
+                # carry no <a> tag, so the new_npc branch above never runs and
+                # never sets it), so the &. keeps this a safe no-op in DR while
+                # still annotating the last GemStone npc.
                 @last_npc&.status = $1
               end
             elsif @active_ids.include?('room players')

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -218,10 +218,15 @@ module Lich
 
       # Splits an `assess` parenthetical status into [balance, conditions].
       # Balance is the DR_BALANCE_VALUES descriptor before "balance(d)"; the rest
-      # (afflictions joined by "and") becomes the conditions list. crtrStatus
-      # states are not present here, so they are never captured as conditions.
+      # (afflictions joined by "and") becomes the conditions list.
       #
-      # @param status [String, nil] e.g. "cursed and solidly balanced".
+      # crtrStatus flag words that also appear in the parenthetical (e.g.
+      # "immobile") are dropped from conditions: they are tracked fresh via
+      # crtr_flag?/has_status? (a "push" source), whereas assess is a staleable
+      # "pull" snapshot, so keeping them here would duplicate and could disagree.
+      # Only assess-only afflictions (cursed, poisoned, ...) remain.
+      #
+      # @param status [String, nil] e.g. "immobile and slightly off balance".
       # @return [Array(String, Array<String>)] [balance_or_nil, conditions].
       def parse_assess_status(status)
         return [nil, []] if status.nil? || status.strip.empty?
@@ -229,7 +234,10 @@ module Lich
         pattern = self.class.balance_pattern
         balance = status[pattern, 1]
         remainder = balance ? status.sub(pattern, '') : status
-        conditions = remainder.split(/\s+and\s+|,/).map(&:strip).reject { |w| w.empty? || w == 'and' }
+        conditions = remainder.split(/\s+and\s+|,/)
+                              .map(&:strip)
+                              .reject { |w| w.empty? || w == 'and' }
+                              .reject { |w| Lich::Common::CreatureBase::ALL_CRTR_FLAGS.key?(w) }
         [balance, conditions]
       end
 

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -43,9 +43,11 @@ module Lich
 
       # @return [Integer] server creature id.
       attr_reader :id
-      # @return [String, nil] noun, when a feed supplies one (usually nil in DR).
+      # @return [String, nil] attack noun (the trailing word of the name),
+      #   derived whenever a name is set; nil until then.
       attr_reader :noun
-      # @return [String, nil] display name; nil until an `assess` tie-in arrives.
+      # @return [String, nil] display name; nil until a room-objs backfill or an
+      #   `assess` tie-in supplies one.
       attr_accessor :name
       # @return [Time] when this instance was first registered.
       attr_reader :created_at
@@ -74,6 +76,11 @@ module Lich
         @assess_status = nil
         @range = nil
         @target_id = nil
+        # The assess stream is the authoritative id<->name tie; once it names a
+        # creature, the room-objs backfill must not overwrite it (see
+        # #apply_room_name). Room-objs may still supply a name first, before any
+        # assess has run.
+        @name_from_assess = false
         initialize_status_tracking
       end
 
@@ -88,12 +95,38 @@ module Lich
       #   `:name`, `:number`, `:status`, `:relation`, `:range`, `:target_id`.
       # @return [void]
       def feed_assess(entry)
-        @name = entry[:name].to_s.downcase if entry[:name]
+        if entry[:name]
+          @name = entry[:name].to_s.downcase
+          @noun = derive_noun(@name)
+          # Authoritative from here on: subsequent room-objs backfills no-op.
+          @name_from_assess = true
+        end
         @assess_number = entry[:number]
         @assess_status = entry[:status]
         @relation = entry[:relation]
         @range = entry[:range]
         @target_id = entry[:target_id]
+      end
+
+      # Applies a name learned from the room-objs stream, and derives the attack
+      # noun from it.
+      #
+      # Two producers call this, both via the XML parser: the stream-order
+      # backfill that pairs the Nth bold room-objs name with the Nth
+      # `<crtrStatus>` id, and (future-proofing) a GemStone-style
+      # `<a exist noun>` room-objs tag if DragonRealms ever emits one. The
+      # `assess` stream is the authoritative id<->name tie, so once #feed_assess
+      # has named the creature this is a no-op. A nil name (e.g. an out-of-range
+      # positional lookup, the count-guard) is ignored, leaving any existing name
+      # intact.
+      #
+      # @param name [String, nil] display name from the room-objs stream.
+      # @return [void]
+      def apply_room_name(name)
+        return if name.nil? || @name_from_assess
+
+        @name = name
+        @noun = derive_noun(name)
       end
 
       # Whether this creature should be considered attackable.
@@ -104,6 +137,19 @@ module Lich
       # @return [Boolean]
       def valid_target?
         !crtr_flag?(:dead)
+      end
+
+      private
+
+      # Extracts the attack noun (trailing word) from a display name, matching
+      # DragonRealms' end-anchored creature-name convention (see
+      # DRDefsPattern::CREATURE_NAME) so `noun` is a drop-in for `attack <noun>`
+      # -- e.g. "a jeol moradu" -> "moradu".
+      #
+      # @param name [String, nil]
+      # @return [String, nil]
+      def derive_noun(name)
+        name && name[/[A-Za-z'-]+$/]
       end
     end
 
@@ -130,13 +176,21 @@ module Lich
       # This is the automatic, name-less DragonRealms feed: it produces an
       # id-keyed hostile roster with flags before any `assess` has run.
       #
+      # The optional `name` is the stream-order backfill: the XML parser pairs the
+      # Nth bold room-objs name with the Nth `<crtrStatus>` in the batch and passes
+      # it here, so creatures are named every refresh without waiting for `assess`.
+      # It is applied via {CreatureInstance#apply_room_name} (assess still wins;
+      # a nil name is ignored), and works whether the id is new or already known.
+      #
       # @param id [Integer, String] server creature id (the tag's `exist`).
       # @param flags [Hash{String=>String}] tag attributes excluding `exist`.
+      # @param name [String, nil] stream-order room-objs name for this id, if any.
       # @return [CreatureInstance, nil] the synced instance, or nil if disabled/full.
-      def self.sync(id, flags)
-        instance = CreatureInstance.register(nil, id)
+      def self.sync(id, flags, name = nil)
+        instance = CreatureInstance.register(name, id)
         return nil unless instance
 
+        instance.apply_room_name(name)
         instance.sync_crtr_status(flags)
         instance
       end

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -204,10 +204,17 @@ module Lich
         condition?('cursed')
       end
 
-      # The assess "friendly" marker: a creature that will not attack you (a
-      # summon or charmed ally). This is the ONLY friend/foe signal DragonRealms
-      # exposes - crtrStatus does not carry it (a friendly plague spawn still
-      # reports hostile="1"). Assess-only, so it is a staleable pull field.
+      # True while assess reports this creature as "friendly" - i.e. it has been
+      # empathically manipulated (an Empath ability: "manipulate ... to consider
+      # you friend, not foe") into treating you as a friend.
+      #
+      # This is a TEMPORARY, manipulated state, NOT a permanent classification:
+      # crtrStatus keeps reporting hostile="1" throughout, and it wears off.
+      # Confirmed from logs - one jeol moradu (exist 105829093) went
+      # hostile/flanking-you -> manipulated "friendly" (and turned on its own
+      # kind) while crtrStatus stayed hostile the whole time. Assess-only, so it
+      # is a staleable pull field: re-assess before relying on it, and do not
+      # treat it as a durable friend/foe flag (a summon/pet is a different thing).
       #
       # @return [Boolean]
       def friendly?

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -249,7 +249,9 @@ module Lich
       # @param name [String, nil]
       # @return [String, nil]
       def derive_noun(name)
-        name && name[/[A-Za-z'-]+$/]
+        # scan+last (not an end-anchored match) so trailing whitespace or
+        # punctuation on the name can't swallow the noun.
+        name && name.scan(/[A-Za-z'-]+/).last
       end
     end
 

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -29,6 +29,7 @@
 # =============================================================================
 
 require_relative '../common/creature/creature_base'
+require_relative 'drinfomon/drvariables' # DR_BALANCE_VALUES (assess balance parsing)
 
 module Lich
   module DragonRealms
@@ -62,6 +63,24 @@ module Lich
       attr_reader :range
       # @return [String, nil] id of the creature/PC this one is engaging, from `assess`.
       attr_reader :target_id
+      # @return [String, nil] name of the creature/PC this one is engaging, from
+      #   `assess` (e.g. "you", "Holdigor", "a plague spawn").
+      attr_reader :target
+      # @return [Integer, nil] the engaged target's `assess` list number, if any.
+      attr_reader :target_number
+      # @return [String, nil] balance descriptor parsed from the `assess`
+      #   parenthetical, one of DR_BALANCE_VALUES (e.g. "solidly", "off"). nil
+      #   until an assess with a balance phrase arrives. See #off_balance?.
+      attr_reader :balance
+      # @return [Array<String>] afflictions parsed from the `assess` parenthetical
+      #   that crtrStatus does NOT carry (e.g. ["cursed"]); [] when none/unseen.
+      #   crtrStatus states (prone/sleeping/stunned/...) live in crtr_flag?, not here.
+      attr_reader :conditions
+      # @return [Time, nil] when assess enrichment last landed for this id; nil
+      #   until first assess. See #enriched?. Assess fields (range/balance/
+      #   conditions/relation/target) are "pull" snapshots and can go stale -
+      #   poll assess before relying on one.
+      attr_reader :enriched_at
 
       # @param id [Integer, String] server creature id.
       # @param noun [String, nil] noun, when available.
@@ -76,6 +95,11 @@ module Lich
         @assess_status = nil
         @range = nil
         @target_id = nil
+        @target = nil
+        @target_number = nil
+        @balance = nil
+        @conditions = []
+        @enriched_at = nil
         # The assess stream is the authoritative id<->name tie; once it names a
         # creature, the room-objs backfill must not overwrite it (see
         # #apply_room_name). Room-objs may still supply a name first, before any
@@ -103,9 +127,13 @@ module Lich
         end
         @assess_number = entry[:number]
         @assess_status = entry[:status]
+        @balance, @conditions = parse_assess_status(entry[:status])
         @relation = entry[:relation]
         @range = entry[:range]
         @target_id = entry[:target_id]
+        @target = entry[:target]
+        @target_number = entry[:target_number]
+        @enriched_at = Time.now
       end
 
       # Applies a name learned from the room-objs stream, and derives the attack
@@ -139,7 +167,71 @@ module Lich
         !crtr_flag?(:dead)
       end
 
+      # Whether any `assess` enrichment (range/balance/conditions/relation/target)
+      # has landed for this id. These are "pull" snapshots -- poll assess before
+      # relying on them, and see #enriched_at for staleness.
+      #
+      # @return [Boolean]
+      def enriched?
+        !@enriched_at.nil?
+      end
+
+      # Whether the creature is below "solidly balanced" per the last `assess`
+      # (a softer target). False when balance is unknown.
+      #
+      # @return [Boolean]
+      def off_balance?
+        return false unless @balance
+
+        idx = DR_BALANCE_VALUES.index(@balance)
+        !idx.nil? && idx < DR_BALANCE_VALUES.index('solidly')
+      end
+
+      # Whether a given assess affliction is present (e.g. "cursed", "poisoned").
+      #
+      # @param name [String, Symbol]
+      # @return [Boolean]
+      def condition?(name)
+        @conditions.include?(name.to_s)
+      end
+
+      # Convenience for the one affliction confirmed so far; use #condition? for
+      # others until they are confirmed and given their own predicate.
+      #
+      # @return [Boolean]
+      def cursed?
+        condition?('cursed')
+      end
+
+      # Matches a DR_BALANCE_VALUES descriptor followed by "balance(d)" in an
+      # assess parenthetical, e.g. "solidly balanced", "off balance". Built lazily
+      # so DR_BALANCE_VALUES (loaded with drvariables) is present by first use;
+      # union order (longest multi-word values first in the array) resolves
+      # "somewhat off" ahead of "off".
+      #
+      # @return [Regexp]
+      def self.balance_pattern
+        @balance_pattern ||= /\b(#{Regexp.union(DR_BALANCE_VALUES)})\s+balanced?\b/i
+      end
+
       private
+
+      # Splits an `assess` parenthetical status into [balance, conditions].
+      # Balance is the DR_BALANCE_VALUES descriptor before "balance(d)"; the rest
+      # (afflictions joined by "and") becomes the conditions list. crtrStatus
+      # states are not present here, so they are never captured as conditions.
+      #
+      # @param status [String, nil] e.g. "cursed and solidly balanced".
+      # @return [Array(String, Array<String>)] [balance_or_nil, conditions].
+      def parse_assess_status(status)
+        return [nil, []] if status.nil? || status.strip.empty?
+
+        pattern = self.class.balance_pattern
+        balance = status[pattern, 1]
+        remainder = balance ? status.sub(pattern, '') : status
+        conditions = remainder.split(/\s+and\s+|,/).map(&:strip).reject { |w| w.empty? || w == 'and' }
+        [balance, conditions]
+      end
 
       # Extracts the attack noun (trailing word) from a display name, matching
       # DragonRealms' end-anchored creature-name convention (see

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+# =============================================================================
+# dragonrealms/creature.rb
+#
+# DragonRealms runtime creature tracking, built on the shared
+# {Lich::Common::CreatureBase} mixin (see lib/common/creature/creature_base.rb).
+#
+# DragonRealms delivers creature information across three streams, unlike
+# GemStone's single structured room-object tag:
+#
+#   * `<crtrStatus exist="..." hostile="1" immobile="1"/>` - an id-keyed, full
+#     snapshot of combat status and classification flags. Emitted automatically
+#     with room refreshes, but *name-less* and batched after the room-objs
+#     component closes.
+#   * room-objs bold text (`<pushBold/>a jeol moradu<popBold/>`) - names only,
+#     with no `exist` id (consumed separately by DRRoom; not used here).
+#   * the `assess` combat stream (`<d cmd='look #NNN'>A jeol moradu</d>
+#     (1: ...) is behind you at melee range`) - the only feed that ties an
+#     `exist` id to a name, plus assess number, relation and range.
+#
+# So {CreatureInstance}s are created id-first from `<crtrStatus>` (flags, no
+# name) and have their name/position/range backfilled from `assess` via
+# {CreatureInstance#feed_assess}. The XML parser drives both paths (see
+# lib/common/xmlparser.rb).
+#
+# This layer is additive: it does not touch DRRoom or the name-string roster the
+# existing DragonRealms scripts rely on.
+# =============================================================================
+
+require_relative '../common/creature/creature_base'
+
+module Lich
+  module DragonRealms
+    # A single DragonRealms creature, keyed by its server `exist` id.
+    #
+    # Shares its registry, room roster and `<crtrStatus>` flag handling with
+    # GemStone through {Lich::Common::CreatureBase}; the DragonRealms-specific
+    # layer adds the `assess`-stream backfill (name, assess number, relation,
+    # range) and a DragonRealms `valid_target?` rule.
+    class CreatureInstance
+      include Lich::Common::CreatureBase
+
+      # @return [Integer] server creature id.
+      attr_reader :id
+      # @return [String, nil] noun, when a feed supplies one (usually nil in DR).
+      attr_reader :noun
+      # @return [String, nil] display name; nil until an `assess` tie-in arrives.
+      attr_accessor :name
+      # @return [Time] when this instance was first registered.
+      attr_reader :created_at
+      # @return [Integer, nil] the `assess` list number (1-based), if seen.
+      attr_reader :assess_number
+      # @return [String, nil] the `assess` relation phrase, e.g. "behind you".
+      attr_reader :relation
+      # @return [String, nil] the `assess` parenthetical status, e.g.
+      #   "cursed and solidly balanced".
+      attr_reader :assess_status
+      # @return [Symbol, nil] `assess` range bucket: `:melee`, `:pole` or `:missile`.
+      attr_reader :range
+      # @return [String, nil] id of the creature/PC this one is engaging, from `assess`.
+      attr_reader :target_id
+
+      # @param id [Integer, String] server creature id.
+      # @param noun [String, nil] noun, when available.
+      # @param name [String, nil] display name, when already known.
+      def initialize(id, noun, name)
+        @id = id.to_i
+        @noun = noun
+        @name = name
+        @created_at = Time.now
+        @assess_number = nil
+        @relation = nil
+        @assess_status = nil
+        @range = nil
+        @target_id = nil
+        initialize_status_tracking
+      end
+
+      # Backfills name and positional data from a parsed `assess` entry.
+      #
+      # `<crtrStatus>` registers a creature id-first with no name, so this is how
+      # DragonRealms learns which name/relation/range belongs to that id. The
+      # `assess` feed capitalizes the subject ("A jeol moradu"); the name is
+      # downcased to match the room-objs vocabulary DragonRealms scripts expect.
+      #
+      # @param entry [Hash] an entry from `XMLData.parse_assess_line`, with keys
+      #   `:name`, `:number`, `:status`, `:relation`, `:range`, `:target_id`.
+      # @return [void]
+      def feed_assess(entry)
+        @name = entry[:name].to_s.downcase if entry[:name]
+        @assess_number = entry[:number]
+        @assess_status = entry[:status]
+        @relation = entry[:relation]
+        @range = entry[:range]
+        @target_id = entry[:target_id]
+      end
+
+      # Whether this creature should be considered attackable.
+      #
+      # DragonRealms has no UCS or appendage decoys to exclude, so the rule is
+      # simply "not confirmed dead by `<crtrStatus>`".
+      #
+      # @return [Boolean]
+      def valid_target?
+        !crtr_flag?(:dead)
+      end
+    end
+
+    # Public Creature API for DragonRealms runtime creature tracking.
+    #
+    # Mirrors `Lich::Gemstone::Creature`: registry/roster/query operations
+    # delegate to {CreatureInstance} (which carries the shared
+    # {Lich::Common::CreatureBase} class methods), plus the two DragonRealms feed
+    # entry points {sync} and {feed_assess} used by the XML parser.
+    module Creature
+      # Toggles live echo of status, flag, and registration changes.
+      #
+      # @param level [Boolean, Symbol] false disables debug output; true or
+      #   `:changes` reports changes only; `:all` reports every `<crtrStatus>`
+      #   flag; `:active` reports only active `<crtrStatus>` flags.
+      # @return [Boolean, Symbol] the configured debug value.
+      def self.debug_on(level = :changes)
+        $creature_debug = level
+      end
+
+      # Applies a `<crtrStatus>` snapshot, registering the creature id-first if
+      # it has not been seen yet.
+      #
+      # This is the automatic, name-less DragonRealms feed: it produces an
+      # id-keyed hostile roster with flags before any `assess` has run.
+      #
+      # @param id [Integer, String] server creature id (the tag's `exist`).
+      # @param flags [Hash{String=>String}] tag attributes excluding `exist`.
+      # @return [CreatureInstance, nil] the synced instance, or nil if disabled/full.
+      def self.sync(id, flags)
+        instance = CreatureInstance.register(nil, id)
+        return nil unless instance
+
+        instance.sync_crtr_status(flags)
+        instance
+      end
+
+      # Backfills a creature from a parsed `assess` entry, registering it if the
+      # id has not been seen yet.
+      #
+      # @param entry [Hash] a creature entry from `XMLData.parse_assess_line`.
+      # @return [CreatureInstance, nil] the updated instance, or nil if disabled/full.
+      def self.feed_assess(entry)
+        id = entry[:id]
+        return nil unless id
+
+        instance = CreatureInstance.register(entry[:name], id)
+        return nil unless instance
+
+        instance.feed_assess(entry)
+        instance
+      end
+
+      # Lookup creature instance by id.
+      #
+      # @param id [Integer, String] server creature id.
+      # @return [CreatureInstance, nil]
+      def self.[](id)
+        CreatureInstance[id]
+      end
+
+      # Returns attackable hostile creatures currently in the room.
+      #
+      # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
+      # @return [Array<CreatureInstance>]
+      def self.targets(*filters)
+        CreatureInstance.targets(*filters)
+      end
+
+      # Returns all tracked creatures currently in the room.
+      #
+      # @param filters [Array<String, Symbol>] optional ANDed status/classification filters.
+      # @return [Array<CreatureInstance>]
+      def self.in_room(*filters)
+        CreatureInstance.in_room(*filters)
+      end
+
+      # Empties the current room roster.
+      #
+      # @return [void]
+      def self.clear_room
+        CreatureInstance.clear_room
+      end
+
+      # Registers a creature.
+      #
+      # @param name [String, nil] display name (may be nil for an id-first feed).
+      # @param id [Integer, String] server creature id.
+      # @param noun [String, nil] noun, when available.
+      # @return [CreatureInstance, nil]
+      def self.register(name, id, noun = nil)
+        CreatureInstance.register(name, id, noun)
+      end
+
+      # Configures the registry.
+      #
+      # @return [void]
+      def self.configure(**options)
+        CreatureInstance.configure(**options)
+      end
+
+      # @return [Hash] registry statistics.
+      def self.stats
+        {
+          instances: CreatureInstance.size,
+          max_size: CreatureInstance.max_size,
+          auto_register: CreatureInstance.auto_register?
+        }
+      end
+
+      # Clears every instance and the room roster.
+      #
+      # @return [void]
+      def self.clear
+        CreatureInstance.clear
+      end
+
+      # Removes creatures older than the given age (in seconds).
+      #
+      # Positional to match {CreatureInstance#cleanup_old} (supplied by
+      # {Lich::Common::CreatureBase}); a keyword-only signature would raise
+      # ArgumentError against the positional base method.
+      #
+      # @param max_age_seconds [Integer] age cutoff in seconds.
+      # @return [Integer] number of instances removed.
+      def self.cleanup_old(max_age_seconds = 600)
+        CreatureInstance.cleanup_old(max_age_seconds)
+      end
+
+      # @return [Array<CreatureInstance>] every registered instance.
+      def self.all
+        CreatureInstance.all
+      end
+    end
+  end
+end

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -72,9 +72,11 @@ module Lich
       #   parenthetical, one of DR_BALANCE_VALUES (e.g. "solidly", "off"). nil
       #   until an assess with a balance phrase arrives. See #off_balance?.
       attr_reader :balance
-      # @return [Array<String>] afflictions parsed from the `assess` parenthetical
-      #   that crtrStatus does NOT carry (e.g. ["cursed"]); [] when none/unseen.
-      #   crtrStatus states (prone/sleeping/stunned/...) live in crtr_flag?, not here.
+      # @return [Array<String>] assess-only condition/classification words parsed
+      #   from the `assess` parenthetical that crtrStatus does NOT carry (e.g.
+      #   ["cursed"], ["friendly", "cursed"]); [] when none/unseen. crtrStatus
+      #   states (prone/sleeping/stunned/immobile/hidden/...) live in crtr_flag?/
+      #   has_status?, not here. See #cursed? and #friendly?.
       attr_reader :conditions
       # @return [Time, nil] when assess enrichment last landed for this id; nil
       #   until first assess. See #enriched?. Assess fields (range/balance/
@@ -195,23 +197,33 @@ module Lich
         @conditions.include?(name.to_s)
       end
 
-      # Convenience for the one affliction confirmed so far; use #condition? for
-      # others until they are confirmed and given their own predicate.
+      # Convenience for the "cursed" affliction; use #condition? for others.
       #
       # @return [Boolean]
       def cursed?
         condition?('cursed')
       end
 
-      # Matches a DR_BALANCE_VALUES descriptor followed by "balance(d)" in an
-      # assess parenthetical, e.g. "solidly balanced", "off balance". Built lazily
+      # The assess "friendly" marker: a creature that will not attack you (a
+      # summon or charmed ally). This is the ONLY friend/foe signal DragonRealms
+      # exposes - crtrStatus does not carry it (a friendly plague spawn still
+      # reports hostile="1"). Assess-only, so it is a staleable pull field.
+      #
+      # @return [Boolean]
+      def friendly?
+        condition?('friendly')
+      end
+
+      # Matches a DR_BALANCE_VALUES descriptor followed by the balance word in an
+      # assess parenthetical, e.g. "solidly balanced", "off balance", and the
+      # worst levels' "imbalanced" phrasing ("extremely imbalanced"). Built lazily
       # so DR_BALANCE_VALUES (loaded with drvariables) is present by first use;
       # union order (longest multi-word values first in the array) resolves
       # "somewhat off" ahead of "off".
       #
       # @return [Regexp]
       def self.balance_pattern
-        @balance_pattern ||= /\b(#{Regexp.union(DR_BALANCE_VALUES)})\s+balanced?\b/i
+        @balance_pattern ||= /\b(#{Regexp.union(DR_BALANCE_VALUES)})\s+(?:im)?balanced?\b/i
       end
 
       private

--- a/lib/dragonrealms/creature.rb
+++ b/lib/dragonrealms/creature.rb
@@ -278,21 +278,18 @@ module Lich
       # This is the automatic, name-less DragonRealms feed: it produces an
       # id-keyed hostile roster with flags before any `assess` has run.
       #
-      # The optional `name` is the stream-order backfill: the XML parser pairs the
-      # Nth bold room-objs name with the Nth `<crtrStatus>` in the batch and passes
-      # it here, so creatures are named every refresh without waiting for `assess`.
-      # It is applied via {CreatureInstance#apply_room_name} (assess still wins;
-      # a nil name is ignored), and works whether the id is new or already known.
+      # Name-less on purpose: the stream-order room-objs name is applied
+      # separately via {CreatureInstance#apply_room_name}, batched at the prompt
+      # once the parser has confirmed the bold-name and crtrStatus counts match
+      # (see lib/common/xmlparser.rb). assess later backfills authoritatively.
       #
       # @param id [Integer, String] server creature id (the tag's `exist`).
       # @param flags [Hash{String=>String}] tag attributes excluding `exist`.
-      # @param name [String, nil] stream-order room-objs name for this id, if any.
       # @return [CreatureInstance, nil] the synced instance, or nil if disabled/full.
-      def self.sync(id, flags, name = nil)
-        instance = CreatureInstance.register(name, id)
+      def self.sync(id, flags)
+        instance = CreatureInstance.register(nil, id)
         return nil unless instance
 
-        instance.apply_room_name(name)
         instance.sync_crtr_status(flags)
         instance
       end

--- a/spec/lib/common/xmlparser_crtr_status_spec.rb
+++ b/spec/lib/common/xmlparser_crtr_status_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Lich::Common::XMLParser <crtrStatus> handling' do
   end
 
   it 'still registers via the pre-existing current_target_ids path when crtrStatus is absent' do
-    stub_const('XMLData', double(current_target_ids: ['614999']))
+    stub_const('XMLData', double(current_target_ids: ['614999'], game: 'GSIV'))
 
     feed(%(<component id='room objs'>  You notice <pushBold/>a <a exist="614999" noun="ooze">gelatinous ooze</a><popBold/>.</component>))
 
@@ -152,7 +152,7 @@ RSpec.describe 'Lich::Common::XMLParser <crtrStatus> handling' do
       expect(parser.instance_variable_get(:@pending_crtr_status)).to be_empty
 
       # Id reused later by an unrelated creature via the current_target_ids path.
-      stub_const('XMLData', double(current_target_ids: ['999999']))
+      stub_const('XMLData', double(current_target_ids: ['999999'], game: 'GSIV'))
       feed(%(<component id='room objs'>  You notice <pushBold/>a <a exist="999999" noun="crab">giant crab</a><popBold/>.</component>))
 
       expect(Lich::Gemstone::Creature[999999].crtr_flag?(:dead)).to be false

--- a/spec/lib/common/xmlparser_crtr_status_spec.rb
+++ b/spec/lib/common/xmlparser_crtr_status_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe 'Lich::Common::XMLParser <crtrStatus> handling' do
 
   before do
     Lich::Gemstone::Creature.clear
-    stub_const('XMLData', double(current_target_ids: []))
+    # game is consulted by the <crtrStatus> handler to route GS vs DR; these
+    # fixtures are GemStone captures, so it must report a GS instance.
+    stub_const('XMLData', double(current_target_ids: [], game: 'GSIV'))
     allow(Lich::Common::GameObj).to receive(:new_npc)
     allow(Lich::Common::GameObj).to receive(:new_loot)
     allow(Lich::Common::GameObj).to receive(:clear_loot)

--- a/spec/lib/common/xmlparser_dr_creature_spec.rb
+++ b/spec/lib/common/xmlparser_dr_creature_spec.rb
@@ -93,21 +93,32 @@ RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
       expect(Lich::DragonRealms::Creature[99355351].noun).to eq('moradu')
     end
 
-    it 'count-guards: crtrStatus beyond the captured bold names get no name' do
+    it 'count-guard (all-or-nothing): more crtrStatus than bold names -> no names applied' do
       feed(%(<component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/>, <pushBold/>a kobold<popBold/> and some junk.</component><crtrStatus exist="1" hostile="1"/><crtrStatus exist="2" hostile="1"/><crtrStatus exist="3" hostile="1"/><prompt time="1785273999">R&gt;</prompt>))
 
-      expect(Lich::DragonRealms::Creature[1].name).to eq('a jeol moradu')
-      expect(Lich::DragonRealms::Creature[2].name).to eq('a kobold')
-      expect(Lich::DragonRealms::Creature[3].name).to be_nil # no matching bold slot
+      # 3 crtrStatus vs 2 bold names: counts differ, so NONE are positionally
+      # named (assess would backfill). Roster/flags still built from crtrStatus.
+      expect(Lich::DragonRealms::Creature.in_room.map(&:id)).to contain_exactly(1, 2, 3)
+      expect(Lich::DragonRealms::Creature.in_room.map(&:name)).to all(be_nil)
     end
 
-    it 'count-guards the reverse: more bold names than crtrStatus, extras unregistered' do
+    it 'count-guard (all-or-nothing): more bold names than crtrStatus -> no names applied' do
       feed(%(<component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/>, <pushBold/>a kobold<popBold/>, <pushBold/>an orc<popBold/> and some junk.</component><crtrStatus exist="1" hostile="1"/><crtrStatus exist="2" hostile="1"/><prompt time="1785274111">R&gt;</prompt>))
 
-      # two crtrStatus -> the first two bold names by position; third name unused
-      expect(Lich::DragonRealms::Creature[1].name).to eq('a jeol moradu')
-      expect(Lich::DragonRealms::Creature[2].name).to eq('a kobold')
       expect(Lich::DragonRealms::Creature.in_room.map(&:id)).to contain_exactly(1, 2)
+      expect(Lich::DragonRealms::Creature.in_room.map(&:name)).to all(be_nil)
+    end
+
+    it 'count-guard: a bold entity with no crtrStatus never mis-names the real mob' do
+      # The mid-list-gap case: a bold room entity that emits no crtrStatus (a
+      # gelapod-like object) would shift a positional pairing. The all-or-nothing
+      # gate refuses to name on the count mismatch, so the real mob is NOT named
+      # after the odd entity - it stays nil until assess ties it by id.
+      feed(%(<component id='room objs'>You also see <pushBold/>a domesticated gelapod<popBold/>, <pushBold/>a jeol moradu<popBold/> and some junk.</component><crtrStatus exist="42" hostile="1"/><prompt time="1785274444">R&gt;</prompt>))
+
+      moradu = Lich::DragonRealms::Creature[42]
+      expect(moradu).not_to be_nil # tracked by crtrStatus (id + flags)
+      expect(moradu.name).to be_nil # NOT mis-named "a domesticated gelapod"
     end
 
     it 'derives the noun for a multi-word bold name via the positional path' do
@@ -126,14 +137,14 @@ RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
       expect(Lich::DragonRealms::Creature[500].name).to eq('a kobold')
     end
 
-    it 'reset clears the room-objs name buffer and batch index' do
+    it 'reset clears the room-objs name buffer and collected crtrStatus ids' do
       feed(%(<component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/> and some junk.</component>))
       expect(parser.instance_variable_get(:@dr_room_npc_names)).not_to be_empty
 
       parser.reset
 
       expect(parser.instance_variable_get(:@dr_room_npc_names)).to eq([])
-      expect(parser.instance_variable_get(:@dr_crtr_index)).to eq(0)
+      expect(parser.instance_variable_get(:@dr_crtr_ids)).to eq([])
     end
 
     it 'applies each creature\'s flags from its own tag' do

--- a/spec/lib/common/xmlparser_dr_creature_spec.rb
+++ b/spec/lib/common/xmlparser_dr_creature_spec.rb
@@ -101,6 +101,41 @@ RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
       expect(Lich::DragonRealms::Creature[3].name).to be_nil # no matching bold slot
     end
 
+    it 'count-guards the reverse: more bold names than crtrStatus, extras unregistered' do
+      feed(%(<component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/>, <pushBold/>a kobold<popBold/>, <pushBold/>an orc<popBold/> and some junk.</component><crtrStatus exist="1" hostile="1"/><crtrStatus exist="2" hostile="1"/><prompt time="1785274111">R&gt;</prompt>))
+
+      # two crtrStatus -> the first two bold names by position; third name unused
+      expect(Lich::DragonRealms::Creature[1].name).to eq('a jeol moradu')
+      expect(Lich::DragonRealms::Creature[2].name).to eq('a kobold')
+      expect(Lich::DragonRealms::Creature.in_room.map(&:id)).to contain_exactly(1, 2)
+    end
+
+    it 'derives the noun for a multi-word bold name via the positional path' do
+      feed(%(<component id='room objs'>You also see <pushBold/>a void-black umbral moth<popBold/> and some junk.</component><crtrStatus exist="7" hostile="1"/><prompt time="1785274222">R&gt;</prompt>))
+
+      moth = Lich::DragonRealms::Creature[7]
+      expect(moth.name).to eq('a void-black umbral moth')
+      expect(moth.noun).to eq('moth')
+    end
+
+    it 'resets the name buffer on each room-objs refresh (no stale carry-over)' do
+      feed(DR_ROOM_AND_CRTR) # five jeol moradu captured
+      feed(%(<component id='room objs'>You also see <pushBold/>a kobold<popBold/> and some junk.</component><crtrStatus exist="500" hostile="1"/><prompt time="1785274333">R&gt;</prompt>))
+
+      # the new room's crtrStatus pairs with the fresh buffer, not a leftover name
+      expect(Lich::DragonRealms::Creature[500].name).to eq('a kobold')
+    end
+
+    it 'reset clears the room-objs name buffer and batch index' do
+      feed(%(<component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/> and some junk.</component>))
+      expect(parser.instance_variable_get(:@dr_room_npc_names)).not_to be_empty
+
+      parser.reset
+
+      expect(parser.instance_variable_get(:@dr_room_npc_names)).to eq([])
+      expect(parser.instance_variable_get(:@dr_crtr_index)).to eq(0)
+    end
+
     it 'applies each creature\'s flags from its own tag' do
       feed(DR_ROOM_AND_CRTR)
 

--- a/spec/lib/common/xmlparser_dr_creature_spec.rb
+++ b/spec/lib/common/xmlparser_dr_creature_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Drives the real Ox SAX pipeline with fragments captured from a live
+# DragonRealms session (five "a jeol moradu", exist 99353095..99355351) to
+# verify that the DragonRealms creature layer is fed end-to-end the way
+# production sees it:
+#
+#   * the room-objs component + the <crtrStatus> batch that follows it build an
+#     id-keyed hostile roster with flags (no names yet), and
+#   * the assess stream backfills each id's name, assess number, relation and
+#     range.
+#
+# Contrast spec/lib/common/xmlparser_crtr_status_spec.rb, which covers the
+# GemStone path where <crtrStatus> is interleaved with an <a exist> name tag.
+
+require_relative '../../spec_helper'
+require 'ox'
+require 'dragonrealms/creature'
+require 'common/xmlparser'
+
+# The room-objs component followed by the standalone <crtrStatus> batch, verbatim
+# shape from the live stream (five jeol moradu, the first immobile, the last
+# three disengaged). Kept at file scope so it is a normal constant.
+DR_ROOM_AND_CRTR = <<~XML.delete("\n")
+  <component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/> (immobile), <pushBold/>a jeol moradu<popBold/>, <pushBold/>a jeol moradu<popBold/>, a medium steel bar, a small pewter bar, <pushBold/>a jeol moradu<popBold/>, <pushBold/>a jeol moradu<popBold/> and some junk.</component>
+  <crtrStatus exist="99353095" hostile="1" immobile="1"/><crtrStatus exist="99353135" hostile="1"/><crtrStatus exist="99355263" hostile="1" disengaged="1"/><crtrStatus exist="99355283" hostile="1" disengaged="1"/><crtrStatus exist="99355351" hostile="1" disengaged="1"/><prompt time="1785273427">R&gt;</prompt>
+XML
+
+# One assess cycle per creature/PC (pushStream .. popStream), including the
+# trailing "| F" face hint the parser is expected to strip.
+DR_ASSESS = <<~XML.delete("\n")
+  <pushStream id="assess"/><clearStream id="assess"/>You assess your combat situation...<popStream/>
+  <pushStream id="assess"/><d cmd='look #99353095'>A jeol moradu</d> (1: cursed and solidly balanced) is behind you at melee range.  | <d cmd='face #99353095'>F</d><popStream/>
+  <pushStream id="assess"/><d cmd='look #99355263'>A jeol moradu</d> (3: solidly balanced) is moving to flank <d cmd='look #-10544759'>Kythkani</d> at pole weapon range.  | <d cmd='face #99355263'>F</d><popStream/>
+  <pushStream id="assess"/><d cmd='look #-10544759'>Kythkani</d> (incredibly balanced) is behind <d cmd='look #99353095'>a jeol moradu</d> (1) at missile range.  | <d cmd='face #99353095'>F</d><popStream/>
+  <prompt time="1785273425">R&gt;</prompt>
+XML
+
+RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
+  subject(:parser) { Lich::Common::XMLParser.new }
+
+  before do
+    Lich::DragonRealms::Creature.clear
+    $creature_debug = nil
+    allow(XMLData).to receive(:game).and_return('DRF')
+    allow(XMLData).to receive(:current_target_ids).and_return([])
+    # The parser refers to GameObj unqualified, which resolves to
+    # Lich::Common::GameObj (its lexical scope), so it must be stubbed there.
+    # DragonRealms room-objs carry no <a> tag, so GameObj is only touched for
+    # clear_* housekeeping and the status-annotation path (npcs[-1].status=).
+    # Stubbing keeps those harmless; an unstubbed npcs[-1] on the "(immobile)"
+    # annotation would raise and the parser would silently rescue+reset,
+    # skipping the very roster-clear these tests assert on.
+    %i[clear_loot clear_npcs clear_pcs clear_room_desc new_npc new_loot].each do |m|
+      allow(Lich::Common::GameObj).to receive(m)
+    end
+    allow(Lich::Common::GameObj).to receive(:npcs).and_return([double('npc').as_null_object])
+  end
+
+  def feed(fragment)
+    Ox.sax_parse(parser, fragment, convert_special: false, symbolize: false, skip: :skip_none)
+  end
+
+  describe 'the <crtrStatus> batch after the room-objs component' do
+    it 'builds an id-keyed hostile roster from crtrStatus alone, with no names yet' do
+      feed(DR_ROOM_AND_CRTR)
+
+      expect(Lich::DragonRealms::Creature.targets.map(&:id)).to contain_exactly(
+        99353095, 99353135, 99355263, 99355283, 99355351
+      )
+      expect(Lich::DragonRealms::Creature[99353095].name).to be_nil
+    end
+
+    it 'applies each creature\'s flags from its own tag' do
+      feed(DR_ROOM_AND_CRTR)
+
+      expect(Lich::DragonRealms::Creature[99353095].has_status?('immobilized')).to be true
+      expect(Lich::DragonRealms::Creature[99353095].crtr_flag?(:disengaged)).to be false
+      expect(Lich::DragonRealms::Creature[99355263].crtr_flag?(:disengaged)).to be true
+      expect(Lich::DragonRealms::Creature[99355263].has_status?('immobilized')).to be false
+    end
+
+    it 'rebuilds the roster on each room-objs refresh (departed creatures drop out)' do
+      feed(DR_ROOM_AND_CRTR)
+      # A later refresh in which only the first creature remains.
+      feed(%(<component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/> (immobile).</component><crtrStatus exist="99353095" hostile="1" immobile="1"/><prompt time="1785273500">R&gt;</prompt>))
+
+      expect(Lich::DragonRealms::Creature.targets.map(&:id)).to eq([99353095])
+    end
+  end
+
+  describe 'the assess stream backfilling names and position' do
+    it 'ties each exist id to its name, assess number, relation and range' do
+      feed(DR_ROOM_AND_CRTR)
+      feed(DR_ASSESS)
+
+      melee = Lich::DragonRealms::Creature[99353095]
+      expect(melee.name).to eq('a jeol moradu') # downcased from "A jeol moradu"
+      expect(melee.assess_number).to eq(1)
+      # parse_assess_line splits "behind you" into relation + target ("you"),
+      # so the stored relation is the bare positional word.
+      expect(melee.relation).to eq('behind')
+      expect(melee.range).to eq(:melee)
+
+      flanker = Lich::DragonRealms::Creature[99355263]
+      expect(flanker.assess_number).to eq(3)
+      expect(flanker.relation).to eq('flanking') # "moving to flank" normalized
+      expect(flanker.range).to eq(:pole)
+      expect(flanker.target_id).to eq('-10544759')
+    end
+
+    it 'preserves the crtrStatus flags through the assess backfill' do
+      feed(DR_ROOM_AND_CRTR)
+      feed(DR_ASSESS)
+
+      melee = Lich::DragonRealms::Creature[99353095]
+      expect(melee.crtr_flag?(:hostile)).to be true
+      expect(melee.has_status?('immobilized')).to be true
+      expect(melee.name).to eq('a jeol moradu')
+    end
+
+    it 'does not register the player (a negative-id assess subject) as a creature' do
+      feed(DR_ROOM_AND_CRTR)
+      feed(DR_ASSESS)
+
+      expect(Lich::DragonRealms::Creature[-10544759]).to be_nil
+      expect(Lich::DragonRealms::Creature.all.map(&:id)).to all(be > 0)
+    end
+  end
+end

--- a/spec/lib/common/xmlparser_dr_creature_spec.rb
+++ b/spec/lib/common/xmlparser_dr_creature_spec.rb
@@ -130,13 +130,23 @@ RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
       # parse_assess_line splits "behind you" into relation + target ("you"),
       # so the stored relation is the bare positional word.
       expect(melee.relation).to eq('behind')
+      expect(melee.target).to eq('you')
       expect(melee.range).to eq(:melee)
+      # parenthetical "(1: cursed and solidly balanced)" -> balance + conditions
+      expect(melee.balance).to eq('solidly')
+      expect(melee.off_balance?).to be false
+      expect(melee.conditions).to eq(['cursed'])
+      expect(melee.cursed?).to be true
+      expect(melee.enriched?).to be true
 
       flanker = Lich::DragonRealms::Creature[99355263]
       expect(flanker.assess_number).to eq(3)
       expect(flanker.relation).to eq('flanking') # "moving to flank" normalized
       expect(flanker.range).to eq(:pole)
+      expect(flanker.target).to eq('Kythkani')
       expect(flanker.target_id).to eq('-10544759')
+      expect(flanker.balance).to eq('solidly') # "(3: solidly balanced)" -> no conditions
+      expect(flanker.conditions).to eq([])
     end
 
     it 'preserves the crtrStatus flags through the assess backfill' do

--- a/spec/lib/common/xmlparser_dr_creature_spec.rb
+++ b/spec/lib/common/xmlparser_dr_creature_spec.rb
@@ -36,6 +36,13 @@ DR_ASSESS = <<~XML.delete("\n")
   <prompt time="1785273425">R&gt;</prompt>
 XML
 
+# Future-proofing fixture: DragonRealms room-objs using GemStone's inline
+# <a exist noun> creature shape (does not occur today), plus the crtrStatus batch.
+DR_ROOM_WITH_A_TAGS = <<~XML.delete("\n")
+  <component id='room objs'>You also see <pushBold/><a exist="4001" noun="moradu">a jeol moradu</a><popBold/>, <pushBold/><a exist="4002" noun="kobold">a kobold</a><popBold/> and some junk.</component>
+  <crtrStatus exist="4001" hostile="1" immobile="1"/><crtrStatus exist="4002" hostile="1"/><prompt time="1785273999">R&gt;</prompt>
+XML
+
 RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
   subject(:parser) { Lich::Common::XMLParser.new }
 
@@ -47,14 +54,16 @@ RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
     # The parser refers to GameObj unqualified, which resolves to
     # Lich::Common::GameObj (its lexical scope), so it must be stubbed there.
     # DragonRealms room-objs carry no <a> tag, so GameObj is only touched for
-    # clear_* housekeeping and the status-annotation path (npcs[-1].status=).
-    # Stubbing keeps those harmless; an unstubbed npcs[-1] on the "(immobile)"
-    # annotation would raise and the parser would silently rescue+reset,
-    # skipping the very roster-clear these tests assert on.
+    # clear_* housekeeping and the status-annotation path (npcs&.last&.status=).
     %i[clear_loot clear_npcs clear_pcs clear_room_desc new_npc new_loot].each do |m|
       allow(Lich::Common::GameObj).to receive(m)
     end
-    allow(Lich::Common::GameObj).to receive(:npcs).and_return([double('npc').as_null_object])
+    # nil is the real DragonRealms value: GameObj.npcs is registry_or_nil over an
+    # empty registry (nothing populates it from DR room-objs). The parser now
+    # guards the annotation against nil, so a "(immobile)"/"(dead)" run no longer
+    # raises + resets mid-fragment (which would drop the room-objs<->crtrStatus
+    # name pairing). Returning nil here exercises that real condition.
+    allow(Lich::Common::GameObj).to receive(:npcs).and_return(nil)
   end
 
   def feed(fragment)
@@ -62,13 +71,34 @@ RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
   end
 
   describe 'the <crtrStatus> batch after the room-objs component' do
-    it 'builds an id-keyed hostile roster from crtrStatus alone, with no names yet' do
+    it 'builds an id-keyed hostile roster from crtrStatus, named from room-objs order' do
       feed(DR_ROOM_AND_CRTR)
 
       expect(Lich::DragonRealms::Creature.targets.map(&:id)).to contain_exactly(
         99353095, 99353135, 99355263, 99355283, 99355351
       )
-      expect(Lich::DragonRealms::Creature[99353095].name).to be_nil
+      # Stream-order backfill: each id is named from its bold room-objs slot,
+      # before any assess has run.
+      expect(Lich::DragonRealms::Creature[99353095].name).to eq('a jeol moradu')
+      expect(Lich::DragonRealms::Creature[99353095].noun).to eq('moradu')
+    end
+
+    it 'names every id in the batch from its stream-order room-objs slot' do
+      feed(DR_ROOM_AND_CRTR)
+
+      names = [99353095, 99353135, 99355263, 99355283, 99355351].map do |id|
+        Lich::DragonRealms::Creature[id].name
+      end
+      expect(names).to all(eq('a jeol moradu'))
+      expect(Lich::DragonRealms::Creature[99355351].noun).to eq('moradu')
+    end
+
+    it 'count-guards: crtrStatus beyond the captured bold names get no name' do
+      feed(%(<component id='room objs'>You also see <pushBold/>a jeol moradu<popBold/>, <pushBold/>a kobold<popBold/> and some junk.</component><crtrStatus exist="1" hostile="1"/><crtrStatus exist="2" hostile="1"/><crtrStatus exist="3" hostile="1"/><prompt time="1785273999">R&gt;</prompt>))
+
+      expect(Lich::DragonRealms::Creature[1].name).to eq('a jeol moradu')
+      expect(Lich::DragonRealms::Creature[2].name).to eq('a kobold')
+      expect(Lich::DragonRealms::Creature[3].name).to be_nil # no matching bold slot
     end
 
     it 'applies each creature\'s flags from its own tag' do
@@ -125,6 +155,32 @@ RSpec.describe 'Lich::Common::XMLParser DragonRealms creature feed' do
 
       expect(Lich::DragonRealms::Creature[-10544759]).to be_nil
       expect(Lich::DragonRealms::Creature.all.map(&:id)).to all(be > 0)
+    end
+  end
+
+  describe 'future-proofing: GemStone-style <a exist noun> room-objs in DR' do
+    # If DragonRealms ever emits creatures with GemStone's inline <a exist noun>
+    # tag (the shape we already handle for GS), the DR path must register id-first
+    # from the inline name/noun -- and must not touch the unqualified Gemstone
+    # Creature (not loaded in DR). The stream-order capture branch is skipped when
+    # an <a> is present, so it degrades cleanly. Fixture: DR_ROOM_WITH_A_TAGS.
+    it 'registers id + name + noun + flags from the inline tag without raising' do
+      expect { feed(DR_ROOM_WITH_A_TAGS) }.not_to raise_error
+
+      c1 = Lich::DragonRealms::Creature[4001]
+      expect(c1.name).to eq('a jeol moradu')
+      expect(c1.noun).to eq('moradu')
+      expect(c1.has_status?('immobilized')).to be true
+
+      c2 = Lich::DragonRealms::Creature[4002]
+      expect(c2.name).to eq('a kobold')
+      expect(c2.crtr_flag?(:hostile)).to be true
+    end
+
+    it 'ties both creatures into the room roster' do
+      feed(DR_ROOM_WITH_A_TAGS)
+
+      expect(Lich::DragonRealms::Creature.targets.map(&:id)).to contain_exactly(4001, 4002)
     end
   end
 end

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -383,6 +383,18 @@ RSpec.describe Lich::DragonRealms::Creature do
       expect(described_class.targets.map(&:id)).to eq([99353135])
       expect(described_class.in_room.map(&:id)).to contain_exactly(99353095, 99353135)
     end
+
+    it 'excludes a non-hostile creature (crtrStatus hostile="0") from .targets but tracks it' do
+      # Real case: a Warrior Mage familiar (a white-tailed leopard, exist 104139961)
+      # reports hostile="0" -- durable friend/foe straight from crtrStatus, unlike
+      # an empath-manipulated enemy which stays hostile="1". targets' hostile
+      # baseline must skip it; in_room must still track it.
+      described_class.sync('104139961', 'hostile' => '0', 'disengaged' => '1') # familiar
+      described_class.sync('105955994', 'hostile' => '1') # a real mob
+
+      expect(described_class.targets.map(&:id)).to eq([105955994])
+      expect(described_class.in_room.map(&:id)).to contain_exactly(104139961, 105955994)
+    end
   end
 
   describe '.cleanup_old (positional, per the shared base contract)' do

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -413,4 +413,55 @@ RSpec.describe Lich::DragonRealms::Creature do
       expect(described_class.cleanup_old).to eq(1)
     end
   end
+
+  # Data-driven over the ACTUAL vocabularies so every flag/balance value is
+  # covered by construction -- a new entry added to CreatureBase's maps or
+  # DR_BALANCE_VALUES is exercised automatically, with no hand-maintained list to
+  # fall out of date. (This is why "flying", "hidden", etc. can't be missed.)
+  describe 'exhaustive crtrStatus + balance vocabulary coverage' do
+    Lich::Common::CreatureBase::CRTR_STATUS_FLAGS.each do |xml_name, status|
+      it "tracks status flag #{xml_name.inspect} as has_status?(#{status.inspect}), and clears it" do
+        creature = described_class.sync('1', 'hostile' => '1', xml_name => '1')
+        expect(creature.has_status?(status)).to be true
+
+        described_class.sync('1', 'hostile' => '1') # flag dropped on next snapshot
+        expect(creature.has_status?(status)).to be false
+      end
+    end
+
+    Lich::Common::CreatureBase::CRTR_CLASSIFICATION_FLAGS.each do |xml_name, key|
+      it "tracks classification flag #{xml_name.inspect} as crtr_flag?(#{key.inspect}), and clears it" do
+        creature = described_class.sync('1', xml_name => '1')
+        expect(creature.crtr_flag?(key)).to be true
+
+        described_class.sync('1', {}) # dropped on next snapshot
+        expect(creature.crtr_flag?(key)).to be false
+      end
+    end
+
+    Lich::Common::CreatureBase::ALL_CRTR_FLAGS.each_key do |xml_name|
+      it "never leaks crtrStatus flag word #{xml_name.inspect} into assess conditions" do
+        described_class.feed_assess(
+          name: 'A test creature', id: '1', number: 1,
+          status: "#{xml_name} and solidly balanced", relation: 'facing',
+          range: :melee, self: false, pc: false
+        )
+        expect(described_class[1].conditions).not_to include(xml_name)
+      end
+    end
+
+    solidly_idx = Lich::DragonRealms::DR_BALANCE_VALUES.index('solidly')
+    Lich::DragonRealms::DR_BALANCE_VALUES.each_with_index do |descriptor, idx|
+      it "captures balance descriptor #{descriptor.inspect} (off_balance?=#{idx < solidly_idx})" do
+        described_class.feed_assess(
+          name: 'A test creature', id: '1', number: 1,
+          status: "#{descriptor} balanced", relation: 'facing',
+          range: :melee, self: false, pc: false
+        )
+        creature = described_class[1]
+        expect(creature.balance).to eq(descriptor)
+        expect(creature.off_balance?).to be(idx < solidly_idx)
+      end
+    end
+  end
 end

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe Lich::DragonRealms::Creature do
       expect(described_class[99353095].name).to eq('a jeol moradu')
       expect(described_class[99353095].noun).to eq('moradu')
     end
+
+    it 'a nil backfill name (out-of-range count-guard) leaves an existing name intact' do
+      described_class.sync('99353095', { 'hostile' => '1' }, 'a jeol moradu')
+      described_class.sync('99353095', 'hostile' => '1', 'dead' => '1') # later refresh, no name
+      # nil positional name (surplus crtrStatus / no bold slot) must not wipe it
+      described_class.sync('99353095', { 'hostile' => '1' }, nil)
+
+      expect(described_class[99353095].name).to eq('a jeol moradu')
+      expect(described_class[99353095].noun).to eq('moradu')
+    end
   end
 
   describe '.feed_assess (the id-to-name tie-in)' do
@@ -207,6 +217,128 @@ RSpec.describe Lich::DragonRealms::Creature do
     it 'ignores an entry with no id' do
       expect(described_class.feed_assess(name: 'You', id: nil, self: true, pc: false)).to be_nil
       expect(described_class.all).to be_empty
+    end
+
+    it 'stores the engaged target name and its assess number when present' do
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '99353095', number: 5,
+        status: 'solidly balanced', relation: 'facing', target: 'a plague spawn',
+        target_number: 2, target_id: '99351111', range: :melee, self: false, pc: false
+      )
+
+      c = described_class[99353095]
+      expect(c.target).to eq('a plague spawn')
+      expect(c.target_number).to eq(2)
+      expect(c.target_id).to eq('99351111')
+    end
+  end
+
+  describe 'assess status parsing (parse_assess_status edge cases)' do
+    def assess(id, status)
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: id, number: 1, status: status,
+        relation: 'facing', range: :melee, self: false, pc: false
+      )
+      described_class[id.to_i]
+    end
+
+    it 'parses multiple assess-only afflictions' do
+      c = assess('1', 'cursed and poisoned and solidly balanced')
+      expect(c.balance).to eq('solidly')
+      expect(c.conditions).to eq(%w[cursed poisoned])
+      expect(c.cursed?).to be true
+      expect(c.condition?('poisoned')).to be true
+    end
+
+    it 'drops crtrStatus flag words even when mixed with real afflictions' do
+      c = assess('2', 'cursed and stunned and off balance')
+      expect(c.balance).to eq('off')
+      expect(c.conditions).to eq(['cursed']) # stunned excluded, cursed kept
+    end
+
+    it 'handles a status with afflictions but no balance phrase' do
+      c = assess('3', 'cursed')
+      expect(c.balance).to be_nil
+      expect(c.off_balance?).to be false # unknown balance is not "off"
+      expect(c.conditions).to eq(['cursed'])
+    end
+
+    it 'handles an empty or nil status (still enriched, no balance/conditions)' do
+      empty = assess('4', '')
+      expect(empty.balance).to be_nil
+      expect(empty.conditions).to eq([])
+      expect(empty.enriched?).to be true
+
+      nilst = assess('5', nil)
+      expect(nilst.balance).to be_nil
+      expect(nilst.conditions).to eq([])
+      expect(nilst.enriched?).to be true
+    end
+
+    it 'maps the balance ladder for off_balance? on both sides of "solidly"' do
+      expect(assess('10', 'incredibly balanced').off_balance?).to be false
+      expect(assess('11', 'nimbly balanced').off_balance?).to be false
+      expect(assess('12', 'solidly balanced').off_balance?).to be false
+      expect(assess('13', 'somewhat off balance').off_balance?).to be true # multi-word, below solidly
+      expect(assess('14', 'hopelessly balanced').off_balance?).to be true
+      expect(assess('13', 'somewhat off balance').balance).to eq('somewhat off')
+    end
+  end
+
+  describe '#noun (derive_noun) across DragonRealms name shapes' do
+    def named(id, assess_name)
+      described_class.feed_assess(
+        name: assess_name, id: id, number: 1, status: 'solidly balanced',
+        relation: 'facing', range: :melee, self: false, pc: false
+      )
+      described_class[id.to_i]
+    end
+
+    it 'takes the trailing noun of a multi-word name' do
+      expect(named('1', 'A void-black umbral moth').noun).to eq('moth')
+    end
+
+    it 'keeps an apostrophe when it is part of the trailing noun' do
+      expect(named('2', "A lesser Adan'f").noun).to eq("adan'f") # downcased
+    end
+
+    it 'takes the last word past an apostrophe-bearing adjective' do
+      expect(named('3', "An elder Adan'f blademaster").noun).to eq('blademaster')
+    end
+
+    it 'is robust to trailing whitespace or punctuation on the name' do
+      # end-anchored matching would return nil here; scan+last must not.
+      expect(named('4', 'A jeol moradu ').noun).to eq('moradu')
+      expect(named('5', 'A jeol moradu.').noun).to eq('moradu')
+    end
+  end
+
+  describe 'hidden (a crtrStatus flag DR emits but the maps originally omitted)' do
+    it 'tracks a hidden creature via has_status? from crtrStatus' do
+      described_class.sync('9001', 'hostile' => '1', 'hidden' => '1')
+
+      c = described_class[9001]
+      expect(c.has_status?('hidden')).to be true
+    end
+
+    it 'clears hidden on a later snapshot that drops it' do
+      described_class.sync('9001', 'hostile' => '1', 'hidden' => '1')
+      described_class.sync('9001', 'hostile' => '1') # came out of hiding
+
+      expect(described_class[9001].has_status?('hidden')).to be false
+    end
+
+    it 'excludes hidden from assess conditions (now a known crtrStatus flag)' do
+      described_class.sync('9001', 'hostile' => '1', 'hidden' => '1')
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '9001', number: 1,
+        status: 'hidden and solidly balanced', relation: 'facing',
+        range: :melee, self: false, pc: false
+      )
+
+      c = described_class[9001]
+      expect(c.conditions).to eq([]) # hidden excluded, tracked via crtrStatus
+      expect(c.has_status?('hidden')).to be true
     end
   end
 

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -103,9 +103,58 @@ RSpec.describe Lich::DragonRealms::Creature do
       expect(creature.relation).to eq('behind you')
       expect(creature.range).to eq(:melee)
       expect(creature.assess_status).to eq('cursed and solidly balanced')
+      # parsed breakdown of the parenthetical
+      expect(creature.balance).to eq('solidly')
+      expect(creature.off_balance?).to be false
+      expect(creature.conditions).to eq(['cursed'])
+      expect(creature.cursed?).to be true
+      expect(creature.condition?('poisoned')).to be false
+      expect(creature.enriched?).to be true
       # flags from the earlier crtrStatus are preserved through the backfill
       expect(creature.crtr_flag?(:hostile)).to be true
       expect(creature.has_status?('immobilized')).to be true
+    end
+
+    it 'parses balance, target and open-ended conditions from assess' do
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '99355263', number: 6,
+        status: 'poisoned and off balance', relation: 'facing',
+        target: 'Mithandres', target_number: nil, target_id: '-10579963',
+        range: :melee, self: false, pc: false
+      )
+
+      c = described_class[99355263]
+      expect(c.balance).to eq('off')
+      expect(c.off_balance?).to be true
+      expect(c.conditions).to eq(['poisoned'])
+      # generic predicate covers not-yet-confirmed statuses like poisoned
+      expect(c.condition?('poisoned')).to be true
+      expect(c.cursed?).to be false
+      expect(c.target).to eq('Mithandres')
+      expect(c.target_id).to eq('-10579963')
+    end
+
+    it 'is not enriched (and has empty conditions/nil balance) until an assess arrives' do
+      described_class.sync('99353095', 'hostile' => '1')
+
+      c = described_class[99353095]
+      expect(c.enriched?).to be false
+      expect(c.balance).to be_nil
+      expect(c.conditions).to eq([])
+      expect(c.off_balance?).to be false
+    end
+
+    it 'reports prone from crtrStatus (a push flag), not from assess conditions' do
+      # prone/sleeping/stunned/etc. are crtrStatus flags, kept out of #conditions.
+      described_class.sync('99353095', 'hostile' => '1', 'prone' => '1')
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '99353095', number: 1,
+        status: 'cursed and solidly balanced', range: :melee, self: false, pc: false
+      )
+
+      c = described_class[99353095]
+      expect(c.has_status?('prone')).to be true # from crtrStatus
+      expect(c.conditions).to eq(['cursed']) # assess conditions exclude prone
     end
 
     it 'registers a creature from assess when no crtrStatus has been seen yet' do

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require 'dragonrealms/creature'
+
+# DragonRealms creature tracking, built on Lich::Common::CreatureBase. These
+# examples pin down the DragonRealms-specific behaviour: id-first registration
+# from <crtrStatus> (name-less), name/position backfill from the assess stream,
+# and the DragonRealms valid_target? rule. The shared registry/roster/query
+# contract is covered by spec/lib/common/creature/creature_base_spec.rb.
+RSpec.describe Lich::DragonRealms::Creature do
+  before do
+    described_class.clear
+    $creature_debug = nil
+  end
+
+  describe '.sync (the automatic <crtrStatus> feed)' do
+    it 'registers a creature id-first, with no name, and applies its flags' do
+      described_class.sync('99353095', 'hostile' => '1', 'immobile' => '1')
+
+      creature = described_class[99353095]
+      expect(creature).not_to be_nil
+      expect(creature.name).to be_nil
+      expect(creature.crtr_flag?(:hostile)).to be true
+      expect(creature.has_status?('immobilized')).to be true
+    end
+
+    it 'marks the synced creature present in the room' do
+      described_class.sync('99353095', 'hostile' => '1')
+
+      expect(described_class[99353095]).not_to be_nil
+      expect(Lich::DragonRealms::CreatureInstance.current_room_ids).to eq([99353095])
+    end
+
+    it 'reconciles a later snapshot on the same id as a full snapshot' do
+      described_class.sync('99353095', 'hostile' => '1', 'immobile' => '1')
+      described_class.sync('99353095', 'hostile' => '1') # immobile dropped
+
+      creature = described_class[99353095]
+      expect(creature.has_status?('immobilized')).to be false
+      expect(creature.crtr_flag?(:hostile)).to be true
+    end
+
+    it 'exposes synced hostiles through .targets even before any name is known' do
+      described_class.sync('99353095', 'hostile' => '1')
+      described_class.sync('99355263', 'hostile' => '1', 'disengaged' => '1')
+
+      expect(described_class.targets.map(&:id)).to contain_exactly(99353095, 99355263)
+    end
+  end
+
+  describe '.feed_assess (the id-to-name tie-in)' do
+    it 'backfills name, assess number, relation and range onto a synced id' do
+      described_class.sync('99353095', 'hostile' => '1', 'immobile' => '1')
+
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '99353095', number: 1,
+        status: 'cursed and solidly balanced', relation: 'behind you',
+        target_id: nil, range: :melee, self: false, pc: false
+      )
+
+      creature = described_class[99353095]
+      expect(creature.name).to eq('a jeol moradu') # downcased to match DR vocab
+      expect(creature.assess_number).to eq(1)
+      expect(creature.relation).to eq('behind you')
+      expect(creature.range).to eq(:melee)
+      expect(creature.assess_status).to eq('cursed and solidly balanced')
+      # flags from the earlier crtrStatus are preserved through the backfill
+      expect(creature.crtr_flag?(:hostile)).to be true
+      expect(creature.has_status?('immobilized')).to be true
+    end
+
+    it 'registers a creature from assess when no crtrStatus has been seen yet' do
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '99355263', number: 3,
+        status: 'solidly balanced', relation: 'flanking',
+        target_id: '-10544759', range: :pole, self: false, pc: false
+      )
+
+      creature = described_class[99355263]
+      expect(creature).not_to be_nil
+      expect(creature.name).to eq('a jeol moradu')
+      expect(creature.target_id).to eq('-10544759')
+      expect(creature.range).to eq(:pole)
+    end
+
+    it 'ignores an entry with no id' do
+      expect(described_class.feed_assess(name: 'You', id: nil, self: true, pc: false)).to be_nil
+      expect(described_class.all).to be_empty
+    end
+  end
+
+  describe '#valid_target?' do
+    it 'is true for a live creature and false once crtrStatus reports it dead' do
+      creature = described_class.sync('99353095', 'hostile' => '1')
+      expect(creature.valid_target?).to be true
+
+      described_class.sync('99353095', 'hostile' => '1', 'dead' => '1')
+      expect(creature.valid_target?).to be false
+    end
+
+    it 'drops dead creatures from .targets but keeps them in .in_room for looting' do
+      described_class.sync('99353095', 'hostile' => '1', 'dead' => '1')
+      described_class.sync('99353135', 'hostile' => '1')
+
+      expect(described_class.targets.map(&:id)).to eq([99353135])
+      expect(described_class.in_room.map(&:id)).to contain_exactly(99353095, 99353135)
+    end
+  end
+
+  describe '.cleanup_old (positional, per the shared base contract)' do
+    # #configure mutates per-class state on CreatureInstance; restore defaults so
+    # nothing leaks into another example under random ordering.
+    after { described_class.configure }
+
+    it 'accepts a positional age and removes aged creatures' do
+      old = described_class.register('an orc', 1)
+      old.instance_variable_set(:@created_at, Time.now - 10_800) # 3 hours old
+      described_class.register('a kobold', 2)
+
+      # A keyword-only facade would raise ArgumentError against the positional
+      # base method; the fix keeps the facade positional.
+      removed = nil
+      expect { removed = described_class.cleanup_old(600) }.not_to raise_error
+
+      expect(removed).to eq(1)
+      expect(described_class[1]).to be_nil
+      expect(described_class[2]).not_to be_nil
+    end
+
+    it 'defaults to a 600s cutoff when called with no argument' do
+      old = described_class.register('an orc', 1)
+      old.instance_variable_set(:@created_at, Time.now - 601)
+      described_class.register('a kobold', 2)
+
+      expect(described_class.cleanup_old).to eq(1)
+    end
+  end
+end

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -47,6 +47,43 @@ RSpec.describe Lich::DragonRealms::Creature do
 
       expect(described_class.targets.map(&:id)).to contain_exactly(99353095, 99355263)
     end
+
+    it 'names a creature from the stream-order backfill and derives its noun' do
+      described_class.sync('99353095', { 'hostile' => '1' }, 'a jeol moradu')
+
+      creature = described_class[99353095]
+      expect(creature.name).to eq('a jeol moradu')
+      expect(creature.noun).to eq('moradu')
+    end
+
+    it 'backfills the name onto an already id-first-registered instance' do
+      described_class.sync('99353095', 'hostile' => '1') # id-first, no name
+      expect(described_class[99353095].name).to be_nil
+
+      described_class.sync('99353095', { 'hostile' => '1' }, 'a jeol moradu')
+      expect(described_class[99353095].name).to eq('a jeol moradu')
+      expect(described_class[99353095].noun).to eq('moradu')
+    end
+
+    it 'leaves name and noun nil when no backfill name is supplied' do
+      described_class.sync('99353095', 'hostile' => '1')
+
+      expect(described_class[99353095].name).to be_nil
+      expect(described_class[99353095].noun).to be_nil
+    end
+
+    it 'does not let a stream-order name overwrite an assess-set name' do
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '99353095', number: 1,
+        relation: 'behind you', range: :melee, self: false, pc: false
+      )
+      # A later refresh's positional guess must never clobber the authoritative
+      # assess name (they normally match; this pins the precedence).
+      described_class.sync('99353095', { 'hostile' => '1' }, 'a wrong name')
+
+      expect(described_class[99353095].name).to eq('a jeol moradu')
+      expect(described_class[99353095].noun).to eq('moradu')
+    end
   end
 
   describe '.feed_assess (the id-to-name tie-in)' do
@@ -61,6 +98,7 @@ RSpec.describe Lich::DragonRealms::Creature do
 
       creature = described_class[99353095]
       expect(creature.name).to eq('a jeol moradu') # downcased to match DR vocab
+      expect(creature.noun).to eq('moradu') # derived from the name
       expect(creature.assess_number).to eq(1)
       expect(creature.relation).to eq('behind you')
       expect(creature.range).to eq(:melee)

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -283,6 +283,31 @@ RSpec.describe Lich::DragonRealms::Creature do
       expect(assess('14', 'hopelessly balanced').off_balance?).to be true
       expect(assess('13', 'somewhat off balance').balance).to eq('somewhat off')
     end
+
+    it 'parses the "imbalanced" phrasing used by the worst balance levels' do
+      # Real log form: the worst levels say "extremely imbalanced", not
+      # "...balanced". Must still capture the descriptor (and be off_balance?).
+      c = assess('20', 'cursed and extremely imbalanced')
+      expect(c.balance).to eq('extremely')
+      expect(c.off_balance?).to be true
+      expect(c.conditions).to eq(['cursed']) # "extremely imbalanced" is balance, not a condition
+    end
+
+    it 'parses "friendly" and an Oxford-comma condition list (real log form)' do
+      c = assess('21', 'friendly, cursed, and nimbly balanced')
+      expect(c.balance).to eq('nimbly')
+      expect(c.conditions).to eq(%w[friendly cursed])
+      expect(c.friendly?).to be true # assess friend/foe marker
+      expect(c.cursed?).to be true
+    end
+
+    it 'drops a crtrStatus flag from an Oxford-comma list, keeping real conditions' do
+      # "hidden, cursed, and solidly balanced" -> hidden excluded (crtrStatus),
+      # cursed kept; validates comma handling + flag exclusion together.
+      c = assess('22', 'hidden, cursed, and solidly balanced')
+      expect(c.balance).to eq('solidly')
+      expect(c.conditions).to eq(['cursed'])
+    end
   end
 
   describe '#noun (derive_noun) across DragonRealms name shapes' do

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -48,51 +48,51 @@ RSpec.describe Lich::DragonRealms::Creature do
       expect(described_class.targets.map(&:id)).to contain_exactly(99353095, 99355263)
     end
 
-    it 'names a creature from the stream-order backfill and derives its noun' do
-      described_class.sync('99353095', { 'hostile' => '1' }, 'a jeol moradu')
+    it 'names a creature (via apply_room_name) from the stream-order backfill and derives its noun' do
+      creature = described_class.sync('99353095', 'hostile' => '1')
+      creature.apply_room_name('a jeol moradu')
 
-      creature = described_class[99353095]
       expect(creature.name).to eq('a jeol moradu')
       expect(creature.noun).to eq('moradu')
     end
 
-    it 'backfills the name onto an already id-first-registered instance' do
+    it 'applies the room name to an already id-first-registered instance' do
       described_class.sync('99353095', 'hostile' => '1') # id-first, no name
       expect(described_class[99353095].name).to be_nil
 
-      described_class.sync('99353095', { 'hostile' => '1' }, 'a jeol moradu')
+      described_class[99353095].apply_room_name('a jeol moradu')
       expect(described_class[99353095].name).to eq('a jeol moradu')
       expect(described_class[99353095].noun).to eq('moradu')
     end
 
-    it 'leaves name and noun nil when no backfill name is supplied' do
+    it 'leaves name and noun nil when no room name is applied' do
       described_class.sync('99353095', 'hostile' => '1')
 
       expect(described_class[99353095].name).to be_nil
       expect(described_class[99353095].noun).to be_nil
     end
 
-    it 'does not let a stream-order name overwrite an assess-set name' do
+    it 'does not let a stream-order room name overwrite an assess-set name' do
       described_class.feed_assess(
         name: 'A jeol moradu', id: '99353095', number: 1,
         relation: 'behind you', range: :melee, self: false, pc: false
       )
       # A later refresh's positional guess must never clobber the authoritative
       # assess name (they normally match; this pins the precedence).
-      described_class.sync('99353095', { 'hostile' => '1' }, 'a wrong name')
+      described_class[99353095].apply_room_name('a wrong name')
 
       expect(described_class[99353095].name).to eq('a jeol moradu')
       expect(described_class[99353095].noun).to eq('moradu')
     end
 
-    it 'a nil backfill name (out-of-range count-guard) leaves an existing name intact' do
-      described_class.sync('99353095', { 'hostile' => '1' }, 'a jeol moradu')
-      described_class.sync('99353095', 'hostile' => '1', 'dead' => '1') # later refresh, no name
-      # nil positional name (surplus crtrStatus / no bold slot) must not wipe it
-      described_class.sync('99353095', { 'hostile' => '1' }, nil)
+    it 'a nil room name (count-gate skip) leaves an existing name intact' do
+      creature = described_class.sync('99353095', 'hostile' => '1')
+      creature.apply_room_name('a jeol moradu')
+      # count mismatch on a later refresh -> the gate applies no name at all
+      creature.apply_room_name(nil)
 
-      expect(described_class[99353095].name).to eq('a jeol moradu')
-      expect(described_class[99353095].noun).to eq('moradu')
+      expect(creature.name).to eq('a jeol moradu')
+      expect(creature.noun).to eq('moradu')
     end
   end
 

--- a/spec/lib/dragonrealms/creature_spec.rb
+++ b/spec/lib/dragonrealms/creature_spec.rb
@@ -144,6 +144,39 @@ RSpec.describe Lich::DragonRealms::Creature do
       expect(c.off_balance?).to be false
     end
 
+    it 'keeps a crtrStatus flag word (immobile) out of assess conditions' do
+      # "immobile" appears in the assess parenthetical AND as a crtrStatus flag;
+      # it must be tracked via crtr_flag? (fresh), not duplicated into conditions.
+      described_class.sync('103723880', 'hostile' => '1', 'immobile' => '1')
+      described_class.feed_assess(
+        name: 'A jeol moradu', id: '103723880', number: 1,
+        status: 'immobile and slightly off balance', relation: 'facing',
+        target: 'Holdigor', target_id: '-10592432', range: :melee, self: false, pc: false
+      )
+
+      c = described_class[103723880]
+      expect(c.balance).to eq('slightly off')
+      expect(c.off_balance?).to be true
+      expect(c.conditions).to eq([]) # immobile excluded (it is a crtrStatus flag)
+      expect(c.has_status?('immobilized')).to be true # tracked via crtrStatus, fresh
+    end
+
+    it 'excludes stunned (a crtrStatus flag) and parses a multi-word balance' do
+      described_class.sync('103732844', 'hostile' => '1', 'stunned' => '1')
+      described_class.feed_assess(
+        name: 'A void-black umbral moth', id: '103732844', number: 1,
+        status: 'stunned and very badly balanced', relation: 'facing',
+        target: 'you', target_id: nil, range: :melee, self: false, pc: false
+      )
+
+      c = described_class[103732844]
+      expect(c.balance).to eq('very badly') # multi-word DR_BALANCE_VALUES entry
+      expect(c.off_balance?).to be true
+      expect(c.conditions).to eq([]) # stunned excluded (crtrStatus flag)
+      expect(c.has_status?('stunned')).to be true # tracked via crtrStatus, fresh
+      expect(c.noun).to eq('moth') # trailing noun of a multi-word name
+    end
+
     it 'reports prone from crtrStatus (a push flag), not from assess conditions' do
       # prone/sleeping/stunned/etc. are crtrStatus flags, kept out of #conditions.
       described_class.sync('99353095', 'hostile' => '1', 'prone' => '1')


### PR DESCRIPTION
## Stacked on #1484

This PR is **stacked on #1484** (the behavior-preserving `CreatureBase` extraction) and contains that commit as its base. Please review #1484 first; the net-new surface here is the single `feat(dr): ...` commit. Once #1484 merges, this PR's diff reduces to just the DragonRealms layer.

## What

Adds a DragonRealms runtime creature layer (`lib/dragonrealms/creature.rb`) on top of the shared `Lich::Common::CreatureBase`, giving DR the id-keyed, flag-aware creature model GemStone already has. DR previously had no ids for room creatures — only name strings in `DRRoom` — so this is **purely additive** and leaves `DRRoom` and its ~120 script consumers untouched.

## Why now

DragonRealms recently began emitting `<crtrStatus exist=... hostile=1 immobile=1/>` — the same structured, id-keyed feed GemStone gets, with an identical flag vocabulary. DR splits creature data across three streams (vs GemStone's single `<a exist noun>` room-object tag):

| Stream | Gives | Missing |
|---|---|---|
| `<crtrStatus>` (automatic, batched after room-objs) | `exist` id + `hostile`/`immobile`/`disengaged` | name |
| room-objs bold text | name | id (left to `DRRoom` as before) |
| `assess` stream | id **+** name + assess number + relation + range | — |

So creatures are registered **id-first** from `<crtrStatus>` (name-less) and have their name/position **backfilled from `assess`** — the only feed that ties an `exist` id to a name.

## Parser wiring (`lib/common/xmlparser.rb`) — all guarded by game + `defined?`

- The `<crtrStatus>` handler routes DR tags to `Creature.sync` immediately (DR has no `<a>` text path to defer to), while GemStone keeps its existing deferred `@pending_crtr_status` path unchanged.
- `nav` and room-objs refresh now also clear the DR roster, so the following `<crtrStatus>` batch rebuilds a clean snapshot.
- Completed `assess` creature entries are fed to `Creature.feed_assess`.
- `gameloader` loads the DR creature file for DR sessions.

## Tests

- DAMP unit spec for the DR layer (`spec/lib/dragonrealms/creature_spec.rb`).
- End-to-end spec (`spec/lib/common/xmlparser_dr_creature_spec.rb`) driving the **real Ox pipeline** with fragments captured from a live DR session (five jeol moradu, exist 99353095..99355351): crtrStatus roster + flags, roster rebuild on refresh, and assess name/position backfill.
- The GemStone crtrStatus spec's `XMLData` double now also reports `game` (the handler consults it to route GS vs DR).
- Full suite green (no new failures); touched files rubocop-clean.

## Follow-up commits (on this branch, after the base `feat(dr)` commit)

These build on the layer above; the "assess is the *only* id→name tie" note in **Why now** is superseded by the first of these (room-objs order is now a second, every-refresh id→name path).

- **`feat(dr): name creatures from room-objs stream order + future-proof <a>`** — DR emits `<crtrStatus>` in the same order as the bold room-objs names (one per bold NPC, items skipped, counts equal, cross-checked vs assess id-order). Pair the Nth bold name → Nth `crtrStatus` id, so creatures are **named every refresh without waiting for `assess`**. Adds a derived `noun` (`"a jeol moradu"` → `"moradu"`; DRRoom `CREATURE_NAME` convention) making the layer a superset of `DRRoom.npcs`. Bounds-checked (surplus `crtrStatus` → nil, never a mis-pair); `assess` stays authoritative. Also: future-proofs the room-objs bold-`<a>` path (if DR ever emits GemStone-style `<a exist noun>`, route to DR's `Creature`, guarded — the stream-order branch then goes dormant), and fixes a latent DR crash — `GameObj.npcs&.last&.status=` guard, since `GameObj.npcs` is nil in DR so a `(dead)`/`(immobile)` room run raised and reset the parser mid-fragment.

- **`feat(dr): parse assess enrichment (balance, conditions, target)`** — expands the assess backfill: `target`/`target_number` (already parsed, previously dropped); `balance` (a `DR_BALANCE_VALUES` descriptor) + `off_balance?`; an open-ended `conditions` array with `condition?(name)`/`cursed?`; and `enriched?`/`enriched_at` so consumers can **poll-before-act** (assess only when a mob is un-enriched or a depended-on field is stale — assess fields are a staleable *pull* snapshot, unlike the *push* `crtrStatus` flags refreshed every room update).

- **`fix(dr): keep crtrStatus flag words out of assess conditions`** — live assess puts crtrStatus states in the parenthetical too (e.g. `(1: immobile and slightly off balance)`, `(1: stunned and very badly balanced)`). Those words are dropped from `conditions` (rejected via `CreatureBase::ALL_CRTR_FLAGS`) and tracked via `crtr_flag?`/`has_status?` (fresh), so the two sources never duplicate or disagree; `conditions` holds only assess-only afflictions (`cursed`, `poisoned`, …).

- **`fix(dr): track hidden crtrStatus flag, harden noun derivation, expand adversarial specs`** — adversarial review found two real bugs: (1) `hidden` was in none of the flag maps, so DR's `<crtrStatus ... hidden="1"/>` was silently dropped (`has_status?('hidden')` always false) — added to `CRTR_STATUS_FLAGS` (touches the shared `CreatureBase`; arguably belongs in #1484); (2) `derive_noun` was end-anchored, returning a nil noun on any trailing whitespace/punctuation — switched to `scan+last`. Plus edge/boundary specs: multi-affliction, no-balance, nil/empty status, the balance ladder both sides of "solidly", apostrophe/multi-word nouns.

- **`fix(dr): all-or-nothing count gate for room-objs name pairing`** — the per-tag pairing could mis-name on a *mid-list gap* (a bold room entity that emits no `crtrStatus`, e.g. a gelapod-like object, shifts every creature after it). Replaced with a batched gate: collect crtrStatus ids in order (flags still applied id-first immediately), then at the following `<prompt>` apply bold names by position **only when the counts match exactly**; on any mismatch apply **no** names (assess backfills by id) rather than risk a shifted mis-pair. `Creature.sync` dropped its now-unused `name` param.

- **`fix(dr): parse "imbalanced" balance phrasing; add friendly?`** — harvested ~2M assess parentheticals from live logs: the worst balance levels are phrased `extremely imbalanced` (not `...balanced`), which the pattern missed → `balance` nil and `off_balance?` false for the *most* vulnerable creatures; now accepts the optional `im`. The harvest also showed assess exposes friend/foe via a `friendly` marker (`friendly, cursed, and nimbly balanced`) that crtrStatus does **not** carry — added `friendly?`. Confirmed Oxford-comma separators too.

Each ships with specs — stream-order naming + noun, count-gate (both mismatch directions + a gelapod-like no-crtrStatus mob never mis-named), GemStone-`<a>` future-proofing, enrichment fields, flag-word exclusion, and parser edge cases drawn from the real log vocabulary (`extremely imbalanced`, `friendly`/Oxford-comma, `hidden`/`immobile`/`stunned` exclusion). Full suite green apart from two pre-existing flaky specs (enhancive order-dependence, hmr worktree-path); touched files rubocop-clean. Verified live in a DR combat room: names/nouns populate before any `assess`, enrichment fills in on assess and persists by id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

