### PR TITLE
refactor(all): stop map pathfinding scaling with highest room id

### DIFF
--- a/lib/common/map/map_base.rb
+++ b/lib/common/map/map_base.rb
@@ -69,6 +69,34 @@ module Lich
       end
     end
 
+    # An Array of tag names that tells its owning Map class to drop the tag
+    # index whenever it is mutated, so Map.rooms_by_tag cannot go stale behind
+    # a caller's back. Reads are plain Array reads with no added indirection.
+    class TagList < Array
+      # Array methods that change the receiver's contents.
+      MUTATORS = %i[
+        << []= append clear collect! compact! concat delete delete_at delete_if
+        fill flatten! insert keep_if map! pop prepend push reject! replace
+        rotate! select! shift shuffle! slice! sort! sort_by! uniq! unshift
+      ].freeze
+
+      # @param contents [Array, nil] initial tag names
+      # @param owner [Class, nil] Map class notified on mutation
+      def initialize(contents = nil, owner = nil)
+        super()
+        concat(contents.to_a) unless contents.nil?
+        @owner = owner
+      end
+
+      MUTATORS.each do |name|
+        define_method(name) do |*args, &block|
+          result = super(*args, &block)
+          @owner.reset_tag_index if @owner.respond_to?(:reset_tag_index)
+          result
+        end
+      end
+    end
+
     # Base module containing shared map functionality
     # Include this in game-specific Map classes
     module MapBase
@@ -117,6 +145,49 @@ module Lich
             echo 'Map.dijkstra: error: invalid source room'
             nil
           end
+        end
+
+        # Class-level dispatcher for the hash-returning variant of #dijkstra
+        def dijkstra_hashes(source, destination = nil)
+          if source.is_a?(self)
+            source.dijkstra_hashes(destination)
+          elsif (room = self[source])
+            room.dijkstra_hashes(destination)
+          else
+            echo 'Map.dijkstra: error: invalid source room'
+            nil
+          end
+        end
+
+        # Tag name => Array of room ids carrying that tag. Memoized; the memo
+        # shares its lifecycle with Map.tags and is dropped by #reset_tag_index.
+        # @return [Hash{String => Array<Integer>}]
+        def tag_index
+          self.load unless loaded?
+          @tag_index = build_tag_index if @tag_index.nil? || @tag_index.empty?
+          @tag_index
+        end
+
+        # Room ids carrying a tag, nearest-agnostic and in room id order
+        # @param tag_name [String] Tag to look up
+        # @return [Array<Integer>] Room ids, empty when the tag is unknown
+        def rooms_by_tag(tag_name)
+          (tag_index[tag_name] || []).dup
+        end
+
+        # Drop the tag memo. Call after mutating any room's tags in place.
+        # @return [nil]
+        def reset_tag_index
+          @tag_index = nil
+        end
+
+        # @return [Hash{String => Array<Integer>}]
+        def build_tag_index
+          index = {}
+          list.compact.each do |room|
+            room.tags.each { |tag| (index[tag] ||= []) << room.id }
+          end
+          index
         end
 
         # Find path between two rooms
@@ -323,8 +394,28 @@ module Lich
 
         # Run Dijkstra's algorithm from this room
         # @param destination [Integer, Array, nil] Target room(s) or nil for full graph
-        # @return [Array] [previous_hash, distances_hash] for path reconstruction
+        # @return [Array, nil] [previous, distances] as Arrays indexed by room id
         def dijkstra(destination = nil)
+          previous_hash, shortest_distances_hash = dijkstra_hashes(destination)
+          return nil if previous_hash.nil?
+
+          # Convert hashes back to arrays for backward compatibility
+          max_room_id = [previous_hash.keys.max, shortest_distances_hash.keys.max].compact.max || 0
+          previous = Array.new(max_room_id + 1)
+          shortest_distances = Array.new(max_room_id + 1)
+
+          previous_hash.each { |key, value| previous[key] = value }
+          shortest_distances_hash.each { |key, value| shortest_distances[key] = value }
+
+          [previous, shortest_distances]
+        end
+
+        # Same search as #dijkstra, returning the raw hashes keyed by room id.
+        # Internal callers use this so nothing allocates arrays sized by the
+        # highest room id in the database.
+        # @param destination [Integer, Array, nil] Target room(s) or nil for full graph
+        # @return [Array, nil] [previous_hash, distances_hash], or nil on error
+        def dijkstra_hashes(destination = nil)
           self.class.load unless self.class.loaded?
           source = @id
           visited = {}
@@ -376,15 +467,7 @@ module Lich
             end
           end
 
-          # Convert hashes back to arrays for backward compatibility
-          max_room_id = [previous_hash.keys.max, shortest_distances_hash.keys.max].compact.max || 0
-          previous = Array.new(max_room_id + 1)
-          shortest_distances = Array.new(max_room_id + 1)
-
-          previous_hash.each { |key, value| previous[key] = value }
-          shortest_distances_hash.each { |key, value| shortest_distances[key] = value }
-
-          [previous, shortest_distances]
+          [previous_hash, shortest_distances_hash]
         rescue StandardError => e
           echo "Map.dijkstra: error: #{e}"
           respond e.backtrace
@@ -397,7 +480,7 @@ module Lich
         def path_to(destination)
           self.class.load unless self.class.loaded?
           destination = destination.to_i
-          previous, = dijkstra(destination)
+          previous, = dijkstra_hashes(destination)
           return nil unless previous[destination]
 
           path = [destination]
@@ -409,9 +492,8 @@ module Lich
         # @param tag_name [String] Tag to search for
         # @return [Integer, nil] Room ID of nearest tagged room
         def find_nearest_by_tag(tag_name)
