### PR TITLE
feat(all): teardown and distinguishable errors for Script.run_child

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -348,6 +348,21 @@ module Lich
 
       class JumpError < StandardError; end
       class LibraryJoinTimeout < LoadError; end
+
+      # Raised when a script cannot be started (shutdown in progress,
+      # duplicate name, or launch failure).
+      class StartError < StandardError; end
+
+      # Raised when a supervised script outlives its timeout. The script has
+      # already been torn down (kill_sync) by the time this raises.
+      class TimeoutError < StandardError
+        attr_reader :script
+
+        def initialize(script)
+          @script = script
+          super("script timed out: #{script.name}")
+        end
+      end
       JUMP = JumpError.exception('JUMP')
       JUMP_ERROR = JumpError.exception('JUMP_ERROR')
 
@@ -966,16 +981,29 @@ module Lich
 
       # Starts a child script and waits for it to finish.
       #
+      # The returned script has always terminated: inspect
+      # {#completed_successfully?} / {#exit_error} to distinguish success from
+      # a crash. Startup refusal and timeout raise instead of overloading the
+      # return value, and a timed-out child is torn down before the raise, so
+      # no unsupervised child ever survives this call.
+      #
       # @param timeout [Numeric, nil] maximum seconds to wait, or nil to wait indefinitely
-      # @return [Script, nil] the completed child, or nil on startup failure or timeout
+      # @return [Script] the terminated child
       # @raise [ArgumentError] when the timeout is negative, before the child starts
+      # @raise [StartError] when the child cannot be started
+      # @raise [TimeoutError] when the child outlives the timeout, after its teardown
       def Script.run_child(*args, timeout: nil)
         raise ArgumentError, 'timeout must be non-negative' if timeout && timeout.negative?
 
         child = Script.start_child(*args)
-        return nil unless child
+        unless child
+          name = args.first.is_a?(Hash) ? args.first[:name] : args.first
+          raise StartError, "script failed to start: #{name}"
+        end
+        return child if child.join(timeout)
 
-        child.join(timeout) ? child : nil
+        child.kill_sync
+        raise TimeoutError.new(child)
       end
 
       # Marks the current script as hidden and protected from kill-all and

--- a/spec/lib/common/script_lifecycle_spec.rb
+++ b/spec/lib/common/script_lifecycle_spec.rb
@@ -565,12 +565,25 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.run_child('child')).to equal(child)
     end
 
-    it 'applies an explicit Script.run_child timeout' do
+    it 'tears down and raises when the Script.run_child timeout expires' do
       child = build_script('child')
       allow(script_class).to receive(:start_child).with('child').and_return(child)
       expect(child).to receive(:join).with(0.25).and_return(nil)
+      expect(child).to receive(:kill_sync)
 
-      expect(script_class.run_child('child', :timeout => 0.25)).to be_nil
+      expect {
+        script_class.run_child('child', :timeout => 0.25)
+      }.to raise_error(script_class::TimeoutError) { |error|
+        expect(error.script).to equal(child)
+      }
+    end
+
+    it 'raises when a Script.run_child child cannot be started' do
+      allow(script_class).to receive(:start_child).with('child').and_return(nil)
+
+      expect {
+        script_class.run_child('child')
+      }.to raise_error(script_class::StartError, /script failed to start: child/)
     end
 
     it 'rejects a negative Script.run_child timeout before starting the child' do
@@ -1073,11 +1086,13 @@ RSpec.describe 'Lich::Common::Script lifecycle extensions' do
       expect(script_class.run_child('worker')).to equal(child)
     end
 
-    it 'returns nil when run_child teardown times out' do
-      child = instance_double(script_class, :join => nil)
+    it 'tears down and raises when run_child teardown times out' do
+      child = instance_double(script_class, :join => nil, :name => 'worker')
+      allow(child).to receive(:kill_sync)
       allow(script_class).to receive(:start_child).with('worker').and_return(child)
 
-      expect(script_class.run_child('worker')).to be_nil
+      expect { script_class.run_child('worker') }.to raise_error(script_class::TimeoutError)
+      expect(child).to have_received(:kill_sync)
     end
 
     it 'waits for exit handlers in kill_sync' do


### PR DESCRIPTION
Follow-up to the supervised child script API (#1474–#1479).

`Script.run_child` previously overloaded `nil` across two outcomes with opposite liveness — "never started" (nothing running) and "timed out" (a live child the caller now unknowingly owns) — and a returned script still required knowing to inspect exit state. A field incident (a helper script that outlived its supervisor's patience and kept manipulating the character's hands) motivated tightening the contract.

New contract:

- **Timeout tears the child down**: on `join` timeout the child is `kill_sync`ed before `Script::TimeoutError` (carrying the script via `#script`) is raised — no unsupervised child ever survives the call.
- **Startup refusal raises** `Script::StartError` instead of returning `nil`.
- **A returned script has always terminated**; callers distinguish success from crash via `completed_successfully?` / `exit_error`.
- Negative timeouts still raise `ArgumentError` before the child starts.

The error classes are deliberately generic (`StartError` / `TimeoutError`, not child-specific) so future supervision APIs can reuse them.

There are no in-repo callers besides the definition; external callers that invoke `run_child` without a timeout only see startup refusal change from a (typically ignored) `nil` to a raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMEQExmjRiUdtWvbVPH9XD
