### PR TITLE
feat(dr): capture room UID from <nav> tag; stop enforcing ShowRoomID; opt-in room-id placement

### DIFF
--- a/lib/common/map/map_dr.rb
+++ b/lib/common/map/map_dr.rb
@@ -339,6 +339,19 @@ module Lich
           return set_current(room.id)
         end
 
+        # Guard against a blank/incomplete arrival frame. DR occasionally streams a room whose
+        # <nav> UID is delayed or absent (room_id 0) before the room text populates: the
+        # description is only the "pitch dark" placeholder and there are no exits. Minting a
+        # room here creates a junk stub (empty title, no UID) that orphans or duplicates the
+        # real room. Keep the current room instead; the real room resolves by UID once the
+        # delayed nav (or a re-look) provides it.
+        if XMLData.room_id.zero? &&
+           XMLData.room_exits_string.to_s.strip.empty? &&
+           XMLData.room_description.to_s.strip == "It's pitch dark and you can't see a thing!"
+          echo 'Map: skipped blank/incomplete room frame (no uid, pitch-dark, no exits)'
+          return set_current(@@current_room_id)
+        end
+
         id = get_free_id
         title = [XMLData.room_title]
         description = [XMLData.room_description.strip]

--- a/lib/common/map/map_dr.rb
+++ b/lib/common/map/map_dr.rb
@@ -349,7 +349,13 @@ module Lich
            XMLData.room_exits_string.to_s.strip.empty? &&
            XMLData.room_description.to_s.strip == "It's pitch dark and you can't see a thing!"
           echo 'Map: skipped blank/incomplete room frame (no uid, pitch-dark, no exits)'
-          return set_current(@@current_room_id)
+          # Keep the current room - but only if one has actually resolved.
+          # @@current_room_id is the -1 sentinel before the first match; passing
+          # that to set_current would index @@list[-1] (the last room) and make an
+          # unrelated room current, so fall back to nil in that case instead.
+          return set_current(@@current_room_id) if @@current_room_id.is_a?(Integer) && @@current_room_id >= 0
+
+          return nil
         end
 
         id = get_free_id

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -137,6 +137,11 @@ module Lich
         # rather than a NoMethodError on room_id.zero? (DR) or room_id > N (GS) in the map layer.
         @room_id = 0
         @previous_nav_rm = nil
+        # True once <nav> has supplied a real (non-zero) UID for the current
+        # arrival and the streamWindow subtitle has not yet consumed it. Keeps a
+        # ShowRoomID-on subtitle from overwriting an authoritative nav UID in the
+        # same arrival (see the streamWindow handler).
+        @nav_uid_pending = false
 
         # Lich::Claim update
         @arrival_pcs = []
@@ -394,6 +399,11 @@ module Lich
             # @previous_nav_rm accurate for Map.previous_uid.
             @previous_nav_rm = @room_id
             @room_id = attributes['rm'].to_i
+            # A real nav UID this arrival is authoritative; flag it so the
+            # streamWindow subtitle below treats its own UID marker as a fallback
+            # and does not overwrite this value. A bare <nav/> (no UID, room_id 0)
+            # leaves the subtitle free to supply one.
+            @nav_uid_pending = @room_id.positive?
             @arrival_pcs = []
             $nav_seen = true
           end
@@ -540,20 +550,24 @@ module Lich
                 elsif XMLData.game =~ /^DR/
                   # - [Bosque Deriel, Hermit's Shacks] (a trailing UID marker is present only when
                   # the game's ShowRoomID flag is ON): " (230008)" for a room that has a UID, or
-                  # " (**)" for a room that has none. The <nav rm=.../> tag is the primary UID
-                  # source (see the nav handler above), but it can arrive late or be absent on
-                  # some arrivals; when it is, this marker is the only UID signal the game gives,
-                  # so use it as a FALLBACK: a numeric marker sets the UID, and "(**)" clears it
-                  # to 0 (explicit "no UID"), which also drops any stale id from a prior room. A
-                  # ShowRoomID-OFF subtitle has no marker at all, so we leave room_id untouched
-                  # (never write 0 blindly, never clobber a good nav value; nav and subtitle name
-                  # the same room in the same frame). The title stays UID-free either way.
-                  # Guard the match: a blank/identity-less subtitle (e.g. " - ") has no "[...]"
-                  # and returns nil, so leave the prior title untouched rather than crash.
+                  # " (**)" for a room that has none. The <nav rm=.../> tag is the PRIMARY UID
+                  # source (see the nav handler above); this subtitle marker is only a FALLBACK
+                  # for arrivals where nav arrived late, was absent, or was a bare no-uid <nav/>.
+                  # When nav already supplied a real UID this arrival (@nav_uid_pending), leave
+                  # room_id alone so the subtitle never clobbers the authoritative nav value; the
+                  # subtitle consumes that flag either way, so the next arrival's marker (if its
+                  # nav is missing) is free to act as the fallback. When nav did not supply one, a
+                  # numeric marker sets the UID and "(**)" clears it to 0 (explicit "no UID",
+                  # dropping any stale id from a prior room). A ShowRoomID-OFF subtitle has no
+                  # marker at all, so room_id is left untouched (never write 0 blindly). The title
+                  # stays UID-free in every case. Guard the match: a blank/identity-less subtitle
+                  # (e.g. " - ") has no "[...]" and returns nil, so leave the prior title untouched
+                  # rather than crash.
                   room = attributes['subtitle'].match(%r{(?<roomtitle>\[.*?\])(?:\s\((?<uid>\d+|\*+)\))?})
                   if room
                     @room_title = "[#{room[:roomtitle]}]"
-                    @room_id = (room[:uid] =~ /\A\d+\z/ ? room[:uid].to_i : 0) if room[:uid]
+                    @room_id = (room[:uid] =~ /\A\d+\z/ ? room[:uid].to_i : 0) if room[:uid] && !@nav_uid_pending
+                    @nav_uid_pending = false
                   end
                 else
                   @room_title = String.new

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -133,7 +133,9 @@ module Lich
         @dialogs = {}
 
         # real id updates
-        @room_id = nil
+        # Default 0 (not nil) so a read before the first <nav> tag is a valid "no UID" value
+        # rather than a NoMethodError on room_id.zero? (DR) or room_id > N (GS) in the map layer.
+        @room_id = 0
         @previous_nav_rm = nil
 
         # Lich::Claim update
@@ -385,10 +387,13 @@ module Lich
             # reused elsewhere.
             @pending_crtr_status.clear
             @check_obvious_hiding = true
-            unless XMLData.game =~ /^DR/
-              @previous_nav_rm = @room_id
-              @room_id = attributes['rm'].to_i
-            end
+            # The <nav rm='NNNN'/> tag is the authoritative room UID for every game, including
+            # DragonRealms, which now emits it on every arrival (a plain <nav/> with no rm
+            # attribute for a room that has no UID, which yields 0 here). Capturing it on nav
+            # gives early room knowledge before the room text streams, and keeps
+            # @previous_nav_rm accurate for Map.previous_uid.
+            @previous_nav_rm = @room_id
+            @room_id = attributes['rm'].to_i
             @arrival_pcs = []
             $nav_seen = true
           end
