### PR TITLE
fix(all): harden detachable client teardown and escape init payload

### DIFF
--- a/lib/common/xml_entities.rb
+++ b/lib/common/xml_entities.rb
@@ -15,6 +15,14 @@ module Lich
 
         str.gsub('&lt;', '<').gsub('&gt;', '>').gsub('&quot;', '"').gsub('&apos;', "'").gsub('&amp;', '&')
       end
+
+      # Encodes the three markup-significant characters so a raw value can be
+      # safely embedded in an XML-like payload sent to a frontend. &amp; is
+      # encoded first so the ampersands introduced by encoding < and > are not
+      # themselves double-encoded.
+      def self.encode(str)
+        str.to_s.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+      end
     end
   end
 end

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -1812,9 +1812,9 @@ def respond(first = "", *messages)
     str.split(/\r?\n/).each { |line| Script.new_script_output(line); Buffer.update(line, Buffer::SCRIPT_OUTPUT) }
     # str.gsub!(/\r?\n/, "\r\n") if $frontend == 'genie'
     if Frontend.supports_mono?
-      str = "<output class=\"mono\"/>\r\n#{str.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')}<output class=\"\"/>\r\n"
+      str = "<output class=\"mono\"/>\r\n#{Lich::Common::XmlEntities.encode(str)}<output class=\"\"/>\r\n"
     elsif Frontend.client.eql?('profanity')
-      str = str.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+      str = Lich::Common::XmlEntities.encode(str)
     end
     $_CLIENT_.puts_main_stream(str) if $_CLIENT_&.alive?
     detachable_clients_respond(str)
@@ -2283,7 +2283,14 @@ def detachable_clients_respond(string)
       next
     end
 
-    client.puts_main_stream(string)
+    # Isolate per-client failures: a raise from one client's socket must not
+    # abort the loop and starve the remaining attached clients of this output.
+    # Mirrors the per-client rescue in detachable_clients_close.
+    begin
+      client.puts_main_stream(string)
+    rescue StandardError => e
+      Lich.log "warning: detachable_clients_respond: #{e}"
+    end
     detachable_client_unregister(client) unless client.alive?
   end
 end
@@ -2303,16 +2310,16 @@ def detachable_client_send_init(client)
   init_str.concat "<progressBar id='health' value='0' text='health #{XMLData.health}/#{XMLData.max_health}'/>"
   init_str.concat "<progressBar id='spirit' value='0' text='spirit #{XMLData.spirit}/#{XMLData.max_spirit}'/>"
   init_str.concat "<progressBar id='stamina' value='0' text='stamina #{XMLData.stamina}/#{XMLData.max_stamina}'/>"
-  init_str.concat "<spell>#{XMLData.prepared_spell}</spell>"
+  init_str.concat "<spell>#{Lich::Common::XmlEntities.encode(XMLData.prepared_spell)}</spell>"
   %w[IconBLEEDING IconPOISONED IconDISEASED IconSTANDING IconKNEELING IconSITTING IconPRONE].each do |indicator|
     init_str.concat "<indicator id='#{indicator}' visible='#{XMLData.indicator[indicator]}'/>"
   end
   if XMLData.game.to_s.match?(/GS/)
     init_str.concat "<progressBar id='pbarStance' value='#{XMLData.stance_value}'/>"
-    init_str.concat "<progressBar id='mindState' value='#{XMLData.mind_value}' text='#{XMLData.mind_text}'/>"
-    init_str.concat "<progressBar id='encumlevel' value='#{XMLData.encumbrance_value}' text='#{XMLData.encumbrance_text}'/>"
-    init_str.concat "<right>#{GameObj.right_hand.name}</right>"
-    init_str.concat "<left>#{GameObj.left_hand.name}</left>"
+    init_str.concat "<progressBar id='mindState' value='#{XMLData.mind_value}' text='#{Lich::Common::XmlEntities.encode(XMLData.mind_text)}'/>"
+    init_str.concat "<progressBar id='encumlevel' value='#{XMLData.encumbrance_value}' text='#{Lich::Common::XmlEntities.encode(XMLData.encumbrance_text)}'/>"
+    init_str.concat "<right>#{Lich::Common::XmlEntities.encode(GameObj.right_hand.name)}</right>"
+    init_str.concat "<left>#{Lich::Common::XmlEntities.encode(GameObj.left_hand.name)}</left>"
     %w[back leftHand rightHand head rightArm abdomen leftEye leftArm chest rightLeg neck leftLeg nsys rightEye].each do |area|
       if Wounds.send(area) > 0
         init_str.concat "<image id=\"#{area}\" name=\"Injury#{Wounds.send(area)}\"/>"

