### PR TITLE
fix(dr): reduce symbol-torn scale scrolls to gettable noun

### DIFF
--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -332,6 +332,7 @@ module Lich
           entry
             .sub(/(an|some|a(?: piece of)?)\s/, '')
             .sub(/\slabeled with.*/, '')
+            .sub(/large midnight-blue scale torn with symbols/, 'midnight-blue scale')
             .sub(/icy blue vellum scroll/, 'icy scroll')
             .sub(/green vellum scroll/, 'green scroll')
             .sub(/fetid antelope vellum/, 'antelope vellum')


### PR DESCRIPTION
## Problem

Scrolls described as `large midnight-blue scale torn with symbols` are returned by `rummage /SC` (they are scroll-type items), but `DRC.scroll_list_to_adj_and_noun` has no rewrite rule for this description shape. The full multi-word description therefore passes through unchanged, and the caller's follow-up `get` uses it verbatim (`get my large midnight-blue scale torn with symbols from my pack`) instead of a gettable noun. `get_noun` doesn't help either — it would reduce the string to `torn` (the last word after flavor-stripping), not the actual noun.

## Fix

Add one literal rewrite to the existing chain, mapping the description to its gettable form `midnight-blue scale`. This matches the style of the surrounding rules (`icy blue vellum scroll` → `icy scroll`, `pallid red scroll` → `pallid scroll`, etc.) — no capture/replace, just a specific substitution.

```ruby
.sub(/large midnight-blue scale torn with symbols/, 'midnight-blue scale')
```

## Tests

`rubocop lib/dragonrealms/commons/common.rb` — 1 file inspected, no offenses. Per the change author, no spec is included for this one-line literal substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)