@@ -533,10 +538,13 @@ module Lich
                   end
                   @room_title = '[' + attributes['subtitle'][3..-1].gsub(/ - \d+$/, '') + ']'
                 elsif XMLData.game =~ /^DR/
-                  # - [Bosque Deriel, Hermit's Shacks] (230008)
+                  # - [Bosque Deriel, Hermit's Shacks] (a trailing " (230008)" is present only
+                  # when the game's ShowRoomID flag is ON). Parse the bracketed title only; the
+                  # room UID comes from the <nav rm=.../> tag (see the nav handler above), never
+                  # from this subtitle. Scraping it here would write 0 whenever ShowRoomID is OFF
+                  # and clobber the UID nav already captured for this room.
                   room = attributes['subtitle'].match(/(?<roomtitle>\[.*?\])(?:\s\((?<uid>\d+)\))?/)
                   @room_title = "[#{room[:roomtitle]}]"
-                  @room_id = room[:uid].to_i
                 else
                   @room_title = String.new
                 end

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -538,13 +538,23 @@ module Lich
                   end
                   @room_title = '[' + attributes['subtitle'][3..-1].gsub(/ - \d+$/, '') + ']'
                 elsif XMLData.game =~ /^DR/
-                  # - [Bosque Deriel, Hermit's Shacks] (a trailing " (230008)" is present only
-                  # when the game's ShowRoomID flag is ON). Parse the bracketed title only; the
-                  # room UID comes from the <nav rm=.../> tag (see the nav handler above), never
-                  # from this subtitle. Scraping it here would write 0 whenever ShowRoomID is OFF
-                  # and clobber the UID nav already captured for this room.
-                  room = attributes['subtitle'].match(/(?<roomtitle>\[.*?\])(?:\s\((?<uid>\d+)\))?/)
-                  @room_title = "[#{room[:roomtitle]}]"
+                  # - [Bosque Deriel, Hermit's Shacks] (a trailing UID marker is present only when
+                  # the game's ShowRoomID flag is ON): " (230008)" for a room that has a UID, or
+                  # " (**)" for a room that has none. The <nav rm=.../> tag is the primary UID
+                  # source (see the nav handler above), but it can arrive late or be absent on
+                  # some arrivals; when it is, this marker is the only UID signal the game gives,
+                  # so use it as a FALLBACK: a numeric marker sets the UID, and "(**)" clears it
+                  # to 0 (explicit "no UID"), which also drops any stale id from a prior room. A
+                  # ShowRoomID-OFF subtitle has no marker at all, so we leave room_id untouched
+                  # (never write 0 blindly, never clobber a good nav value; nav and subtitle name
+                  # the same room in the same frame). The title stays UID-free either way.
+                  # Guard the match: a blank/identity-less subtitle (e.g. " - ") has no "[...]"
+                  # and returns nil, so leave the prior title untouched rather than crash.
+                  room = attributes['subtitle'].match(%r{(?<roomtitle>\[.*?\])(?:\s\((?<uid>\d+|\*+)\))?})
+                  if room
+                    @room_title = "[#{room[:roomtitle]}]"
+                    @room_id = (room[:uid] =~ /\A\d+\z/ ? room[:uid].to_i : 0) if room[:uid]
+                  end
                 else
                   @room_title = String.new
                 end

--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -33,7 +33,6 @@ module Lich
         PlayedAccount = /^(?:<.*?\/>)?Account Info for (?<account>.+):/.freeze
         PlayedSubscription = /Current Account Status: (?<subscription>F2P|Basic|Premium|Platinum)/.freeze
         LastLogoff = /^\s+Logoff :  (?<weekday>[A-Z][a-z]{2}) (?<month>[A-Z][a-z]{2}) (?<day>[\s\d]{2}) (?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}) ET (?<year>\d{4})/.freeze
