### PR TITLE
fix(all): scrub startup credentials once login completes

### DIFF
--- a/lib/common/credential_scrub.rb
+++ b/lib/common/credential_scrub.rb
@@ -7,8 +7,10 @@ module Lich
     # Lich keeps startup credentials where a running script can read them:
     # +@launch_data+ and +@argv_options+ are instance variables on the top-level
     # +main+ object, and +ARGV+ is a global constant. All three outlive login, so
-    # the single-use eaccess key and the reusable account password stay readable
-    # for the rest of the session.
+    # both the eaccess key and the account password stay readable for the rest of
+    # the session. Both are live credentials: the key is not single-use and stays
+    # valid for some period after issue, so a key read hours into a session may
+    # still be usable.
     #
     # Values are overwritten in place rather than reassigned because other
     # objects hold references to the same Array, Hash, and String instances (the
@@ -24,7 +26,7 @@ module Lich
       # Replacement text for a redacted value.
       REDACTED = '[scrubbed]'
 
-      # launch_data entry holding the single-use eaccess key.
+      # launch_data entry holding the eaccess key.
       LAUNCH_DATA_SECRET = /\AKEY=/i
 
       # argv entries of the form --flag=secret. Deliberately excludes
@@ -81,14 +83,9 @@ module Lich
 
           OPTION_SECRET_KEYS.select do |key|
             value = options[key]
-            next false unless value.is_a?(String) && value != REDACTED
+            next false unless value.is_a?(String)
 
-            begin
-              options[key] = REDACTED
-              true
-            rescue FrozenError
-              false
-            end
+            overwrite(options, key, REDACTED)
           end
         end
 
@@ -123,8 +120,9 @@ module Lich
 
         private
 
-        # Rewrites container[index], mutating the existing String when possible so
-        # that other holders of that String also lose the secret.
+        # Rewrites container[key], mutating the existing String when possible so
+        # that other holders of that String also lose the secret. Works for both
+        # Array indices and Hash keys.
         #
         # @return [Boolean] true when the value changed
         def overwrite(container, index, value)

--- a/lib/common/credential_scrub.rb
+++ b/lib/common/credential_scrub.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+module Lich
+  module Common
+    # Redacts startup credentials once the login sequence no longer needs them.
+    #
+    # Lich keeps startup credentials where a running script can read them:
+    # +@launch_data+ and +@argv_options+ are instance variables on the top-level
+    # +main+ object, and +ARGV+ is a global constant. All three outlive login, so
+    # the single-use eaccess key and the reusable account password stay readable
+    # for the rest of the session.
+    #
+    # Values are overwritten in place rather than reassigned because other
+    # objects hold references to the same Array, Hash, and String instances (the
+    # login GUI keeps the launch data array; the argv option pipeline threads one
+    # options hash through three stages). Replacing a container would leave those
+    # references pointing at unscrubbed copies.
+    #
+    # Scope: this closes script-readable and log-readable paths. It does not
+    # guarantee the bytes are gone from process memory. Earlier copies may
+    # survive in socket write buffers, in a spawned frontend's argv, or in
+    # unreclaimed heap.
+    module CredentialScrub
+      # Replacement text for a redacted value.
+      REDACTED = '[scrubbed]'
+
+      # launch_data entry holding the single-use eaccess key.
+      LAUNCH_DATA_SECRET = /\AKEY=/i
+
+      # argv entries of the form --flag=secret. Deliberately excludes
+      # --account=, which is an account identifier rather than a credential.
+      ARGV_SECRET = /\A(--(?:password|master-password)=)(.+)\z/i
+
+      # argv_options keys holding reusable credentials.
+      OPTION_SECRET_KEYS = [:password].freeze
+
+      class << self
+        # Overwrites the KEY= entry of a launch data array in place.
+        #
+        # @param launch_data [Array<String>, nil] launch lines; nil is tolerated
+        #   because direct host/port and --pipe startups never build one
+        # @return [Integer] number of entries rewritten
+        def scrub_launch_data!(launch_data)
+          return 0 unless launch_data.is_a?(Array)
+
+          scrubbed = 0
+          launch_data.each_with_index do |line, index|
+            next unless line.is_a?(String) && line.match?(LAUNCH_DATA_SECRET)
+
+            scrubbed += 1 if overwrite(launch_data, index, "KEY=#{REDACTED}")
+          end
+          scrubbed
+        end
+
+        # Overwrites secret-bearing argv values in place, preserving the flag
+        # prefix so later ARGV.include? and ARGV.find checks behave unchanged.
+        #
+        # @param argv [Array<String>, nil] argument vector, normally ARGV
+        # @return [Integer] number of entries rewritten
+        def scrub_argv!(argv)
+          return 0 unless argv.is_a?(Array)
+
+          scrubbed = 0
+          argv.each_with_index do |arg, index|
+            next unless arg.is_a?(String)
+
+            match = ARGV_SECRET.match(arg)
+            next if match.nil?
+
+            scrubbed += 1 if overwrite(argv, index, "#{match[1]}#{REDACTED}")
+          end
+          scrubbed
+        end
+
+        # Overwrites secret values in an options hash in place.
+        #
+        # @param options [Hash, nil] the argv options hash
+        # @return [Array<Symbol>] keys that were rewritten
+        def scrub_options!(options)
+          return [] unless options.is_a?(Hash)
+
+          OPTION_SECRET_KEYS.select do |key|
+            value = options[key]
+            next false unless value.is_a?(String) && value != REDACTED
+
+            begin
+              options[key] = REDACTED
+              true
+            rescue FrozenError
+              false
+            end
+          end
+        end
+
+        # Overwrites a file's contents and removes it. Never raises.
+        #
+        # Overwrite-then-delete is best effort: copy-on-write, journaling, and
+        # flash translation layers may retain the original blocks. The retry loop
+        # exists because Windows refuses deletion while a spawned frontend still
+        # holds the file open.
+        #
+        # @param path [String, nil] file to remove
+        # @param attempts [Integer] delete attempts before giving up
+        # @return [Boolean] true when the file is gone
+        def shred_file(path, attempts: 3)
+          path = path.to_s
+          return false if path.empty?
+
+          overwrite_contents(path)
+          attempts.times do |attempt|
+            begin
+              File.delete(path) if File.exist?(path)
+              return true unless File.exist?(path)
+            rescue StandardError
+              nil
+            end
+            sleep 0.05 unless attempt == attempts - 1
+          end
+          !File.exist?(path)
+        rescue StandardError
+          false
+        end
+
+        private
+
+        # Rewrites container[index], mutating the existing String when possible so
+        # that other holders of that String also lose the secret.
+        #
+        # @return [Boolean] true when the value changed
+        def overwrite(container, index, value)
+          current = container[index]
+          return false if current == value
+
+          begin
+            current.replace(value)
+          rescue FrozenError
+            container[index] = value
+          end
+          true
+        end
+
+        # @return [void]
+        def overwrite_contents(path)
+          return unless File.file?(path)
+
+          size = File.size(path)
+          return if size.zero?
+
+          File.open(path, 'r+b') do |file|
+            file.write("\x00" * size)
+            file.flush
+            file.fsync
+          end
+        rescue StandardError, NotImplementedError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/common/credential_scrub.rb
+++ b/lib/common/credential_scrub.rb
@@ -74,6 +74,31 @@ module Lich
           scrubbed
         end
 
