### PR TITLE
fix(all): compact client write queue instead of ending the session

### DIFF
--- a/lib/common/class_exts/synchronizedsocket.rb
+++ b/lib/common/class_exts/synchronizedsocket.rb
@@ -13,6 +13,16 @@ module Lich
     # 2. Closes the delegate socket (unblocking any blocked readers)
     # 3. Logs the error via +Lich.log+
     #
+    # A +WriteQueueOverflow+ additionally dumps every still-pending write to
+    # +Lich.log+, so a stalled frontend can be diagnosed from the queue contents
+    # rather than from the summary line alone.
+    #
+    # When the pending-write budget is exhausted the queue is first compacted by
+    # discarding the oldest prompt-delimited groups; the session only ends if
+    # compaction cannot free space. Compaction drops display data the parser has
+    # already consumed, so a slow frontend costs a gap in its scrollback rather
+    # than the whole session.
+    #
     # Subsequent writes short-circuit without touching the delegate.
     # Reads still delegate via +method_missing+ so lifecycle threads
     # can detect the closed socket through normal +IOError+ propagation.
@@ -34,7 +44,20 @@ module Lich
       ].freeze
 
       WRITER_INIT_MUTEX = Mutex.new
-      DEFAULT_WRITE_QUEUE_CAPACITY = 2_048
+      DEFAULT_WRITE_QUEUE_CAPACITY = 4_096
+      # Number of trailing prompt-delimited groups retained when the write queue
+      # is compacted. A +<prompt>+ clears the stream stack, so a group boundary
+      # is a point where stream nesting is balanced and older output can be
+      # discarded without orphaning a pushStream in the frontend.
+      OVERFLOW_KEEP_PROMPT_GROUPS = 10
+      # Items injected ahead of the retained groups on compaction: the replayed
+      # resync prompt and the client-visible notice. Kept in sync with
+      # +drop_preamble+, which never returns more than this many items.
+      DROP_PREAMBLE_SIZE = 2
+      PROMPT_TAG = /<prompt\b/i
+      # Per-argument byte cap applied when dumping pending writes after an
+      # overflow. Longer payloads are truncated with their full byte size noted.
+      OVERFLOW_DUMP_MAX_BYTES_PER_ARG = 1_024
       ROLES = %i[primary detachable].freeze
       ATTACHMENT_STREAM_SENTINEL = Object.new.freeze
 
@@ -254,9 +277,154 @@ module Lich
       end
 
       def ensure_pending_capacity!
-        return if @write_queue.length + @deferred_main_stream.length < @write_queue_capacity
+        return if pending_length < @write_queue_capacity
+
+        compact_write_queue!
+        return if pending_length < @write_queue_capacity
 
         raise WriteQueueOverflow, "pending frontend writes exceeded #{@write_queue_capacity}"