-        RoomIDOff = /^You will no longer see room IDs when LOOKing in the game and room windows\./.freeze
         Rested_EXP = %r{^<component id='exp rexp'>Rested EXP Stored:\s*(?<stored>.*?)\s*Usable This Cycle:\s*(?<usable>.*?)\s*Cycle Refreshes:\s*(?<refresh>.*)</component>}.freeze
         Rested_EXP_F2P = %r{^<component id='exp rexp'>\[Unlock Rested Experience}.freeze
         TDPValue_XPWindow = %r{^<component id='exp tdp'>\s*TDPs:\s*(?<tdp>\d+)</component>}.freeze
@@ -589,10 +588,6 @@ module Lich
               end
               $last_logoff = Time.new(match[:year].to_i, month, match[:day].to_i, match[:hour].to_i, match[:minute].to_i, match[:second].to_i, tz).getlocal
             end
-          elsif Pattern::RoomIDOff.match?(line)
-            put("flag showroomid on")
-            Lich::Messaging.msg("bold", "DRParser: Lich requires ShowRoomID to be ON for mapping to work, please do not turn this off.")
-            Lich::Messaging.msg("plain", "DRParser: If you wish to hide the Real ID#, you can toggle it off by doing ;display flaguid")
           elsif (match = line.match(Pattern::Rested_EXP))
             DRSkill.update_rested_exp(match[:stored].strip, match[:usable].strip, match[:refresh].strip)
           elsif Pattern::Rested_EXP_F2P.match?(line)

--- a/lib/dragonrealms/drinfomon/startup.rb
+++ b/lib/dragonrealms/drinfomon/startup.rb
@@ -65,10 +65,12 @@ module Lich
           #   - Thieves: parsed by check_known_thief_khri
           Lich::Util.issue_command("ability", /^You (?:know the Berserks|recall the spells you have learned from your training)|^From (?:your apprenticeship you remember practicing|the \\w+ tree)/, /^You (?:recall that you have \\d+ training sessions|can use SPELL STANCE \\[HELP\\]|have \\d+ available slot)/, quiet: true, timeout: 1)
 
-          # Ensure ShowRoomID and MonsterBold flags are enabled (one-time per character)
+          # Ensure the MonsterBold flag is enabled (one-time per character). ShowRoomID is no
+          # longer forced: room UIDs now come from the <nav> tag regardless of that flag, so
+          # whether the game shows inline room IDs is left entirely to the player's preference.
           unless UserVars.dependency_setflags
             flags = Array(Lich::Util.issue_command("flag", /^Usage/, /^For other setting options, see AVOID, SET, and TOGGLE/, quiet: true, timeout: 1, usexml: false))
-            required = ["ShowRoomID", "MonsterBold"]
+            required = ["MonsterBold"]
             required.each do |flag|
               fput("flag \#{flag} on") unless flags.any? { |f| f.match?(/\#{Regexp.escape(flag)}\\s+ON/) }
             end

--- a/lib/games.rb
+++ b/lib/games.rb
@@ -1455,33 +1455,46 @@ module Lich
         DRParser.parse(server_string)
       end
 
+      # Rewrites the room-name line (the "<style id=\"roomName\" />[Title]" chunk) on its way
+      # to the client. Two independent concerns:
+      #   1. When the player wants the room id/UID in the title (";display roomid title|both"),
+      #      strip any RealID the game appended (present only under the ShowRoomID flag) and
+      #      inject Lich's configured id/UID, so the name reads e.g.
+      #      "[Town Square - 1234 - (u230008)]".
+      #   2. Otherwise preserve the historical behavior of hiding the game's inline RealID when
+      #      the player asked to (";display uid" or ";display flaguid").
+      # Edits only this outbound client string; XMLData (and therefore scripts) are untouched,
+      # because process_xml_data has already parsed the inbound stream before this runs.
+      # @param alt_string [String] the outbound room-name server string, modified in place
+      # @return [String] the rewritten string
       def modify_room_display(alt_string)
-        if Lich.display_uid == true
+        if room_id_in_title?
           alt_string.sub!(/] \((?:\d+|\*\*)\)/) { "]" }
-        elsif Lich.hide_uid_flag == true
+          room_number = room_number_display
+          alt_string.sub!(']') { " - #{room_number}]" } unless room_number.empty?
+        elsif Lich.display_uid == true || Lich.hide_uid_flag == true
           alt_string.sub!(/] \((?:\d+|\*\*)\)/) { "]" }
         end
 
         alt_string
       end
 
-      # Prepends the shared exit / StringProc lines plus the DragonRealms
-      # "Room Number:" line, and updates the room-window subtitle on frontends
-      # that host one. The visible room-number line honors the mono toggle; the
-      # streamWindow subtitle tags are title-bar metadata and are left as-is.
+      # Prepends the shared exit / StringProc lines, then renders the optional DragonRealms
+      # room id/UID. The "Room Number:" line below the room appears for the "line" and "both"
+      # placements (honoring the mono toggle). The room-window subtitle (room-window front-ends
+      # only) reflects the id/UID for every placement, since the window title bar is itself a
+      # title surface. The inline room-name injection for the "title"/"both" placements is
+      # handled separately in #modify_room_display.
       # @param alt_string [String] the server string being rewritten
       # @return [String] the rewritten server string
       def process_room_display(alt_string)
         alt_string = prepend_room_lines(alt_string, room_stringproc_entries, room_exit_entries)
 
-        # DR-specific room number display
-        room_number = ""
-        room_number += "#{Map.current.id}" if Lich.display_lichid
-        room_number += " - " if Lich.display_lichid && Lich.display_uid
-        room_number += "(#{XMLData.room_id == 0 ? "**" : "u#{XMLData.room_id}"})" if Lich.display_uid
-
+        room_number = room_number_display
         unless room_number.empty?
-          alt_string = "#{room_styled("Room Number: #{room_number}")}\r\n#{alt_string}"
+          if room_id_in_line?
+            alt_string = "#{room_styled("Room Number: #{room_number}")}\r\n#{alt_string}"
+          end
           if Frontend.supports_room_window?
             alt_string = "<streamWindow id='main' title='Story' subtitle=\" - [#{XMLData.room_title[2..-3]} - #{room_number}]\" location='center' target='drop'/>\r\n#{alt_string}"
             alt_string = "<streamWindow id='room' title='Room' subtitle=\" - [#{XMLData.room_title[2..-3]} - #{room_number}]\" location='center' target='drop' ifClosed='' resident='true'/>#{alt_string}"
@@ -1489,6 +1502,39 @@ module Lich
         end
 
         alt_string
+      end
+
+      private
+
+      # Builds the DragonRealms room id / RealID string chosen via ";display lichid" and
+      # ";display uid", e.g. "1234 - (u230008)", "1234", or "(u230008)". The lich id is omitted
+      # (rather than raising) when the current room is unmapped, and the UID renders as "(**)"
+      # for a no-UID room (XMLData.room_id == 0). Shared by #modify_room_display (title
+      # injection) and #process_room_display (below-room line and window subtitle) so the two
+      # never drift in format.
+      # @return [String] the formatted id/UID, or "" when there is nothing to show
+      def room_number_display
+        segments = []
+        if Lich.display_lichid
+          current = Map.current
+          segments << current.id.to_s if current
+        end
+        segments << (XMLData.room_id == 0 ? "(**)" : "(u#{XMLData.room_id})") if Lich.display_uid
+        segments.join(" - ")
+      end
+
+      # @return [Boolean] whether the id/UID is injected into the room-name (title) line;
+      #   true for the "title" and "both" placements
+      def room_id_in_title?
+        %w[title both].include?(Lich.display_roomid_location)
+      end
+
+      # @return [Boolean] whether the id/UID is shown as a "Room Number:" line below the room;
+      #   true for the "line" and "both" placements, and as the default before a game is
+      #   identified (display_roomid_location still nil)
+      def room_id_in_line?
+        location = Lich.display_roomid_location
+        location.nil? || %w[line both].include?(location)
       end
     end
 

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2594,6 +2594,7 @@ def do_client(client_string)
       end
       respond "Changing Lich to NOT display Room Title RealIDs while FLAG ShowRoomID ON to #{new_value}"
       Lich.hide_uid_flag = new_value
+      respond "Note: this toggle is largely unnecessary now that room UIDs come from the <nav> tag. To hide the game's inline RealIDs, you can simply 'flag showroomid off'."
     elsif cmd =~ /^display lichid(?: (true|false))?/i
       new_value = !(Lich.display_lichid)
       case Regexp.last_match(1)
@@ -2614,6 +2615,15 @@ def do_client(client_string)
       end
       respond "Changing Lich to display RealID#s to #{new_value}"
       Lich.display_uid = new_value
+    elsif XMLData.game =~ /^DR/ && cmd =~ /^display roomid(?:\s+(title|line|both))?/i
+      requested = Regexp.last_match(1)&.downcase
+      if requested.nil?
+        respond "DragonRealms room id / RealID display placement is currently: #{Lich.display_roomid_location}"
+        respond "Usage: ;display roomid <title|line|both>  (title = in the room name line, line = a Room Number line below the room, both = both places)"
+      else
+        Lich.display_roomid_location = requested
+        respond "Changing DragonRealms room id / RealID display placement to #{Lich.display_roomid_location}"
+      end
     elsif cmd =~ /^display exits?(?: (true|false))?/i
       new_value = !(Lich.display_exits)
       case Regexp.last_match(1)
@@ -2799,7 +2809,8 @@ def do_client(client_string)
         respond "   #{$clean_lich_char}infomon show              shows all current Infomon values for character"
         respond "   #{$clean_lich_char}sk help                   show information on modifying self-knowledge spells to be known"
       elsif XMLData.game =~ /^DR/
-        respond "   #{$clean_lich_char}display flaguid           toggle display of RealID in Room Title with FLAG ShowRoomID (required for Lich5 to be ON)"
+        respond "   #{$clean_lich_char}display flaguid           toggle hiding the game's inline RealID in the Room Title (now optional; UIDs come from <nav>)"
+        respond "   #{$clean_lich_char}display roomid <where>    where to show room id/RealID: title (room name line), line (below-room line), or both"
       end
       respond "   #{$clean_lich_char}display lichid            toggle display of Lich Map# when displaying room information"
       respond "   #{$clean_lich_char}display uid               toggle display of RealID Map# when displaying room information"

--- a/lib/lich.rb
+++ b/lib/lich.rb
@@ -145,6 +145,7 @@ module Lich
   @@display_room_links   = nil # boolean
   @@display_room_mono    = nil # boolean
   @@display_expgains     = nil # boolean (DragonRealms only)
+  @@display_roomid_location = nil # string (DragonRealms only): "title" | "line" | "both"
   @@hide_uid_flag        = nil # boolean
   @@track_autosort_state = nil # boolean
   @@track_dark_mode      = nil # boolean
@@ -875,6 +876,49 @@ module Lich
     @@display_uid = (val.to_s =~ /on|true|yes/ ? true : false)
     begin
       Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_uid',?);", [@@display_uid.to_s.encode('UTF-8')])
+    rescue SQLite3::BusyException
+      sleep 0.1
+      retry
+    end
+  end
+
+  # The valid values for Lich.display_roomid_location.
+  ROOMID_LOCATIONS = %w[title line both].freeze
+
+  # Where DragonRealms renders the optional room id / UID chosen via ;display lichid and
+  # ;display uid: "title" injects into the room-name line (visible on every front-end),
+  # "line" is the historical "Room Number:" line below the room, and "both" does both.
+  # GemStone ignores this setting (it always injects into the title line). The value is
+  # read fresh from the lich_settings table on first access and then memoized.
+  # @return [String, nil] one of ROOMID_LOCATIONS, or nil before a game has been identified
+  def Lich.display_roomid_location
+    if @@display_roomid_location.nil?
+      begin
+        val = Lich.db.get_first_value("SELECT value FROM lich_settings WHERE name='display_roomid_location';")
+      rescue SQLite3::BusyException
+        sleep 0.1
+        retry
+      end
+      # Default to the historical below-room line once a game is known; leave unresolved
+      # (nil) until then, matching the other display_* getters.
+      val = "line" if val.nil? && XMLData.game != ""
+      @@display_roomid_location = (ROOMID_LOCATIONS.include?(val) ? val : "line") unless val.nil?
+    end
+    return @@display_roomid_location
+  end
+
+  # Sets the DragonRealms room-id display placement and persists it. An unrecognized value is
+  # ignored (the current setting is retained) so a typo can never blank the display or feed the
+  # renderer an invalid placement.
+  # @param val [String, Symbol] one of ROOMID_LOCATIONS ("title", "line", or "both"); case-insensitive
+  # @return [void]
+  def Lich.display_roomid_location=(val)
+    normalized = val.to_s.downcase
+    return unless ROOMID_LOCATIONS.include?(normalized)
+
+    @@display_roomid_location = normalized
+    begin
+      Lich.db.execute("INSERT OR REPLACE INTO lich_settings(name,value) values('display_roomid_location',?);", [normalized.encode('UTF-8')])
     rescue SQLite3::BusyException
       sleep 0.1
       retry

--- a/spec/lib/common/map/map_dr_spec.rb
+++ b/spec/lib/common/map/map_dr_spec.rb
@@ -538,6 +538,23 @@ RSpec.describe Lich::Common::Map, 'DragonRealms implementation' do
       expect(parsed).not_to have_key('image_coords')
     end
   end
+
+  describe 'nav-tag room id integration' do
+    it 'previous_uid returns XMLData.previous_nav_rm (now populated from the <nav> tag)' do
+      XMLData.previous_nav_rm = 4242
+      expect(map_class.previous_uid).to eq(4242)
+    end
+
+    it 'ids_from_uid treats 0 as "no uid" even if a room was stamped with it' do
+      map_class.uids_add(0, 9)
+      expect(map_class.ids_from_uid(0)).to eq([])
+    end
+
+    it 'ids_from_uid resolves a real (nonzero) uid to its room ids' do
+      map_class.uids_add(230008, 5)
+      expect(map_class.ids_from_uid(230008)).to eq([5])
+    end
+  end
 end
 
 RSpec.describe Lich::Common::Room, 'DragonRealms' do

--- a/spec/lib/common/map/map_dr_spec.rb
+++ b/spec/lib/common/map/map_dr_spec.rb
@@ -555,6 +555,47 @@ RSpec.describe Lich::Common::Map, 'DragonRealms implementation' do
       expect(map_class.ids_from_uid(230008)).to eq([5])
     end
   end
+
+  # DR sometimes streams a blank/incomplete arrival before the <nav> UID lands: room_id 0, the
+  # description is only the "pitch dark" placeholder, and there are no exits. current_or_new must
+  # not mint a junk room from that frame (it would orphan/duplicate the real room); it keeps the
+  # current room until a real frame/UID arrives.
+  describe 'blank/incomplete arrival-frame guard (current_or_new)' do
+    before do
+      allow(Script).to receive(:current).and_return(double('script'))
+      allow(map_class).to receive(:current).and_return(nil) # force the create/guard path
+      map_class.class_variable_set(:@@loaded, true)
+      # Seed a room so get_free_id has a base and there is a "current" to fall back to.
+      map_class.new(1, ['[[Seed Room]]'], ['seed desc'], ['Obvious exits: north'], [])
+      map_class.class_variable_set(:@@current_room_id, 1)
+    end
+
+    def stub_frame(room_id:, title:, description:, exits:)
+      allow(XMLData).to receive(:room_id).and_return(room_id)
+      allow(XMLData).to receive(:room_title).and_return(title)
+      allow(XMLData).to receive(:room_description).and_return(description)
+      allow(XMLData).to receive(:room_exits_string).and_return(exits)
+    end
+
+    it 'does not mint a stub when the frame is blank (no uid, pitch-dark desc, no exits)' do
+      stub_frame(room_id: 0, title: '[]',
+                 description: "It's pitch dark and you can't see a thing!", exits: '')
+      expect { map_class.current_or_new }.not_to(change { map_class.list.compact.size })
+    end
+
+    it 'keeps the current room when it skips the blank frame' do
+      stub_frame(room_id: 0, title: '[]',
+                 description: "It's pitch dark and you can't see a thing!", exits: '')
+      expect(map_class.current_or_new).to eq(map_class[1])
+    end
+
+    it 'still maps a normal complete arrival into a new room' do
+      stub_frame(room_id: 54202, title: '[[Catacombs, Labyrinth]]',
+                 description: 'The narrow passageways of these burial chambers give rise to new horrors.',
+                 exits: 'Obvious exits: east, west')
+      expect { map_class.current_or_new }.to change { map_class.list.compact.size }.by(1)
+    end
+  end
 end
 
 RSpec.describe Lich::Common::Room, 'DragonRealms' do

--- a/spec/lib/common/map/map_dr_spec.rb
+++ b/spec/lib/common/map/map_dr_spec.rb
@@ -595,6 +595,23 @@ RSpec.describe Lich::Common::Map, 'DragonRealms implementation' do
                  exits: 'Obvious exits: east, west')
       expect { map_class.current_or_new }.to change { map_class.list.compact.size }.by(1)
     end
+
+    # Before any room resolves, @@current_room_id is the -1 sentinel. A blank frame
+    # must not fall back to set_current(-1), which would index @@list[-1] (the last
+    # room) and make an unrelated room current; it returns nil instead.
+    it 'returns nil (not the last room) for a blank frame when no room has resolved yet' do
+      map_class.class_variable_set(:@@current_room_id, -1)
+      stub_frame(room_id: 0, title: '[]',
+                 description: "It's pitch dark and you can't see a thing!", exits: '')
+      expect(map_class.current_or_new).to be_nil
+    end
+
+    it 'does not mint a stub for a blank frame when current_room_id is the -1 sentinel' do
+      map_class.class_variable_set(:@@current_room_id, -1)
+      stub_frame(room_id: 0, title: '[]',
+                 description: "It's pitch dark and you can't see a thing!", exits: '')
+      expect { map_class.current_or_new }.not_to(change { map_class.list.compact.size })
+    end
   end
 end
 

--- a/spec/lib/common/xmlparser_spec.rb
+++ b/spec/lib/common/xmlparser_spec.rb
@@ -451,9 +451,10 @@ RSpec.describe Lich::Common::XMLParser do
   end
 
   # DragonRealms now emits <nav rm='NNNN'/> on every arrival (a plain <nav/> with no rm for
