### PR TITLE
fix(all): identify Genie as the frontend for headless launches

### DIFF
--- a/lib/common/authentication/login_helpers.rb
+++ b/lib/common/authentication/login_helpers.rb
@@ -543,6 +543,28 @@ module Lich
           requested_frontend
         end
 
+        # Resolves the frontend identity for a headless (`--without-frontend`)
+        # launch.
+        #
+        # Lich spawns no frontend here, but a detachable client still attaches
+        # and renders the stream, so the identity has to name whatever is
+        # reading it: `respond` uses the frontend's registered capabilities to
+        # decide whether to XML-escape script output and wrap it in mono
+        # brackets. A Genie client left as 'unknown' receives unescaped output,
+        # so any script text containing angle brackets is swallowed by Genie's
+        # XML parser as if it were a tag.
+        #
+        # @param argv [Array<String>] command line arguments
+        # @param detachable_client [Boolean] whether a detachable client port is configured
+        # @return [String] frontend identity for Frontend.client
+        def self.resolve_headless_frontend(argv, detachable_client: false)
+          return 'saga' if argv.any? { |arg| arg.match?(/^--saga$/i) }
+          return 'unknown' unless detachable_client
+          return 'genie' if argv.any? { |arg| arg.match?(/^--genie$/i) }
+
+          'profanity'
+        end
+
         # Formats the game instance launch flag for Lich based on version.
         #
         # Older versions of Lich (pre-5.12) only recognize specific lowercase flags

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -235,13 +235,9 @@ reconnect_if_wanted = proc {
       Lich.log "info: Current WINE working directory is #{custom_launch_dir}"
     end
     if ARGV.include?('--without-frontend')
-      Frontend.client = if ARGV.any? { |a| a =~ /^--saga$/i }
-                          'saga'
-                        elsif @argv_options[:detachable_client_port] && !ARGV.any? { |a| a =~ /^--genie$/i }
-                          'profanity'
-                        else
-                          'unknown'
-                        end
+      Frontend.client = Lich::Common::Authentication::LoginHelpers.resolve_headless_frontend(
+        ARGV, detachable_client: !@argv_options[:detachable_client_port].nil?
+      )
       unless (game_key = @launch_data.find { |opt| opt =~ /KEY=/ }) && (game_key = game_key.split('=').last.chomp)
         $stdout.puts "error: launch_data contains no KEY info"
         Lich.log "error: launch_data contains no KEY info"

--- a/spec/lib/common/authentication/login_helpers_spec.rb
+++ b/spec/lib/common/authentication/login_helpers_spec.rb
@@ -498,6 +498,28 @@ RSpec.describe Lich::Common::Authentication::LoginHelpers do
     end
   end
 
+  describe '.resolve_headless_frontend' do
+    it 'identifies a Genie client attached to the detachable port' do
+      expect(
+        described_class.resolve_headless_frontend(['--login', 'pickasso', '--genie'], detachable_client: true)
+      ).to eq('genie')
+    end
+
+    it 'identifies Saga regardless of the detachable port' do
+      expect(described_class.resolve_headless_frontend(['--saga'], detachable_client: true)).to eq('saga')
+      expect(described_class.resolve_headless_frontend(['--saga'], detachable_client: false)).to eq('saga')
+    end
+
+    it 'assumes Profanity for a detachable client with no frontend flag' do
+      expect(described_class.resolve_headless_frontend(['--login', 'pickasso'], detachable_client: true)).to eq('profanity')
+    end
+
+    it 'returns unknown when nothing can attach' do
+      expect(described_class.resolve_headless_frontend(['--login', 'pickasso', '--genie'])).to eq('unknown')
+      expect(described_class.resolve_headless_frontend(['--login', 'pickasso'])).to eq('unknown')
+    end
+  end
+
   describe '.format_launch_flag' do
     it 'returns nil for empty game code' do
       expect(described_class.format_launch_flag('')).to be_nil


### PR DESCRIPTION
## Problem

`--headless PORT` normalizes to `--without-frontend --detachable-client=PORT` (`lib/main/arg_normalization.rb`), and the `--without-frontend` branch in `lib/main/main.rb` resolved `Frontend.client` like this:

```ruby
Frontend.client = if ARGV.any? { |a| a =~ /^--saga$/i }
                    'saga'
                  elsif @argv_options[:detachable_client_port] && !ARGV.any? { |a| a =~ /^--genie$/i }
                    'profanity'
                  else
                    'unknown'
                  end
```

The `!--genie` guard correctly keeps a Genie client from being labelled `profanity`, but there is no branch that labels it `genie`, so `lich.rbw --login Char --dragonrealms --genie --headless 8000` ends up as `'unknown'`.

`'unknown'` isn't in the capability registry, so `Frontend.supports_mono?` is false and `respond` skips both the `<output class="mono"/>` wrapper and the XML escaping:

```ruby
if Frontend.supports_mono?
  str = "<output class=\"mono\"/>\r\n#{str.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')}<output class=\"\"/>\r\n"
elsif Frontend.client.eql?('profanity')
```

Genie then receives script output with raw angle brackets and its XML parser consumes anything between `<` and `>` as a tag. `;validate` is where I hit this — it wraps every message as `ERROR:< #{message}  >`, so the entire body vanished and the run reported counts with no text:

```
  CHECKING: 108 different potential errors in [Char-setup.yaml]
[validate: ERROR:]
[validate: WARNING:]
[validate: WARNING:]
[validate: WARNING:]
[validate: WARNING:]
[validate: ERROR:]
  WARNINGS:4 ERRORS:2
```

The same session also loses monospace for all script output, since the mono bracket is never emitted. A profanity user is unaffected — the `elsif` branch escapes for them.

`handle_detachable_client` in `lib/global_defs.rb` already special-cases `--genie` for detachable clients, so the combination is supported elsewhere; this branch just never got the case.

## Change

Move the resolution into `LoginHelpers.resolve_headless_frontend` (next to `resolve_lookup_frontend`, which already reasons about the frontend a headless launch intends) so it's unit-testable, and add the missing genie branch.

Behavior is otherwise unchanged: saga still wins outright, a detachable client with no frontend flag is still assumed to be profanity, and everything else is still `'unknown'`.

## Test plan

- [x] `bundle exec rspec spec/lib/common/authentication/login_helpers_spec.rb` — 80 examples, 0 failures (4 new, confirmed failing before the fix)
- [x] `bundle exec rspec` — 4932 examples, 0 failures
- [x] `bundle exec rubocop` on the changed files — no offenses
- [ ] Live: `lich.rbw --login Char --dragonrealms --genie --headless 8000` with Genie attached; `;validate` prints its warning and error text, and script output renders monospaced again