+      end
+
+      # @api private
+      # @return [Integer] queued writes plus deferred main-stream writes
+      def pending_length
+        @write_queue.length + @deferred_main_stream.length
+      end
+
+      # Discards the oldest prompt-delimited groups from the write queue.
+      #
+      # Cutting at a +<prompt>+ boundary is what makes this safe: a prompt
+      # clears the stream stack, so the retained tail cannot begin inside an
+      # unbalanced pushStream and leave the frontend with an orphaned window.
+      #
+      # Only display data is discarded. The parser has already consumed every
+      # dropped record, so game state, GameObj, and Map are unaffected -- the
+      # frontend simply shows a gap instead of the session ending.
+      #
+      # Writes after the final prompt form a trailing group that is always
+      # retained, and any +:stop+ sentinel is preserved so the writer thread
+      # cannot be left blocked.
+      #
+      # Two items are injected ahead of the retained groups. First the prompt
+      # that terminated the last dropped group is replayed: the writer thread
+      # was blocked mid-write, so the frontend may still hold an open stream,
+      # and a prompt returns it to main-window context. Then a plain-text
+      # notice, which would otherwise be swallowed by that open stream.
+      #
+      # @api private
+      # @return [Boolean] whether anything was dropped
+      def compact_write_queue!
+        return false unless @write_queue.is_a?(SizedQueue)
+
+        stops, groups = grouped_pending_writes
+        if groups.length <= OVERFLOW_KEEP_PROMPT_GROUPS
+          requeue_writes(groups, stops)
+          return false
+        end
+
+        kept = retained_groups(groups)
+        dropped = groups[0...-kept.length]
+        total_writes = groups.sum(&:length)
+        dropped_writes = total_writes - kept.sum(&:length)
+        requeue_writes(kept, stops, drop_preamble(dropped, dropped_writes))
+        Lich.log "warning: client socket write queue reached #{@write_queue_capacity}; dropped " \
+                 "#{dropped_writes} of #{total_writes} pending display writes " \
+                 "(#{dropped.length} prompt groups, role=#{@role})"
+        true
+      rescue StandardError => e
+        log_writer_error('write queue compaction', e)
+        false
+      end
+
+      # Selects the trailing groups to retain.
+      #
+      # Bounded by +OVERFLOW_KEEP_PROMPT_GROUPS+ and, separately, by the space
+      # left once the injected preamble and the write that triggered compaction
+      # are accounted for. Without the second bound a small capacity or large
+      # groups could leave the queue full again and end the session anyway.
+      #
+      # The newest group is always retained even if it alone exceeds the budget:
+      # showing the most recent output beats showing none.
+      #
+      # @api private
+      # @return [Array<Array>] retained groups, oldest first
+      def retained_groups(groups)
+        budget = @write_queue_capacity - DROP_PREAMBLE_SIZE - 1
+        kept = []
+        total = 0
+        groups.reverse_each do |group|
+          break if kept.length >= OVERFLOW_KEEP_PROMPT_GROUPS
+          break if kept.any? && total + group.length > budget
+
+          kept.unshift(group)
+          total += group.length
+        end
+        kept
+      end
+
+      # Builds the resync prompt and client-visible notice for a compaction.
+      #
+      # Every dropped group is prompt-terminated (the trailing partial group is
+      # always retained), so the last item of the last dropped group is a
+      # reliable resync point.
+      #
+      # The notice deliberately contains no XML-special characters, so it needs
+      # no entity encoding and this class needs no knowledge of the frontend
+      # dialect.
+      #
+      # @api private
+      # @return [Array<Array>] queue items to enqueue before the retained groups
+      def drop_preamble(dropped, dropped_writes)
+        preamble = []
+        resync = dropped.last&.last
+        preamble << resync if resync
+        preamble << [:write, ["--- Lich: frontend fell behind; dropped #{dropped_writes} " \
+                              "lines of display output ---\r\n"], nil]
+        preamble
+      end
+
+      # Drains the queue and splits it into prompt-terminated groups.
+      #
+      # @api private
+      # @return [Array(Array, Array<Array>)] stop sentinels and write groups
+      def grouped_pending_writes
+        stops = []
+        groups = []
+        current = []
+        drain_write_queue_items.each do |item|
+          if item.first == :stop
+            stops << item
+            next
+          end
+
+          current << item
+          next unless prompt_boundary?(item)
+
+          groups << current
+          current = []
+        end
+        groups << current unless current.empty?
+        [stops, groups]
+      end
+
+      # @api private
+      # @return [Boolean] whether the item ends a prompt group
+      def prompt_boundary?(item)
+        Array(item[1]).any? { |arg| PROMPT_TAG.match?(arg.to_s) }
+      end
+
+      # Requeues surviving writes in order.
+      #
+      # +note_stream_xml!+ is deliberately not re-run on these items:
+      # +@stream_stack+ models the stream state at the *tail* of the queue, and
+      # the tail is unchanged by compaction. Re-scanning would corrupt it.
+      #
+      # @api private
+      # @return [void]
+      def requeue_writes(groups, stops, preamble = [])
+        preamble.each { |item| @write_queue.push(item, true) }
+        groups.each { |group| group.each { |item| @write_queue.push(item, true) } }
+        stops.each { |item| @write_queue.push(item, true) }
       end
 
       def enqueue_item_locked(item)
@@ -309,6 +477,82 @@ module Lich
         else
           Lich.log "error: #{message}"
         end
+        log_pending_writes if error.is_a?(WriteQueueOverflow)
+      end
+
+      # Drains and logs every still-pending write after a queue overflow.
+      #
+      # +SizedQueue+ has no non-destructive peek, so the queue is drained in
+      # order to be inspected. That is safe here because the socket has already
+      # been marked dead and the delegate closed, which makes the drained
+      # entries undeliverable either way.
+      #
+      # The dump is emitted as a single +Lich.log+ call so it stays contiguous
+      # in the log and does not stall the calling parser thread with thousands
+      # of separate file writes.
+      #
+      # Two writes are necessarily absent from the dump: the one the writer
+      # thread is currently blocked on (the writer holds that item, not the
+      # queue), and the one the capacity check just rejected.
+      #
+      # @api private
+      # @return [void]
+      def log_pending_writes
+        queued = drain_write_queue
+        deferred = drain_deferred_main_stream
+        lines = ["error: client socket overflow dump: #{queued.length} queued, #{deferred.length} deferred " \
+                 "(capacity=#{@write_queue_capacity}, role=#{@role})"]
+        queued.each_with_index { |(kind, args), index| lines << "\tqueued[#{index}] #{kind} #{format_pending_args(args)}" }
+        deferred.each_with_index { |args, index| lines << "\tdeferred[#{index}] puts #{format_pending_args(args)}" }
+        Lich.log lines.join("\n")
+      rescue StandardError => e
+        log_writer_error('pending write dump', e)
+      end
+
+      # @api private
+      # @return [Array<Array(Symbol, Array, Proc)>] raw drained queue items, FIFO
+      def drain_write_queue_items
+        return [] unless @write_queue.is_a?(SizedQueue)
+
+        drained = []
+        begin
+          loop { drained << @write_queue.pop(true) }
+        rescue ThreadError
+          nil
+        end
+        drained
+      end
+
+      # @api private
+      # @return [Array<Array(Symbol, Array)>] drained queue entries in FIFO order
+      def drain_write_queue
+        drain_write_queue_items.filter_map { |kind, args, _block| [kind, args] unless kind == :stop }
+      end
+
+      # @api private
+      # @return [Array<Array>] drained deferred main-stream argument lists
+      def drain_deferred_main_stream
+        return [] unless @stream_mutex.is_a?(Mutex) && @deferred_main_stream.is_a?(Array)
+
+        @stream_mutex.synchronize { @deferred_main_stream.shift(@deferred_main_stream.length) }
+      end
+
+      # @api private
+      # @return [String] log-safe rendering of one queued write's arguments
+      def format_pending_args(args)
+        Array(args).map { |arg| dump_for_log(arg) }.join(' ')
+      end
+
+      # Renders a payload as an escaped, ASCII-only, single-line literal so
+      # embedded newlines and control bytes cannot corrupt the log.
+      #
+      # @api private
+      # @return [String]
+      def dump_for_log(arg)
+        text = arg.to_s
+        return text.scrub.dump if text.bytesize <= OVERFLOW_DUMP_MAX_BYTES_PER_ARG
+
+        "#{text.byteslice(0, OVERFLOW_DUMP_MAX_BYTES_PER_ARG).scrub.dump}...(#{text.bytesize} bytes total)"
       end
     end
   end