-          target_list = []
-          self.class.list.each { |room| target_list.push(room.id) if room.tags.include?(tag_name) }
-          _, shortest_distances = self.class.dijkstra(@id, target_list)
+          target_list = self.class.rooms_by_tag(tag_name)
+          _, shortest_distances = self.class.dijkstra_hashes(@id, target_list)
           if target_list.include?(@id)
             @id
           else
@@ -424,9 +506,8 @@ module Lich
         # @param tag_name [String] Tag to search for
         # @return [Array<Integer>] Room IDs sorted by distance
         def find_all_nearest_by_tag(tag_name)
-          target_list = []
-          self.class.list.each { |room| target_list.push(room.id) if room.tags.include?(tag_name) }
-          _, shortest_distances = self.class.dijkstra(@id)
+          target_list = self.class.rooms_by_tag(tag_name)
+          _, shortest_distances = self.class.dijkstra_hashes(@id)
           target_list.delete_if { |room_num| shortest_distances[room_num].nil? }
           target_list.sort { |a, b| shortest_distances[a] <=> shortest_distances[b] }
         end
@@ -439,7 +520,7 @@ module Lich
           if target_list.include?(@id)
             @id
           else
-            _, shortest_distances = self.class.dijkstra(@id, target_list)
+            _, shortest_distances = self.class.dijkstra_hashes(@id, target_list)
             valid_rooms = target_list.select { |room_num| shortest_distances[room_num].is_a?(Numeric) }
             valid_rooms.min_by { |room_num| shortest_distances[room_num] }
           end

--- a/lib/common/map/map_base.rb
+++ b/lib/common/map/map_base.rb
@@ -164,8 +164,7 @@ module Lich
         # @return [Hash{String => Array<Integer>}]
         def tag_index
           self.load unless loaded?
-          @tag_index = build_tag_index if @tag_index.nil? || @tag_index.empty?
-          @tag_index
+          @tag_index ||= build_tag_index
         end
 
         # Room ids carrying a tag, nearest-agnostic and in room id order

--- a/lib/common/map/map_dr.rb
+++ b/lib/common/map/map_dr.rb
@@ -13,7 +13,6 @@ module Lich
       @@loaded                   = false
       @@load_mutex               = Mutex.new
       @@list                   ||= []
-      @@tags                   ||= []
       @@current_room_mutex       = Mutex.new
       @@current_room_id        ||= -1
       @@current_room_count     ||= -1
@@ -27,9 +26,20 @@ module Lich
 
       attr_reader :id
       attr_accessor :title, :description, :paths, :location, :climate, :terrain,
-                    :wayto, :timeto, :image, :image_coords, :tags, :check_location,
+                    :wayto, :timeto, :image, :image_coords, :check_location,
                     :unique_loot, :uid, :room_objects,
                     :genie_id, :genie_zone, :genie_pos
+
+      # @return [TagList] mutation-aware list of this room's tags
+      attr_reader :tags
+
+      # Replace this room's tags and drop the tag index
+      # @param value [Array, nil] new tag names
+      # @return [Array, nil] the assigned value, per Ruby writer semantics
+      def tags=(value)
+        @tags = TagList.new(value, self.class)
+        self.class.reset_tag_index
+      end
 
       def initialize(id, title, description, paths, uid = [], location = nil,
                      climate = nil, terrain = nil, wayto = {}, timeto = {},
@@ -48,7 +58,7 @@ module Lich
         @timeto = timeto
         @image = image
         @image_coords = image_coords
-        @tags = tags
+        @tags = TagList.new(tags, self.class)
         @check_location = check_location
         @unique_loot = unique_loot
         @genie_id = genie_id
@@ -85,7 +95,7 @@ module Lich
         end
 
         def clear_tags_cache
-          @@tags.clear
+          reset_tag_index
         end
 
         def mark_loaded
@@ -117,9 +127,21 @@ module Lich
         else
           chkre = /#{val.strip.sub(/\.$/, '').gsub(/\.(?:\.\.)?/, '|')}/i
           chk = /#{Regexp.escape(val.strip)}/i
-          @@list.find { |room| room&.title&.find { |title| title =~ chk } } ||
-            @@list.find { |room| room&.description&.find { |desc| desc =~ chk } } ||
-            @@list.find { |room| room&.description&.find { |desc| desc =~ chkre } }
+          # Title and exact-description matches share one pass; the loose
+          # regex pass only runs when neither found anything. Same precedence
+          # as the three sequential scans this replaces.
+          rooms = @@list.compact
+          by_title = nil
+          by_desc = nil
+          rooms.each do |room|
+            if room.title.find { |title| title =~ chk }
+              by_title = room
+              break
+            end
+            by_desc = room if by_desc.nil? && room.description.find { |desc| desc =~ chk }
+          end
+          by_title || by_desc ||
+            rooms.find { |room| room.description.find { |desc| desc =~ chkre } }
         end
       end
 
@@ -323,8 +345,7 @@ module Lich
 
       def self.tags
         self.load unless @@loaded
-        @@tags = @@list.compact.each_with_object({}) { |r, h| r.tags.each { |t| h[t] = nil unless h.key?(t) } }.keys if @@tags.empty?
-        @@tags.dup
+        tag_index.keys
       end
 
       def self.ids_from_uid(n)
@@ -334,7 +355,7 @@ module Lich
       def self.clear
         @@load_mutex.synchronize do
           @@list.clear
-          @@tags.clear
+          clear_tags_cache
           @@loaded = false
           GC.start
         end
@@ -415,7 +436,7 @@ module Lich
                 )
               end
             end