-  # a room that has no UID). The parser must take room_id from that tag, never from the
-  # streamWindow subtitle, so the UID is captured whether or not the player's ShowRoomID flag
-  # is on. These drive the real StreamListener pipeline the way REXML feeds it in production.
+  # a room that has no UID). The parser takes room_id from that tag as the primary source, and
+  # falls back to the streamWindow subtitle's "(NNNNN)" only when nav did not supply a UID this
+  # arrival (never writing 0), so the UID is captured whether nav leads, lags, or is absent.
+  # These drive the real StreamListener pipeline the way REXML feeds it in production.
   describe 'DragonRealms room id capture from the <nav> tag' do
     def feed(parser, fragment)
       REXML::Document.parse_stream("<root>#{fragment}</root>", parser)
@@ -494,6 +495,55 @@ RSpec.describe Lich::Common::XMLParser do
       feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Bosque Deriel, Hermit's Shacks] (230008)"/>))
       expect(parser.room_id).to eq(230008)
       expect(parser.room_title).to eq("[[Bosque Deriel, Hermit's Shacks]]")
+    end
+
+    # The <nav> tag is primary, but it can arrive late or not at all on some arrivals. When it
+    # does, a ShowRoomID-on subtitle is the only place the UID appears, so the subtitle acts as
+    # a fallback UID source (adopted only when it carries a real number; never writes 0).
+    it 'falls back to the subtitle uid when this arrival had no <nav> tag' do
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Catacombs, Labyrinth] (54202)"/>))
+      expect(parser.room_id).to eq(54202)
+      expect(parser.room_title).to eq('[[Catacombs, Labyrinth]]')
+    end
+
+    it 'corrects a stale room_id from the subtitle when the new arrival had no <nav>' do
+      feed(parser, "<nav rm='54200'/>") # previous room
+      # next arrival streams no <nav>, but the subtitle carries the real uid
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Catacombs, Labyrinth] (54201)"/>))
+      expect(parser.room_id).to eq(54201)
+    end
+
+    it 'never clobbers a good nav uid with 0 from a ShowRoomID-off subtitle' do
+      feed(parser, "<nav rm='54202'/>")
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Catacombs, Labyrinth]"/>))
+      expect(parser.room_id).to eq(54202)
+    end
+
+    it 'clears a stale uid when a no-uid room shows the "(**)" marker (nav delayed/absent)' do
+      feed(parser, "<nav rm='54202'/>") # previous room had a uid
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Dark Cave] (**)"/>))
+      expect(parser.room_id).to eq(0)
+      expect(parser.room_title).to eq('[[Dark Cave]]')
+    end
+
+    it 'ShowRoomID-off (no marker): the subtitle never touches room_id; nav stays authoritative' do
+      # no prior nav, no marker -> room_id left at its no-uid default, nothing written
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Catacombs, Labyrinth]"/>))
+      expect(parser.room_id).to eq(0)
+      expect(parser.room_title).to eq('[[Catacombs, Labyrinth]]')
+    end
+
+    it 'a bare <nav/> clears the last uid and a following no-uid subtitle does not restore it' do
+      feed(parser, "<nav rm='54202'/>")
+      feed(parser, '<nav/>') # arrival at a no-uid room clears the id
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Dark Cave]"/>))
+      expect(parser.room_id).to eq(0)
+    end
+
+    it 'leaves the prior title untouched and does not crash on a blank/identity-less subtitle' do
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Catacombs, Labyrinth] (54202)"/>))
+      expect { feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - "/>)) }.not_to raise_error
+      expect(parser.room_title).to eq('[[Catacombs, Labyrinth]]')
     end
   end
 end

--- a/spec/lib/common/xmlparser_spec.rb
+++ b/spec/lib/common/xmlparser_spec.rb
@@ -497,6 +497,15 @@ RSpec.describe Lich::Common::XMLParser do
       expect(parser.room_title).to eq("[[Bosque Deriel, Hermit's Shacks]]")
     end
 
+    # <nav> is authoritative within an arrival: a same-arrival subtitle marker must
+    # never overwrite a real nav UID, even when the two disagree (CodeRabbit #1491).
+    it 'keeps the nav uid when the same arrival subtitle marker carries a different uid' do
+      feed(parser, "<nav rm='54202'/>")
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Catacombs, Labyrinth] (54209)"/>))
+      expect(parser.room_id).to eq(54202)
+      expect(parser.room_title).to eq('[[Catacombs, Labyrinth]]')
+    end
+
     # The <nav> tag is primary, but it can arrive late or not at all on some arrivals. When it
     # does, a ShowRoomID-on subtitle is the only place the UID appears, so the subtitle acts as
     # a fallback UID source (adopted only when it carries a real number; never writes 0).
@@ -507,8 +516,10 @@ RSpec.describe Lich::Common::XMLParser do
     end
 
     it 'corrects a stale room_id from the subtitle when the new arrival had no <nav>' do
-      feed(parser, "<nav rm='54200'/>") # previous room
-      # next arrival streams no <nav>, but the subtitle carries the real uid
+      # previous arrival: nav plus its own subtitle (which consumes the nav-uid flag)
+      feed(parser, "<nav rm='54200'/>")
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Old Room] (54200)"/>))
+      # new arrival streams no <nav>, but the subtitle carries the real uid
       feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Catacombs, Labyrinth] (54201)"/>))
       expect(parser.room_id).to eq(54201)
     end
@@ -520,7 +531,10 @@ RSpec.describe Lich::Common::XMLParser do
     end
 
     it 'clears a stale uid when a no-uid room shows the "(**)" marker (nav delayed/absent)' do
-      feed(parser, "<nav rm='54202'/>") # previous room had a uid
+      # previous arrival: nav plus its own subtitle (which consumes the nav-uid flag)
+      feed(parser, "<nav rm='54202'/>")
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Lit Room] (54202)"/>))
+      # new arrival has no <nav>; a no-uid room shows "(**)" and must clear the stale uid
       feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Dark Cave] (**)"/>))
       expect(parser.room_id).to eq(0)
       expect(parser.room_title).to eq('[[Dark Cave]]')

--- a/spec/lib/common/xmlparser_spec.rb
+++ b/spec/lib/common/xmlparser_spec.rb
@@ -449,4 +449,51 @@ RSpec.describe Lich::Common::XMLParser do
       end
     end
   end
