### PR TITLE
fix(all): restore detachable client disconnect notice to stdout

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -2382,6 +2382,21 @@ rescue StandardError => e
 ensure
   client.close rescue nil
   detachable_client_unregister(client)
+  # Mirror the connect-side "listening on" line so an operator sharing the
+  # controlling terminal (for example a wrapper script that exec's a frontend)
+  # sees which session dropped and from where. Emitted after unregister so the
+  # attached count reflects the clients that remain.
+  if $_DETACHABLE_LISTENER_
+    session_name = Lich::Common::SessionLifecycle.resolve_session_name(
+      argv: ARGV, account_character: (Lich::Common::Account.character rescue nil)
+    )
+    $stdout.puts Lich::Main::DetachableClientNotice.disconnected(
+      name: session_name,
+      host: $_DETACHABLE_LISTENER_[:host],
+      port: $_DETACHABLE_LISTENER_[:port],
+      attached: detachable_client_count
+    ) rescue nil
+  end
   Lich::Common::ShutdownLog.info("detachable client cleaned up (#{detachable_client_count} attached)")
 end
 

--- a/lib/main/detachable_client_notice.rb
+++ b/lib/main/detachable_client_notice.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Lich
+  module Main
+    # Builds the human-facing notices Lich prints to $stdout for detachable
+    # client listener lifecycle events: when the listener starts accepting
+    # connections and when an attached client drops.
+    #
+    # These notices share a controlling terminal with an exec'd frontend (for
+    # example ProfanityFE launched by a wrapper script), so they only become
+    # visible once that frontend releases the screen. Keeping the wording in one
+    # pure formatter ensures the connect and disconnect paths stay symmetric and
+    # can be unit tested without opening sockets.
+    #
+    # @since 5.18.0
+    module DetachableClientNotice
+      PREFIX = '--- Lich: detachable client'
+
+      # Formats a "host:port" endpoint, bracketing IPv6 literals so the port is
+      # unambiguous (for example +[::1]:8000+). A host that is already bracketed
+      # is left as-is.
+      #
+      # @param host [String, nil] bind host or address
+      # @param port [Integer, String] listener port
+      # @return [String] "host:port" with IPv6 literals bracketed
+      def self.address(host, port)
+        formatted_host = host.to_s
+        formatted_host = "[#{formatted_host}]" if formatted_host.include?(':') && !formatted_host.start_with?('[')
+        "#{formatted_host}:#{port}"
+      end
+
+      # Notice emitted when the detachable listener is ready for connections.
+      #
+      # @param host [String, nil] bind host or address
+      # @param port [Integer, String] listener port
+      # @return [String]
+      def self.listening(host:, port:)
+        "#{PREFIX} listening on #{address(host, port)}"
+      end
+
+      # Notice emitted when an attached client disconnects. Includes the session
+      # name so an operator can tell which character's frontend dropped, the
+      # endpoint it was attached to, and how many clients remain attached.
+      #
+      # @param name [String, nil] character/session name the client was attached
+      #   to; when blank the name is omitted
+      # @param host [String, nil] bind host or address
+      # @param port [Integer, String] listener port
+      # @param attached [Integer] detachable clients still attached after the drop
+      # @return [String]
+      def self.disconnected(name:, host:, port:, attached:)
+        subject = name.to_s.empty? ? PREFIX : "#{PREFIX} #{name}"
+        "#{subject} disconnected from #{address(host, port)} (#{attached} attached)"
+      end
+    end
+  end
+end

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -65,6 +65,9 @@ reconnect_if_wanted = proc {
   require File.join(LIB_DIR, 'common', 'shutdown_script_drain.rb')
   require File.join(LIB_DIR, 'common', 'shutdown_watchdog.rb')
   require File.join(LIB_DIR, 'main', 'user_exit_dispatch.rb')
+  # Detachable listener stdout notices (connect/disconnect); the disconnect
+  # notice is emitted from handle_detachable_client in global_defs at runtime.
+  require File.join(LIB_DIR, 'main', 'detachable_client_notice.rb')
 
   # Arms the shutdown watchdog before the user-initiated ("...exit") drain, which
   # kills scripts and runs their before_dying hooks inline (any of which can
@@ -743,11 +746,13 @@ reconnect_if_wanted = proc {
               end
               detachable_listener_connected(detachable_client_count.positive?)
 
-              listen_ip = $_DETACHABLE_LISTENER_[:host]
-              listen_ip = "[#{listen_ip}]" if server.local_address.ipv6?
-              listen_address = "#{listen_ip}:#{$_DETACHABLE_LISTENER_[:port]}"
+              listen_address = Lich::Main::DetachableClientNotice.address(
+                $_DETACHABLE_LISTENER_[:host], $_DETACHABLE_LISTENER_[:port]
+              )
               Lich.log "info: detachable client server listening on #{listen_address}"
-              $stdout.puts "--- Lich: detachable client listening on #{listen_address}" rescue nil
+              $stdout.puts Lich::Main::DetachableClientNotice.listening(
+                host: $_DETACHABLE_LISTENER_[:host], port: $_DETACHABLE_LISTENER_[:port]
+              ) rescue nil
             end
 
             accepted_socket, = server.accept

--- a/spec/lib/main/detachable_client_notice_spec.rb
+++ b/spec/lib/main/detachable_client_notice_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+require_relative '../../../lib/main/detachable_client_notice'
+
+RSpec.describe Lich::Main::DetachableClientNotice do
+  describe '.address' do
+    it 'joins an IPv4 host and port' do
+      expect(described_class.address('127.0.0.1', 8000)).to eq('127.0.0.1:8000')
+    end
+
+    it 'brackets an IPv6 literal' do
+      expect(described_class.address('::1', 8000)).to eq('[::1]:8000')
+    end
+
+    it 'leaves an already-bracketed IPv6 host untouched' do
+      expect(described_class.address('[::1]', 8000)).to eq('[::1]:8000')
+    end
+
+    it 'joins a hostname and port' do
+      expect(described_class.address('mypc.tailnet.ts.net', 8000)).to eq('mypc.tailnet.ts.net:8000')
+    end
+
+    it 'renders a nil host as an empty host' do
+      expect(described_class.address(nil, 8000)).to eq(':8000')
+    end
+  end
+
+  describe '.listening' do
+    it 'formats the listening notice' do
+      expect(described_class.listening(host: '127.0.0.1', port: 8000))
+        .to eq('--- Lich: detachable client listening on 127.0.0.1:8000')
+    end
+
+    it 'brackets an IPv6 endpoint' do
+      expect(described_class.listening(host: '::1', port: 8000))
+        .to eq('--- Lich: detachable client listening on [::1]:8000')
+    end
+  end
+
+  describe '.disconnected' do
+    it 'includes the session name, endpoint, and remaining attached count' do
+      expect(described_class.disconnected(name: 'Mahtra', host: '127.0.0.1', port: 8000, attached: 0))
+        .to eq('--- Lich: detachable client Mahtra disconnected from 127.0.0.1:8000 (0 attached)')
+    end
+
+    it 'reports remaining clients when more than one was attached' do
+      expect(described_class.disconnected(name: 'Mahtra', host: '127.0.0.1', port: 8000, attached: 2))
+        .to eq('--- Lich: detachable client Mahtra disconnected from 127.0.0.1:8000 (2 attached)')
+    end
+
+    it 'omits the name when it is nil' do
+      expect(described_class.disconnected(name: nil, host: '127.0.0.1', port: 8000, attached: 0))
+        .to eq('--- Lich: detachable client disconnected from 127.0.0.1:8000 (0 attached)')
+    end
+
+    it 'omits the name when it is blank' do
+      expect(described_class.disconnected(name: '', host: '127.0.0.1', port: 8000, attached: 0))
+        .to eq('--- Lich: detachable client disconnected from 127.0.0.1:8000 (0 attached)')
+    end
+
+    it 'brackets an IPv6 endpoint' do
+      expect(described_class.disconnected(name: 'Mahtra', host: '::1', port: 8000, attached: 0))
+        .to eq('--- Lich: detachable client Mahtra disconnected from [::1]:8000 (0 attached)')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Since #1459 made the detachable listener persistent, `Frontend.create_session_file` (which printed `character/host/port`) runs **once at startup** instead of on every re-listen. As a side effect, closing a detachable frontend no longer prints any session info to the shared controlling terminal.

Concretely: a wrapper script that spawns Lich with `--detachable-client` and then `exec`s ProfanityFE in the same terminal used to see the session descriptor (character/host/port) reappear when Profanity closed and released the screen. After #1459 that line is gone, so an operator no longer sees which session they just disconnected from.

This restores a **symmetric disconnect notice**, mirroring the existing connect-side line:

```
--- Lich: detachable client listening on 127.0.0.1:8000        <- connect (existing)
--- Lich: detachable client Mahtra disconnected from 127.0.0.1:8000 (0 attached)   <- disconnect (new)
```

## Changes

- **New `lib/main/detachable_client_notice.rb`** — `Lich::Main::DetachableClientNotice`, a pure formatter (`.address`, `.listening`, `.disconnected`) with IPv6-safe bracketing and YARD docs. Mirrors the existing `DetachableClientTarget` pattern so the notice wording lives in one place (DRY) and is unit-testable without sockets.
- **`lib/main/main.rb`** — the connect-side listening line now routes through the module (single source for the wording). Behavior-preserving; IPv6 bracketing moves from `server.local_address.ipv6?` to a host-string check, which is equivalent for real addresses and is covered by the spec.
- **`lib/global_defs.rb`** — `handle_detachable_client` now emits the disconnect notice to `$stdout` in its `ensure`, after `detachable_client_unregister` so the attached count reflects the clients that remain. Character comes from `SessionLifecycle.resolve_session_name` (the same derivation the old session descriptor used).
- **New `spec/lib/main/detachable_client_notice_spec.rb`** — 12 examples covering IPv4/IPv6/hostname/nil endpoints, the listening notice, and the disconnect notice with/without a name and varying attached counts.

## Testing

- `rubocop -A` on all touched files: no offenses.
- New spec: 12 examples, 0 failures. Related `detachable_client_target_spec` + `session_lifecycle_spec`: 36 examples, 0 failures.
- `ruby -c` clean on all edited files.

## CodeRabbit

CodeRabbit CLI (repo `.coderabbit.yaml`) was already run locally against this change: **0 findings on the code in this PR** (the new module, both wired lines, and the spec all clean).

It did surface **2 findings in pre-existing adjacent code from #1459** that this PR does not touch, so they are intentionally left out and will be addressed in a separate follow-up PR:

1. *(major)* `detachable_clients_respond` does not isolate per-client failures — a raise from one client's `puts_main_stream` aborts the loop and blocks output to the remaining attached clients.
2. *(minor)* `detachable_client_send_init` concatenates raw `GameObj`/`XMLData` values into the XML init payload without escaping `&`/`<`/`>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