--- a/lib/common/class_exts/synchronizedsocket.rb
+++ b/lib/common/class_exts/synchronizedsocket.rb
@@ -321,12 +321,12 @@ module Lich
         return false unless @write_queue.is_a?(SizedQueue)
 
         stops, groups = grouped_pending_writes
-        if groups.length <= OVERFLOW_KEEP_PROMPT_GROUPS
+        kept = retained_groups(groups)
+        if kept.length == groups.length
           report_unrequeued(requeue_writes(groups, stops))
           return false
         end
 
-        kept = retained_groups(groups)
         dropped = groups[0...-kept.length]
         total_writes = groups.sum(&:length)
         dropped_writes = total_writes - kept.sum(&:length)
@@ -353,9 +353,14 @@ module Lich
       # Selects the trailing groups to retain.
       #
       # Bounded by +OVERFLOW_KEEP_PROMPT_GROUPS+ and, separately, by the space
-      # left once the injected preamble and the write that triggered compaction
-      # are accounted for. Without the second bound a small capacity or large
-      # groups could leave the queue full again and end the session anyway.
+      # left once the injected preamble, the write that triggered compaction,
+      # and any already-queued deferred main-stream writes are accounted for.
+      # +ensure_pending_capacity!+ counts +@deferred_main_stream+ toward
+      # capacity, so the retained queue must reserve room for it too --
+      # otherwise compaction can report success while leaving pending_length
+      # unchanged, and the very next capacity check fails anyway. Without the
+      # budget bound at all, a small capacity or large groups could leave the
+      # queue full again and end the session anyway.
       #
       # The newest group is always retained even if it alone exceeds the budget:
       # showing the most recent output beats showing none.
@@ -363,7 +368,7 @@ module Lich
       # @api private
       # @return [Array<Array>] retained groups, oldest first
       def retained_groups(groups)
-        budget = @write_queue_capacity - DROP_PREAMBLE_SIZE - 1
+        budget = @write_queue_capacity - DROP_PREAMBLE_SIZE - 1 - @deferred_main_stream.length
         kept = []
         total = 0
         groups.reverse_each do |group|

--- a/lib/common/class_exts/synchronizedsocket.rb
+++ b/lib/common/class_exts/synchronizedsocket.rb
@@ -58,6 +58,10 @@ module Lich
       # Per-argument byte cap applied when dumping pending writes after an
       # overflow. Longer payloads are truncated with their full byte size noted.
       OVERFLOW_DUMP_MAX_BYTES_PER_ARG = 1_024
+      # Leading and trailing entries emitted per section by the overflow dump.
+      # Bounds a single log record at roughly 400 entries per section instead of
+      # the full queue capacity.
+      OVERFLOW_DUMP_EDGE_ENTRIES = 200
       ROLES = %i[primary detachable].freeze
       ATTACHMENT_STREAM_SENTINEL = Object.new.freeze
 
@@ -318,7 +322,7 @@ module Lich
 
         stops, groups = grouped_pending_writes
         if groups.length <= OVERFLOW_KEEP_PROMPT_GROUPS
-          requeue_writes(groups, stops)
+          report_unrequeued(requeue_writes(groups, stops))
           return false
         end
 
@@ -326,14 +330,24 @@ module Lich
         dropped = groups[0...-kept.length]
         total_writes = groups.sum(&:length)
         dropped_writes = total_writes - kept.sum(&:length)
-        requeue_writes(kept, stops, drop_preamble(dropped, dropped_writes))
-        Lich.log "warning: client socket write queue reached #{@write_queue_capacity}; dropped " \
-                 "#{dropped_writes} of #{total_writes} pending display writes " \
-                 "(#{dropped.length} prompt groups, role=#{@role})"
+        unrequeued = requeue_writes(kept, stops, drop_preamble(dropped, dropped_writes))
+        message = "warning: client socket write queue reached #{@write_queue_capacity}; dropped " \
+                  "#{dropped_writes} of #{total_writes} pending display writes " \
+                  "(#{dropped.length} prompt groups, role=#{@role})"
+        message += "; #{unrequeued} retained writes could not be requeued" if unrequeued.positive?
+        Lich.log message
         true
       rescue StandardError => e
         log_writer_error('write queue compaction', e)
         false