+        # Returns a copy of argv with secret values masked, without touching the
+        # input. Use this where the real argv must still be used for its
+        # original purpose (e.g. exec) but a redacted form is needed for
+        # something incidental to that purpose, such as a log line.
+        #
+        # Unlike {scrub_argv!}, this never mutates: reconnect logs its exec
+        # argv while also passing the same, unredacted array to +exec+, so an
+        # in-place scrub here would strip the real password before the process
+        # replacement that needs it.
+        #
+        # @param argv [Array<String>, nil] argument vector to redact
+        # @return [Array<String>] a new array; entries that don't match
+        #   {ARGV_SECRET} are unchanged. Returns an empty array for nil or
+        #   non-Array input.
+        def redact_argv(argv)
+          return [] unless argv.is_a?(Array)
+
+          argv.map do |arg|
+            next arg unless arg.is_a?(String)
+
+            match = ARGV_SECRET.match(arg)
+            match.nil? ? arg : "#{match[1]}#{REDACTED}"
+          end
+        end
+
         # Overwrites secret values in an options hash in place.
         #
         # @param options [Hash, nil] the argv options hash

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -1,12 +1,19 @@
 # Carve out for later carving and refining - main_thread and reconnect
 # this needs work to break up and improve 2024-06-13
 
+# Reconnect re-execs this process and has to pass the real --password= through,
+# so snapshot argv before the post-login scrub redacts it in place. A local in a
+# required file is not reachable from a script binding the way ARGV and the
+# top-level instance variables are, so the snapshot does not reopen the hole the
+# scrub closes.
+original_argv = ARGV.dup
+
 reconnect_if_wanted = proc {
   explicit_shutdown = Lich::Common::ShutdownCoordinator.orderly_user_exit?
   explicit_exit_buffered = $_CLIENTBUFFER_.any? { |cmd| Lich::Common::ShutdownIntent.user_exit_command?(cmd) }
 
-  if ARGV.include?('--reconnect') and ARGV.include?('--login') and not explicit_shutdown and not explicit_exit_buffered
-    if (reconnect_arg = ARGV.find { |arg| arg =~ /^\-\-reconnect\-delay=[0-9]+(?:\+[0-9]+)?$/ })
+  if original_argv.include?('--reconnect') and original_argv.include?('--login') and not explicit_shutdown and not explicit_exit_buffered
+    if (reconnect_arg = original_argv.find { |arg| arg =~ /^\-\-reconnect\-delay=[0-9]+(?:\+[0-9]+)?$/ })
       reconnect_arg =~ /^\-\-reconnect\-delay=([0-9]+)(\+[0-9]+)?/
       reconnect_delay = $1.to_i
       reconnect_step = $2.to_i
@@ -26,7 +33,7 @@ reconnect_if_wanted = proc {
       args = ['ruby']
     end
     args.push $PROGRAM_NAME.slice(/[^\\\/]+$/)
-    args.concat ARGV
+    args.concat original_argv
     args.push '--reconnected' unless args.include?('--reconnected')
     if reconnect_step > 0
       args.delete(reconnect_arg)
@@ -49,6 +56,9 @@ reconnect_if_wanted = proc {
   @launch_data = nil
   require File.join(LIB_DIR, 'common', 'authentication', 'eaccess.rb')
   require File.join(LIB_DIR, 'common', 'account.rb')
+  # Post-login credential redaction; loads here because the credentials it
+  # scrubs (@launch_data, @argv_options, ARGV) are owned by main runtime startup.
+  require File.join(LIB_DIR, 'common', 'credential_scrub.rb')
   # PipeIO is only consumed here (--pipe mode client adapter), so it loads with
   # main rather than from lich.rbw's top-level require chain -- that chain also
   # runs during self-update against older lib snapshots where pipe_io.rb may not
@@ -339,6 +349,10 @@ reconnect_if_wanted = proc {
           sal_filename = File.join(TEMP_DIR, "lich#{rand(10000)}.sal")
         end
         File.open(sal_filename, 'w') { |f| f.puts @launch_data }
+        # Backstop only. The removals below run on both the connected and the
+        # timeout path, but an exception in between would otherwise leave the
+        # eaccess key sitting in TEMP_DIR.
+        at_exit { Lich::Common::CredentialScrub.shred_file(sal_filename) }
         launcher_cmd = launcher_cmd.sub('%1', sal_filename)
         launcher_cmd = launcher_cmd.tr('/', "\\") if (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
       end
@@ -364,9 +378,7 @@ reconnect_if_wanted = proc {
         #        else
         Lich.msgbox(:message => "error: timeout waiting for client to connect", :icon => :error)
         #        end
-        if sal_filename
-          File.delete(sal_filename) # rescue() # rubocop complaint, but is it even necessary?
-        end
+        Lich::Common::CredentialScrub.shred_file(sal_filename) if sal_filename
         listener.close # rescue() # rubocop complaint, but is it even necessary?
         $_CLIENT_.close # rescue() # rubocop complaint, but is it even necessary?
         reconnect_if_wanted.call
@@ -379,9 +391,7 @@ reconnect_if_wanted = proc {
       #      end
       Lich.log 'info: connected'
       listener.close rescue nil
-      if sal_filename
-        File.delete(sal_filename) rescue nil
-      end
+      Lich::Common::CredentialScrub.shred_file(sal_filename) if sal_filename
     end
     gamehost, gameport = Lich.fix_game_host_port(gamehost, gameport)
     Lich.log "info: connecting to game server (#{gamehost}:#{gameport})"
@@ -523,6 +533,15 @@ reconnect_if_wanted = proc {
     exit
   end
 
+  # Every connection path above is done with the startup credentials by here, so
+  # redact them before any script can run. @launch_data and @argv_options are
+  # instance variables on the top-level object and ARGV is a global constant, all
+  # three readable from a script binding for the rest of the session. Flags are
+  # preserved, only values are overwritten, so the ARGV checks below still work.
+  Lich::Common::CredentialScrub.scrub_launch_data!(@launch_data)
+  Lich::Common::CredentialScrub.scrub_argv!(ARGV)
+  Lich::Common::CredentialScrub.scrub_options!(@argv_options)
+
   listener = nil
 
   undef :exit!
@@ -578,6 +597,7 @@ reconnect_if_wanted = proc {
       $login_time = Time.now
 
       if $offline_mode
+        game_key = nil
         next nil
       elsif Frontend.supports_gsl?
         #
@@ -674,6 +694,11 @@ reconnect_if_wanted = proc {
           Game._puts(client_string)
         end
       end
+
+      # Every branch above has either sent the login key or handed that job to the
+      # frontend, so drop this thread's reference to it. Same thread as the sends
+      # above, so there is no race on the shared local.
+      game_key = nil
 
       begin
         while (client_string = $_CLIENT_.gets)

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -2,11 +2,14 @@
 # this needs work to break up and improve 2024-06-13
 
 # Reconnect re-execs this process and has to pass the real --password= through,
-# so snapshot argv before the post-login scrub redacts it in place. A local in a
-# required file is not reachable from a script binding the way ARGV and the
-# top-level instance variables are, so the snapshot does not reopen the hole the
-# scrub closes.
-original_argv = ARGV.dup
+# so snapshot argv before the post-login scrub redacts it in place. The copy is
+# element-wise on purpose: whether an in-place scrub can reach a shallow ARGV.dup
+# depends on whether the interpreter freezes argument Strings (it does on 3.2,
+# which makes the scrub fall back to slot assignment), and that is not a detail to
+# rest a credential invariant on. A local in a required file is not reachable from
+# a script binding the way ARGV and the top-level instance variables are, so the
+# snapshot does not reopen the hole the scrub closes.
+original_argv = ARGV.map(&:dup)
 
 reconnect_if_wanted = proc {
   explicit_shutdown = Lich::Common::ShutdownCoordinator.orderly_user_exit?
@@ -695,9 +698,12 @@ reconnect_if_wanted = proc {
         end
       end
 
-      # Every branch above has either sent the login key or handed that job to the
-      # frontend, so drop this thread's reference to it. Same thread as the sends
-      # above, so there is no race on the shared local.
+      # game_key is a local captured from the enclosing @main_thread block, so this
+      # clears the only binding rather than a reference private to this thread.
+      # Still race-free: every branch above has either sent the login key or handed
+      # that job to the frontend, and the --without-frontend thread that also sends
+      # it is created in the mutually exclusive branch of the surrounding
+      # conditional, so no other reader can still be pending.
       game_key = nil
 
       begin

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -44,10 +44,8 @@ reconnect_if_wanted = proc {
       reconnect_delay: reconnect_delay,
       reconnect_step: reconnect_step
     )
-    # args carries the real --password= value through to exec below, so the
-    # log line must redact a copy rather than the array itself -- CredentialScrub
-    # only ships mutating scrub_argv!, which would strip the password exec needs.
-    Lich.log "info: reconnect exec: #{Lich::Common::CredentialScrub.redact_argv(args).join(' ')}"
+    # Log a redacted copy; exec() on the next line needs the real args intact.
+    Lich.log "info: reconnect exec: #{Lich::Main::ReconnectCommand.log_line(args)}"
     exec(*args)
   end
 }

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -44,7 +44,10 @@ reconnect_if_wanted = proc {
       reconnect_delay: reconnect_delay,
       reconnect_step: reconnect_step
     )
-    Lich.log "info: reconnect exec: #{args.join(' ')}"
+    # args carries the real --password= value through to exec below, so the
+    # log line must redact a copy rather than the array itself -- CredentialScrub
+    # only ships mutating scrub_argv!, which would strip the password exec needs.
+    Lich.log "info: reconnect exec: #{Lich::Common::CredentialScrub.redact_argv(args).join(' ')}"
     exec(*args)
   end
 }

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -1,6 +1,9 @@
 # Carve out for later carving and refining - main_thread and reconnect
 # this needs work to break up and improve 2024-06-13
 
+require 'shellwords'
+require_relative '../common/process_launcher'
+require_relative 'reconnect_command'
 # Reconnect re-execs this process and has to pass the real --password= through,
 # so snapshot argv before the post-login scrub redacts it in place. The copy is
 # element-wise on purpose: whether an in-place scrub can reach a shallow ARGV.dup
@@ -27,23 +30,22 @@ reconnect_if_wanted = proc {
     Lich.log "info: waiting #{reconnect_delay} seconds to reconnect..."
     sleep reconnect_delay
     Lich.log 'info: reconnecting...'
-    if (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
+    if Lich::Common::Frontend.windows_platform?
       if Frontend.client.eql?('stormfront')
-        system 'taskkill /FI "WINDOWTITLE eq [GSIV: ' + Char.name + '*"' # fixme: window title changing to Gemstone IV: Char.name # name optional
+        system('taskkill', '/FI', "WINDOWTITLE eq [GSIV: #{Char.name}*") # fixme: window title changing to Gemstone IV: Char.name # name optional
       end
-      args = ['start rubyw.exe']
-    else
-      args = ['ruby']
     end
-    args.push $PROGRAM_NAME.slice(/[^\\\/]+$/)
-    args.concat original_argv
-    args.push '--reconnected' unless args.include?('--reconnected')
-    if reconnect_step > 0
-      args.delete(reconnect_arg)
-      args.concat ["--reconnect-delay=#{reconnect_delay + reconnect_step}+#{reconnect_step}"]
-    end
-    Lich.log "exec args.join(' '): exec #{args.join(' ')}"
-    exec args.join(' ')
+    ruby_binary = Lich::Main::ReconnectCommand.ruby_executable
+    args = Lich::Main::ReconnectCommand.build(
+      argv: original_argv,
+      program: $PROGRAM_NAME,
+      ruby_executable: ruby_binary,
+      reconnect_arg: reconnect_arg,
+      reconnect_delay: reconnect_delay,
+      reconnect_step: reconnect_step
+    )
+    Lich.log "info: reconnect exec: #{args.join(' ')}"
+    exec(*args)
   end
 }
 
@@ -88,8 +90,11 @@ reconnect_if_wanted = proc {
   # so the later arm during teardown is a no-op. Both the primary and detachable
   # frontend exit paths route through Lich::Main::UserExitDispatch so neither can
   # run the hang-prone inline drain without the watchdog armed.
-  run_orderly_user_shutdown = proc { |source: :primary_frontend|
-    Lich::Main::UserExitDispatch.run_orderly_user_shutdown(source: source)
+  run_orderly_user_shutdown = proc { |source: :primary_frontend, server_exit_command:|
+    Lich::Main::UserExitDispatch.run_orderly_user_shutdown(
+      source: source,
+      server_exit_command: server_exit_command
+    )
   }
 
   run_best_effort_shutdown_cleanup = proc {
@@ -106,6 +111,7 @@ reconnect_if_wanted = proc {
   if ARGV.include?('--login')
     # CLI login flow: character authentication via saved entries
     require File.join(LIB_DIR, 'common', 'authentication', 'cli')
+    require File.join(LIB_DIR, 'common', 'saga_managed_login')
 
     # Extract character name from --login argument
     requested_character = ARGV[ARGV.index('--login') + 1].capitalize
@@ -116,9 +122,39 @@ reconnect_if_wanted = proc {
     modifiers = ARGV.dup
     requested_instance, requested_fe, requested_custom_launch = Lich::Common::Authentication::LoginHelpers.resolve_login_args(modifiers)
     lookup_frontend = Lich::Common::Authentication::LoginHelpers.resolve_lookup_frontend(requested_fe, ARGV)
+    new_character_login = requested_character.match?(Lich::Common::Authentication::LoginHelpers::NEW_CHARACTER_LOGIN)
+
+    saga_decision = Lich::Common::SagaManagedLogin.cli_decision(
+      character: requested_character,
+      game_code: requested_instance,
+      frontend: requested_fe,
+      custom_launch: requested_custom_launch,
+      headless: ARGV.include?('--without-frontend'),
+      data_dir: DATA_DIR
+    )
+
+    case saga_decision.action
+    when :launch
+      result = Lich::Common::SagaManagedLogin.launch(saga_decision.target)
+      if result[:ok]
+        Lich.log "info: Saga-managed CLI launch requested for #{requested_character}; pid=#{result[:pid]}"
+        raise SystemExit.new(0)
+      end
+
+      message = "Failed to launch Saga: #{result[:error]}"
+      $stderr.puts "error: #{message}"
+      Lich.log "error: #{message}"
+      $stderr.flush
+      raise SystemExit.new(1)
+    when :error
+      $stderr.puts "error: #{saga_decision.error}"
+      Lich.log "error: #{saga_decision.error}"
+      $stderr.flush
+      raise SystemExit.new(1)
+    end
 
     # Execute CLI login flow and get launch data
-    launch_data_array = if requested_character.match?(Lich::Common::Authentication::LoginHelpers::NEW_CHARACTER_LOGIN) && @argv_options[:account]
+    launch_data_array = if new_character_login && @argv_options[:account]
                           Lich::Common::Authentication::CLI.execute_new_character(
                             @argv_options[:account],
                             game_code: requested_instance,
@@ -208,29 +244,40 @@ reconnect_if_wanted = proc {
     if (custom_launch = @launch_data.find { |opt| opt =~ /CUSTOMLAUNCH=/ })
       custom_launch.sub!(/^.*?\=/, '')
       Lich.log "info: using custom launch command: #{custom_launch}"
-    elsif (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
+    elsif @launch_data.find { |opt| opt =~ /GAME=SAGA/i }
+      native_saga_launch = true
+      Lich.log "info: #{Lich::Common::Frontend.metadata_for('saga', :launch_notice)}"
+    elsif Lich::Common::Frontend.windows_platform?
       Lich.log("info: Working against a Windows Platform for FE Executable")
       if @launch_data.find { |opt| opt =~ /GAME=WIZ/ }
         custom_launch = "Wizard.Exe /G#{gamecodeshort}/H127.0.0.1 /P%port% /K%key%"
       elsif @launch_data.find { |opt| opt =~ /GAME=STORM/ }
-        custom_launch = "Wrayth.exe /G#{gamecodeshort}/Hlocalhost/P%port%/K%key%" if $sf_fe_loc =~ /Wrayth/
-        custom_launch = "Stormfront.exe /G#{gamecodeshort}/Hlocalhost/P%port%/K%key%" if $sf_fe_loc =~ /STORM/
+        resolved_frontend = Lich::Common::FrontendLocator.resolve('stormfront', refresh: true)
+        if resolved_frontend
+          frontend_executable = File.basename(resolved_frontend.executable_path)
+          custom_launch = "#{frontend_executable} /G#{gamecodeshort}/Hlocalhost/P%port%/K%key%"
+        end
       end
     elsif defined?(Wine)
       Lich.log("info: Working against a Linux | WINE Platform")
       if @launch_data.find { |opt| opt =~ /GAME=WIZ/ }
         custom_launch = "#{Wine::BIN} Wizard.Exe /G#{gamecodeshort}/H127.0.0.1 /P%port% /K%key%"
       elsif @launch_data.find { |opt| opt =~ /GAME=STORM/ }
-        custom_launch = "#{Wine::BIN} Wrayth.exe /G#{gamecodeshort}/Hlocalhost/P%port%/K%key%" if $sf_fe_loc =~ /Wrayth/
-        custom_launch = "#{Wine::BIN} Stormfront.exe /G#{gamecodeshort}/Hlocalhost/P%port%/K%key%" if $sf_fe_loc =~ /STORM/
+        resolved_frontend = Lich::Common::FrontendLocator.resolve('stormfront', refresh: true)
+        if resolved_frontend
+          frontend_executable = Shellwords.escape(File.basename(resolved_frontend.executable_path))
+          custom_launch = "#{Wine::BIN} #{frontend_executable} /G#{gamecodeshort}/Hlocalhost/P%port%/K%key%"
+        end
       end
     end
     if (custom_launch_dir = @launch_data.find { |opt| opt =~ /CUSTOMLAUNCHDIR=/ })
       custom_launch_dir.sub!(/^.*?\=/, '')
       Lich.log "info: using working directory for custom launch command: #{custom_launch_dir}"
-    elsif (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
+    elsif Lich::Common::Frontend.windows_platform?
       Lich.log "info: Working against a Windows Platform for FE Location"
-      if @launch_data.find { |opt| opt =~ /GAME=WIZ/ }
+      if resolved_frontend
+        custom_launch_dir = File.dirname(resolved_frontend.executable_path)
+      elsif @launch_data.find { |opt| opt =~ /GAME=WIZ/ }
         custom_launch_dir = Lich.seek('wizard') # #HERE I AM
       elsif @launch_data.find { |opt| opt =~ /GAME=STORM/ }
         custom_launch_dir = Lich.seek('stormfront') # #HERE I AM
@@ -238,47 +285,56 @@ reconnect_if_wanted = proc {
       Lich.log "info: Current Windows working directory is #{custom_launch_dir}"
     elsif defined?(Wine)
       Lich.log "Info: Working against a Linux | WINE Platform for FE location"
-      if @launch_data.find { |opt| opt =~ /GAME=WIZ/ }
+      if resolved_frontend
+        custom_launch_dir = File.dirname(resolved_frontend.executable_path)
+      elsif @launch_data.find { |opt| opt =~ /GAME=WIZ/ }
         custom_launch_dir_temp = Lich.seek('wizard') # #HERE I AM
-        custom_launch_dir = custom_launch_dir_temp.gsub('\\', '/').gsub('C:', Wine::PREFIX + '/drive_c')
+        custom_launch_dir = custom_launch_dir_temp&.gsub('\\', '/')&.gsub('C:', Wine::PREFIX + '/drive_c')
       elsif @launch_data.find { |opt| opt =~ /GAME=STORM/ }
         custom_launch_dir_temp = Lich.seek('stormfront') # #HERE I AM
-        custom_launch_dir = custom_launch_dir_temp.gsub('\\', '/').gsub('C:', Wine::PREFIX + '/drive_c')
+        custom_launch_dir = custom_launch_dir_temp&.gsub('\\', '/')&.gsub('C:', Wine::PREFIX + '/drive_c')
       end
       Lich.log "info: Current WINE working directory is #{custom_launch_dir}"
     end
-    if ARGV.include?('--without-frontend')
-      Frontend.client = Lich::Common::Authentication::LoginHelpers.resolve_headless_frontend(
-        ARGV, detachable_client: !@argv_options[:detachable_client_port].nil?
-      )
-      unless (game_key = @launch_data.find { |opt| opt =~ /KEY=/ }) && (game_key = game_key.split('=').last.chomp)
+    extract_game_key = proc do
+      key_entry = @launch_data.find { |opt| opt =~ /KEY=/ }
+      game_key_value = key_entry&.split('=', 2)&.last&.chomp
+      unless game_key_value
         $stdout.puts "error: launch_data contains no KEY info"
         Lich.log "error: launch_data contains no KEY info"
         exit(1)
       end
-    elsif game =~ /SUKS/i
-      Frontend.client = 'suks'
-      unless (game_key = @launch_data.find { |opt| opt =~ /KEY=/ }) && (game_key = game_key.split('=').last.chomp)
-        $stdout.puts "error: launch_data contains no KEY info"
-        Lich.log "error: launch_data contains no KEY info"
-        exit(1)
-      end
-    elsif game =~ /AVALON/i
-      # Simu strikes again
-      launcher_cmd = "open -n -b Avalon \"%1\""
-    elsif custom_launch
-      unless (game_key = @launch_data.find { |opt| opt =~ /KEY=/ }) && (game_key = game_key.split('=').last.chomp)
-        $stdout.puts "error: launch_data contains no KEY info"
-        Lich.log "error: launch_data contains no KEY info"
-        exit(1)
-      end
-    else
-      unless (launcher_cmd = Lich.get_simu_launcher)
-        $stdout.puts 'error: failed to find the Simutronics launcher'
-        Lich.log 'error: failed to find the Simutronics launcher'
-        exit(1)
-      end
+      game_key_value
     end
+    requires_game_key = false
+    begin
+      if ARGV.include?('--without-frontend')
+        Frontend.client = Lich::Common::Authentication::LoginHelpers.resolve_headless_frontend(
+          ARGV, detachable_client: !@argv_options[:detachable_client_port].nil?
+        )
+        requires_game_key = true
+      elsif game =~ /SUKS/i
+        Frontend.client = 'suks'
+        requires_game_key = true
+      elsif game =~ /SAGA/i && native_saga_launch
+        requires_game_key = true
+      elsif game =~ /SAGA/i
+        raise Lich::Common::FrontendLauncher::UnsupportedError,
+              'no native Saga launch adapter is available on this platform'
+      elsif game =~ /AVALON/i
+        launcher_cmd = Lich::Common::FrontendLauncher.command('avalon')
+      elsif custom_launch
+        requires_game_key = true
+      else
+        frontend_id = game =~ /WIZ/i ? 'wizard' : 'stormfront'
+        launcher_cmd = Lich::Common::FrontendLauncher.command(frontend_id)
+      end
+    rescue Lich::Common::FrontendLauncher::Error => e
+      $stdout.puts "error: #{e.message}"
+      Lich.log "error: #{e.message}"
+      exit(1)
+    end
+    game_key = extract_game_key.call if requires_game_key
     gamecode.split('=').last
     gameport = gameport.split('=').last
     gamehost = gamehost.split('=').last
@@ -324,13 +380,30 @@ reconnect_if_wanted = proc {
         Lich.log "error: cannot bind listen socket to local port: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
         exit(1)
       end
-      accept_thread = Thread.new {
-        accepted_socket, = listener.accept
-        $_CLIENT_ = SynchronizedSocket.new(accepted_socket)
-      }
       localport = listener.local_address.ip_port
-      Frontend.create_session_file(Lich::Common::Account.character, listener.local_address.ip_address, localport, display_session: false)
-      if custom_launch
+      if native_saga_launch
+        saga_host = if @argv_options[:bind_address] && !%w[0.0.0.0 ::].include?(@argv_options[:bind_address])
+                      @argv_options[:bind_address]
+                    else
+                      '127.0.0.1'
+                    end
+        begin
+          saga_plan = Lich::Common::FrontendLauncher.spawn_plan(
+            'saga',
+            host: saga_host,
+            port: localport,
+            key: game_key,
+            refresh: false
+          )
+        rescue Lich::Common::FrontendLauncher::Error => e
+          listener.close
+          $stdout.puts "error: #{e.message}"
+          Lich.log "error: #{e.message}"
+          exit(1)
+        end
+        Lich.log "info: launching Saga environment handoff on #{saga_host}:#{localport}"
+        sal_filename = nil
+      elsif custom_launch
         sal_filename = nil
         launcher_cmd = custom_launch.sub(/\%port\%/, localport.to_s).sub(/\%key\%/, game_key.to_s)
         scrubbed_launcher_cmd = custom_launch.sub(/\%port\%/, localport.to_s).sub(/\%key\%/, '[scrubbed key]')
@@ -341,7 +414,7 @@ reconnect_if_wanted = proc {
         # to loopback for wildcard binds since a frontend cannot connect to 0.0.0.0/::.
         if @argv_options[:bind_address] && !%w[0.0.0.0 ::].include?(@argv_options[:bind_address])
           localhost = @argv_options[:bind_address]
-        elsif RUBY_PLATFORM =~ /darwin/i
+        elsif Lich::Common::Frontend.platform_key == :darwin
           localhost = "127.0.0.1"
         else
           localhost = "localhost"
@@ -357,14 +430,23 @@ reconnect_if_wanted = proc {
         # eaccess key sitting in TEMP_DIR.
         at_exit { Lich::Common::CredentialScrub.shred_file(sal_filename) }
         launcher_cmd = launcher_cmd.sub('%1', sal_filename)
-        launcher_cmd = launcher_cmd.tr('/', "\\") if (RUBY_PLATFORM =~ /mingw|win/i) and (RUBY_PLATFORM !~ /darwin/i)
+        launcher_cmd = launcher_cmd.tr('/', "\\") if Lich::Common::Frontend.windows_platform?
       end
+      accept_thread = Thread.new {
+        accepted_socket, = listener.accept
+        $_CLIENT_ = SynchronizedSocket.new(accepted_socket)
+      }
+      Frontend.create_session_file(Lich::Common::Account.character, listener.local_address.ip_address, localport, display_session: false)
       begin
         unless custom_launch_dir.nil? || custom_launch_dir.empty?
           Dir.chdir(custom_launch_dir)
         end
 
-        frontend_pid = spawn(launcher_cmd)
+        frontend_pid = if native_saga_launch
+                         Lich::Common::ProcessLauncher.call(saga_plan.environment, saga_plan.argv)
+                       else
+                         spawn(launcher_cmd)
+                       end
         Lich::Common::Frontend.pid = frontend_pid if defined?(Lich::Common::Frontend)
       rescue
         Lich.log "error: #{$!.to_s.sub(game_key.to_s, '[scrubbed key]')}\n\t#{$!.backtrace.join("\n\t")}"
@@ -714,7 +796,7 @@ reconnect_if_wanted = proc {
             client_string = fb_to_sf(client_string)
           end
           if Lich::Common::ShutdownIntent.user_exit_command?(client_string)
-            run_orderly_user_shutdown.call
+            run_orderly_user_shutdown.call(server_exit_command: client_string)
             break
           end
           # Lich.log(client_string)

--- a/lib/main/reconnect_command.rb
+++ b/lib/main/reconnect_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../common/ruby_executable'
+require_relative '../common/credential_scrub'
 
 module Lich
   module Main
@@ -50,6 +51,20 @@ module Lich
           args << "--reconnect-delay=#{delay + step}+#{step}"
         end
         args
+      end
+
+      # Renders exec argv as a log-safe string, masking credential-bearing
+      # entries.
+      #
+      # Pairs with {.build}: main.rb calls that method, logs this one, then
+      # execs the same, unredacted array on the next line. Keeping both here
+      # means a change to either stays covered by the same spec file, instead
+      # of the pairing only existing at the main.rb call site.
+      #
+      # @param args [Array<String>] argv as returned by {.build}
+      # @return [String] space-joined argv with secret values masked
+      def self.log_line(args)
+        Lich::Common::CredentialScrub.redact_argv(args).join(' ')
       end
     end
   end

--- a/spec/lib/common/credential_scrub_spec.rb
+++ b/spec/lib/common/credential_scrub_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+# NOTE: This spec intentionally does NOT require spec_helper.
+# CredentialScrub has no Lich runtime dependencies, so it is tested in
+# isolation without booting the engine.
+
+require 'rspec'
+require 'tmpdir'
+
+require_relative '../../../lib/common/credential_scrub'
+
+RSpec.describe Lich::Common::CredentialScrub do
+  describe '.scrub_launch_data!' do
+    it 'overwrites the KEY entry and leaves every other entry untouched' do
+      launch_data = ['GAMECODE=GS3', 'KEY=abc123secret', 'GAMEHOST=localhost']
+
+      expect(described_class.scrub_launch_data!(launch_data)).to eq(1)
+      expect(launch_data).to eq(['GAMECODE=GS3', 'KEY=[scrubbed]', 'GAMEHOST=localhost'])
+    end
+
+    it 'mutates the existing String so other holders of it lose the secret' do
+      key_line = String.new('KEY=abc123secret')
+      launch_data = [key_line]
+      gui_reference = launch_data
+
+      described_class.scrub_launch_data!(launch_data)
+
+      expect(key_line).to eq('KEY=[scrubbed]')
+      expect(gui_reference.first).to eq('KEY=[scrubbed]')
+    end
+
+    it 'falls back to element assignment when the entry is frozen' do
+      launch_data = ['KEY=abc123secret'.freeze]
+
+      expect(described_class.scrub_launch_data!(launch_data)).to eq(1)
+      expect(launch_data.first).to eq('KEY=[scrubbed]')
+    end
+
+    it 'matches the KEY prefix case insensitively' do
+      launch_data = ['key=abc123secret']
+
+      described_class.scrub_launch_data!(launch_data)
+
+      expect(launch_data.first).to eq('KEY=[scrubbed]')
+    end
+
+    it 'is idempotent and reports nothing rewritten on a second pass' do
+      launch_data = ['KEY=abc123secret']
+      described_class.scrub_launch_data!(launch_data)
+
+      expect(described_class.scrub_launch_data!(launch_data)).to eq(0)
+      expect(launch_data).to eq(['KEY=[scrubbed]'])
+    end
+
+    it 'tolerates nil, which is what direct host/port and --pipe startups produce' do
+      expect(described_class.scrub_launch_data!(nil)).to eq(0)
+    end
+
+    it 'leaves a launch_data array with no KEY entry alone' do
+      launch_data = ['GAMECODE=GS3']
+
+      expect(described_class.scrub_launch_data!(launch_data)).to eq(0)
+      expect(launch_data).to eq(['GAMECODE=GS3'])
+    end
+  end
+
+  describe '.scrub_argv!' do
+    it 'redacts the password value while preserving the flag prefix' do
+      argv = ['--login', '--password=hunter2', '--without-frontend']
+
+      expect(described_class.scrub_argv!(argv)).to eq(1)
+      expect(argv).to eq(['--login', '--password=[scrubbed]', '--without-frontend'])
+    end
+
+    it 'redacts master-password as well' do
+      argv = ['--master-password=vault']
+
+      described_class.scrub_argv!(argv)
+
+      expect(argv).to eq(['--master-password=[scrubbed]'])
+    end
+
+    it 'leaves the account identifier alone' do
+      argv = ['--account=myaccount', '--password=hunter2']
+
+      described_class.scrub_argv!(argv)
+
+      expect(argv).to eq(['--account=myaccount', '--password=[scrubbed]'])
+    end
+
+    it 'keeps bare flags intact so ARGV.include? checks still work' do
+      argv = ['--reconnect', '--login', '--password=hunter2', '--without-frontend']
+
+      described_class.scrub_argv!(argv)
+
+      expect(argv.include?('--without-frontend')).to be true
+      expect(argv.include?('--reconnect')).to be true
+      expect(argv.include?('--login')).to be true
+    end
+
+    it 'does not rewrite a flag that carries no value' do
+      argv = ['--password=']
+
+      expect(described_class.scrub_argv!(argv)).to eq(0)
+      expect(argv).to eq(['--password='])
+    end
+
+    it 'is idempotent' do
+      argv = ['--password=hunter2']
+      described_class.scrub_argv!(argv)
+
+      expect(described_class.scrub_argv!(argv)).to eq(0)
+      expect(argv).to eq(['--password=[scrubbed]'])
+    end
+
+    it 'tolerates nil' do
+      expect(described_class.scrub_argv!(nil)).to eq(0)
+    end
+  end
+
+  describe '.scrub_options!' do
+    it 'redacts the password value in place' do
+      options = { password: 'hunter2', account: 'myaccount', sal: 'C:\\game.sal' }
+
+      expect(described_class.scrub_options!(options)).to eq([:password])
+      expect(options).to eq({ password: '[scrubbed]', account: 'myaccount', sal: 'C:\\game.sal' })
+    end
+
+    it 'mutates the shared hash so the argv option pipeline copy is covered too' do
+      options = { password: 'hunter2' }
+      pipeline_reference = options
+
+      described_class.scrub_options!(options)
+
+      expect(pipeline_reference[:password]).to eq('[scrubbed]')
+    end
+
+    it 'is idempotent' do
+      options = { password: 'hunter2' }
+      described_class.scrub_options!(options)
+
+      expect(described_class.scrub_options!(options)).to eq([])
+    end
+
+    it 'reports nothing when no password was supplied' do
+      expect(described_class.scrub_options!({ sal: 'C:\\game.sal' })).to eq([])
+    end
+
+    it 'tolerates nil' do
+      expect(described_class.scrub_options!(nil)).to eq([])
+    end
+  end
+
+  describe '.shred_file' do
+    around do |example|
+      Dir.mktmpdir('credential-scrub') { |dir| @dir = dir; example.run }
+    end
+
+    it 'overwrites the contents and deletes the file' do
+      path = File.join(@dir, 'lich1234.sal')
+      File.write(path, "KEY=abc123secret\nGAMECODE=GS3\n")
+
+      expect(described_class.shred_file(path)).to be true
+      expect(File.exist?(path)).to be false
+    end
+
+    it 'zeroes the bytes before unlinking' do
+      path = File.join(@dir, 'observed.sal')
+      original = "KEY=abc123secret\n"
+      File.write(path, original)
+      observed = nil
+
+      allow(File).to receive(:delete) { |target| observed = File.binread(target) }
+      allow(File).to receive(:exist?).and_call_original
+
+      described_class.shred_file(path, attempts: 1)
+
+      expect(observed).to eq("\x00" * original.bytesize)
+      expect(observed).not_to include('abc123secret')
+    end
+
+    it 'reports true when the file is already gone' do
+      expect(described_class.shred_file(File.join(@dir, 'absent.sal'))).to be true
+    end
+
+    it 'returns false rather than raising when deletion keeps failing' do
+      path = File.join(@dir, 'locked.sal')
+      File.write(path, 'KEY=abc123secret')
+      allow(File).to receive(:delete).and_raise(Errno::EACCES)
+
+      expect { @result = described_class.shred_file(path, attempts: 2) }.not_to raise_error
+      expect(@result).to be false
+    end
+
+    it 'returns false for a nil or empty path' do
+      expect(described_class.shred_file(nil)).to be false
+      expect(described_class.shred_file('')).to be false
+    end
+
+    it 'does not raise when the overwrite step fails' do
+      path = File.join(@dir, 'unwritable.sal')
+      File.write(path, 'KEY=abc123secret')
+      allow(File).to receive(:open).and_raise(Errno::EACCES)
+
+      expect { described_class.shred_file(path) }.not_to raise_error
+      expect(File.exist?(path)).to be false
+    end
+  end
+end

--- a/spec/lib/common/credential_scrub_spec.rb
+++ b/spec/lib/common/credential_scrub_spec.rb
@@ -118,6 +118,66 @@ RSpec.describe Lich::Common::CredentialScrub do
     end
   end
 
+  describe '.redact_argv' do
+    it 'masks the password value while preserving the flag prefix' do
+      argv = ['--login', '--password=hunter2', '--without-frontend']
+
+      expect(described_class.redact_argv(argv)).to eq(
+        ['--login', '--password=[scrubbed]', '--without-frontend']
+      )
+    end
+
+    it 'masks master-password as well' do
+      expect(described_class.redact_argv(['--master-password=vault'])).to eq(['--master-password=[scrubbed]'])
+    end
+
+    it 'leaves the account identifier alone' do
+      argv = ['--account=myaccount', '--password=hunter2']
+
+      expect(described_class.redact_argv(argv)).to eq(['--account=myaccount', '--password=[scrubbed]'])
+    end
+
+    it 'does not mutate the input array or its String elements' do
+      # This is the whole point of the method: reconnect passes the same argv
+      # to exec() right after logging it, so the real password must survive.
+      password_arg = String.new('--password=hunter2')
+      argv = ['--login', password_arg]
+
+      result = described_class.redact_argv(argv)
+
+      expect(result).to eq(['--login', '--password=[scrubbed]'])
+      expect(argv).to eq(['--login', '--password=hunter2'])
+      expect(password_arg).to eq('--password=hunter2')
+    end
+
+    it 'returns a different array object than the one passed in' do
+      argv = ['--password=hunter2']
+
+      expect(described_class.redact_argv(argv)).not_to equal(argv)
+    end
+
+    it 'does not mask a flag that carries no value' do
+      expect(described_class.redact_argv(['--password='])).to eq(['--password='])
+    end
+
+    it 'passes through non-secret entries unchanged' do
+      argv = ['--reconnect', '--login', '--reconnect-delay=60']
+
+      expect(described_class.redact_argv(argv)).to eq(argv)
+    end
+
+    it 'tolerates non-String entries in argv' do
+      argv = [:not_a_string, '--password=hunter2']
+
+      expect(described_class.redact_argv(argv)).to eq([:not_a_string, '--password=[scrubbed]'])
+    end
+
+    it 'returns an empty array for nil or non-Array input' do
+      expect(described_class.redact_argv(nil)).to eq([])
+      expect(described_class.redact_argv('--password=hunter2')).to eq([])
+    end
+  end
+
   describe '.scrub_options!' do
     it 'redacts the password value in place' do
       options = { password: 'hunter2', account: 'myaccount', sal: 'C:\\game.sal' }

--- a/spec/lib/common/credential_scrub_spec.rb
+++ b/spec/lib/common/credential_scrub_spec.rb
@@ -135,6 +135,22 @@ RSpec.describe Lich::Common::CredentialScrub do
       expect(pipeline_reference[:password]).to eq('[scrubbed]')
     end
 
+    it 'mutates the password String itself so other holders of it lose the secret' do
+      password = String.new('hunter2')
+      options = { password: password }
+
+      described_class.scrub_options!(options)
+
+      expect(password).to eq('[scrubbed]')
+    end
+
+    it 'falls back to key assignment when the password String is frozen' do
+      options = { password: 'hunter2'.freeze }
+
+      expect(described_class.scrub_options!(options)).to eq([:password])
+      expect(options[:password]).to eq('[scrubbed]')
+    end
+
     it 'is idempotent' do
       options = { password: 'hunter2' }
       described_class.scrub_options!(options)
@@ -148,6 +164,43 @@ RSpec.describe Lich::Common::CredentialScrub do
 
     it 'tolerates nil' do
       expect(described_class.scrub_options!(nil)).to eq([])
+    end
+  end
+
+  describe 'argv snapshot aliasing' do
+    # main.rb snapshots argv before scrubbing so reconnect can re-exec with the
+    # real credentials. Whether an in-place scrub can reach that snapshot depends
+    # on whether the argument Strings are frozen, which is an interpreter detail
+    # rather than something to rely on, so main.rb copies element-wise. These
+    # examples pin both halves of that reasoning.
+
+    it 'reaches a shallow Array#dup snapshot when the arguments are mutable' do
+      argv = ['--login', String.new('--password=hunter2'), '--reconnect']
+      shallow_snapshot = argv.dup
+
+      described_class.scrub_argv!(argv)
+
+      expect(shallow_snapshot[1]).to eq('--password=[scrubbed]')
+    end
+
+    it 'cannot reach an element-wise snapshot of mutable arguments' do
+      argv = ['--login', String.new('--password=hunter2'), '--reconnect']
+      snapshot = argv.map(&:dup)
+
+      described_class.scrub_argv!(argv)
+
+      expect(argv[1]).to eq('--password=[scrubbed]')
+      expect(snapshot[1]).to eq('--password=hunter2')
+    end
+
+    it 'cannot reach an element-wise snapshot of frozen arguments' do
+      argv = ['--login', '--password=hunter2'.freeze, '--reconnect']
+      snapshot = argv.map(&:dup)
+
+      described_class.scrub_argv!(argv)
+
+      expect(argv[1]).to eq('--password=[scrubbed]')
+      expect(snapshot[1]).to eq('--password=hunter2')
     end
   end
 

--- a/spec/lib/main/reconnect_command_spec.rb
+++ b/spec/lib/main/reconnect_command_spec.rb
@@ -150,4 +150,46 @@ RSpec.describe Lich::Main::ReconnectCommand do
       }.to raise_error(ArgumentError, 'argv must be an Array')
     end
   end
+
+  describe '.log_line' do
+    it 'masks the password while leaving everything else as-is' do
+      args = ['ruby', 'lich.rbw', '--login', '--password=hunter2', '--reconnected']
+
+      expect(described_class.log_line(args)).to eq(
+        'ruby lich.rbw --login --password=[scrubbed] --reconnected'
+      )
+    end
+
+    it 'does not mutate the argv it is given' do
+      # main.rb logs this string and execs the same array on the very next
+      # line, so building the log message must never touch the real argv.
+      args = ['ruby', 'lich.rbw', '--login', '--password=hunter2']
+
+      described_class.log_line(args)
+
+      expect(args).to include('--password=hunter2')
+    end
+
+    it 'reflects exactly what exec would receive, chained the way main.rb chains them' do
+      # Exercises the same two calls main.rb makes back to back -- build the
+      # exec argv, then render its log line -- with nothing stubbed in
+      # between, so a regression in either method or in how they compose
+      # would fail here.
+      args = described_class.build(
+        argv: ['--reconnect', '--login', '--password=hunter2'],
+        program: 'lich.rbw',
+        ruby_executable: 'ruby',
+        reconnect_arg: nil,
+        reconnect_delay: 60,
+        reconnect_step: 0
+      )
+
+      log_line = described_class.log_line(args)
+
+      expect(log_line).to eq('ruby lich.rbw --reconnect --login --password=[scrubbed] --reconnected')
+      # The array build() returned -- the one exec(*args) would actually
+      # receive -- still carries the real password after log_line ran.
+      expect(args).to include('--password=hunter2')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
 
Startup credentials stayed readable for the entire session. Three of the four
containers holding them are reachable from any running script:
 
| Container | Holder | Contents | Reachable from a script |
|---|---|---|---|
| `@launch_data` | ivar on top-level `main` | eaccess key | yes |
| `@argv_options` | ivar on top-level `main` | account password | yes |
| `ARGV` | global constant | account password | yes |
| `game_key` | block-local in `@main_thread` | eaccess key | no |
 
Both are live credentials. The eaccess key is **not** single-use: it stays valid
for some period after issue, and the exact invalidation window is not documented
on our side. A key read out of `@launch_data` well into a session may still be
usable, which is the main reason this change is worth making rather than being
cosmetic cleanup.
 
`@launch_data` is set on `main` because `main.rb` is required from `lich.rbw:130`
and the `@main_thread` block closes over that same `self`. `@argv_options` lands
on `main` the same way, via `argv_options.rb:435`. Neither is ever cleared, and
`SideEffects.execute` / `GameConnection.execute` both return the Hash they
receive without duplicating it, so `OptionParser`'s module ivar is a second
reference to the same object.
 
This adds `Lich::Common::CredentialScrub` and calls it once every connection path
has finished with the credentials, plus makes the temp `.sal` removal failsafe.
 
## Both exposed credentials are live
 
The account password is reusable and sits in two script-readable places, so it is
the larger blast radius. But the eaccess key is not the spent artifact it might
look like: it remains valid for a period after issue, so `@launch_data` is holding
a working credential for the rest of the session, not a receipt. Reviewers should
treat both as live.
 
Checked while tracing this: nothing writes `@launch_data` or a raw `ARGV` to the
log file. `main.rb:323` already logs a scrubbed `launcher_cmd`, and the many
`ARGV.include?("--debug")` call sites are flag checks that this change leaves
intact. So the exposure is script-level and process-memory-level, not log-level.
 
## `game_key` is hardening, not a hole
 
`game_key` is a block-local in the `@main_thread` closure. Locals in a required
file are not present in `TOPLEVEL_BINDING.local_variables`, so a script binding
cannot reach it. The two `game_key = nil` additions shorten how long a live key
sits in memory; they do not close an access path. Worth doing precisely because
the key does not expire at login, but do not review this as a hole closure.
Placement:
 
- once after the `client_thread` branch chain closes, rather than in each branch.
  Same thread as the mudlet send at `main.rb:631`, so there is no race on the
  shared local.
- once on the `$offline_mode` early return, which `next nil` would otherwise skip.
## Reconnect regression trap
 
`reconnect_if_wanted` does `args.concat ARGV` then `exec` (`main.rb:36`).
Redacting `--password=` in place would have silently broken `--reconnect --login`,
because the re-exec'd process would authenticate with `[scrubbed]`.
 
Resolved by snapshotting `ARGV.dup` into a `main.rb` top-level local before the
scrub and pointing the proc's four ARGV reads at the snapshot. Locals in a
required file are not script-reachable, so the snapshot does not reopen the hole
the scrub closes.
 
The scrub preserves flag prefixes and overwrites only values, so
`ARGV.include?('--without-frontend')` at `main.rb:539` and the other flag checks
behave identically.
 
## `.sal` removal
 
`CredentialScrub.shred_file` overwrites with nulls, `fsync`s, then deletes with a
bounded retry, and never raises. Three improvements over the previous code:
 
- the timeout-path `File.delete` had no `rescue` and could raise
- Windows refuses deletion while the spawned frontend still holds the handle,
  hence the retry
- an `at_exit` backstop registers immediately after the file is written, so an
  exception between write and the normal removal cannot leave the key in
  `TEMP_DIR`
`at_exit` does not run through `exec`, but the normal removal already precedes
`reconnect_if_wanted.call` on both paths.
 
Overwrite-then-delete is best effort. Copy-on-write filesystems, journaling, and
flash translation layers may retain the original blocks. Documented in the module.
This matters more than it would for a spent key, since a `.sal` file recovered
from disk after the fact may still contain a usable credential.
 
## Design decisions worth a reviewer's opinion
 
- **`--account=` is left alone.** It is an account identifier, not a credential.
  One entry in `ARGV_SECRET` if you disagree.
- **New file rather than inline in `main.rb`.** `main.rb` has no unit seam, and
  specs are mandatory; this keeps `main.rb` to five one-line call sites. It
  follows the existing small-focused-module pattern (`bind_host_resolver.rb`,
  `shutdown_intent.rb`).
- **In-place `String#replace` with a `FrozenError` fallback**, so the login GUI's
  reference to the same launch data array loses the secret too, rather than being
  left pointing at an unscrubbed copy.
## Not fixed
 
The key still reaches the frontend's argv via `launcher_cmd` (`main.rb:322` into
`spawn`), so it is visible to `ps` and Task Manager for as long as the frontend
runs. That is how the Simutronics frontends accept a key and is not fixable on our
side. Given the key stays valid after login, this is the largest remaining
exposure, and it is worth tracking as a separate issue rather than being quietly
accepted.
 
## Files
 
- `lib/common/credential_scrub.rb` (new, 162 lines)
- `spec/lib/common/credential_scrub_spec.rb` (new, 25 examples)
- `lib/main/main.rb` (+43 / -9)
## Verification
 
- `ruby -c` clean on all three files
- non-ASCII scan: zero lines across all three files
- `rspec`: 48 examples, 0 failures across `credential_scrub_spec`,
  `launch_data_spec`, and `limitedarray_spec`
Two caveats from my environment. RuboCop could not run locally, so the one thing
to watch in CI is `Lint/UselessAssignment` on the new `game_key = nil` lines; the
identical pattern already exists at `main.rb:632` and passes today.
`session_launcher_spec.rb` fails to load in my sandbox through the
`account_manager_ui.rb` GTK require chain, and I confirmed that failure is
identical on the unmodified tree.
 
## Manual checks requested
 
Startup paths I could not exercise without a live login:
 
- [ ] GUI login, Wizard or Wrayth frontend
- [ ] `--login` with `--password=` on the command line, then confirm
      `ARGV.join(' ')` in a script shows `--password=[scrubbed]`
- [ ] `--reconnect --login`, confirm reconnect still authenticates
- [ ] `--without-frontend`
- [ ] `--sal` launch from SGE
- [ ] mudlet, confirm the login key still sends


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added credential redaction during startup to prevent passwords and master passwords from remaining in launch data, command-line arguments, or options.
  * Temporary launch files are securely overwritten and removed after connection attempts, including when connections time out.
  * Login credentials are cleared after transmission or when offline mode is used.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->