-            @@tags.clear
+            clear_tags_cache
             respond "--- Map loaded #{filename}"
             @@loaded = true
             load_uids
@@ -549,7 +570,7 @@ module Lich
               return false
             end
 
-            @@tags.clear
+            clear_tags_cache
             load_uids
             @@loaded = true
             true

--- a/lib/common/map/map_dr.rb
+++ b/lib/common/map/map_dr.rb
@@ -65,6 +65,7 @@ module Lich
         @genie_zone = genie_zone
         @genie_pos = genie_pos
         @@list[@id] = self
+        self.class.reset_tag_index
       end
 
       def to_s

--- a/lib/common/map/map_gs.rb
+++ b/lib/common/map/map_gs.rb
@@ -62,6 +62,7 @@ module Lich
         @check_location = check_location
         @unique_loot = unique_loot
         @@list[@id] = self
+        self.class.reset_tag_index
       end
 
       # Class method accessors required by MapBase

--- a/lib/common/map/map_gs.rb
+++ b/lib/common/map/map_gs.rb
@@ -16,7 +16,6 @@ module Lich
       @@list                   ||= []
       @@images                 ||= []
       @@locations              ||= []
-      @@tags                   ||= []
       @@current_room_mutex       = Mutex.new
       @@current_room_id        ||= nil
       @@current_room_count     ||= -1
@@ -30,7 +29,18 @@ module Lich
 
       attr_reader :id
       attr_accessor :title, :description, :paths, :uid, :location, :climate, :terrain,
-                    :wayto, :timeto, :image, :image_coords, :tags, :check_location, :unique_loot
+                    :wayto, :timeto, :image, :image_coords, :check_location, :unique_loot
+
+      # @return [TagList] mutation-aware list of this room's tags
+      attr_reader :tags
+
+      # Replace this room's tags and drop the tag index
+      # @param value [Array, nil] new tag names
+      # @return [Array, nil] the assigned value, per Ruby writer semantics
+      def tags=(value)
+        @tags = TagList.new(value, self.class)
+        self.class.reset_tag_index
+      end
 
       def initialize(id, title, description, paths, uid = [], location = nil,
                      climate = nil, terrain = nil, wayto = {}, timeto = {},
@@ -48,7 +58,7 @@ module Lich
         @timeto = timeto
         @image = image
         @image_coords = image_coords
-        @tags = tags
+        @tags = TagList.new(tags, self.class)
         @check_location = check_location
         @unique_loot = unique_loot
         @@list[@id] = self
@@ -94,7 +104,7 @@ module Lich
         end
 
         def clear_tags_cache
-          @@tags.clear
+          reset_tag_index
         end
 
         def mark_loaded
@@ -133,9 +143,21 @@ module Lich
         else
           chkre = /#{val.strip.sub(/\.$/, '').gsub(/\.(?:\.\.)?/, '|')}/i
           chk = /#{Regexp.escape(val.strip)}/i
-          @@list.find { |room| room.title.find { |title| title =~ chk } } ||
-            @@list.find { |room| room.description.find { |desc| desc =~ chk } } ||
-            @@list.find { |room| room.description.find { |desc| desc =~ chkre } }
+          # Title and exact-description matches share one pass; the loose
+          # regex pass only runs when neither found anything. Same precedence
+          # as the three sequential scans this replaces.
+          rooms = @@list.compact
+          by_title = nil
+          by_desc = nil
+          rooms.each do |room|
+            if room.title.find { |title| title =~ chk }
+              by_title = room
+              break
+            end
+            by_desc = room if by_desc.nil? && room.description.find { |desc| desc =~ chk }
+          end
+          by_title || by_desc ||
+            rooms.find { |room| room.description.find { |desc| desc =~ chkre } }
         end
       end
 
@@ -494,8 +516,7 @@ module Lich
 
       def self.tags
         self.load unless @@loaded
-        @@tags = @@list.compact.each_with_object({}) { |r, h| r.tags.each { |t| h[t] = nil unless h.key?(t) } }.keys if @@tags.empty?
-        @@tags.dup
+        tag_index.keys
       end
 
       def self.uids_clear
@@ -517,7 +538,7 @@ module Lich
       def self.clear
         @@load_mutex.synchronize do
           @@list.clear
-          @@tags.clear
+          clear_tags_cache
           @@locations.clear
           @@images.clear
           @@loaded = false
@@ -602,7 +623,7 @@ module Lich
                 )
               end
             end
-            @@tags.clear
+            clear_tags_cache
             respond "--- #{Script.current.name} Map loaded #{filename}"
             @@loaded = true
             load_uids
@@ -734,7 +755,7 @@ module Lich
               return false
             end
 
-            @@tags.clear
+            clear_tags_cache
             load_uids
             @@loaded = true
             true

--- a/spec/lib/common/map/map_base_spec.rb
+++ b/spec/lib/common/map/map_base_spec.rb
@@ -568,6 +568,22 @@ RSpec.describe Lich::Common::MapBase do
         expect(test_class.tag_index).to eq({})
       end
 
+      it 'memoizes an empty index instead of rebuilding on every call' do
+        test_class.test_list[0] = test_class.new(0)
+        first_call = test_class.tag_index
+
+        expect(test_class.tag_index).to be(first_call)
+      end
+
+      it 'builds only once when no room carries a tag' do
+        test_class.test_list[0] = test_class.new(0)
+        allow(test_class).to receive(:build_tag_index).and_call_original
+
+        3.times { test_class.tag_index }
+
+        expect(test_class).to have_received(:build_tag_index).once
+      end
+
       it 'memoizes the index across calls' do
         test_class.test_list[0] = test_class.new(0, tags: ['shop'])
         first_call = test_class.tag_index

