### PR TITLE
fix(dr): Refine need_buffs? logic for non-recast spells to correctly check cyclic spells.

### DIFF
--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -316,8 +316,8 @@ module Lich
         else
           # for MUs check list of required buffs against list of active spells and their durations/recast
           buff_list.each do |spell, data|
-            # ignore spells which don't recast (ignite, etf, etc.)
-            next if data['recast'] < 0
+            # ignore spells which don't recast (ignite, etf, etc.) but not cyclics
+            next if data['recast'] < 0 && !data['cyclic']
             # if any buff is not in the active spells, or whose duration is less than recast, need to buff
             return true if !DRSpells.active_spells.key?(spell) || DRSpells.active_spells[spell] <= (data['recast'] ? data['recast'] : 1)
           end


### PR DESCRIPTION
Updated logic to ignore non-recast spells only if they are not cyclic.