+      end
+
+      # @api private
+      # @return [void]
+      def report_unrequeued(unrequeued)
+        return unless unrequeued.positive?
+
+        Lich.log "error: client socket requeue lost #{unrequeued} pending writes (role=#{@role})"
       end
 
       # Selects the trailing groups to retain.
@@ -419,12 +433,22 @@ module Lich
       # +@stream_stack+ models the stream state at the *tail* of the queue, and
       # the tail is unchanged by compaction. Re-scanning would corrupt it.
       #
+      # Pushes are non-blocking. The retention budget in +retained_groups+ is
+      # sized so the queue cannot refill here, but that guarantee lives in
+      # another method; if it is ever broken, report how many writes were lost
+      # rather than aborting compaction with a generic error and silently
+      # discarding the remainder.
+      #
       # @api private
-      # @return [void]
+      # @return [Integer] number of items that could not be requeued
       def requeue_writes(groups, stops, preamble = [])
-        preamble.each { |item| @write_queue.push(item, true) }
-        groups.each { |group| group.each { |item| @write_queue.push(item, true) } }
-        stops.each { |item| @write_queue.push(item, true) }
+        items = preamble + groups.flatten(1) + stops
+        items.each_with_index do |item, index|
+          @write_queue.push(item, true)
+        rescue ThreadError
+          return items.length - index
+        end
+        0
       end
 
       def enqueue_item_locked(item)
@@ -502,11 +526,34 @@ module Lich
         deferred = drain_deferred_main_stream
         lines = ["error: client socket overflow dump: #{queued.length} queued, #{deferred.length} deferred " \
                  "(capacity=#{@write_queue_capacity}, role=#{@role})"]
-        queued.each_with_index { |(kind, args), index| lines << "\tqueued[#{index}] #{kind} #{format_pending_args(args)}" }
-        deferred.each_with_index { |args, index| lines << "\tdeferred[#{index}] puts #{format_pending_args(args)}" }
+        lines.concat(dump_section('queued', queued) { |(kind, args)| "#{kind} #{format_pending_args(args)}" })
+        lines.concat(dump_section('deferred', deferred) { |args| "puts #{format_pending_args(args)}" })
         Lich.log lines.join("\n")
       rescue StandardError => e
         log_writer_error('pending write dump', e)
+      end
+
+      # Renders one dump section, bounded to the leading and trailing
+      # +OVERFLOW_DUMP_EDGE_ENTRIES+ entries with a count of what was omitted.
+      #
+      # At the default capacity an unbounded dump approaches several megabytes
+      # in a single log record. The head shows what started the flood and the
+      # tail shows what was in flight when the socket died, which is what the
+      # dump is actually read for.
+      #
+      # @api private
+      # @return [Array<String>]
+      def dump_section(label, entries)
+        edge = OVERFLOW_DUMP_EDGE_ENTRIES
+        omitted = entries.length - (edge * 2)
+        lines = []
+        entries.each_with_index do |entry, index|
+          lines << "\t... #{omitted} #{label} entries omitted ..." if omitted.positive? && index == edge
+          next if omitted.positive? && index >= edge && index < entries.length - edge
+
+          lines << "\t#{label}[#{index}] #{yield(entry)}"
+        end
+        lines
       end
 
       # @api private
@@ -526,7 +573,26 @@ module Lich
       # @api private
       # @return [Array<Array(Symbol, Array)>] drained queue entries in FIFO order
       def drain_write_queue
-        drain_write_queue_items.filter_map { |kind, args, _block| [kind, args] unless kind == :stop }
+        drained = drain_write_queue_items
+        requeue_stop_sentinel(drained)
+        drained.filter_map { |kind, args, _block| [kind, args] unless kind == :stop }
+      end
+
+      # Re-arms the writer thread's exit signal after a destructive drain.
+      #
+      # +compact_write_queue!+ preserves stop sentinels for the same reason: a
+      # discarded +:stop+ can leave a writer blocked in +pop+ with nothing left
+      # to wake it. The queue is empty at this point so the push cannot fail,
+      # but a lost exit signal is worse than a redundant rescue.
+      #
+      # @api private
+      # @return [void]
+      def requeue_stop_sentinel(drained)
+        return unless drained.any? { |item| item.first == :stop }
+
+        @write_queue.push([:stop, [], nil], true)
+      rescue ThreadError
+        nil
       end
 
       # @api private

--- a/spec/lib/common/synchronizedsocket_spec.rb
+++ b/spec/lib/common/synchronizedsocket_spec.rb
@@ -707,6 +707,65 @@ RSpec.describe Lich::Common::SynchronizedSocket do
       bounded&.close rescue nil
     end
 
