### PR TITLE
fix(all): bound GemCheck alert dialogs with a timeout so they can't hang forever

### DIFF
--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -1,5 +1,6 @@
 # lib/gemcheck.rb
 require 'bundler'
+require 'timeout'
 require_relative 'bundler_recovery'
 require_relative 'dependency_recovery'
 
@@ -18,6 +19,7 @@ module Lich
     LOG_FILENAME    = 'lich5-missing-gems.log'
     CONSENT_TIMEOUT_SECONDS = 120
     BUNDLER_RECOVERY_TIMEOUT_SECONDS = 120
+    ALERT_TIMEOUT_SECONDS = 120
 
     # Records why a recovery did not run without treating that decision as a
     # manifest or Bundler failure.
@@ -479,7 +481,7 @@ module Lich
       require 'win32ole'
       shell = WIN32OLE.new('WScript.Shell')
       result = shell.Popup("#{body}\nClick OK to open the download page.",
-                           0, TITLE, 1 + 64) # OK/Cancel + Information icon
+                           ALERT_TIMEOUT_SECONDS, TITLE, 1 + 64) # OK/Cancel + Information icon
       shell.Run(RELEASE_URL) if result == 1
     end
 
@@ -506,11 +508,11 @@ module Lich
     # @return [void]
     def alert_linux(body)
       if cmd_available?('zenity')
-        system('zenity', '--info', '--title', TITLE, '--text', body)
+        run_with_timeout(['zenity', '--info', '--title', TITLE, '--text', body], ALERT_TIMEOUT_SECONDS)
       elsif cmd_available?('kdialog')
-        system('kdialog', '--title', TITLE, '--msgbox', body)
+        run_with_timeout(['kdialog', '--title', TITLE, '--msgbox', body], ALERT_TIMEOUT_SECONDS)
       elsif cmd_available?('xmessage')
-        system('xmessage', '-center', body)
+        run_with_timeout(['xmessage', '-center', body], ALERT_TIMEOUT_SECONDS)
       else
         warn "!!ALERT!! #{body}"
       end
@@ -520,6 +522,25 @@ module Lich
     # @return [Boolean]
     def cmd_available?(cmd)
       system('which', cmd, out: File::NULL, err: File::NULL)
+    end
+
+    # Runs an external command that would otherwise block indefinitely (a
+    # GUI dialog with no one present to dismiss it, e.g. a dead or forwarded
+    # X display) and forcibly reclaims control once the timeout elapses.
+    # Wrapping a blocking Kernel#system call in Timeout can't do this safely,
+    # since the spawned child keeps running as an orphan; spawning it
+    # ourselves lets us kill it directly.
+    # @param cmd [Array<String>] command and arguments for Process.spawn
+    # @param timeout [Integer] seconds to wait before killing the process
+    # @return [Boolean] whether the command exited on its own within the timeout
+    def run_with_timeout(cmd, timeout)
+      pid = Process.spawn(*cmd, out: File::NULL, err: File::NULL)
+      Timeout.timeout(timeout) { Process.wait(pid) }
+      true
+    rescue Timeout::Error
+      Process.kill('TERM', pid)
+      Process.wait(pid)
+      false
     end
   end
 end

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -1,6 +1,7 @@
 # spec/lib/gemcheck_spec.rb
 require 'tmpdir'
 require 'fileutils'
+require 'benchmark'
 
 # TEMP_DIR is referenced by GemCheck#write_log; it must exist before that
 # method runs. Constants are resolved at call time (not require time),
@@ -301,7 +302,8 @@ RSpec.describe Lich::GemCheck do
 
     it 'waits for the release-page alert and opens the URL only after OK' do
       expect(shell).to receive(:Popup)
-        .with("alert\nClick OK to open the download page.", 0, described_class::TITLE, 1 + 64).and_return(1)
+        .with("alert\nClick OK to open the download page.", described_class::ALERT_TIMEOUT_SECONDS,
+              described_class::TITLE, 1 + 64).and_return(1)
       expect(shell).to receive(:Run).with(described_class::RELEASE_URL)
 
       described_class.alert_windows('alert')
@@ -692,9 +694,10 @@ RSpec.describe Lich::GemCheck do
     context 'when zenity is available' do
       before { stub_only_available('zenity') }
 
-      it 'shows a zenity info dialog with the given body' do
-        expect(described_class).to receive(:system)
-          .with('zenity', '--info', '--title', described_class::TITLE, '--text', 'body text')
+      it 'shows a zenity info dialog bounded by a timeout' do
+        expect(described_class).to receive(:run_with_timeout)
+          .with(['zenity', '--info', '--title', described_class::TITLE, '--text', 'body text'],
+                described_class::ALERT_TIMEOUT_SECONDS)
         described_class.alert_linux('body text')
       end
     end
@@ -702,9 +705,10 @@ RSpec.describe Lich::GemCheck do
     context 'when only kdialog is available' do
       before { stub_only_available('kdialog') }
 
-      it 'shows a kdialog msgbox' do
-        expect(described_class).to receive(:system)
-          .with('kdialog', '--title', described_class::TITLE, '--msgbox', 'body text')
+      it 'shows a kdialog msgbox bounded by a timeout' do
+        expect(described_class).to receive(:run_with_timeout)
+          .with(['kdialog', '--title', described_class::TITLE, '--msgbox', 'body text'],
+                described_class::ALERT_TIMEOUT_SECONDS)
         described_class.alert_linux('body text')
       end
     end
@@ -712,9 +716,9 @@ RSpec.describe Lich::GemCheck do
     context 'when only xmessage is available' do
       before { stub_only_available('xmessage') }
 
-      it 'shows an xmessage dialog' do
-        expect(described_class).to receive(:system)
-          .with('xmessage', '-center', 'body text')
+      it 'shows an xmessage dialog bounded by a timeout' do
+        expect(described_class).to receive(:run_with_timeout)
+          .with(['xmessage', '-center', 'body text'], described_class::ALERT_TIMEOUT_SECONDS)
         described_class.alert_linux('body text')
       end
     end
@@ -741,6 +745,19 @@ RSpec.describe Lich::GemCheck do
         .with('which', 'definitely-not-a-real-command', out: File::NULL, err: File::NULL)
         .and_return(false)
       expect(described_class.cmd_available?('definitely-not-a-real-command')).to be(false)
+    end
+  end
+
+  describe '.run_with_timeout' do
+    it 'returns true when the command exits on its own before the timeout' do
+      expect(described_class.run_with_timeout(['true'], 5)).to be(true)
+    end
+
+    it 'kills the process and returns false when it outlives the timeout' do
+      elapsed = Benchmark.realtime do
+        expect(described_class.run_with_timeout(['sleep', '30'], 1)).to be(false)
+      end
+      expect(elapsed).to be < 5
     end
   end
 end


### PR DESCRIPTION
## Summary
- `alert_linux`'s `system('zenity', ...)` call had no timeout, so on a display with no one present to click the dialog (e.g. a dead or forwarded X session), it blocked `lich.rbw`'s startup indefinitely.
- `alert_windows` had the same latent issue: `WScript.Shell.Popup`'s timeout was hardcoded to `0` (wait forever).
- Adds a `run_with_timeout` helper that spawns the dialog process directly and kills it if it outlives `ALERT_TIMEOUT_SECONDS` (120s), since wrapping a blocking `Kernel#system` call in `Timeout` can't safely reclaim an orphaned child process.

## Test plan
- [x] `bundle exec rspec spec/lib/gemcheck_spec.rb`
- [x] Manually confirmed `run_with_timeout` reclaims control from a hung `zenity`/`sleep` process within the timeout window