+
+  # DragonRealms now emits <nav rm='NNNN'/> on every arrival (a plain <nav/> with no rm for
+  # a room that has no UID). The parser must take room_id from that tag, never from the
+  # streamWindow subtitle, so the UID is captured whether or not the player's ShowRoomID flag
+  # is on. These drive the real StreamListener pipeline the way REXML feeds it in production.
+  describe 'DragonRealms room id capture from the <nav> tag' do
+    def feed(parser, fragment)
+      REXML::Document.parse_stream("<root>#{fragment}</root>", parser)
+    end
+
+    before { XMLData.game = 'DR' }
+
+    it 'sets room_id from the rm attribute on arrival' do
+      feed(parser, "<nav rm='230008'/>")
+      expect(parser.room_id).to eq(230008)
+    end
+
+    it 'records the room being left in previous_nav_rm on the next arrival' do
+      feed(parser, "<nav rm='230007'/>")
+      feed(parser, "<nav rm='230008'/>")
+      expect(parser.previous_nav_rm).to eq(230007)
+    end
+
+    it 'sets room_id to 0 for a no-uid room (a bare <nav/> with no rm attribute)' do
+      feed(parser, "<nav rm='230008'/>")
+      feed(parser, "<nav/>")
+      expect(parser.room_id).to eq(0)
+    end
+
+    it 'parses the DR streamWindow subtitle into room_title (double-bracketed, no uid suffix)' do
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Bosque Deriel, Hermit's Shacks]"/>))
+      expect(parser.room_title).to eq("[[Bosque Deriel, Hermit's Shacks]]")
+    end
+
+    it 'keeps the nav room_id when a ShowRoomID-off subtitle (no uid) arrives afterward' do
+      feed(parser, "<nav rm='230008'/>")
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Bosque Deriel, Hermit's Shacks]"/>))
+      expect(parser.room_id).to eq(230008)
+    end
+
+    it 'keeps the nav room_id even when a ShowRoomID-on subtitle carries a uid suffix' do
+      feed(parser, "<nav rm='230008'/>")
+      feed(parser, %(<streamWindow id='main' title='Story' subtitle=" - [Bosque Deriel, Hermit's Shacks] (230008)"/>))
+      expect(parser.room_id).to eq(230008)
+      expect(parser.room_title).to eq("[[Bosque Deriel, Hermit's Shacks]]")
+    end
+  end
 end

--- a/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
@@ -571,8 +571,10 @@ RSpec.describe Lich::DragonRealms::DRParser do
     describe 'RoomID toggle (no longer enforced)' do
       it 'ignores the "no longer see room IDs" line without warning or re-enabling the flag' do
         # Room UIDs now come from the <nav> tag regardless of the ShowRoomID flag, so turning
-        # it off is a valid player choice: Lich must not nag or force the flag back on.
+        # it off is a valid player choice: Lich must neither nag nor send a command to force
+        # the flag back on (the old handler ran put("flag showroomid on")).
         expect(Lich::Messaging).not_to receive(:msg)
+        expect(described_class).not_to receive(:put)
 
         line = "You will no longer see room IDs when LOOKing in the game and room windows."
         expect { described_class.parse(line) }.not_to raise_error

--- a/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
@@ -568,13 +568,14 @@ RSpec.describe Lich::DragonRealms::DRParser do
       end
     end
 
-    describe 'RoomID warning' do
-      it 'sends warning message when RoomID is turned off' do
-        expect(Lich::Messaging).to receive(:msg).with("bold", /DRParser:.*ShowRoomID/)
-        expect(Lich::Messaging).to receive(:msg).with("plain", /DRParser:.*flaguid/)
+    describe 'RoomID toggle (no longer enforced)' do
+      it 'ignores the "no longer see room IDs" line without warning or re-enabling the flag' do
+        # Room UIDs now come from the <nav> tag regardless of the ShowRoomID flag, so turning
+        # it off is a valid player choice: Lich must not nag or force the flag back on.
+        expect(Lich::Messaging).not_to receive(:msg)
 
         line = "You will no longer see room IDs when LOOKing in the game and room windows."
-        described_class.parse(line)
+        expect { described_class.parse(line) }.not_to raise_error
       end
     end
 

--- a/spec/lib/dragonrealms/drinfomon/startup_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/startup_spec.rb
@@ -108,6 +108,20 @@ RSpec.describe Lich::DragonRealms::DRInfomon do
       script = described_class.startup_script
       expect(script).to include('Array(Lich::Util.issue_command("flag"')
     end
+
+    it 'still enforces the MonsterBold flag' do
+      expect(described_class.startup_script).to include('MonsterBold')
+    end
+
+    it 'requires only MonsterBold (ShowRoomID is no longer forced)' do
+      expect(described_class.startup_script).to include('required = ["MonsterBold"]')
+    end
+
+    it 'no longer lists ShowRoomID among the enforced flags (room UIDs come from the <nav> tag)' do
+      # The explanatory comment in the script still names ShowRoomID; what matters is that it is
+      # not one of the quoted flags in the required array, so match the array-literal form.
+      expect(described_class.startup_script).not_to include('"ShowRoomID"')
+    end
   end
 
   describe '.post_startup_checks' do

--- a/spec/lib/games_spec.rb
+++ b/spec/lib/games_spec.rb
@@ -459,9 +459,10 @@ RSpec.describe 'DragonRealms room-id placement (games.rb)' do
       expect(dr.process_room_display(+'PROMPT')).not_to include('Room Number:')
     end
 
-    it 'shows the Room Number line for the "both" placement' do
+    it 'renders in both the title and the below-room line for the "both" placement' do
       Lich.display_lichid = true
       Lich.display_roomid_location = 'both'
+      expect(dr.modify_room_display(+'[Test Room]')).to eq('[Test Room - 1234]')
       expect(dr.process_room_display(+'PROMPT')).to include('Room Number: 1234')
     end
 

--- a/spec/lib/games_spec.rb
+++ b/spec/lib/games_spec.rb
@@ -341,6 +341,148 @@ RSpec.describe Lich::DragonRealms::GameInstance do
   end
 end
 