--- a/spec/lib/common/xml_entities_spec.rb
+++ b/spec/lib/common/xml_entities_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+require_relative '../../../lib/common/xml_entities'
+
+RSpec.describe Lich::Common::XmlEntities do
+  describe '.encode' do
+    it 'encodes the three markup-significant characters' do
+      expect(described_class.encode('a & b < c > d')).to eq('a &amp; b &lt; c &gt; d')
+    end
+
+    it 'encodes ampersands before the ones introduced by < and >, so nothing double-encodes' do
+      expect(described_class.encode('<tag>')).to eq('&lt;tag&gt;')
+      expect(described_class.encode('&amp;')).to eq('&amp;amp;')
+    end
+
+    it 'leaves a value with no markup characters untouched' do
+      expect(described_class.encode('a rune-etched short sword')).to eq('a rune-etched short sword')
+    end
+
+    it 'coerces non-string values via to_s' do
+      expect(described_class.encode(nil)).to eq('')
+      expect(described_class.encode(42)).to eq('42')
+    end
+  end
+
+  describe '.decode' do
+    it 'decodes the five standard entities' do
+      expect(described_class.decode('&lt;a&gt; &amp; &quot;b&quot; &apos;c&apos;'))
+        .to eq('<a> & "b" \'c\'')
+    end
+
+    it 'returns the input unchanged when there is no ampersand' do
+      expect(described_class.decode('no entities here')).to eq('no entities here')
+    end
+  end
+
+  describe 'round-trip' do
+    it 'decode(encode(str)) restores the three encoded characters' do
+      original = 'a & b < c > d'
+      expect(described_class.decode(described_class.encode(original))).to eq(original)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #1492. While reviewing that PR, CodeRabbit flagged two issues in **pre-existing** detachable-client code (introduced by #1459) that #1492 intentionally left untouched to stay focused. This PR fixes both, plus a small DRY refactor.

## Changes

1. **`detachable_clients_respond` isolates per-client failures** *(was: major)*
   A raise from one client's `puts_main_stream` aborted the `each` loop, so a single broken detachable connection starved every other attached client of that output. The write is now wrapped in a per-client `rescue`, mirroring the per-client rescue already used by `detachable_clients_close`.

2. **`detachable_client_send_init` escapes its free-text values** *(was: minor)*
   The init payload embedded raw game-state strings (`prepared_spell`, `mind_text`, `encumbrance_text`, and both hand item names) into XML-like markup. Unescaped `&`/`<`/`>` produced malformed markup for a newly attached frontend, the same class of issue `respond` already guards against. These values are now escaped.

3. **New `Lich::Common::XmlEntities.encode`** (DRY)
   A mirror of the existing `.decode`, giving XML entity encoding a single home (`&amp;` encoded first so nothing double-encodes). The two previously inlined encode chains in `respond` are routed through it as well, behavior-identical.

## Testing

- New `spec/lib/common/xml_entities_spec.rb`: 7 examples (encode incl. double-encode + `to_s` coercion, decode, and a decode(encode(x)) round-trip), 0 failures.
- `rubocop -A` on all touched files: no offenses.
- `ruby -c` clean on edited files.

## CodeRabbit

CodeRabbit CLI (repo `.coderabbit.yaml`) was run locally against this change, scoped to the base commit: **No findings.**

The two functional fixes above are the exact findings CodeRabbit raised during the #1492 review; this PR resolves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