--- a/spec/lib/common/map/map_base_spec.rb
+++ b/spec/lib/common/map/map_base_spec.rb
@@ -420,6 +420,70 @@ RSpec.describe Lich::Common::MapBase do
       end
     end
 
+    describe '#dijkstra_hashes' do
+      it 'returns hashes keyed by room id rather than arrays' do
+        previous, distances = test_class.test_list[0].dijkstra_hashes
+
+        expect(previous).to be_a(Hash)
+        expect(distances).to be_a(Hash)
+      end
+
+      it 'keys only the rooms it actually reached' do
+        _, distances = test_class.test_list[0].dijkstra_hashes
+
+        expect(distances.keys).to contain_exactly(0, 1, 2, 3)
+      end
+
+      it 'does not grow with the highest room id in the list' do
+        test_class.test_list[500_000] = test_class.new(500_000)
+        _, distances = test_class.test_list[0].dijkstra_hashes
+
+        expect(distances).not_to have_key(500_000)
+        expect(distances.size).to eq(4)
+      end
+
+      it 'agrees with the array form returned by #dijkstra' do
+        previous_hash, distances_hash = test_class.test_list[0].dijkstra_hashes
+        previous, distances = test_class.test_list[0].dijkstra
+
+        previous_hash.each { |id, from| expect(previous[id]).to eq(from) }
+        distances_hash.each { |id, dist| expect(distances[id]).to eq(dist) }
+      end
+    end
+
+    describe '#dijkstra return contract' do
+      it 'still returns two Arrays for backward compatibility' do
+        previous, distances = test_class.test_list[0].dijkstra
+
+        expect(previous).to be_a(Array)
+        expect(distances).to be_a(Array)
+      end
+
+      it 'indexes the arrays by room id' do
+        _, distances = test_class.test_list[0].dijkstra
+
+        expect(distances[0]).to eq(0)
+        expect(distances[1]).to eq(1)
+        expect(distances[2]).to eq(2)
+      end
+
+      it 'sizes the arrays to the highest room id reached' do
+        test_class.test_list[7] = test_class.new(7, wayto: { '0' => 'south' }, timeto: { '0' => 0.1 })
+        test_class.test_list[0].wayto['7'] = 'north'
+        test_class.test_list[0].timeto['7'] = 0.1
+        _, distances = test_class.test_list[0].dijkstra
+
+        expect(distances.length).to eq(8)
+      end
+
+      it 'returns nil when the search raises' do
+        room = test_class.test_list[0]
+        allow(room).to receive(:dijkstra_hashes).and_return(nil)
+
+        expect(room.dijkstra).to be_nil
+      end
+    end
+
     describe '#find_nearest_by_tag' do
       before do
         test_class.test_list[2].tags = ['shop']
@@ -471,6 +535,114 @@ RSpec.describe Lich::Common::MapBase do
         test_class.test_list[5] = test_class.new(5)
 
         expect(test_class.get_free_id).to eq(6)
+      end
+    end
+
+    describe '.tag_index' do
+      it 'maps each tag to the ids of the rooms carrying it' do
+        test_class.test_list[0] = test_class.new(0, tags: ['shop', 'bank'])
+        test_class.test_list[1] = test_class.new(1, tags: ['shop'])
+
+        expect(test_class.tag_index).to eq('shop' => [0, 1], 'bank' => [0])
+      end
+
+      it 'lists ids in ascending room id order' do
+        test_class.test_list[5] = test_class.new(5, tags: ['shop'])
+        test_class.test_list[2] = test_class.new(2, tags: ['shop'])
+        test_class.test_list[9] = test_class.new(9, tags: ['shop'])
+
+        expect(test_class.tag_index['shop']).to eq([2, 5, 9])
+      end
+
+      it 'skips nil holes in the room list' do
+        test_class.test_list[0] = test_class.new(0, tags: ['shop'])
+        test_class.test_list[3] = test_class.new(3, tags: ['shop'])
+
+        expect { test_class.tag_index }.not_to raise_error
+        expect(test_class.tag_index['shop']).to eq([0, 3])
+      end
+
+      it 'returns an empty index when no room carries a tag' do
+        test_class.test_list[0] = test_class.new(0)
+
+        expect(test_class.tag_index).to eq({})
+      end
+
+      it 'memoizes the index across calls' do
+        test_class.test_list[0] = test_class.new(0, tags: ['shop'])
+        first_call = test_class.tag_index
+
+        expect(test_class.tag_index).to be(first_call)
+      end
+    end
+
+    describe '.rooms_by_tag' do
+      before do
+        test_class.test_list[0] = test_class.new(0, tags: ['shop'])
+        test_class.test_list[1] = test_class.new(1, tags: ['bank'])
+      end
+
+      it 'returns the ids carrying the tag' do
+        expect(test_class.rooms_by_tag('shop')).to eq([0])
+      end
+
+      it 'returns an empty array for an unknown tag' do
+        expect(test_class.rooms_by_tag('nonexistent')).to eq([])
+      end
+
+      it 'returns a copy so callers cannot corrupt the index' do
+        returned = test_class.rooms_by_tag('shop')
+        returned.clear
+
+        expect(test_class.rooms_by_tag('shop')).to eq([0])
+      end
+
+      it 'is stable across repeated calls that mutate the result' do
+        3.times { test_class.rooms_by_tag('shop').delete_if { true } }
+
+        expect(test_class.rooms_by_tag('shop')).to eq([0])
+      end
+    end
+
+    describe '.reset_tag_index' do
+      it 'forces the index to be rebuilt on the next read' do
+        test_class.test_list[0] = test_class.new(0, tags: ['shop'])
+        expect(test_class.rooms_by_tag('shop')).to eq([0])
+
+        test_class.test_list[1] = test_class.new(1, tags: ['shop'])
+        test_class.reset_tag_index
+
+        expect(test_class.rooms_by_tag('shop')).to eq([0, 1])
+      end
+
+      it 'returns nil' do
+        expect(test_class.reset_tag_index).to be_nil
+      end
+    end
+
+    describe '.dijkstra_hashes' do
+      before do
+        test_class.test_list[0] = test_class.new(0, wayto: { '1' => 'north' }, timeto: { '1' => 0.5 })
+        test_class.test_list[1] = test_class.new(1)
+      end
+
+      it 'accepts a room instance as the source' do
+        previous, distances = test_class.dijkstra_hashes(test_class.test_list[0])
+
+        expect(previous).to be_a(Hash)
+        expect(distances[1]).to be_within(0.001).of(0.5)
+      end
+
+      it 'accepts a room id as the source' do
+        _, distances = test_class.dijkstra_hashes(0)
+
+        expect(distances[1]).to be_within(0.001).of(0.5)
+      end
+
+      it 'returns nil for an invalid source room' do
+        allow(test_class).to receive(:echo)
+
+        expect(test_class.dijkstra_hashes(999)).to be_nil
       end
     end
 