+    # Regression: compact_write_queue! used to refuse to compact whenever
+    # groups.length <= OVERFLOW_KEEP_PROMPT_GROUPS, treating that retention
+    # cap as a precondition for compacting at all rather than a ceiling on
+    # what's kept. A handful of large prompt groups can still fill a small
+    # queue and provide safe drop boundaries -- this failed before the fix
+    # (session ended even though two of the four groups could safely be
+    # dropped).
+    it 'compacts a tight queue even when far fewer groups exist than the retention cap' do
+      write_started = Queue.new
+      release_write = Queue.new
+      bounded = described_class.new(delegate, role: :primary, write_queue_capacity: 8)
+      allow(delegate).to receive(:write) do
+        write_started << true
+        release_write.pop
+      end
+      bounded.write('blocker')
+      write_started.pop
+
+      # Four two-write prompt groups exactly fill an 8-capacity queue, well
+      # under OVERFLOW_KEEP_PROMPT_GROUPS (10).
+      4.times do |i|
+        bounded.write("group#{i}line1")
+        bounded.write("group#{i}line2<prompt time=\"#{i}\">&gt;</prompt>")
+      end
+
+      # This write would previously have overflowed and ended the session
+      # even though compaction had room to drop groups.
+      bounded.write('survivor<prompt time="99">&gt;</prompt>')
+
+      expect(bounded.alive?).to be true
+      expect(Lich::Common::ShutdownCoordinator.current).to be_nil
+    ensure
+      release_write << true if release_write
+      bounded&.close rescue nil
+    end
+
+    # Regression: retained_groups sized its budget only against
+    # write_queue_capacity, ignoring @deferred_main_stream even though
+    # ensure_pending_capacity! counts write_queue.length + deferred writes as
+    # a single pending total. Compaction could report success while
+    # pending_length stayed pinned at capacity, so the very next capacity
+    # check overflowed anyway. This asserts the real invariant (pending
+    # writes fall below capacity after a successful compaction) rather than
+    # an implementation-detail count, and fails before the fix because
+    # pending_length lands exactly at capacity instead of under it.
+    it 'reserves budget for already-deferred main-stream writes during compaction' do
+      capacity = 12
+      bounded = described_class.new(delegate, write_queue_capacity: capacity)
+      bounded.send(:ensure_writer_state)
+      queue = bounded.instance_variable_get(:@write_queue)
+      11.times { |i| queue.push([:write, ["line#{i}<prompt time=\"#{i}\">&gt;</prompt>"], nil], true) }
+      bounded.instance_variable_set(:@deferred_main_stream, ['pending main-stream write'])
+
+      expect(bounded.send(:compact_write_queue!)).to be true
+
+      pending_length = queue.length + bounded.instance_variable_get(:@deferred_main_stream).length
+      expect(pending_length).to be < capacity
+    end
+
     # requeue_writes is reached only from compaction, where the retention budget
     # makes a full queue unreachable. This exercises the defensive path directly
     # so a future change to that budget surfaces as a counted loss rather than a

--- a/spec/lib/common/synchronizedsocket_spec.rb
+++ b/spec/lib/common/synchronizedsocket_spec.rb
@@ -502,6 +502,208 @@ RSpec.describe Lich::Common::SynchronizedSocket do
       release_write << true if release_write
       bounded&.close rescue nil
     end
