### PR TITLE
fix(all): resolve GameObj status visibility during staged  refresh

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -1185,34 +1185,21 @@ module Lich
         end
       end
 
-      # Returns +true+ if this object's ID is found in any active registry,
-      # published or staged.
-      #
-      # Staged pools count as present: an object accumulating in a refresh that
-      # has not committed yet is in flight, not +"gone"+.
+      # Returns +true+ if this object's ID is found in any active registry.
       #
       # @return [Boolean]
       def present_in_any_registry?
-        return true if all_flat_registries.any? { |obj| obj.id == @id }
-
-        [@@contents, @@staging_contents].any? do |contents|
-          contents.values.any? { |list| list.any? { |obj| obj.id == @id } }
-        end
+        all_flat_registries.any? { |obj| obj.id == @id } ||
+          @@contents.values.any? { |list| list.any? { |obj| obj.id == @id } }
       end
 
       # Returns all flat (non-container) registries combined with hands as a
-      # single array for iteration. Covers both the published registries and any
-      # staging buffers currently in flight; a +nil+ staging buffer splats to
-      # nothing, so this is safe when no refresh is open.
+      # single array for iteration.
       #
       # @return [Array<GameObj>]
       def all_flat_registries
-        [*@@loot, *@@inv, *@@reserve, *@@room_desc, *@@npcs, *@@pcs,
+        [*@@loot, *@@inv, *@@reserve, *@@room_desc,
          *@@fam_loot, *@@fam_npcs, *@@fam_pcs, *@@fam_room_desc,
-         *@@staging_loot, *@@staging_inv, *@@staging_reserve, *@@staging_room_desc,
-         *@@staging_npcs, *@@staging_pcs,
-         *@@staging_fam_loot, *@@staging_fam_npcs, *@@staging_fam_pcs,
-         *@@staging_fam_room_desc,
          @@right_hand, @@left_hand].compact
       end
 

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -247,10 +247,28 @@ module Lich
       # Returns the current status string of this object, or +nil+ if present
       # but unstated, or +"gone"+ if not found in any registry.
       #
+      # The published status maps are consulted first, then the staging maps.
+      # That order is deliberate: while a refresh is in flight a reader must
+      # still see the previous complete snapshot (see the staging notes above),
+      # so a staged value must never shadow a published one. The staging maps
+      # are only a fallback for an object that has no published entry at all,
+      # which would otherwise be reported as +"gone"+ despite being mid-refresh.
+      #
+      # Note that a dedupe hit in +find_or_create+ means a staged object and its
+      # published counterpart are frequently the *same* instance, so this method
+      # cannot distinguish which of the two a caller holds. Callers that need
+      # the in-flight value (i.e. the parser) must track it themselves and write
+      # through +#status=+ rather than reading it back through here.
+      #
+      # The +"gone"+ sentinel is a frozen literal and must not be mutated in
+      # place; build a new String from it instead.
+      #
       # @return [String, nil]
       def status
         return @@npc_status[@id] if @@npc_status.key?(@id)
         return @@pc_status[@id]  if @@pc_status.key?(@id)
+        return @@staging_npc_status[@id] if @@staging_npc_status&.key?(@id)
+        return @@staging_pc_status[@id]  if @@staging_pc_status&.key?(@id)
 
         present_in_any_registry? ? nil : 'gone'
       end
@@ -1167,21 +1185,34 @@ module Lich
         end
       end
 
-      # Returns +true+ if this object's ID is found in any active registry.
+      # Returns +true+ if this object's ID is found in any active registry,
+      # published or staged.
+      #
+      # Staged pools count as present: an object accumulating in a refresh that
+      # has not committed yet is in flight, not +"gone"+.
       #
       # @return [Boolean]
       def present_in_any_registry?
-        all_flat_registries.any? { |obj| obj.id == @id } ||
-          @@contents.values.any? { |list| list.any? { |obj| obj.id == @id } }
+        return true if all_flat_registries.any? { |obj| obj.id == @id }
+
+        [@@contents, @@staging_contents].any? do |contents|
+          contents.values.any? { |list| list.any? { |obj| obj.id == @id } }
+        end
       end
 
       # Returns all flat (non-container) registries combined with hands as a
-      # single array for iteration.
+      # single array for iteration. Covers both the published registries and any
+      # staging buffers currently in flight; a +nil+ staging buffer splats to
+      # nothing, so this is safe when no refresh is open.
       #
       # @return [Array<GameObj>]
       def all_flat_registries
-        [*@@loot, *@@inv, *@@reserve, *@@room_desc,
+        [*@@loot, *@@inv, *@@reserve, *@@room_desc, *@@npcs, *@@pcs,
          *@@fam_loot, *@@fam_npcs, *@@fam_pcs, *@@fam_room_desc,
+         *@@staging_loot, *@@staging_inv, *@@staging_reserve, *@@staging_room_desc,
+         *@@staging_npcs, *@@staging_pcs,
+         *@@staging_fam_loot, *@@staging_fam_npcs, *@@staging_fam_pcs,
+         *@@staging_fam_room_desc,
          @@right_hand, @@left_hand].compact
       end
 

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -44,6 +44,7 @@ module Lich
         @obj_name = nil
         @obj_after_name = nil
         @pc = nil
+        @pc_status = nil
         @last_obj = nil
         @last_npc = nil
         @in_stream = false
@@ -1082,9 +1083,14 @@ module Lich
               if @active_tags.include?('a')
                 if @obj_exist.to_s.start_with?('-')
                   @pc = GameObj.new_pc(@obj_exist, @obj_noun, "#{@player_title}#{text_string}", @player_status)
+                  # Track the status we just staged for this pc. The annotation
+                  # branch below appends to this instead of reading it back
+                  # through GameObj#status, which cannot see the in-flight value.
+                  @pc_status = @player_status
                   @arrival_pcs.push(@pc.noun) if (defined?(Lich::Claim) && Lich::Claim::Lock.owned?)
                 else
                   @pc = nil
+                  @pc_status = nil
                 end
                 @player_status = nil
                 @player_title = nil
@@ -1123,12 +1129,9 @@ module Lich
                   GameObj.commit_room_players
                 else
                   if @pc && ((text_string =~ /^ who (?:is|appears) ([\w\s]+)(?:,| and|\.|$)/) || (text_string =~ / \(([\w\s]+)\)(?: \(([\w\s]+)\))?/))
-                    if @pc.status
-                      @pc.status.concat " #{$1}"
-                    else
-                      @pc.status = $1
-                    end
-                    @pc.status.concat " #{$2}" if $2
+                    @pc_status = @pc_status ? "#{@pc_status} #{$1}" : $1
+                    @pc_status = "#{@pc_status} #{$2}" if $2
+                    @pc.status = @pc_status
                   end
                   if text_string =~ /(?:^Also here: |, )(?:a )?([a-z\s]+)?([\w\s\-!\?',]+)?$/
                     @player_status = ($1.strip.gsub('the body of', 'dead')) if $1

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -951,7 +951,7 @@ RSpec.describe Lich::Common::GameObj do
         expect(departed.status).to eq('gone')
       end
 
-      it 'reports staged status again after an abandoned refresh is discarded' do
+      it 'reports gone once an abandoned refresh is discarded' do
         described_class.begin_room_players
         staged = described_class.new_pc('-31', 'dwarf', 'a dwarf', 'sitting')
         described_class.discard_staged_refreshes

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -905,6 +905,68 @@ RSpec.describe Lich::Common::GameObj do
       end
     end
 
+    describe 'status visibility while a refresh is open' do
+      it 'reports a staged-only object by its staged status rather than gone' do
+        described_class.begin_room_players
+        staged = described_class.new_pc('-31', 'dwarf', 'a dwarf', 'sitting')
+
+        expect(staged.status).to eq('sitting')
+      end
+
+      it 'reports nil, not gone, for a staged object with no status yet' do
+        described_class.begin_room_players
+        staged = described_class.new_pc('-31', 'dwarf', 'a dwarf', nil)
+
+        expect(staged.status).to be_nil
+      end
+
+      it 'keeps the published status visible and does not leak the staged value' do
+        # find_or_create dedupes on id|noun|name, so re-seeing the same pc during
+        # a refresh yields the *same instance* that is still published. A reader
+        # must continue to see the committed snapshot until commit.
+        described_class.new_pc('-30', 'elf', 'an elf', 'standing')
+        published = described_class.pcs.first
+
+        described_class.begin_room_players
+        staged = described_class.new_pc('-30', 'elf', 'an elf', nil)
+
+        expect(staged).to equal(published)
+        expect(published.status).to eq('standing')
+      end
+
+      it 'still reports gone for an object absent from every registry' do
+        described_class.begin_room_players
+        described_class.new_pc('-31', 'dwarf', 'a dwarf', 'sitting')
+
+        expect(described_class.new('-99', 'ghost', 'a ghost').status).to eq('gone')
+      end
+
+      it 'reports gone once a pc is dropped by a committed refresh' do
+        described_class.new_pc('-30', 'elf', 'an elf', 'standing')
+        departed = described_class.pcs.first
+
+        described_class.begin_room_players
+        described_class.commit_room_players
+
+        expect(departed.status).to eq('gone')
+      end
+
+      it 'reports staged status again after an abandoned refresh is discarded' do
+        described_class.begin_room_players
+        staged = described_class.new_pc('-31', 'dwarf', 'a dwarf', 'sitting')
+        described_class.discard_staged_refreshes
+
+        expect(staged.status).to eq('gone')
+      end
+
+      it 'exposes the gone sentinel frozen so it cannot be mutated in place' do
+        missing = described_class.new('-99', 'ghost', 'a ghost')
+
+        expect(missing.status).to be_frozen
+        expect { missing.status.concat(' away') }.to raise_error(FrozenError)
+      end
+    end
+
     describe 'room desc staging' do
       it 'keeps the previous snapshot visible until commit' do
         described_class.new_room_desc('40', 'statue', 'a statue')

--- a/spec/lib/common/xmlparser_spec.rb
+++ b/spec/lib/common/xmlparser_spec.rb
@@ -344,6 +344,65 @@ RSpec.describe Lich::Common::XMLParser do
         parser.tag_end('component') # commit_room_players
         expect(gameobj.pcs.map(&:id)).to eq(['-2'])
       end
+
+      # The annotation arrives in a later text callback, after </a>, while the
+      # refresh is still open. The staged pc has no published status entry, so
+      # reading it back through GameObj#status used to yield the frozen 'gone'
+      # sentinel and raise FrozenError on the in-place append.
+      def feed_pc(exist, noun, name)
+        parser.tag_start('a', { 'exist' => exist, 'noun' => noun })
+        parser.text(name)
+        parser.tag_end('a')
+      end
+
+      it 'annotates a newly staged pc without mutating the gone sentinel' do
+        parser.tag_start('component', { 'id' => 'room players' })
+        feed_pc('-2', 'dwarf', 'a dwarf')
+
+        expect { parser.text(' who is sitting.') }.not_to raise_error
+
+        parser.tag_end('component')
+        expect(gameobj['-2'].status).to eq('sitting')
+      end
+
+      it 'replaces rather than appends to the previously published status' do
+        gameobj.new_pc('-2', 'dwarf', 'a dwarf', 'standing')
+
+        parser.tag_start('component', { 'id' => 'room players' })
+        feed_pc('-2', 'dwarf', 'a dwarf')
+        parser.text(' who is sitting.')
+        parser.tag_end('component')
+
+        expect(gameobj['-2'].status).to eq('sitting')
+      end
+
+      it 'accepts the parenthetical form and combines both captures' do
+        parser.tag_start('component', { 'id' => 'room players' })
+        feed_pc('-2', 'dwarf', 'a dwarf')
+        parser.text(' (kneeling) (hidden)')
+        parser.tag_end('component')
+
+        expect(gameobj['-2'].status).to eq('kneeling hidden')
+      end
+
+      it 'appends the annotation onto a status carried in from the name prefix' do
+        parser.tag_start('component', { 'id' => 'room players' })
+        parser.instance_variable_set(:@player_status, 'dead')
+        feed_pc('-2', 'dwarf', 'a dwarf')
+        parser.text(' who is sitting.')
+        parser.tag_end('component')
+
+        expect(gameobj['-2'].status).to eq('dead sitting')
+      end
+
+      it 'does not annotate once the pc reference has been cleared' do
+        parser.tag_start('component', { 'id' => 'room players' })
+        feed_pc('99', 'dwarf', 'a dwarf') # non-negative exist -> @pc = nil
+        parser.text(' who is sitting.')
+        parser.tag_end('component')
+
+        expect(gameobj.pcs).to be_nil
+      end
     end
 
     describe "'room players' DR 'Also here' rebuild" do


### PR DESCRIPTION
## Summary
 
`GameObj#status` returns the frozen `'gone'` literal for any object that lives only
in a staging buffer. The XML parser then appends to that literal in place, which
raises `FrozenError` on every GemStone `room players` component that carries a
posture suffix. That is an extremely common line, so on current `main` the parser
throws as soon as another player is in the room with a stated posture.
 
```
error: XMLParser.text: can't modify frozen String: "gone"
  lib/common/xmlparser.rb:1127:in 'String#concat'
  lib/common/xmlparser.rb:1127:in 'Lich::Common::XMLParser#text'
  lib/games.rb:991:in 'Ox.sax_parse'
```
 
Reproduces on `main` (`84ce0fb`). Not present in any tagged release; latest stable
is `v5.19.1`.
 
## Reproduction
 
Any of these in GS:
 
```
<component id='room players'>Also here: <a exist="-1234" noun="Player">Player</a> who is sitting.</component>
<component id='room players'>Also here: <a exist="-1234" noun="Player">Player</a> (kneeling)</component>
```
 
## Root cause
 
| Step | Site | Behavior |
| --- | --- | --- |
| 1 | `xmlparser.rb:458` | `<component id='room players'>` opens, calling `GameObj.begin_room_players`, which sets `@@staging_pcs = []` and `@@staging_pc_status = {}` |
| 2 | `xmlparser.rb:1084` | `@pc = GameObj.new_pc(...)` puts the object in `@@staging_pcs` and its status key in `@@staging_pc_status` (`gameobj.rb:312-313`) |
| 3 | `xmlparser.rb:1126` | `if @pc.status` consults the getter |
| 4 | `gameobj.rb:251-255` | The getter reads only the published `@@npc_status` / `@@pc_status`, so it misses. `present_in_any_registry?` (`gameobj.rb:1173`) then misses too, because `all_flat_registries` (`gameobj.rb:1182`) omits `@@npcs` and `@@pcs` as well as every staging pool. Returns `'gone'` |
| 5 | `xmlparser.rb:1126` | `'gone'` is truthy, so control enters the `concat` branch rather than the safe setter branch at `:1129` |
| 6 | `gameobj.rb:1` | `# frozen_string_literal: true` makes `'gone'` frozen, so the `.concat` at `:1127` raises |
 
The underlying defect is a getter/setter asymmetry introduced with the staging
buffers. Every writer was made staging-aware (`status=` at `gameobj.rb:267-275`,
`new_npc`, `new_pc`, `new_loot`, `new_inv`, `new_room_desc`, and so on), but the
reader `#status` was left looking at published state only.
 
## Why this surfaced now
 
Two commits combined. Neither is sufficient alone:
 
- `6a48812` "fix(all): GameObj object dedupe & GC (#1234)", 2026-03-05, first
  released in `v5.15.0`. Added the `frozen_string_literal` magic comment, which
  made the `'gone'` sentinel frozen. Harmless on its own.
- `e9c5eda` "fix(all): prevent empty/partial GameObj registry reads during
  mid-stream refresh (#1370)", 2026-07-31, on `main` only. Introduced the staging
  buffers, which made the sentinel reachable for a staged pc.
Verified by running the same parser sequence against all four source states:
 
| Variant | `@pc.status` | Result |
| --- | --- | --- |
| pre-#1234 | `nil` | setter branch, correct |
| pre-#1370 (frozen literal present) | `nil` | setter branch, correct |
| `main` with the magic comment stripped | `"gone"` | concat succeeds, append silently discarded |
| `main` | `"gone"` frozen | `FrozenError` |
 
Note the third row. Before the literal was frozen, the same append mutated a
throwaway computed String that is never stored, so the posture annotation was
silently dropped rather than applied. The frozen literal did not create a bug, it
exposed one. For a pc that persisted across the refresh the annotation was written
into the outgoing published map and then discarded by `commit_room_players`, which
is why the new spec fails on `main` with `got: "standing"` rather than `"sitting"`.
 
## Why the obvious fix is wrong
 
The tempting fix is to have `#status` consult the staging maps first. That is
incorrect and would regress #1370.
 
`find_or_create` (`gameobj.rb:1251-1269`) dedupes through a global `@@index` keyed
on `id|noun|name`, so when a pc persists across a refresh the staged object and the
published object are the **same Ruby instance**. The getter therefore cannot tell
which of the two a caller holds. Demonstrated:
 
```
same instance?                 true
staging-first getter   -> script reads .status => nil        (should be "standing")
published-first getter -> parser reads .status => "standing" (stale, appends to it)
```
 
Staging-first leaks partial refresh state to readers, defeating the documented
contract at `gameobj.rb:100-108` ("a reader never observes an empty or half-filled
registry mid-stream, it sees the previous complete snapshot until commit").
Published-first leaves the parser appending to a stale value. No single ordering
serves both callers, so the fix splits responsibility instead of reordering.
 
## Changes
 
**`lib/common/xmlparser.rb`** (the load-bearing fix)
 
The parser tracks the status it staged for the current pc in `@pc_status` and writes
it through the already staging-aware `#status=` setter, instead of reading the value
back through the shared getter and mutating it in place. Accumulation semantics are
unchanged, including the case where the annotation arrives across multiple text
callbacks.
 
**`lib/common/gameobj.rb`** (purely additive: two lines plus documentation)
 
`#status` falls back to the staging maps only when the published maps have no entry
at all. Published values are never shadowed, so #1370's snapshot semantics are
preserved, while a staged-only object stops being misreported as `'gone'`. This is
not required to fix the crash - the parser change alone does that - but it is free
on the hot path and closes the same class of bug for any future reader that does
hold a staged object.
 
YARD updated to document the lookup order, the dedupe caveat that makes the getter
unable to identify its caller, and the fact that the `'gone'` sentinel is frozen and
must not be mutated in place.
 
## Deliberately unchanged
 
- **`present_in_any_registry?` and `all_flat_registries` are left exactly as on
  `main`.** An earlier revision of this branch extended them to cover `@@npcs`,
  `@@pcs` and the staging pools. That was removed after checking reachability: every
  status reader in the engine walks the published registries - `GameObj.targets`
  (`gameobj.rb:829`), `GameObj.dead` (`gameobj.rb:858`), `infomon/xmlparser.rb:546`
  all iterate `@@npcs` - and every object in `@@npcs` has its id as a key in
  `@@npc_status`, so `#status` returns on its first lookup and never reaches the
  registry scan. Scripts cannot hold a staged-only object either, since
  `GameObj[]`'s `SEARCH_ORDER` and every collection reader return published
  registries. No spec depended on the extension. It also measured ~32% slower on the
  registry-scan path (20k `#status` calls against 120 registered objects: 0.23s vs
  0.18s across three runs), which is exercised by any status read on loot, inventory
  or room-description objects. Unreachable and not free, so it is out.
- **`'gone'` stays frozen.** It is what surfaced this bug. Nothing mutates it in
  place any more, and a spec pins the frozen-ness so a future in-place mutation
  fails loudly instead of silently discarding data.
- **The DR `status.concat` sites at `xmlparser.rb:1108` and `:1116` are untouched.**
  Those operate on a local from a `$1` capture, which is always a fresh unfrozen
  String, and `xmlparser.rb` has no `frozen_string_literal` comment. They are
  provably safe and outside this fix's scope.
- **No `CHANGELOG.md` edit**, per release-please.
## Testing
 
12 new specs, all ASCII-clean:
 
- `spec/lib/common/gameobj_spec.rb` (7): staged-only object reports its staged
  status rather than `'gone'`; staged object with no status reports `nil`; a
  persisting object still reports its **published** status during an open window
  (pins #1370 and would fail under a staging-first getter); `'gone'` still returned
  for an object absent from every registry; `'gone'` returned once a pc is dropped
  by a committed refresh; `'gone'` returned after `discard_staged_refreshes`; the
  sentinel is frozen and raises on in-place mutation.
- `spec/lib/common/xmlparser_spec.rb` (5): the `who is ...` annotation applies
  without raising; the annotation **replaces** rather than appends to a previously
  published status; the parenthetical form combines both captures; an annotation
  composes onto a status carried in from the name prefix; no annotation is applied
  once `@pc` has been cleared.
Verification:
 
- 6 of the 12 fail on unmodified `lib/`, in exactly the predicted ways
  (`got: "gone"`, `got: "standing"`, `FrozenError`). The other 6 are invariant
  guards that pass both before and after, pinning behavior that must not change.
- `165 examples, 0 failures` across the two touched spec files.
- Full per-file sweep of the suite before and after: the only deltas are
  `gameobj_spec.rb` 2 -> 0 and `xmlparser_spec.rb` 4 -> 0. Nothing else moves.
- `#status` benchmarked against `main` on both the status-map-hit path and the
  registry-scan path; no measurable difference.
- `ruby -c` clean on all four files. ASCII byte scan and non-ASCII escape scan
  clean, matching both rules of `Custom/AsciiOnlySource`.
Coverage gap that let this through: the existing staging spec at
`gameobj_spec.rb:893-905` only reads `.status` **after** `commit_room_players`,
never during an open window.
 
Pre-existing failures unrelated to this change, identical with and without it:
`xmlparser_dr_creature_spec.rb` (7) and `xmlparser_crtr_status_spec.rb` (12), both
from Creature-module dependencies in my sandbox; `script_lifecycle_spec.rb` is
order-flaky on `main` independently of this change.
 
## Risk and blast radius
 
Low, and there is **no script-visible behavior change relative to `main`**.
 
The crashing read path is parser-only: scripts obtain objects from `GameObj.npcs` /
`pcs` / `[]`, which return the published registries whose ids are keys in the
published status maps, so they never reached the sentinel. `xmlparser.rb:1079`
already used the staging-aware setter.
 
The `#status` staging fallback only fires when the published maps have no entry for
the object, a state no engine reader or script can currently observe, so it is
strictly additive. The common `status == 'gone'` idiom for "left the room" is
unaffected and covered by a spec: after a committed refresh drops an object, its
status map entry is gone with it and the sentinel is still returned.
 
## Reviewer notes
 
The two non-obvious decisions, both intentional:
 
1. The getter keeps **published-before-staging** precedence. Reversing it looks
   tidier and is wrong; see "Why the obvious fix is wrong".
2. The registry-presence helpers are deliberately not made staging-aware, even
   though the same asymmetry technically exists there. See "Deliberately unchanged"
   for the reachability and benchmark evidence.
The branch carries two commits; the second narrows the first after the reachability
check above. Intended to squash-merge on the PR title.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved status visibility for staged room players, including NPCs and PCs.
  - Preserved published statuses when available, with correct handling for missing or removed objects.
  - Combined multiple status annotations accurately during refreshes.
  - Prevented status updates from affecting the immutable “gone” state.

- **Tests**
  - Added coverage for open, committed, and discarded room-player refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->