@@ -764,6 +936,104 @@ RSpec.describe Lich::Common::MapBase do
       settings.personal_map_targets = nil
 
       expect { test_class.apply_wayto_overrides }.not_to raise_error
+    end
+  end
+end
+
+RSpec.describe Lich::Common::TagList do
+  let(:owner) { double('MapClass', reset_tag_index: nil) }
+
+  describe 'Array compatibility' do
+    it 'compares equal to a plain Array with the same contents' do
+      expect(described_class.new(['shop'], owner)).to eq(['shop'])
+    end
+
+    it 'compares equal when the plain Array is the receiver' do
+      expect(['shop'] == described_class.new(['shop'], owner)).to be true
+    end
+
+    it 'starts empty when given no contents' do
+      expect(described_class.new).to eq([])
+    end
+
+    it 'tolerates nil contents' do
+      expect(described_class.new(nil, owner)).to eq([])
+    end
+
+    it 'supports read methods without notifying the owner' do
+      list = described_class.new(['shop', 'bank'], owner)
+      expect(owner).not_to receive(:reset_tag_index)
+
+      expect(list.include?('shop')).to be true
+      expect(list.sort).to eq(['bank', 'shop'])
+      expect(list.find { |tag| tag == 'bank' }).to eq('bank')
+    end
+
+    it 'does not notify the owner while being constructed' do
+      expect(owner).not_to receive(:reset_tag_index)
+
+      described_class.new(['shop'], owner)
+    end
+  end
+
+  describe 'mutation notifies the owner' do
+    it 'notifies on append' do
+      list = described_class.new([], owner)
+      expect(owner).to receive(:reset_tag_index)
+
+      list << 'shop'
+    end
+
+    it 'notifies on delete' do
+      list = described_class.new(['shop'], owner)
+      expect(owner).to receive(:reset_tag_index)
+
+      list.delete('shop')
+    end
+
+    it 'notifies on clear' do
+      list = described_class.new(['shop'], owner)
+      expect(owner).to receive(:reset_tag_index)
+
+      list.clear
+    end
+
+    it 'still performs the mutation it reports' do
+      list = described_class.new(['shop'], owner)
+      list << 'bank'
+
+      expect(list).to eq(['shop', 'bank'])
+    end
+
+    described_class::MUTATORS.each do |mutator|
+      it "notifies on ##{mutator}" do
+        list = described_class.new(['shop', 'bank'], owner)
+        expect(owner).to receive(:reset_tag_index).at_least(:once)
+
+        case mutator
+        when :[]= then list[0] = 'inn'
+        when :insert then list.insert(0, 'inn')
+        when :fill then list.fill('inn')
+        when :concat, :replace then list.public_send(mutator, ['inn'])
+        when :delete then list.delete('shop')
+        when :delete_at, :slice! then list.public_send(mutator, 0)
+        when :rotate! then list.rotate!(1)
+        when :sort_by! then list.sort_by! { |tag| tag }
+        when :collect!, :map!, :delete_if, :keep_if, :reject!, :select!
+          list.public_send(mutator) { |tag| tag == 'shop' }
+        when :<<, :push, :append, :prepend, :unshift then list.public_send(mutator, 'inn')
+        else list.public_send(mutator)
+        end
+      end
+    end
+  end
+
+  describe 'without an owner' do
+    it 'mutates without raising' do
+      list = described_class.new(['shop'])
+
+      expect { list << 'bank' }.not_to raise_error
+      expect(list).to eq(['shop', 'bank'])
     end
   end
 end

--- a/spec/lib/common/map/map_dr_spec.rb
+++ b/spec/lib/common/map/map_dr_spec.rb
@@ -427,6 +427,18 @@ RSpec.describe Lich::Common::Map, 'DragonRealms implementation' do
         expect(map_class.rooms_by_tag('shop')).to eq([])
       end
 