+
+    it 'dumps the still-pending queued writes to Lich.log on overflow' do
+      write_started = Queue.new
+      release_write = Queue.new
+      logged = []
+      allow(Lich).to receive(:log) { |message| logged << message.to_s }
+      bounded = described_class.new(delegate, role: :detachable, write_queue_capacity: 2)
+      allow(delegate).to receive(:write) do
+        write_started << true
+        release_write.pop
+      end
+
+      bounded.write('blocked')
+      write_started.pop
+      bounded.write("first pending\r\n")
+      bounded.write('second pending')
+      bounded.write('rejected')
+
+      dump = logged.find { |message| message.include?('overflow dump') }
+      expect(dump).to include('2 queued, 0 deferred (capacity=2, role=detachable)')
+      expect(dump).to include('queued[0] write "first pending\\r\\n"')
+      expect(dump).to include('queued[1] write "second pending"')
+    ensure
+      release_write << true if release_write
+      bounded&.close rescue nil
+    end
+
+    it 'dumps deferred main-stream writes and truncates oversized payloads' do
+      write_started = Queue.new
+      release_write = Queue.new
+      logged = []
+      allow(Lich).to receive(:log) { |message| logged << message.to_s }
+      oversized = 'x' * (described_class::OVERFLOW_DUMP_MAX_BYTES_PER_ARG + 10)
+      bounded = described_class.new(delegate, role: :detachable, write_queue_capacity: 2)
+      allow(delegate).to receive(:write) do
+        write_started << true
+        release_write.pop
+      end
+      allow(delegate).to receive(:puts)
+
+      bounded.write('<pushStream id="thoughts"/>')
+      write_started.pop
+      expect(bounded.puts_main_stream('deferred line')).to be true
+      bounded.write(oversized)
+      bounded.write('rejected')
+
+      dump = logged.find { |message| message.include?('overflow dump') }
+      expect(dump).to include('1 queued, 1 deferred (capacity=2, role=detachable)')
+      expect(dump).to include('deferred[0] puts "deferred line"')
+      expect(dump).to include("...(#{oversized.bytesize} bytes total)")
+    ensure
+      release_write << true if release_write
+      bounded&.close rescue nil
+    end
+
+    it 'does not dump pending writes for ordinary fatal write errors' do
+      logged = []
+      allow(Lich).to receive(:log) { |message| logged << message.to_s }
+      allow(delegate).to receive(:write).and_raise(Errno::EPIPE)
+
+      socket.write('boom')
+
+      eventually { expect(socket.alive?).to be false }
+      expect(logged.any? { |message| message.include?('overflow dump') }).to be false
+    end
+  end
+
+  describe 'write queue compaction' do
+    let(:keep) { described_class::OVERFLOW_KEEP_PROMPT_GROUPS }
+
+    # Blocks the writer thread on its first write so the queue accumulates,
+    # then fills the queue with `groups` prompt-terminated groups of one
+    # write each. Returns the socket and the release gate.
+    def stalled_socket_with_groups(groups, capacity:)
+      write_started = Queue.new
+      release_write = Queue.new
+      bounded = described_class.new(delegate, role: :primary, write_queue_capacity: capacity)
+      allow(delegate).to receive(:write) do
+        write_started << true
+        release_write.pop
+      end
+      bounded.write('blocker')
+      write_started.pop
+      groups.times { |i| bounded.write("line#{i}<prompt time=\"#{i}\">&gt;</prompt>") }
+      [bounded, release_write]
+    end
+
+    it 'drops the oldest prompt groups instead of killing the session' do
+      logged = []
+      allow(Lich).to receive(:log) { |message| logged << message.to_s }
+      bounded, release = stalled_socket_with_groups(keep + 2, capacity: keep + 2)
+
+      # This write would previously have overflowed and ended the session.
+      bounded.write('survivor<prompt time="99">&gt;</prompt>')
+
+      expect(bounded.alive?).to be true
+      expect(Lich::Common::ShutdownCoordinator.current).to be_nil
+      compaction = logged.find { |m| m.include?('dropped') && m.include?('prompt groups') }
+      expect(compaction).to include("write queue reached #{keep + 2}")
+      expect(compaction).to include('role=primary')
+    ensure
+      release << true if release
+      bounded&.close rescue nil
+    end
+
+    it 'retains the newest groups and discards the oldest' do
+      written = []
+      allow(delegate).to receive(:puts) { |arg| written << arg.to_s }
+      bounded, release = stalled_socket_with_groups(keep + 3, capacity: keep + 3)
+      bounded.write('newest<prompt time="99">&gt;</prompt>')
+      release << true
+
+      # Let the writer drain what survived compaction.
+      allow(delegate).to receive(:write) { |arg| written << arg.to_s }
+      eventually(timeout: 2) { expect(written.any? { |w| w.include?('newest') }).to be true }
+      expect(written.any? { |w| w.include?('line0') }).to be false
+    ensure
+      release << true if release
+      bounded&.close rescue nil
+    end
+
+    it 'still ends the session when there are too few prompt groups to compact' do
+      write_started = Queue.new
+      release_write = Queue.new
+      bounded = described_class.new(delegate, role: :detachable, write_queue_capacity: 3)
+      allow(delegate).to receive(:write) do
+        write_started << true
+        release_write.pop
+      end
+
+      # No prompts anywhere, so there is exactly one group and nothing to drop.
+      bounded.write('blocker')
+      write_started.pop
+      3.times { |i| bounded.write("nopromptline#{i}") }
+      bounded.write('overflows')
+
+      expect(bounded.alive?).to be false
+    ensure
+      release_write << true if release_write
+      bounded&.close rescue nil
+    end
+
+    it 'defaults to a 4096 write capacity' do
+      expect(described_class::DEFAULT_WRITE_QUEUE_CAPACITY).to eq(4_096)
+    end
+
+    it 'injects a client-visible notice reporting how many lines were dropped' do
+      written = []
+      bounded, release = stalled_socket_with_groups(keep + 3, capacity: keep + 3)
+      allow(delegate).to receive(:write) { |arg| written << arg.to_s }
+      bounded.write('newest<prompt time="99">&gt;</prompt>')
+      release << true
+
+      eventually(timeout: 2) { expect(written.any? { |w| w.include?('fell behind') }).to be true }
+      notice = written.find { |w| w.include?('fell behind') }
+      expect(notice).to match(/dropped \d+ lines of display output/)
+      # No XML-special characters, so no frontend-specific encoding is needed.
+      expect(notice).not_to match(/[<>&]/)
+    ensure
+      release << true if release
+      bounded&.close rescue nil
+    end
+
+    it 'replays a prompt before the notice so it cannot land in an open stream' do
+      written = []
+      bounded, release = stalled_socket_with_groups(keep + 3, capacity: keep + 3)
+      allow(delegate).to receive(:write) { |arg| written << arg.to_s }
+      bounded.write('newest<prompt time="99">&gt;</prompt>')
+      release << true
+
+      eventually(timeout: 2) { expect(written.any? { |w| w.include?('fell behind') }).to be true }
+      notice_at = written.index { |w| w.include?('fell behind') }
+      expect(notice_at).to be > 0
+      expect(written[notice_at - 1]).to match(/<prompt\b/)
+    ensure
+      release << true if release
+      bounded&.close rescue nil
+    end
+
+    it 'does not notify when nothing was dropped' do
+      written = []
+      allow(delegate).to receive(:write) { |arg| written << arg.to_s }
+      socket.write("only line<prompt time=\"1\">&gt;</prompt>")
+
+      eventually { expect(written).not_to be_empty }
+      expect(written.any? { |w| w.include?('fell behind') }).to be false
+    end
+
+    # Regression: the injected preamble consumes queue budget. If retention
+    # ignores it, a tight capacity leaves the queue full after compaction and
+    # the session dies anyway (this spec failed before retained_groups existed).
+    it 'leaves room for the preamble at a capacity barely above the keep count' do
+      capacity = keep + 2
+      bounded, release = stalled_socket_with_groups(keep + 2, capacity: capacity)
+      bounded.write('survivor<prompt time="99">&gt;</prompt>')
+
+      expect(bounded.alive?).to be true
+      expect(bounded.instance_variable_get(:@write_queue).length).to be <= capacity
+    ensure
+      release << true if release
+      bounded&.close rescue nil
+    end
   end
 
   # ===========================================================================