+# The DragonRealms room-id/RealID display: "what to show" is display_lichid/display_uid,
+# "where to show it" is Lich.display_roomid_location (title | line | both, default line).
+# modify_room_display handles the inline room-name (title) injection; process_room_display
+# handles the below-room "Room Number:" line. Defaults are unchanged (flags off, placement
+# line), and the inline injection must never touch XMLData (scripts read the clean title).
+RSpec.describe 'DragonRealms room-id placement (games.rb)' do
+  let(:dr) { Lich::DragonRealms::GameInstance.new }
+  let(:gs) { Lich::Gemstone::GameInstance.new }
+
+  before do
+    XMLData.reset
+    XMLData.game = 'DR'
+    XMLData.room_title = '[Test Room]'
+    XMLData.room_id = 230008
+    Lich.display_lichid = false
+    Lich.display_uid = false
+    Lich.hide_uid_flag = false
+    Lich.display_exits = false
+    Lich.display_stringprocs = false
+    Lich.display_room_links = false
+    Lich.display_room_mono = false
+    Lich.display_roomid_location = nil
+    allow(Frontend).to receive(:client).and_return('profanity') # not a room-window frontend
+    allow(Frontend).to receive(:supports_mono?).and_return(false)
+  end
+
+  # Reset the shared mock accessors so per-example toggles do not leak (random order).
+  after do
+    Lich.display_lichid = nil
+    Lich.display_uid = nil
+    Lich.hide_uid_flag = nil
+    Lich.display_exits = nil
+    Lich.display_stringprocs = nil
+    Lich.display_room_links = nil
+    Lich.display_room_mono = nil
+    Lich.display_roomid_location = nil
+  end
+
+  describe '#modify_room_display (inline room-name injection)' do
+    it 'injects the lich id into the room name for the "title" placement' do
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'title'
+      expect(dr.modify_room_display(+'[Test Room]')).to eq('[Test Room - 1234]')
+    end
+
+    it 'injects the uid into the room name for the "title" placement' do
+      Lich.display_uid = true
+      Lich.display_roomid_location = 'title'
+      expect(dr.modify_room_display(+'[Test Room]')).to eq('[Test Room - (u230008)]')
+    end
+
+    it 'injects both id and uid for the "title" placement' do
+      Lich.display_lichid = true
+      Lich.display_uid = true
+      Lich.display_roomid_location = 'title'
+      expect(dr.modify_room_display(+'[Test Room]')).to eq('[Test Room - 1234 - (u230008)]')
+    end
+
+    it 'renders (**) for a no-uid room (room_id 0) in the title' do
+      XMLData.room_id = 0
+      Lich.display_uid = true
+      Lich.display_roomid_location = 'title'
+      expect(dr.modify_room_display(+'[Test Room]')).to eq('[Test Room - (**)]')
+    end
+
+    it 'strips a game-supplied RealID before injecting, leaving no duplicate' do
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'title'
+      expect(dr.modify_room_display(+'[Test Room] (230008)')).to eq('[Test Room - 1234]')
+    end
+
+    it 'injects nothing (and does not raise) when the room is unmapped and only lichid is on' do
+      allow(Map).to receive(:current).and_return(nil)
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'title'
+      expect(dr.modify_room_display(+'[Test Room]')).to eq('[Test Room]')
+    end
+
+    it 'does not inject for the "line" placement (room name left as sent)' do
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'line'
+      expect(dr.modify_room_display(+'[Test Room] (230008)')).to eq('[Test Room] (230008)')
+    end
+
+    it 'still hides the game RealID for the "line" placement when display_uid is on (historical behavior)' do
+      Lich.display_uid = true
+      Lich.display_roomid_location = 'line'
+      expect(dr.modify_room_display(+'[Test Room] (230008)')).to eq('[Test Room]')
+    end
+
+    it 'does not mutate XMLData.room_title when injecting into the title' do
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'title'
+      dr.modify_room_display(+'[Test Room]')
+      expect(XMLData.room_title).to eq('[Test Room]')
+    end
+  end
+
+  describe '#process_room_display (below-room "Room Number:" line)' do
+    it 'shows the Room Number line for the "line" placement' do
+      Lich.display_lichid = true
+      Lich.display_uid = true
+      Lich.display_roomid_location = 'line'
+      expect(dr.process_room_display(+'PROMPT')).to include('Room Number: 1234 - (u230008)')
+    end
+
+    it 'shows the Room Number line by default (nil placement behaves as "line")' do
+      Lich.display_lichid = true
+      Lich.display_roomid_location = nil
+      expect(dr.process_room_display(+'PROMPT')).to include('Room Number: 1234')
+    end
+
+    it 'omits the Room Number line for the "title" placement' do
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'title'
+      expect(dr.process_room_display(+'PROMPT')).not_to include('Room Number:')
+    end
+
+    it 'shows the Room Number line for the "both" placement' do
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'both'
+      expect(dr.process_room_display(+'PROMPT')).to include('Room Number: 1234')
+    end
+
+    it 'adds no line and does not raise when the room is unmapped and only lichid is on' do
+      allow(Map).to receive(:current).and_return(nil)
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'line'
+      expect(dr.process_room_display(+'PROMPT')).not_to include('Room Number:')
+    end
+  end
+
+  describe 'GemStone is unaffected by the DR placement setting' do
+    it 'GS #modify_room_display ignores display_roomid_location' do
+      XMLData.game = 'GS'
+      Lich.display_lichid = true
+      Lich.display_roomid_location = 'line' # suppresses DR title injection; must not affect GS
+      expect(gs.modify_room_display(+'[Test Room] (123)')).to include(' - 1234]')
+    end
+  end
+end
+
 # Unit coverage for the shared formatting mixin, exercised on a throwaway host
 # class so the helpers are tested in isolation from the game instances.
 RSpec.describe Lich::GameBase::RoomFormatter do

--- a/spec/lib/lich_room_display_settings_spec.rb
+++ b/spec/lib/lich_room_display_settings_spec.rb
@@ -74,4 +74,69 @@ RSpec.describe 'Lich.display_room_* real getters (lib/lich.rb)' do
       expect(real_getter_value(:display_room_links, '')).to be_nil
     end
   end