+      it 'picks up a newly constructed tagged room' do
+        map_class.new(3, ['C'], ['c'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, ['shop'])
+
+        expect(map_class.rooms_by_tag('shop')).to eq([1, 3])
+      end
+
+      it 'picks up a room replaced at an existing id' do
+        map_class.new(2, ['B'], ['b'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, ['shop'])
+
+        expect(map_class.rooms_by_tag('shop')).to eq([1, 2])
+      end
+
       it 'is reflected in .tags as well' do
         map_class[2].tags << 'inn'
 

--- a/spec/lib/common/map/map_dr_spec.rb
+++ b/spec/lib/common/map/map_dr_spec.rb
@@ -365,6 +365,125 @@ RSpec.describe Lich::Common::Map, 'DragonRealms implementation' do
       end
     end
 
+    describe '.rooms_by_tag' do
+      before do
+        map_class.class_variable_set(:@@loaded, true) # see NOTE above
+        map_class.new(1, ['A'], ['a'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, ['shop'])
+        map_class.new(4, ['B'], ['b'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, ['shop', 'bank'])
+        map_class.new(2, ['C'], ['c'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, [])
+      end
+
+      it 'returns ids of rooms carrying the tag in ascending order' do
+        expect(map_class.rooms_by_tag('shop')).to eq([1, 4])
+      end
+
+      it 'returns an empty array for an unknown tag' do
+        expect(map_class.rooms_by_tag('nonexistent')).to eq([])
+      end
+
+      it 'skips nil holes in the room list' do
+        expect(map_class.class_variable_get(:@@list)[3]).to be_nil
+
+        expect(map_class.rooms_by_tag('bank')).to eq([4])
+      end
+
+      it 'is not corrupted by a caller mutating the result' do
+        map_class.rooms_by_tag('shop').clear
+
+        expect(map_class.rooms_by_tag('shop')).to eq([1, 4])
+      end
+    end
+
+    describe 'tag index invalidation' do
+      before do
+        map_class.class_variable_set(:@@loaded, true) # see NOTE above
+        map_class.new(1, ['A'], ['a'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, ['shop'])
+        map_class.new(2, ['B'], ['b'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, [])
+        map_class.rooms_by_tag('shop') # prime the memo
+      end
+
+      it 'picks up a tag appended in place' do
+        map_class[2].tags << 'shop'
+
+        expect(map_class.rooms_by_tag('shop')).to eq([1, 2])
+      end
+
+      it 'picks up a tag deleted in place' do
+        map_class[1].tags.delete('shop')
+
+        expect(map_class.rooms_by_tag('shop')).to eq([])
+      end
+
+      it 'picks up a whole tag list assignment' do
+        map_class[2].tags = ['shop', 'bank']
+
+        expect(map_class.rooms_by_tag('shop')).to eq([1, 2])
+        expect(map_class.rooms_by_tag('bank')).to eq([2])
+      end
+
+      it 'picks up an in place clear' do
+        map_class[1].tags.clear
+
+        expect(map_class.rooms_by_tag('shop')).to eq([])
+      end
+
+      it 'is reflected in .tags as well' do
+        map_class[2].tags << 'inn'
+
+        expect(map_class.tags).to include('inn')
+      end
+
+      it 'wraps room tags in a TagList' do
+        expect(map_class[1].tags).to be_a(Lich::Common::TagList)
+      end
+
+      it 'keeps room tags comparable to a plain Array' do
+        expect(map_class[1].tags).to eq(['shop'])
+      end
+
+      it 'is dropped by clear_tags_cache' do
+        map_class.new(3, ['C'], ['c'], ['path'], [], nil, nil, nil, {}, {}, nil, nil, ['shop'])
+        map_class.clear_tags_cache
+
+        expect(map_class.rooms_by_tag('shop')).to eq([1, 3])
+      end
+    end
+
+    describe '.[] fuzzy lookup precedence' do
+      before do
+        map_class.class_variable_set(:@@loaded, true) # see NOTE above
+        map_class.new(1, ['[Market Row]'],   ['Stalls line the muddy street.'], ['path'])
+        map_class.new(4, ['[Quiet Lane]'],   ['Marble counters gleam here.'],   ['path'])
+        map_class.new(6, ['[Bank Lobby]'],   ['Stalls line the far wall.'],     ['path'])
+      end
+
+      it 'prefers a title match over an earlier description match' do
+        expect(map_class['[Bank Lobby]'].id).to eq(6)
+      end
+
+      it 'falls back to an exact description match when no title matches' do
+        expect(map_class['Marble counters gleam'].id).to eq(4)
+      end
+
+      it 'returns the first room when several descriptions match' do
+        expect(map_class['Stalls line'].id).to eq(1)
+      end
+
+      it 'falls back to the loose regex form last' do
+        expect(map_class['Stalls line...muddy street'].id).to eq(1)
+      end
+
+      it 'returns nil when nothing matches' do
+        expect(map_class['no such room anywhere']).to be_nil
+      end
+
+      it 'skips nil holes without raising' do
+        expect(map_class.class_variable_get(:@@list)[3]).to be_nil
+
+        expect { map_class['no such room anywhere'] }.not_to raise_error
+      end
+    end
+
     describe '.clear' do
       before do
         map_class.class_variable_set(:@@loaded, true) # see NOTE above

--- a/spec/lib/common/map/map_gs_spec.rb
+++ b/spec/lib/common/map/map_gs_spec.rb
@@ -276,3 +276,83 @@ RSpec.describe 'Code sharing between DR and GS' do
     end
   end
 end
+
+RSpec.describe 'Map sparse room id handling' do
+  let(:base_content) { File.read(File.expand_path('../../../../lib/common/map/map_base.rb', __dir__)) }
+  let(:dr_content) { File.read(File.expand_path('../../../../lib/common/map/map_dr.rb', __dir__)) }
+  let(:gs_content) { File.read(File.expand_path('../../../../lib/common/map/map_gs.rb', __dir__)) }
+
+  describe 'hash returning dijkstra' do
+    it 'base module defines both the instance and class level variants' do
+      expect(base_content).to include('def dijkstra_hashes(destination = nil)')
+      expect(base_content).to include('def dijkstra_hashes(source, destination = nil)')
+    end
+
+    it 'keeps the array conversion on the public dijkstra' do
+      expect(base_content).to include('Convert hashes back to arrays for backward compatibility')
+    end
+
+    it 'internal callers use the hash variant' do
+      expect(base_content).to include('previous, = dijkstra_hashes(destination)')
+      expect(base_content).to include('self.class.dijkstra_hashes(@id, target_list)')
+      expect(base_content).to include('self.class.dijkstra_hashes(@id)')
+    end
+
+    it 'neither game overrides the pathfinding methods' do
+      [dr_content, gs_content].each do |content|
+        expect(content).not_to include('def dijkstra')
+        expect(content).not_to include('def path_to')
+        expect(content).not_to include('def find_nearest')
+      end
+    end
+  end
+
+  describe 'tag index' do
+    it 'base module defines the index and its accessors' do
+      expect(base_content).to include('class TagList < Array')
+      expect(base_content).to include('def tag_index')
+      expect(base_content).to include('def rooms_by_tag(tag_name)')
+      expect(base_content).to include('def reset_tag_index')
+      expect(base_content).to include('def build_tag_index')
+    end
+
+    it 'the tag finders read the index instead of scanning the room list' do
+      expect(base_content).to include('target_list = self.class.rooms_by_tag(tag_name)')
+      expect(base_content).not_to include('target_list.push(room.id) if room.tags.include?')
+    end
+
+    it 'both games retire the separate tag name cache' do
+      [dr_content, gs_content].each do |content|
+        expect(content).not_to include('@@tags')
+      end
+    end
+
+    it 'both games route invalidation through clear_tags_cache' do
+      [dr_content, gs_content].each do |content|
+        expect(content).to include("def clear_tags_cache\n          reset_tag_index")
+      end
+    end
+
+    it 'both games wrap room tags in a TagList with an invalidating writer' do
+      [dr_content, gs_content].each do |content|
+        expect(content).to include('@tags = TagList.new(tags, self.class)')
+        expect(content).to include('def tags=(value)')
+        expect(content).not_to include(':image_coords, :tags,')
+      end
+    end
+  end
+
+  describe 'fuzzy lookup' do
+    it 'both games compact the room list once instead of scanning it three times' do
+      [dr_content, gs_content].each do |content|
+        expect(content).to include('rooms = @@list.compact')
+        expect(content).not_to include('@@list.find { |room| room.title.find')
+        expect(content).not_to include('@@list.find { |room| room&.title&.find')
+      end
+    end
+
+    it 'base module compacts before building the tag index' do
+      expect(base_content).to include('list.compact.each do |room|')
+    end
+  end
+end

--- a/spec/lib/common/map/map_gs_spec.rb
+++ b/spec/lib/common/map/map_gs_spec.rb
@@ -321,6 +321,16 @@ RSpec.describe 'Map sparse room id handling' do
       expect(base_content).not_to include('target_list.push(room.id) if room.tags.include?')
     end
 
+    it 'base module memoizes the index unconditionally' do
+      expect(base_content).to include('@tag_index ||= build_tag_index')
+    end
+
+    it 'both games invalidate the index when the room list is mutated' do
+      [dr_content, gs_content].each do |content|
+        expect(content).to include("@@list[@id] = self\n        self.class.reset_tag_index")
+      end
+    end
+
     it 'both games retire the separate tag name cache' do
       [dr_content, gs_content].each do |content|
         expect(content).not_to include('@@tags')


### PR DESCRIPTION
## Problem

Map pathfinding and room lookup slow down as room ids grow, independently of how
many rooms actually exist. Ids are never reused, so the gap between room count
and highest room id widens permanently over the life of a mapdb.

Holding the room count at 20,000 and raising only the highest room id from
19,999 to 999,950, on current `main`:

| operation | degradation |
|---|---|
| `Room#find_all_nearest_by_tag` | 7.9x slower |
| `Map[String]`, no match | 6.6x slower |
| `Map[String]`, description hit | 6.3x slower |
| `Room#path_to` | 1.2x slower |

## Root cause

Three places assumed a dense room list.

1. `map_base.rb:379-386`. The dijkstra search itself is already sparse-safe:
   `MinHeap` plus `previous_hash` / `shortest_distances_hash` only touch nodes
   that get pushed. But the backward-compatibility conversion allocated two
   Arrays sized by the highest room id reached, and every internal caller paid
   for that while only ever doing `[]` lookups by room id.
2. `find_nearest_by_tag` and `find_all_nearest_by_tag` walked every slot in
   `Map.list` to build their target lists.
3. `Map[String]` made three sequential full passes over `Map.list`. In GS,
   which has no safe navigation there, every nil hole dispatched through the
   `NilClass#method_missing` override twice per pass.

## Changes

**Hash-returning dijkstra.** The search body moves to `dijkstra_hashes`, which
returns the raw id-keyed hashes. `dijkstra` becomes a thin wrapper that still
materializes the two Arrays, so the public contract is untouched for scripts
calling it directly. `path_to`, `find_nearest_by_tag`, `find_all_nearest_by_tag`
and `find_nearest` use the hash variant. A class-level `dijkstra_hashes`
dispatcher mirrors the existing class-level `dijkstra` so the finders keep going
through `self.class`, preserving the original dispatch exactly.

**Tag index.** `rooms_by_tag(tag_name)` reads a memoized `tag_index` of tag name
to room ids, so the finders no longer scan the room list. Rather than adding a
second memo beside `@@tags`, the existing tag name cache is retired and
`Map.tags` now reads `tag_index.keys`. `clear_tags_cache` already existed in both
game files but nothing called it; the three inline `@@tags.clear` sites now route
through it, so there is a single invalidation path.

**Automatic invalidation.** `Lich::Common::TagList < Array` wraps the 28 mutating
Array methods and notifies its owning Map class, so `room.tags << 'shop'`,
`room.tags.delete(...)` and `room.tags.clear` all drop the index. `tags` also
gets an explicit writer so whole-list assignment invalidates, and
`Room#initialize` drops the index at the `@@list[@id] = self` assignment so
adding or replacing a room is covered too. Reads are plain Array reads with no
added indirection, and a `TagList` compares equal to a plain Array in both
directions.

**Single-pass fuzzy lookup.** `Map[String]` compacts once, then matches title and
exact description in one pass with an early break on a title hit. The loose regex
pass only runs when neither found anything. Precedence is identical to the three
scans it replaces.

Using C-level `Array#compact` rather than a Ruby-level nil check per slot is
worth 5.1 ms vs 31.9 ms per pass at a million slots, and is why both
`build_tag_index` and the fuzzy scan compact first.

## Results

Median of three runs, each the minimum of seven trials, 20,000 rooms. Absolute
timings are machine dependent; the ratios held steady across runs.

| operation | dense | sparse (max id 999,950) |
|---|---|---|
| `Room#find_all_nearest_by_tag` | 0.89x | **0.12x** |
| `Map[String]` no match | 0.82x | **0.16x** |
| `Map[String]` description hit | 0.77x | **0.17x** |
| `Room#path_to` | 0.94x | **0.80x** |
| `Map.tags`, forced rebuild | 0.82x | 1.56x |

Nothing regresses except a forced tag index rebuild, which is the inherent cost
of storing ids rather than names only. It is memoized, so it is paid once per
invalidation. Note these trials run `GC.start` before each iteration, which
strips out GC pressure and therefore understates the real gain, since allocating
two million-element arrays per pathfind is itself a GC cost.

## Behaviour

No intended behaviour change. Verified against the real DR Map class, baseline vs
this branch, across 21 checks: `Map.tags` contents and key order, lookup by
integer, numeric string, uid, exact title, duplicate title, title outranking
description, description only, shared description prefix, dotted loose regex, no
match, both tag finders, `find_nearest`, `path_to`, `dijkstra` return types, and
the class-level dispatcher. All identical.

## Testing

272 map spec examples, 0 failures, up from 175. Built on the three existing spec
files and matching each one's conventions.

| file | before | after |
|---|---|---|
| `map_base_spec.rb` | 66 | 130 |
| `map_dr_spec.rb` | 53 | 73 |
| `map_gs_spec.rb` | 56 | 69 |

New coverage:

- `TagList` Array compatibility, plus a data-driven loop asserting every entry in
  `MUTATORS` notifies the owner, and that construction and reads do not
- `tag_index` ordering, nil holes, and memoization including the untagged case
- `rooms_by_tag` dup safety under repeated `delete_if`, and `reset_tag_index`
- Index invalidation end to end on the real DR class: in-place append, delete and
  clear, whole assignment, newly constructed tagged room, and a room replaced at
  an existing id
- Both `dijkstra_hashes` variants including the invalid-source nil, plus a
  `#dijkstra return contract` block pinning the two-Array shape, room-id
  indexing, array sizing and nil on error
- Every fuzzy lookup precedence branch
- map_gs_spec additions are negative source assertions that would catch a
  regression: neither game overrides the pathfinding methods, `@@tags` is gone,
  the finders no longer scan the room list, and the three-scan fuzzy lookup is
  gone from both games

RuboCop with the repo config is at parity with `main`: 4 offenses, all
pre-existing in `method_missing` / `respond_to_missing?`. All touched files are
ASCII clean.

## Reviewer notes

- The `@@tags` retirement is the one structural change worth deliberate review.
  `Map.tags` output including key order is verified unchanged, but it does change
  what the class variable holds.
- Invalidation is deliberately hooked at `@@list[@id] = self` rather than inside
  `TagList#initialize`, so that replacing a room at an existing id is covered and
  a full load does not fire per-room notifications during construction.
- `reset_tag_index` uses `self.class`, and `@tag_index` is a class-level instance
  variable, so it is not shared with subclasses. `Room < Map` is a compatibility
  shim that only forwards `method_missing` and is never instantiated in lib, so
  the normal path is correct. Constructing via `Room.new` and reading via
  `Map.rooms_by_tag` would invalidate the wrong class. That combination was
  uniformly broken before this PR and is not made worse by it, but I am happy to
  anchor the memo to the class that owns `@@list` if reviewers prefer.
- `dijkstra` keeps returning dense Arrays on purpose. Scripts calling
  `Map.dijkstra` directly still pay the conversion; only internal callers moved
  off it.

## Not included

- No changes to `get_free_id`. Ids are not recycled and no references are purged.
  Fixing the scaling directly makes id backfilling unnecessary, and avoids
  recycling retired room numbers that appear in scripts, wiki pages and forum
  posts.
- No memoized live-rooms array. `Array#compact` costs about 4 ms per million
  slots, roughly 15 percent of a post-change fuzzy miss, and removing it would
  need a third memo invalidated on room creation. Not worth the staleness surface
  for that.
- `match_current` and the other room-change matching paths are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added faster room lookup by tag with automatic cache updates when tags change.
  - Improved pathfinding support for maps with sparse room IDs.
  - Added hash-based pathfinding results while preserving existing array-based behavior.
  - Enhanced room-name and description matching with clearer exact-match precedence.

- **Bug Fixes**
  - Improved handling of empty or missing rooms during searches and tag lookups.
  - Prevented external changes to tag lookup results from corrupting cached data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->