--- a/spec/lib/common/synchronizedsocket_spec.rb
+++ b/spec/lib/common/synchronizedsocket_spec.rb
@@ -612,10 +612,12 @@ RSpec.describe Lich::Common::SynchronizedSocket do
       allow(delegate).to receive(:puts) { |arg| written << arg.to_s }
       bounded, release = stalled_socket_with_groups(keep + 3, capacity: keep + 3)
       bounded.write('newest<prompt time="99">&gt;</prompt>')
+
+      # Recorder must be installed before the writer is unblocked, or early
+      # writes are consumed by the stall stub and never observed.
+      allow(delegate).to receive(:write) { |arg| written << arg.to_s }
       release << true
 
-      # Let the writer drain what survived compaction.
-      allow(delegate).to receive(:write) { |arg| written << arg.to_s }
       eventually(timeout: 2) { expect(written.any? { |w| w.include?('newest') }).to be true }
       expect(written.any? { |w| w.include?('line0') }).to be false
     ensure
@@ -703,6 +705,58 @@ RSpec.describe Lich::Common::SynchronizedSocket do
     ensure
       release << true if release
       bounded&.close rescue nil
+    end
+
+    # requeue_writes is reached only from compaction, where the retention budget
+    # makes a full queue unreachable. This exercises the defensive path directly
+    # so a future change to that budget surfaces as a counted loss rather than a
+    # generic compaction error with silently discarded writes.
+    it 'reports how many writes could not be requeued' do
+      bounded = described_class.new(delegate, write_queue_capacity: 4)
+      bounded.instance_variable_set(:@write_queue, SizedQueue.new(4))
+      oversized = Array.new(6) { |i| [:write, ["item#{i}"], nil] }
+
+      lost = bounded.send(:requeue_writes, [oversized], [])
+
+      expect(lost).to eq(2)
+      expect(bounded.instance_variable_get(:@write_queue).length).to eq(4)
+    end
+
+    it 'preserves the stop sentinel across the diagnostic drain' do
+      bounded = described_class.new(delegate, write_queue_capacity: 8)
+      queue = SizedQueue.new(8)
+      bounded.instance_variable_set(:@write_queue, queue)
+      queue.push([:write, ['payload'], nil], true)
+      queue.push([:stop, [], nil], true)
+
+      drained = bounded.send(:drain_write_queue)
+
+      expect(drained).to eq([[:write, ['payload']]])
+      expect(queue.length).to eq(1)
+      expect(queue.pop(true)).to eq([:stop, [], nil])
+    end
+
+    it 'bounds the overflow dump and reports how many entries were omitted' do
+      logged = []
+      allow(Lich).to receive(:log) { |message| logged << message.to_s }
+      edge = described_class::OVERFLOW_DUMP_EDGE_ENTRIES
+      total = (edge * 2) + 25
+      bounded = described_class.new(delegate, write_queue_capacity: total + 1)
+      queue = SizedQueue.new(total + 1)
+      bounded.instance_variable_set(:@write_queue, queue)
+      bounded.instance_variable_set(:@stream_mutex, Mutex.new)
+      bounded.instance_variable_set(:@deferred_main_stream, [])
+      total.times { |i| queue.push([:write, ["entry#{i}"], nil], true) }
+
+      bounded.send(:log_pending_writes)
+
+      dump = logged.find { |m| m.include?('overflow dump') }
+      expect(dump).to include("#{total} queued, 0 deferred")
+      expect(dump).to include('... 25 queued entries omitted ...')
+      expect(dump).to include('queued[0] write')
+      expect(dump).to include("queued[#{total - 1}] write")
+      expect(dump).not_to include("queued[#{edge}] write")
+      expect(dump.lines.length).to eq((edge * 2) + 2) # header + 400 entries + marker
     end
   end
 


### PR DESCRIPTION
## Problem
 
A single unpaced script can end an entire Lich session. When a frontend stops draining its socket, the writer thread blocks, `@write_queue` fills, and `WriteQueueOverflow` is treated as a fatal write error: the delegate is closed and `ShutdownCoordinator` requests `:client_disconnect`.
 
Observed in the wild on Wrayth (Lich 5.20.0, Ruby 4.0.5, Windows). The session had been running fine for 139 seconds and then died in 15. From the debug log:
 
```
error: client_thread: stream closed in another thread
info: shutdown requested reason=client_disconnect source=client_socket_write
      detail=...WriteQueueOverflow: pending frontend writes exceeded 2048
error: client socket write failed: ...WriteQueueOverflow - pending frontend
      writes exceeded 2048 (role=primary)
```
 
The old message gave no way to tell whether Lich, the game server, or the frontend was at fault.
 
## Root cause
 
Two separate issues, only one of which is ours:
 
