### PR TITLE
fix(all): bound EAccess auth with a timeout so a stalled SGE backend can't hang Lich silently

### DIFF
--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -36,7 +36,7 @@ module Lich
       def self.authenticate(account:, password:, character: nil, game_code: nil, legacy: false, generator: false)
         with_retry do
           if game_code && (character || generator)
-            EAccess.auth(
+            EAccess.auth_with_timeout(
               account: account,
               password: password,
               character: character,
@@ -44,13 +44,13 @@ module Lich
               generator: generator
             )
           elsif legacy
-            EAccess.auth(
+            EAccess.auth_with_timeout(
               account: account,
               password: password,
               legacy: true
             )
           else
-            EAccess.auth(
+            EAccess.auth_with_timeout(
               account: account,
               password: password
             )

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -232,6 +232,35 @@ module Lich
         def self.read(conn)
           conn.sysread(PACKET_SIZE)
         end
+
+        # Bounds how long the full SGE authentication exchange may block.
+        #
+        # {.auth} has no connect or read timeouts of its own -- every step (TCP
+        # connect, TLS handshake, and each K/A/M/F/G/P/C/L round-trip) is a bare
+        # blocking call. An unresponsive SGE backend (e.g. a stalled connect that
+        # never gets a SYN-ACK) hangs the caller indefinitely with no exception
+        # and no log output. This wraps the whole exchange the same way
+        # {Lich::GameBase::Game.open_with_timeout} bounds the game connect.
+        #
+        # @param timeout [Integer, Float] seconds to wait for the full exchange
+        # @param kwargs [Hash] forwarded to {.auth}
+        # @return [Hash, Array] see {.auth}
+        # @raise [RuntimeError] if the exchange does not complete within +timeout+
+        # @raise [StandardError] re-raises whatever {.auth} raises
+        # @see .auth
+        def self.auth_with_timeout(timeout: 30, **kwargs)
+          auth_thread = Thread.new {
+            # report_on_exception off: a failed auth is surfaced by the join below
+            # (which re-raises it), not by an auto-printed thread warning.
+            Thread.current.report_on_exception = false
+            auth(**kwargs)
+          }
+          if auth_thread.join(timeout).nil?
+            auth_thread.kill rescue nil
+            raise "error: timed out authenticating with EAccess after #{timeout}s"
+          end
+          auth_thread.value
+        end
       end
     end
   end

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -270,4 +270,30 @@ RSpec.describe Lich::Common::Authentication::EAccess do
       end
     end
   end
+
+  describe '.auth_with_timeout' do
+    it 'returns the result when auth succeeds' do
+      allow(described_class).to receive(:auth).and_return({ 'key' => 'abc' })
+
+      result = described_class.auth_with_timeout(timeout: 1, account: 'ACCT', password: 'pass')
+
+      expect(result).to eq({ 'key' => 'abc' })
+    end
+
+    it 'raises when auth does not finish within the timeout' do
+      allow(described_class).to receive(:auth) { sleep 5 } # hangs past the timeout, e.g. an unresponsive SGE backend
+
+      expect {
+        described_class.auth_with_timeout(timeout: 0.3, account: 'ACCT', password: 'pass')
+      }.to raise_error(/timed out/)
+    end
+
+    it 're-raises whatever auth raises' do
+      allow(described_class).to receive(:auth).and_raise(described_class::AuthenticationError.new('REJECT'))
+
+      expect {
+        described_class.auth_with_timeout(timeout: 1, account: 'ACCT', password: 'pass')
+      }.to raise_error(described_class::AuthenticationError, /REJECT/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

While debugging a `--detachable-client` hang (process alive, no crash, no log output past character resolution, no listener ever opened), I traced it to `EAccess.auth`: the TCP connect, TLS handshake, and every K/A/M/F/G/P/C/L round-trip in the SGE protocol exchange are bare blocking calls with no connect or read timeout anywhere. In this instance the SGE backend itself was unreachable (confirmed via `lsof` showing the socket stuck in `SYN_SENT`, and a bare `/dev/tcp` connect from the same host independently timing out on port 7910 while other outbound traffic worked fine) — but regardless of cause, Lich has no way to surface that: the thread just blocks forever, silently.

This is the same failure mode `Game.open_with_timeout` already guards against for the *game* connection (`lib/games.rb`) — the SGE connection just never got the same treatment.

## Changes

- **`EAccess.auth_with_timeout`** (`lib/common/authentication/eaccess.rb`) — wraps `EAccess.auth` in the same `Thread.new { }.join(timeout)` pattern as `Game.open_with_timeout`, defaulting to 30s. Re-raises whatever `auth` raises; raises a clear "timed out authenticating with EAccess after Ns" on timeout. Killing the thread on timeout still runs `auth`'s `ensure`, so the stuck socket gets closed instead of leaked.
- **`authenticator.rb`** — its three `EAccess.auth(...)` call sites now call `EAccess.auth_with_timeout(...)` instead, so a stuck auth flows through the existing retry/backoff/logging path (`with_retry`, `MAX_AUTH_RETRIES`) instead of hanging silently.

## Testing

- New specs in `eaccess_spec.rb` for `.auth_with_timeout` (success passthrough, timeout raises, exception passthrough), written and confirmed failing before implementing.
- Existing `authenticator_spec.rb` specs (which stub `EAccess.auth`) needed no changes — the stub is visible inside the wrapper thread since it's a singleton-method redefinition.
- Full suite: `bundle exec rspec` — 5521 examples, 0 failures.
- `rubocop` on all touched files: no offenses.

## Test plan

- [x] Point `--login` at an account while the SGE backend is unreachable/unresponsive; confirm Lich now logs a timeout error and exits/retries instead of hanging with no listener ever opening.
- [x] Normal login still succeeds and behaves identically under normal network conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now enforces a timeout across supported authentication methods.
  * Expired authentication attempts fail with a timeout error instead of waiting indefinitely.
  * Authentication errors continue to be reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->