### PR TITLE
ci(all): specs - isolate Infomon async writes between examples + worktree-agnostic HMR spec

### DIFF
--- a/spec/lib/common/hmr_spec.rb
+++ b/spec/lib/common/hmr_spec.rb
@@ -30,7 +30,7 @@ end
 RSpec.describe HMR, "#loaded" do
   context "can tell what has been loaded" do
     it "can find itself loaded" do
-      expect(Lich::Common::HMR.loaded.any?(%r{lich-5/lib/common/hmr.rb$})).to be_truthy
+      expect(Lich::Common::HMR.loaded.any?(%r{/lib/common/hmr\.rb$})).to be_truthy
     end
 
     it "can tell something has been freshly loaded" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,6 +77,10 @@ RSpec.configure do |config|
     Lich.reset_display_expgains! if defined?(Lich) && Lich.respond_to?(:reset_display_expgains!)
     Lich.db.reset! if defined?(Lich) && Lich.respond_to?(:db) && Lich.db.respond_to?(:reset!)
     Lich::Common::DB_Store.reset! if defined?(Lich::Common::DB_Store) && Lich::Common::DB_Store.respond_to?(:reset!)
+    # Drain Infomon's async write queue so a queued INSERT from a prior example
+    # cannot land in a later example's freshly reset table (seed/timing-dependent
+    # cross-file leakage). Specs that need a clean slate still call reset! themselves.
+    Lich::Gemstone::Infomon.flush if defined?(Lich::Gemstone::Infomon) && Lich::Gemstone::Infomon.respond_to?(:flush)
 
     # DR production classes - only if they're loaded (may override mocks)
     Lich::DragonRealms::DRExpMonitor.reset! if defined?(Lich::DragonRealms::DRExpMonitor) && Lich::DragonRealms::DRExpMonitor.respond_to?(:reset!)


### PR DESCRIPTION
## Summary

Fixes two independent, pre-existing **spec-only** flaky/failing tests. **No production code is modified** -- both fixes live entirely under `spec/`.

1. **Infomon's async write queue leaks between examples** -> seed/timing-dependent failures in `enhancive_spec` and `infomon_spec`.
2. **`HMR#loaded` spec hardcodes the checkout directory name** -> fails in any git worktree or alternate clone name.

Files changed:
- `spec/spec_helper.rb` (+4) -- drain Infomon's async write queue in the global `before` hook.
- `spec/lib/common/hmr_spec.rb` (+1/-1) -- assert the code's contract instead of the checkout directory name.

---

## Issue 1: Infomon async write queue leaks between examples

### Root cause

`Infomon.set` writes the in-memory cache **synchronously** but enqueues its SQL to a **background worker thread** (`lib/gemstone/infomon.rb`):

```ruby
def self.set(key, value)
  ...
  self.cache.put(key, value)         # synchronous
  self.queue << "INSERT OR REPLACE INTO ..."   # async: handed to a worker Thread
end
```

`Infomon.reset!` drops and recreates the character table **without draining that queue**:

```ruby
def self.reset!
  self.mutex_lock
  Infomon.db.drop_table?(self.table_name)
  self.cache.clear
  @cache_loaded = false
  Infomon.setup!            # recreates the (empty) table
end
```

The worker runs each queued `INSERT` under the same mutex, but the mutex only *serializes* worker-vs-reset -- it does not *order* them. So a still-pending `INSERT` from a prior `set` can execute **after** `reset!` has recreated the table, writing a stale row back into the fresh table. Because `reset!` sets `@cache_loaded = false`, the next `get` reloads the cache from the DB (`get` flushes then reads) and returns the resurrected value.

In tests, `reset!` is used for per-example isolation. When example A sets a value and example B's `reset!` runs before A's queued `INSERT` has drained, B sees A's data.

### Reproduction (on the base commit, before this fix)

`spec/lib/gemstone/enhancive_spec.rb` run **in isolation**, one seed per run:

| seed | 1 | 2 | 3 | 4 | 5 | 42 | 99 | 100 | 777 | 12345 |
|------|---|---|---|---|---|----|----|-----|-----|-------|
| failures | 2 | 2 | 1 | 0 | 2 | 0 | 1 | 1 | 2 | 2 |

8 of 10 seeds fail. Representative failures: `stat accessors returns 0 for unset stats`, `spell accessors returns empty array when no spells`, `pauses returns 0 when not set` -- i.e. a prior value-setting example leaked into an unset-expectation example.

The failure count also **varies run-to-run at a fixed seed** (e.g. seed 1 across five runs: `2, 1, 2, 2, 2`), confirming a genuine thread-timing component layered on top of example ordering -- not a purely deterministic ordering bug.

### Why the fix goes in the global hook, not a single spec

The leak is **cross-file**, not confined to `enhancive_spec`. `spec/lib/gemstone/infomon_spec.rb`'s `db performance ... has a cache that will lazily load` (which calls `reset!` in a loop and asserts `get(k)` is `nil`) **passes in isolation** (5/5 runs) but **fails intermittently only in a full-suite run** -- a prior file's queued write resurrects into this test's freshly reset table. A `before(:each)` added to one spec cannot cover a leak that crosses spec files, and the loop body case can't be covered by a `before(:each)` at all.

The fix drains the queue **once** in the global `spec/spec_helper.rb` `before` hook, next to the existing shared-store resets:

```ruby
Lich.db.reset! if ...
Lich::Common::DB_Store.reset! if ...
# Drain Infomon's async write queue so a queued INSERT from a prior example
# cannot land in a later example's freshly reset table (seed/timing-dependent
# cross-file leakage). Specs that need a clean slate still call reset! themselves.
Lich::Gemstone::Infomon.flush if defined?(Lich::Gemstone::Infomon) && Lich::Gemstone::Infomon.respond_to?(:flush)
```

This guarantees no queued write outlives the example that created it, for **every** spec.

### Why production `reset!` is intentionally left unchanged

An alternative is to add the `flush` inside `Infomon.reset!` itself. This PR deliberately does **not**, because the observable defect is test isolation, and every production `reset!` is safe against the race:

- `;infomon redo`, the init/`watch!` path, and `lib/global_defs.rb` all route through `Infomon.redo!`, which does `reset!` **immediately followed by `sync`** (a full re-parse/repopulate). Any resurrected row is overwritten.
- The only other `reset!` is the one-time schema-migration recovery inside `setup!` (triggered when the `updated_at` column is missing), which runs at initialization **before any writes are queued** (empty queue).

So a production `reset!` never observes a stale-resurrection in practice. Hardening `reset!`'s contract directly is a reasonable **separate** change, but it is a production behavior change and out of scope for a spec-hygiene fix.

Note the `flush` barrier is not new and is already exercised in production -- `get` flushes before every DB read. This hook only makes between-example state match the existing production read contract; `flush` short-circuits (`return true if self.queue.empty?`) so it is a no-op in the common empty-queue case.

---

## Issue 2: `HMR#loaded` spec asserted the checkout directory name, not the code's behavior

`Lich::Common::HMR.loaded` returns `$LOADED_FEATURES` entries -- **absolute filesystem paths**:

```ruby
def self.loaded
  $LOADED_FEATURES.select { |path| path.end_with?(".rb") }
end
```

The example "can find itself loaded" verifies that `hmr.rb` is present in that set. The old assertion required the absolute path to contain the literal segment `lich-5/lib/...`:

```ruby
expect(Lich::Common::HMR.loaded.any?(%r{lich-5/lib/common/hmr.rb$})).to be_truthy
```

That is a fact about the **name of the directory the repo is checked out into**, which `HMR` neither controls nor knows about. It passes in CI only because GitHub Actions checks out into `.../work/lich-5/lich-5/`. It fails for anyone whose working copy is not literally named `lich-5`:

| path | old `lich-5/lib/common/hmr.rb$` | new `/lib/common/hmr\.rb$` |
|------|------|------|
| `/home/runner/work/lich-5/lich-5/lib/common/hmr.rb` (CI) | matches | matches |
| `/Users/dev/repos/lich-5-wt-foo/lib/common/hmr.rb` (git worktree) | **no match** | matches |
| any clone named `lich5`, `l5`, or a hashed CI workspace | **no match** | matches |

The fix asserts exactly the contract -- an entry ending in `/lib/common/hmr.rb` -- and nothing more:

```ruby
expect(Lich::Common::HMR.loaded.any?(%r{/lib/common/hmr\.rb$})).to be_truthy
```

It also escapes the literal `.` (the old `hmr.rb` would also match e.g. `hmrXrb`). No specificity is lost: no other file has the suffix `/lib/common/hmr.rb`.

---

## Testing

- **Full suite green** across seeds `424242`, `200`, `7`, `1`, `999`, multiple runs each (15+ full runs, no surviving flake): `4928 examples, 0 failures`.
- `enhancive_spec` + `hmr_spec` green across the 8 seeds that reliably failed on base.
- `infomon_spec` `lazy load` no longer flakes in full-suite runs.
- `rubocop` clean on both touched files.

Findings and the fix were **independently reproduced from scratch** (separate base worktree, adversarial re-run): base flakiness reproduced on ~7-8/10 seeds, same-seed failure-count variance confirmed, cross-file `infomon_spec:768` failure observed only in full-suite runs, and 15 post-fix full-suite runs with zero failures.

### Reviewer notes / scope caveats

- This is a **spec-hygiene** fix: it removes the between-example leakage so the suite is deterministic. It reduces the race to "cannot occur between examples" via the drain; it does not change production `reset!` (which is self-healing, per above). Hardening `reset!` itself is a separate, optional production PR.
- `infomon_spec:768` is **rare** in full-suite runs (roughly 1 in 8 on base) -- observing it requires many iterations or an unlucky seed, so a couple of green runs on base does not indicate absence. The seed/timing sensitivity documented above is the reliable signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated hot-reload verification to recognize the current file path format.
  * Improved test isolation by clearing pending asynchronous writes between examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->