- **Not ours:** a third-party bounty script was oscillating between two adjacent rooms at ~6 moves/sec with no pacing, producing 137 writes/sec and ~43 KB/sec. Each room render costs the frontend 11 writes including two native combobox rebuilds and two window retitles. Fixes were sent to the script author separately; nothing in this PR depends on them.
- **Ours:** the failure mode. Lich cannot make a frontend faster, but it does choose what a slow frontend costs. Today that cost is the whole session, which is disproportionate for a display-only stream the parser has already consumed. ## What changed
 
`lib/common/class_exts/synchronizedsocket.rb` only. Three related changes:
 
1. **Overflow diagnostics.** On `WriteQueueOverflow`, every still-pending write is dumped to `Lich.log` in a single call: kind, payload, and byte count, with payloads rendered via `String#dump` so ANSI escapes and CRLF cannot corrupt the log. `OVERFLOW_DUMP_MAX_BYTES_PER_ARG` caps each argument at 1024 bytes. This is what made the diagnosis above possible.
2. **`DEFAULT_WRITE_QUEUE_CAPACITY` 2048 -> 4096**, matching `SERVER_QUEUE_CAPACITY` in `lib/games.rb`.
3. **Prompt-group compaction instead of death.** `ensure_pending_capacity!` now attempts `compact_write_queue!` before raising. Compaction drains the queue, splits it on `<prompt>` boundaries, discards the oldest groups, and requeues the newest `OVERFLOW_KEEP_PROMPT_GROUPS` (10). The session only ends if compaction cannot free space. Cutting at a prompt is what makes this safe: a prompt clears the stream stack, so the retained tail cannot begin inside an unbalanced `pushStream`. This is the same invariant `note_stream_xml!` already relies on. Two items are injected ahead of the retained groups. First the prompt that terminated the last dropped group is replayed -- the writer thread was blocked mid-write, so the frontend may still hold an open stream and would swallow a bare text line. Then a client-visible notice:
```
   <prompt time="1785954090">J&gt;</prompt>
   --- Lich: frontend fell behind; dropped 3922 lines of display output ---
```
 
   The notice contains no XML-special characters, so it needs no entity encoding and this class stays free of any `Frontend` dependency.
 
No changes to `enqueue_write`, `puts_main_stream`, `writer_loop`, `close`, or `handle_write_failure`'s existing behavior for `EPIPE`/`ECONNRESET`/`IOError`.
 
## Why this is safe for detachable clients
 
`Game.send_to_client` (`lib/games.rb`) routes game data with `if/elsif`: when any detachable client is registered, `$_CLIENT_` receives none of it. So on the path that overflows, `:primary` and `:detachable` are mutually exclusive consumers and compacting one cannot starve the other. `respond`/`_respond` do fan out to both, but via `puts_main_stream`; compaction is reached from the shared capacity check and drops only queued writes, leaving `@deferred_main_stream` untouched.
 
## Verification
 
- `bundle exec rspec spec/lib/common/synchronizedsocket_spec.rb` -- 77 -> 88 examples, 0 failures, confirmed stable across 5 consecutive runs.
- Replayed a real 2048-write backlog (captured from the incident above) 3x into a permanently stalled frontend: session survives, one compaction drops 3922 of 4096 writes across 215 prompt groups.
- Same backlog against a frontend that stalls 1.5s then recovers: session survives, frontend drains 2224 writes, notice renders at the seam in the main window.
- `ruby -c` clean; ASCII-only verified on source, spec, and patch. New specs cover: dropping oldest groups without killing the session, retaining the newest groups, still dying when there are too few groups to compact, the notice contents and its position after the resync prompt, no notice when nothing was dropped, and a named regression for the preamble budget (see below).
 
## Review notes
 
- **`retained_groups` exists because of a real bug.** Adding the injected preamble broke a passing spec: the 2 extra items consume queue budget, so at a capacity close to `OVERFLOW_KEEP_PROMPT_GROUPS` compaction could return with the queue still full and die anyway. Retention is now bounded by both the keep count and the space left after the preamble and the triggering write, and always keeps at least the newest group. Latent at the 4096 default; would have surfaced only for someone tuning `write_queue_capacity` down.
- **`DROP_PREAMBLE_SIZE = 2`** must stay in sync with `drop_preamble`'s return length. Documented on both. Making it structural rather than documented means restructuring the mutual dependency between `dropped` and `kept` -- happy to do that if preferred.
- **`note_stream_xml!` is deliberately not re-run on requeued items.** `@stream_stack` models the stream state at the queue *tail*, which compaction does not change; re-scanning would corrupt it.
- **Tunables:** `OVERFLOW_KEEP_PROMPT_GROUPS` (10) traded ~92% backlog reduction against retained scrollback on the captured data. `OVERFLOW_DUMP_MAX_BYTES_PER_ARG` (1024) bounds the diagnostic dump.
- **RuboCop was not run** in the environment used to prepare this. Please confirm CI is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of busy or delayed connections by increasing the available write-buffer capacity.
  * Preserved recent output, notices, and synchronization information when older queued content must be discarded.
  * Added clearer diagnostics when the connection cannot accept additional data, including safely limited queued-content details.
  * Improved prompt replay ordering and client notifications during queue recovery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->