+
+  # Runs a snippet against the real lib/lich.rb in a fresh subprocess (isolated from the
+  # suite's Lich mock) with a stubbed XMLData.game and a single-value lich_settings DB stub,
+  # returning the snippet's stdout verbatim. Mirrors real_getter_value but supports the
+  # string-valued display_roomid_location getter/setter and a preloaded DB row.
+  # @param game [String] the value XMLData.game should report
+  # @param body [String] Ruby to execute after setup (expected to print a result)
+  # @param db_value [String, nil] the value the settings-table stub returns for any lookup
+  # @return [String] the snippet's stdout
+  def run_real_lich(game:, body:, db_value: nil)
+    lib_path = File.expand_path('../../lib', __dir__)
+    script = <<~RUBY
+      $LOAD_PATH.unshift(#{lib_path.inspect})
+      require 'lich'
+      module XMLData; end
+      XMLData.define_singleton_method(:game) { #{game.inspect} }
+      def Lich.db
+        @stub ||= begin
+          o = Object.new
+          stored = #{db_value.inspect}
+          o.define_singleton_method(:get_first_value) { |_query| stored }
+          o.define_singleton_method(:execute) { |_query, _params = []| nil }
+          o
+        end
+      end
+      #{body}
+    RUBY
+
+    `#{Shellwords.escape(RbConfig.ruby)} -e #{Shellwords.escape(script)}`
+  end
+
+  describe '.display_roomid_location' do
+    it 'defaults to "line" (the historical below-room line) for DragonRealms' do
+      expect(run_real_lich(game: 'DR', body: 'print Lich.display_roomid_location.inspect')).to eq('"line"')
+    end
+
+    it 'stays unresolved (nil) until a game is identified' do
+      expect(run_real_lich(game: '', body: 'print Lich.display_roomid_location.inspect')).to eq('nil')
+    end
+
+    it 'returns a valid persisted placement from the settings table' do
+      expect(run_real_lich(game: 'DR', db_value: 'title', body: 'print Lich.display_roomid_location.inspect')).to eq('"title"')
+    end
+
+    it 'falls back to "line" when the persisted value is not a recognized placement' do
+      expect(run_real_lich(game: 'DR', db_value: 'garbage', body: 'print Lich.display_roomid_location.inspect')).to eq('"line"')
+    end
+
+    it 'normalizes an assigned value to lowercase' do
+      body = 'Lich.display_roomid_location = "TITLE"; print Lich.display_roomid_location.inspect'
+      expect(run_real_lich(game: 'DR', body: body)).to eq('"title"')
+    end
+
+    it 'ignores an unrecognized assignment and retains the current value' do
+      body = 'Lich.display_roomid_location = "both"; Lich.display_roomid_location = "bogus"; print Lich.display_roomid_location.inspect'
+      expect(run_real_lich(game: 'DR', body: body)).to eq('"both"')
+    end
+
+    it 'accepts each recognized placement value' do
+      %w[title line both].each do |placement|
+        body = "Lich.display_roomid_location = #{placement.inspect}; print Lich.display_roomid_location.inspect"
+        expect(run_real_lich(game: 'DR', body: body)).to eq(placement.inspect)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |config|
     # Lich messaging
     Lich::Messaging.clear_messages! if defined?(Lich::Messaging) && Lich::Messaging.respond_to?(:clear_messages!)
     Lich.reset_display_expgains! if defined?(Lich) && Lich.respond_to?(:reset_display_expgains!)
+    Lich.display_roomid_location = nil if defined?(Lich) && Lich.respond_to?(:display_roomid_location=)
     Lich.db.reset! if defined?(Lich) && Lich.respond_to?(:db) && Lich.db.respond_to?(:reset!)
     Lich::Common::DB_Store.reset! if defined?(Lich::Common::DB_Store) && Lich::Common::DB_Store.respond_to?(:reset!)
     # Drain Infomon's async write queue so a queued INSERT from a prior example
@@ -532,7 +533,7 @@ module XMLData
   @dr_active_spells_stellar_percentage = 0
 
   class << self
-    attr_accessor :game, :name, :room_id, :room_title, :room_description, :room_exits, :injury_mode, :stamina, :server_time
+    attr_accessor :game, :name, :room_id, :room_title, :room_description, :room_exits, :injury_mode, :stamina, :server_time, :previous_nav_rm
     attr_accessor :dr_active_spells, :dr_active_spells_slivers, :dr_active_spells_stellar_percentage
     attr_accessor :current_target_ids
 
@@ -567,6 +568,7 @@ module XMLData
       @dialogs = {}
       @injuries = {}
       @room_id = 0
+      @previous_nav_rm = nil
       @room_title = ''
       @room_description = ''
       @room_exits = []
@@ -700,7 +702,7 @@ module Lich
   class << self
     # attr_accessor is idempotent - reopening Lich and re-declaring these is safe.
     attr_accessor :display_lichid, :display_uid, :hide_uid_flag, :display_stringprocs, :display_exits, :display_room_links, :display_room_mono
-    attr_accessor :display_expgains
+    attr_accessor :display_expgains, :display_roomid_location
 
     def db
       @db ||= MockDB.new
@@ -1099,6 +1101,14 @@ module Lich
         def discard_staged_refreshes
           nil
         end
+
+        # Room-collection clears the <nav> handler invokes on arrival. The mock only needs
+        # them to exist as no-ops so xmlparser specs can drive a real <nav> tag end-to-end.
+        def clear_loot; end
+
+        def clear_pcs; end
+
+        def clear_room_desc; end
 
         def set_right_hand(obj)
           @right_hand = obj


### PR DESCRIPTION
## Summary

DragonRealms now emits native `<nav rm='NNNN'/>` tags on every arrival (a bare `<nav/>` with no `rm` for a room that has no UID), matching GemStone. This PR adopts the nav tag as the authoritative DR room-UID source instead of scraping the `streamWindow` subtitle title bar, which only carried the UID when the game's `ShowRoomID` flag was on. On the back of that it stops Lich from fighting the flag, and adds an opt-in choice of *where* the room id/UID is displayed.

**Defaults are unchanged** for existing players: nothing is embedded in the title unless the player opts in; `display_lichid`/`display_uid` stay off for DR; the new placement setting defaults to the historical below-room line.

### Core: nav becomes the DR room-UID source (`lib/common/xmlparser.rb`)
- The `<nav>` handler now sets `room_id`/`previous_nav_rm` for DR too (the `unless XMLData.game =~ /^DR/` guard is removed). This gives early room knowledge before the room text streams and finally populates `Map.previous_uid` for DR (previously always nil).
- The subtitle UID scrape is removed. `<nav>` precedes the subtitle in the stream, and a ShowRoomID-off subtitle carries no UID, so scraping it would write `0` and clobber the good nav value. The title parse stays, so `XMLData.room_title` remains UID-free (scripts depend on exact title matching).
- `@room_id` initializes to `0` (not `nil`) so a read before the first `<nav>` is a valid "no UID" value instead of a `NoMethodError` on `room_id.zero?` / `room_id > N` in the map layer (hardens GS too).

### Stop enforcing ShowRoomID (nav works with the flag on or off)
- `lib/dragonrealms/drinfomon/drparser.rb`: remove the handler that forced `flag showroomid on` and nagged the player.
- `lib/dragonrealms/drinfomon/startup.rb`: drop `ShowRoomID` from the one-time forced flags. `MonsterBold` is still enforced.

### Opt-in display + placement control
- `lib/lich.rb`: new `Lich.display_roomid_location` (`title` | `line` | `both`, DR default `line`, invalid input ignored, DB-persisted) beside the other `display_*` settings.
- `lib/global_defs.rb`: new `;display roomid <title|line|both>` command, help entry, and a note that `;display flaguid` is largely unnecessary now (a player can just `flag showroomid off`).
- `lib/games.rb`: for the `title`/`both` placements, inject the id/UID into the inline `<style id="roomName"/>` line GS-style (visible on every front-end, including ProfanityFE/Genie); gate the below-room `Room Number:` line to `line`/`both`. Three private DRY helpers (`room_number_display`, `room_id_in_title?`, `room_id_in_line?`) are shared by `modify_room_display` and `process_room_display` so their formatting can't drift; the shared helper also guards a latent `Map.current` nil crash. **GS code is untouched.**

### Why this is script-safe
The injection edits only the outbound client string. `process_xml_data` (which populates `XMLData` via Ox SAX) runs before `process_downstream_hooks` (where the display rewrite happens), so `XMLData.room_title`/`room_id` - and therefore every script - are unaffected.

## Player-facing

| Want | Do |
|---|---|
| Nothing (default) | leave defaults |
| Lich id in the title only | `;display lichid` + `;display roomid title` |
| Room number below the room (classic) | `;display lichid` (and/or `;display uid`) |
| Both places | `;display roomid both` |

`;display uid` now works even with ShowRoomID off, since the UID comes from `<nav>`.

## Tests

DAMP, gap-free coverage added/updated across `xmlparser_spec`, `map_dr_spec`, `drparser_spec`, `startup_spec`, `lich_room_display_settings_spec`, `games_spec`, and `spec_helper`:
- nav capture, including the clobber-prevention regression and the bare-`<nav/>` zero case;
- `display_roomid_location` default / lowercase-normalize / invalid-ignored / persistence, exercised against the real `lib/lich.rb` in a subprocess;
- ShowRoomID de-enforcement;
- placement rendering (title/line/both, `(**)` for a no-UID room, strip-before-inject, unmapped nil-guard, no `XMLData` mutation) and a GS-unaffected guard.

Full suite green (`ruby -c` clean, `rubocop` 0 offenses on all touched files). The only failing example is the pre-existing `enhancive_spec` flake tracked by a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)