### PR TITLE
feat(dr): user-extensible flavor-text stripping (05 of 06)

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -27,6 +27,8 @@
 # @see DRC Core common module
 # @see EquipmentManager Higher-level gear management
 
+require_relative '../custom_substitutions'
+
 module Lich
   module DragonRealms
     module DRCI
@@ -52,7 +54,21 @@ module Lich
       end
 
       ## How to add new trash receptacles https://github.com/elanthia-online/dr-scripts/wiki/Adding-new-trash-receptacles
+      # Default trash-receptacle nouns. Players extend this at runtime via the
+      # +custom_trash_storage+ setting; see {trash_storage} and
+      # {Lich::DragonRealms::CustomSubstitutions}.
       TRASH_STORAGE = %w[arms barrel basin basket bin birdbath bucket chamberpot gloop hole log puddle statue stump tangle tree turtle urn gelapod].freeze
+
+      # Recognized trash-receptacle nouns: the built-in {TRASH_STORAGE} defaults
+      # merged with the player's +custom_trash_storage+ additions. Lets a player
+      # teach {dispose_trash} about a receptacle their town has that Lich does
+      # not yet know, without a Lich release.
+      #
+      # @return [Array<String>] recognized trash-receptacle nouns
+      # @see CustomSubstitutions.resolve
+      def trash_storage
+        CustomSubstitutions.resolve(:custom_trash_storage, TRASH_STORAGE, type: :names)
+      end
 
       DROP_TRASH_SUCCESS_PATTERNS = [
         /^You drop/,
@@ -688,10 +704,11 @@ module Lich
           end
         end
 
+        recognized_trash = trash_storage
         trashcans = DRRoom.room_objs
                           .reject { |obj| obj =~ /azure \w+ tree/ }
                           .map { |long_name| DRC.get_noun(long_name) }
-                          .select { |obj| TRASH_STORAGE.include?(obj) }
+                          .select { |obj| recognized_trash.include?(obj) }
 
         trashcans.each do |trashcan|
           if trashcan == 'gloop'

--- a/lib/dragonrealms/commons/common-summoning.rb
+++ b/lib/dragonrealms/commons/common-summoning.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../custom_substitutions'
+
 module Lich
   module DragonRealms
     module DRCS
@@ -123,11 +125,14 @@ module Lich
             # aren't recognized for shaping summoned elemental weapons, and the error message
             # itself is misleading. Breaking, turning, pulling, pushing work fine with custom adj.
             unless summoned_weapon.nil?
-              adj = settings&.summoned_weapons_adjective || ''
-              retry_result = DRC.bput("shape my #{summoned_weapon.sub(adj, '')} to #{skill}", *WM_SHAPE_FAILURES)
+              # Strip whichever custom adjective is on the weapon so the game
+              # recognizes the base weapon for shaping.
+              present_adjective = custom_summoned_weapon_adjectives(settings).find { |adjective| summoned_weapon.include?(adjective) }
+              base_weapon = present_adjective ? summoned_weapon.sub(present_adjective, '') : summoned_weapon
+              retry_result = DRC.bput("shape my #{base_weapon} to #{skill}", *WM_SHAPE_FAILURES)
               if retry_result == LACK_CHARGE
                 summon_admittance
-                DRC.bput("shape my #{summoned_weapon.sub(adj, '')} to #{skill}", *WM_SHAPE_FAILURES)
+                DRC.bput("shape my #{base_weapon} to #{skill}", *WM_SHAPE_FAILURES)
               end
             end
           end
@@ -139,16 +144,35 @@ module Lich
         waitrt?
       end
 
+      # Player-defined summoned-weapon adjectives (e.g. from Books of Binding
+      # tomes), merged and validated. Combines the plural
+      # +custom_summoned_weapons_adjectives+ list with the legacy singular
+      # +summoned_weapons_adjective+ setting (kept for backward compatibility).
+      # The built-in {WM_ELEMENT_ADJECTIVES} are NOT included here -- callers add
+      # those where needed.
+      #
+      # @param settings [OpenStruct, nil] user settings (for the legacy key)
+      # @return [Array<String>] validated custom adjectives
+      # @see CustomSubstitutions.resolve
+      def custom_summoned_weapon_adjectives(settings = nil)
+        # dup: never mutate CustomSubstitutions' memoized array when adding legacy.
+        adjectives = CustomSubstitutions.resolve(:custom_summoned_weapons_adjectives, [], type: :names).dup
+        legacy = settings&.summoned_weapons_adjective
+        adjectives << legacy if legacy.is_a?(String) && !legacy.empty? && !adjectives.include?(legacy)
+        adjectives
+      end
+
       # Returns what kind of summoned weapon you're holding.
       # Will be the <adj> <noun> like 'red-hot moonblade' or 'electric sword'.
+      # Recognizes {WM_ELEMENT_ADJECTIVES} plus any player-defined adjectives
+      # ({custom_summoned_weapon_adjectives}).
       def identify_summoned_weapon(settings = nil)
         if DRStats.moon_mage?
           return DRC.right_hand if DRCMM.is_moon_weapon?(DRC.right_hand)
           return DRC.left_hand  if DRCMM.is_moon_weapon?(DRC.left_hand)
         elsif DRStats.warrior_mage?
-          custom_adjective = settings&.summoned_weapons_adjective ? "#{settings.summoned_weapons_adjective}|" : ''
-          adjectives = WM_ELEMENT_ADJECTIVES.join('|')
-          weapon_regex = /^You tap (?:a|an|some)(?:[\w\s\-]+)(?:(?:#{custom_adjective}#{adjectives}) [\w\s\-]+) that you are holding\.$/
+          adjectives = (WM_ELEMENT_ADJECTIVES + custom_summoned_weapon_adjectives(settings)).map { |adjective| Regexp.escape(adjective) }.join('|')
+          weapon_regex = /^You tap (?:a|an|some)(?:[\w\s\-]+)(?:(?:#{adjectives}) [\w\s\-]+) that you are holding\.$/
           # For a two-worded weapon like 'short sword' the only way to know
           # which element it was summoned with is by tapping it. That's the only
           # way we can infer if it's a summoned sword or a regular one.

--- a/lib/dragonrealms/commons/common-summoning.rb
+++ b/lib/dragonrealms/commons/common-summoning.rb
@@ -125,10 +125,7 @@ module Lich
             # aren't recognized for shaping summoned elemental weapons, and the error message
             # itself is misleading. Breaking, turning, pulling, pushing work fine with custom adj.
             unless summoned_weapon.nil?
-              # Strip whichever custom adjective is on the weapon so the game
-              # recognizes the base weapon for shaping.
-              present_adjective = custom_summoned_weapon_adjectives(settings).find { |adjective| summoned_weapon.include?(adjective) }
-              base_weapon = present_adjective ? summoned_weapon.sub(present_adjective, '') : summoned_weapon
+              base_weapon = base_summoned_weapon(summoned_weapon, settings)
               retry_result = DRC.bput("shape my #{base_weapon} to #{skill}", *WM_SHAPE_FAILURES)
               if retry_result == LACK_CHARGE
                 summon_admittance
@@ -160,6 +157,23 @@ module Lich
         legacy = settings&.summoned_weapons_adjective
         adjectives << legacy if legacy.is_a?(String) && !legacy.empty? && !adjectives.include?(legacy)
         adjectives
+      end
+
+      # Strips the summoned weapon's custom element adjective so the game
+      # recognizes the base weapon for shaping (custom Books-of-Binding
+      # adjectives aren't accepted by SHAPE).
+      #
+      # Picks the LONGEST matching adjective, not the first: with a substring
+      # pair like ['flame', 'flamewreathed'] a first-match would strip 'flame'
+      # from "flamewreathed sword" and leave a bogus "wreathed sword".
+      #
+      # @param summoned_weapon [String] the held weapon's <adj> <noun>
+      # @param settings [OpenStruct, nil] user settings (for the legacy key)
+      # @return [String] the weapon with its custom adjective removed (if any)
+      # @see #custom_summoned_weapon_adjectives
+      def base_summoned_weapon(summoned_weapon, settings = nil)
+        present = custom_summoned_weapon_adjectives(settings).select { |adjective| summoned_weapon.include?(adjective) }.max_by(&:length)
+        present ? summoned_weapon.sub(present, '') : summoned_weapon
       end
 
       # Returns what kind of summoned weapon you're holding.

--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../custom_substitutions'
+
 module Lich
   module DragonRealms
     module DRC
@@ -327,32 +329,76 @@ module Lich
             .map { |box| box.gsub('ironwood', 'iron') } # make all ironwood into iron because "the parser"
       end
 
+      # Item-specific scroll rewrites applied *before* {SCROLL_KEYWORD_COLLAPSE}.
+      # These full game descriptions contain keywords the collapse would
+      # otherwise mangle (e.g. "icy blue vellum scroll" -> "icy scroll", not
+      # "icy blue vellum"), or must be caught before the collapse can run.
+      # Order matters and is preserved. Players extend this list via the
+      # +custom_scroll_substitutions+ setting; see
+      # {scroll_list_to_adj_and_noun}.
+      #
+      # @return [Array<Array(String, String)>] ordered [from, to] literal pairs
+      DEFAULT_SCROLL_SUBSTITUTIONS_PRE = [
+        ['large midnight-blue scale torn with symbols', 'midnight-blue scale'],
+        ['icy blue vellum scroll', 'icy scroll'],
+        ['green vellum scroll', 'green scroll'],
+        ['fetid antelope vellum', 'antelope vellum'],
+        ['papyrus roll', 'papyrus.roll'],
+        ['pallid red scroll', 'pallid scroll']
+      ].freeze
+
+      # Adjective-pair scroll rewrites applied *after* {SCROLL_KEYWORD_COLLAPSE},
+      # reducing already-collapsed forms (e.g. "stormy grey" -> "stormy"). Order
+      # matters and is preserved. Not player-extensible (these operate on the
+      # collapsed noun, not the raw description).
+      #
+      # @return [Array<Array(String, String)>] ordered [from, to] literal pairs
+      DEFAULT_SCROLL_SUBSTITUTIONS_POST = [
+        ['crumpled paper', 'crumpled'],
+        ['pale ricepaper', 'pale'],
+        ['stormy grey', 'stormy'],
+        ['mossy green', 'mossy'],
+        ['dark purple', 'dark'],
+        ['vibrant red', 'vibrant'],
+        ['bright green', 'bright'],
+        ['icy blue', 'blue'],
+        ['pearl-white silk', 'silk'],
+        ['ghostly white', 'white'],
+        ['crinkled violet', 'crinkled'],
+        ['drawing paper', 'drawing']
+      ].freeze
+
+      # Structural collapse: reduce "<adj> <keyword> <flavor...>" to "<adj>
+      # <keyword>" by keeping the noun keyword and dropping trailing flavor.
+      # Sandwiched between the pre and post substitution passes.
+      #
+      # @return [Regexp]
+      SCROLL_KEYWORD_COLLAPSE = /\s(bark|leaf|ostracon|papyrus|parchment|roll|scroll|tablet|vellum|manuscript)\s.*/.freeze
+
+      # Converts a game rummage scroll list into gettable adjective+noun forms.
+      #
+      # Pipeline per entry: strip the leading article, strip "labeled with...",
+      # apply the pre-collapse literal substitutions ({DEFAULT_SCROLL_SUBSTITUTIONS_PRE}
+      # merged with the player's +custom_scroll_substitutions+), apply the
+      # {SCROLL_KEYWORD_COLLAPSE}, then apply the post-collapse substitutions
+      # ({DEFAULT_SCROLL_SUBSTITUTIONS_POST}).
+      #
+      # @param list [String] game-formatted scroll list (e.g. from rummage /SC)
+      # @return [Array<String>] gettable scroll names
+      # @example
+      #   scroll_list_to_adj_and_noun(' an icy blue parchment') #=> ['blue parchment']
+      # @see CustomSubstitutions.resolve
+      # @see #box_list_to_adj_and_noun
       def scroll_list_to_adj_and_noun(list)
-        list_to_array(list).map { |entry|
-          entry
-            .sub(/(an|some|a(?: piece of)?)\s/, '')
-            .sub(/\slabeled with.*/, '')
-            .sub(/large midnight-blue scale torn with symbols/, 'midnight-blue scale')
-            .sub(/icy blue vellum scroll/, 'icy scroll')
-            .sub(/green vellum scroll/, 'green scroll')
-            .sub(/fetid antelope vellum/, 'antelope vellum')
-            .sub(/papyrus roll/, 'papyrus.roll')
-            .sub(/pallid red scroll/, 'pallid scroll')
-            .sub(/\s(bark|leaf|ostracon|papyrus|parchment|roll|scroll|tablet|vellum|manuscript)\s.*/, ' \1')
-            .sub(/crumpled paper/, 'crumpled')
-            .sub(/pale ricepaper/, 'pale')
-            .sub(/stormy grey/, 'stormy')
-            .sub(/mossy green/, 'mossy')
-            .sub(/dark purple/, 'dark')
-            .sub(/vibrant red/, 'vibrant')
-            .sub(/bright green/, 'bright')
-            .sub(/icy blue/, 'blue')
-            .sub(/pearl-white silk/, 'silk')
-            .sub(/ghostly white/, 'white')
-            .sub(/crinkled violet/, 'crinkled')
-            .sub(/drawing paper/, 'drawing')
-            .strip
-        }
+        pre_substitutions = CustomSubstitutions.resolve(:custom_scroll_substitutions, DEFAULT_SCROLL_SUBSTITUTIONS_PRE, type: :pairs)
+        list_to_array(list).map do |entry|
+          without_article = entry
+                            .sub(/(an|some|a(?: piece of)?)\s/, '')
+                            .sub(/\slabeled with.*/, '')
+          with_pre = pre_substitutions.reduce(without_article) { |text, (from, to)| text.sub(from, to) }
+          collapsed = with_pre.sub(SCROLL_KEYWORD_COLLAPSE, ' \1')
+          DEFAULT_SCROLL_SUBSTITUTIONS_POST.reduce(collapsed) { |text, (from, to)| text.sub(from, to) }.strip
+        end
       end
 
       # Take a game formatted list "an arrow, silver coins and a deobar strongbox"

--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -319,14 +319,41 @@ module Lich
         list.strip.split(/(?:,|(?:, |\s)?and\s?)(?:\s?<pushBold\/>\s?)?(?=\s\ba\b|\s\ban\b|\s\bsome\b|\s\bthe\b)/i).reject(&:empty?)
       end
 
-      # Take a game formated list of boxes "a reinforced wooden strongbox and a plain ironwood crate"
-      # And return an array ["wooden strongbox", "ironwood crate"]
+      # Post-match box name rewrites (applied via gsub after a box is matched).
+      # "ironwood" -> "iron" because the game parser wants the shortened noun.
+      # Players extend this via the +custom_box_substitutions+ setting; see
+      # {box_list_to_adj_and_noun}.
+      #
+      # @return [Array<Array(String, String)>] ordered [from, to] literal pairs
+      DEFAULT_BOX_SUBSTITUTIONS = [%w[ironwood iron]].freeze
+
+      # Take a game formatted list of boxes "a reinforced wooden strongbox and a
+      # plain ironwood crate" and return ["wooden strongbox", "iron crate"].
+      #
+      # The recognized wood and container words are {BOX_WOODS} and
+      # {BOX_CONTAINERS} merged with the player's +custom_box_woods+ /
+      # +custom_box_containers+ settings, so a player can teach Lich about a box
+      # material or container it does not yet know without a Lich release. The
+      # global +$box_regex+ (built from the same defaults) is left untouched for
+      # third-party scripts. Post-match rewrites come from
+      # {DEFAULT_BOX_SUBSTITUTIONS} merged with +custom_box_substitutions+.
+      #
+      # @param list [String] game-formatted box list (e.g. from rummage /B)
+      # @return [Array<String>] gettable box adjective+noun names
+      # @example
+      #   box_list_to_adj_and_noun('an ironwood crate') #=> ['iron crate']
+      # @see CustomSubstitutions.resolve
+      # @see #scroll_list_to_adj_and_noun
       def box_list_to_adj_and_noun(list)
+        woods = CustomSubstitutions.resolve(:custom_box_woods, BOX_WOODS, type: :names)
+        containers = CustomSubstitutions.resolve(:custom_box_containers, BOX_CONTAINERS, type: :names)
+        substitutions = CustomSubstitutions.resolve(:custom_box_substitutions, DEFAULT_BOX_SUBSTITUTIONS, type: :pairs)
+        box_regex = /((?:#{woods.map { |wood| Regexp.escape(wood) }.join('|')}) (?:#{containers.map { |container| Regexp.escape(container) }.join('|')}))/
         list.strip
-            .split($box_regex)
+            .split(box_regex)
             .reject(&:empty?)
-            .select { |item| item =~ $box_regex }
-            .map { |box| box.gsub('ironwood', 'iron') } # make all ironwood into iron because "the parser"
+            .select { |item| item =~ box_regex }
+            .map { |box| substitutions.reduce(box) { |current, (from, to)| current.gsub(from, to) } }
       end
 
       # Item-specific scroll rewrites applied *before* {SCROLL_KEYWORD_COLLAPSE}.

--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -441,8 +441,25 @@ module Lich
         remove_flavor_text(long_name).strip.scan(/[a-z\-']+$/i).first
       end
 
+      # Strips descriptive flavor text ("... adorned with ...") from an item
+      # name, leaving the gettable noun phrase.
+      #
+      # Applies the built-in {FLAVOR_TEXT_PATTERN} first, then any player-defined
+      # +custom_flavor_text_patterns+ (regular expressions) for flavor the
+      # built-in pattern misses -- letting a player strip a new flavor phrasing
+      # without a Lich release. User patterns are compiled with a per-pattern
+      # timeout and validated/guarded by {CustomSubstitutions}; an invalid or
+      # runaway pattern is reported and skipped, never raising here.
+      #
+      # @param item [String] the item long name
+      # @return [String] the item name with flavor text removed
+      # @example
+      #   remove_flavor_text('a sword adorned with rubies of deep crimson') #=> 'a sword'
+      # @see CustomSubstitutions.resolve
+      # @see CustomSubstitutions.apply_regexes
       def remove_flavor_text(item)
-        item.sub(FLAVOR_TEXT_PATTERN, '')
+        custom_patterns = CustomSubstitutions.resolve(:custom_flavor_text_patterns, [], type: :regexes)
+        CustomSubstitutions.apply_regexes(item.sub(FLAVOR_TEXT_PATTERN, ''), custom_patterns)
       end
 
       # Items class. Name is the noun of the object. Leather/metal boolean. Is the item worn (defaults to true). Does it hinder lockpicking? (false)

--- a/lib/dragonrealms/custom_substitutions.rb
+++ b/lib/dragonrealms/custom_substitutions.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+module Lich
+  module DragonRealms
+    # Merges a player's own substitution/normalization entries (from their
+    # character settings) on top of core Lich's built-in defaults, so a player
+    # can teach Lich about their own problematic scrolls, creatures, boxes, etc.
+    # without waiting for a Lich release.
+    #
+    # Core Lich keeps the authoritative default lists as frozen constants; those
+    # are passed in as +defaults+ and are also the fallback when no dr-scripts /
+    # no user additions are present. Only the user's *additions* are read from
+    # settings and validated here -- defaults are trusted.
+    #
+    # Every user entry is validated *before* it is merged. Invalid entries are
+    # dropped individually (lenient per-entry: one bad entry never disables the
+    # rest) and each rejection is reported to the player through
+    # {Lich::Messaging} with the exact key, index, offending value, reason, and
+    # consequence, so they understand precisely what happened and why.
+    #
+    # Results are memoized per settings key (built once, on first use) so hot
+    # parse paths do not repeatedly call +get_settings+ or recompile regexes.
+    # Call {reset!} to rebuild after a settings reload.
+    #
+    # @example Merge user scroll rewrites on top of the built-in defaults
+    #   pre = Lich::DragonRealms::CustomSubstitutions.resolve(
+    #     :custom_scroll_substitutions,
+    #     Lich::DragonRealms::DRC::DEFAULT_SCROLL_SUBSTITUTIONS_PRE,
+    #     type: :pairs
+    #   )
+    #   pre.reduce(entry) { |text, (from, to)| text.sub(from, to) }
+    #
+    # @see DRC.scroll_list_to_adj_and_noun
+    module CustomSubstitutions
+      # Prefix on every player-facing message so the source is unambiguous.
+      MESSAGE_PREFIX = '[CustomSubstitutions]'
+
+      # Per-regex evaluation budget (seconds) applied to every user-supplied
+      # pattern, so a pathological (catastrophic-backtracking) pattern raises
+      # {Regexp::TimeoutError} instead of hanging Lich. See {apply_regexes}.
+      REGEX_TIMEOUT_SECONDS = 1.0
+
+      # Supported validation shapes, dispatched on by {resolve} and
+      # {validate_entry}:
+      # - +:pairs+   -- +[from, to]+ literal String substitution pairs
+      # - +:names+   -- bare canonical-name Strings
+      # - +:regexes+ -- regular-expression Strings (or pre-compiled Regexps)
+      SUPPORTED_TYPES = %i[pairs names regexes].freeze
+
+      class << self
+        # Returns +defaults+ merged with the validated user additions found at
+        # +key+ in the player's settings, deduplicated and memoized.
+        #
+        # @param key [Symbol, String] the settings key holding user additions
+        #   (e.g. +:custom_scroll_substitutions+)
+        # @param defaults [Array] the trusted built-in default list (frozen
+        #   constant); used as-is and returned unchanged when there are no valid
+        #   additions
+        # @param type [Symbol] one of {SUPPORTED_TYPES}; selects the validator
+        # @return [Array] defaults followed by the valid, deduplicated additions
+        # @raise [ArgumentError] if +type+ is not in {SUPPORTED_TYPES}
+        # @example
+        #   resolve(:custom_creature_normalizations, DEFAULTS, type: :names)
+        # @see #reset!
+        def resolve(key, defaults, type:)
+          raise ArgumentError, "unsupported type #{type.inspect}" unless SUPPORTED_TYPES.include?(type)
+
+          @cache ||= {}
+          @cache[key] ||= (Array(defaults) + validated_additions(key, type)).uniq
+        end
+
+        # Clears the memoized merged lists (and the per-pattern timeout-report
+        # dedup set) so the next {resolve}/{apply_regexes} call re-reads settings
+        # and re-validates. Call this whenever settings are reloaded.
+        #
+        # @return [void]
+        # @see #resolve
+        def reset!
+          @cache = {}
+          @reported_timeouts = nil
+        end
+
+        # Folds +patterns+ over +text+ as successive +String#sub(pattern, '')+
+        # deletions, guarding each against {Regexp::TimeoutError}. A pattern that
+        # times out is skipped for this input and reported once (deduplicated by
+        # pattern source), never hanging the caller.
+        #
+        # @param text [String] the text to strip
+        # @param patterns [Array<Regexp>] validated, timeout-bounded patterns
+        #   (typically from {resolve} with +type: :regexes+)
+        # @return [String] +text+ with every applicable pattern removed
+        # @example
+        #   apply_regexes('a gaudy scroll bedizened with gems', patterns)
+        # @see DRC.remove_flavor_text
+        def apply_regexes(text, patterns)
+          patterns.reduce(text) do |current, pattern|
+            current.sub(pattern, '')
+          rescue Regexp::TimeoutError
+            report_timeout(pattern)
+            current
+          end
+        end
+
+        private
+
+        # Reads, validates, and returns the user additions at +key+.
+        #
+        # @param key [Symbol, String] settings key
+        # @param type [Symbol] validator shape
+        # @return [Array] valid additions (possibly empty)
+        def validated_additions(key, type)
+          raw = user_setting(key)
+          return [] if raw.nil?
+
+          unless raw.is_a?(Array)
+            report("#{key} ignored -- expected a list, got #{raw.class}. No custom entries were loaded.")
+            return []
+          end
+
+          valid = raw.each_with_index.filter_map { |entry, index| validate_entry(entry, type, key, index) }
+          report_debug("loaded #{valid.size} custom #{key} #{valid.size == 1 ? 'entry' : 'entries'}") unless valid.empty?
+          valid
+        end
+
+        # Reads a single settings key from +get_settings+, tolerating any
+        # environment where settings are unavailable (no dr-scripts, early boot,
+        # or a raising accessor) by returning +nil+.
+        #
+        # @param key [Symbol, String] settings key
+        # @return [Object, nil] the raw settings value, or nil when unavailable
+        def user_setting(key)
+          return nil unless defined?(get_settings)
+
+          settings = get_settings
+          return nil if settings.nil?
+
+          settings[key]
+        rescue StandardError
+          nil
+        end
+
+        # Dispatches a single entry to the validator for +type+.
+        #
+        # @return [Object, nil] the validated (possibly transformed) entry, or
+        #   nil if it was rejected and reported
+        def validate_entry(entry, type, key, index)
+          case type
+          when :pairs   then validate_pair(entry, key, index)
+          when :names   then validate_name(entry, key, index)
+          when :regexes then validate_regex(entry, key, index)
+          end
+        end
+
+        # Validates a +[from, to]+ literal substitution pair.
+        #
+        # @return [Array(String, String), nil] the pair, or nil if rejected
+        def validate_pair(entry, key, index)
+          unless entry.is_a?(Array) && entry.size == 2
+            report("#{key}[#{index}] skipped -- expected a [from, to] pair, got #{entry.inspect}. This entry will not be applied.")
+            return nil
+          end
+
+          from, to = entry
+          unless from.is_a?(String) && to.is_a?(String)
+            report("#{key}[#{index}] skipped -- both 'from' and 'to' must be strings, got #{entry.inspect}. This entry will not be applied.")
+            return nil
+          end
+
+          if from.empty?
+            report("#{key}[#{index}] skipped -- 'from' must not be empty (it would match everything). This entry will not be applied.")
+            return nil
+          end
+
+          if from == to
+            report("#{key}[#{index}] skipped -- 'from' and 'to' are identical (#{from.inspect}), so it would do nothing. This entry will not be applied.")
+            return nil
+          end
+
+          warn_non_ascii(from, key, index)
+          warn_non_ascii(to, key, index)
+          [from, to]
+        end
+
+        # Validates a bare canonical-name string.
+        #
+        # @return [String, nil] the name, or nil if rejected
+        def validate_name(entry, key, index)
+          unless entry.is_a?(String) && !entry.empty?
+            report("#{key}[#{index}] skipped -- expected a non-empty string, got #{entry.inspect}. This entry will not be applied.")
+            return nil
+          end
+
+          warn_non_ascii(entry, key, index)
+          entry
+        end
+
+        # Validates a regular-expression entry, accepting either a String
+        # (compiled with {REGEX_TIMEOUT_SECONDS}) or a pre-compiled Regexp (from
+        # a YAML +!ruby/regexp+ tag), which is re-wrapped to enforce the timeout.
+        #
+        # @return [Regexp, nil] a timeout-bounded pattern, or nil if rejected
+        def validate_regex(entry, key, index)
+          return timeout_bounded(entry.source, entry.options, key, index) if entry.is_a?(Regexp)
+
+          unless entry.is_a?(String) && !entry.empty?
+            report("#{key}[#{index}] skipped -- expected a regular expression string, got #{entry.inspect}. This entry will not be applied.")
+            return nil
+          end
+
+          warn_non_ascii(entry, key, index)
+          timeout_bounded(entry, 0, key, index)
+        end
+
+        # Compiles +source+ into a timeout-bounded Regexp, reporting and
+        # returning nil on a compile error.
+        #
+        # @param source [String] regex source
+        # @param options [Integer] regex option flags to preserve
+        # @return [Regexp, nil]
+        def timeout_bounded(source, options, key, index)
+          Regexp.new(source, options, timeout: REGEX_TIMEOUT_SECONDS)
+        rescue RegexpError => e
+          report("#{key}[#{index}] skipped -- invalid regular expression #{source.inspect}: #{e.message}. This pattern will not be applied.")
+          nil
+        end
+
+        # Warns (but does not reject) when a value contains non-ASCII bytes,
+        # since game text is ASCII and non-ASCII usually signals a typo (e.g. a
+        # smart quote pasted from a browser).
+        #
+        # @param value [String] the string to check
+        # @return [void]
+        def warn_non_ascii(value, key, index)
+          return if value.ascii_only?
+
+          report("#{key}[#{index}] warning -- contains non-ASCII characters (#{value.inspect}); game text is ASCII, so this may be a typo. It will still be applied.")
+        end
+
+        # Emits a player-facing warning, guarded so it is safe before
+        # {Lich::Messaging} exists.
+        #
+        # @param text [String] message body (the prefix is added)
+        # @return [void]
+        def report(text)
+          return unless defined?(Lich::Messaging) && Lich::Messaging.respond_to?(:msg)
+
+          Lich::Messaging.msg('warn', "#{MESSAGE_PREFIX} #{text}")
+        end
+
+        # Emits a low-noise informational line, routed at debug level so it only
+        # shows when the player has debug messaging enabled.
+        #
+        # @param text [String] message body (the prefix is added)
+        # @return [void]
+        def report_debug(text)
+          return unless defined?(Lich::Messaging) && Lich::Messaging.respond_to?(:msg)
+
+          Lich::Messaging.msg('debug', "#{MESSAGE_PREFIX} #{text}")
+        end
+
+        # Reports a runtime regex timeout once per offending pattern.
+        #
+        # @param pattern [Regexp] the pattern that timed out
+        # @return [void]
+        def report_timeout(pattern)
+          @reported_timeouts ||= []
+          return if @reported_timeouts.include?(pattern.source)
+
+          @reported_timeouts << pattern.source
+          report("a custom regular expression #{pattern.source.inspect} took too long (over #{REGEX_TIMEOUT_SECONDS}s) and was skipped for this text. Consider simplifying it.")
+        end
+      end
+    end
+  end
+end

--- a/lib/dragonrealms/custom_substitutions.rb
+++ b/lib/dragonrealms/custom_substitutions.rb
@@ -47,6 +47,18 @@ module Lich
       # - +:regexes+ -- regular-expression Strings (or pre-compiled Regexps)
       SUPPORTED_TYPES = %i[pairs names regexes].freeze
 
+      # Guards the shared caches below. {resolve}/{apply_regexes} are public
+      # utility methods any number of concurrently-running scripts (each on its
+      # own Thread) can call on shared game text, so the memo must not be
+      # populated by two threads at once. Mirrors the +@@mutex+ idiom used by
+      # {GameObj} and {DRExpMonitor}.
+      @lock = Mutex.new
+      # Memoized merged lists, keyed by settings key. See {resolve}.
+      @cache = {}
+      # Regex sources already reported as timing out, so each is reported at
+      # most once. See {apply_regexes}.
+      @reported_timeouts = []
+
       class << self
         # Returns +defaults+ merged with the validated user additions found at
         # +key+ in the player's settings, deduplicated and memoized.
@@ -65,8 +77,9 @@ module Lich
         def resolve(key, defaults, type:)
           raise ArgumentError, "unsupported type #{type.inspect}" unless SUPPORTED_TYPES.include?(type)
 
-          @cache ||= {}
-          @cache[key] ||= (Array(defaults) + validated_additions(key, type)).uniq
+          # Double-checked: no lock on the warm path (the common case on hot
+          # parse paths), lock only to populate a missing key.
+          @cache[key] || @lock.synchronize { @cache[key] ||= (Array(defaults) + validated_additions(key, type)).uniq }
         end
 
         # Clears the memoized merged lists (and the per-pattern timeout-report
@@ -76,8 +89,10 @@ module Lich
         # @return [void]
         # @see #resolve
         def reset!
-          @cache = {}
-          @reported_timeouts = nil
+          @lock.synchronize do
+            @cache = {}
+            @reported_timeouts = []
+          end
         end
 
         # Folds +patterns+ over +text+ as successive +String#sub(pattern, '')+
@@ -200,7 +215,10 @@ module Lich
         #
         # @return [Regexp, nil] a timeout-bounded pattern, or nil if rejected
         def validate_regex(entry, key, index)
-          return timeout_bounded(entry.source, entry.options, key, index) if entry.is_a?(Regexp)
+          if entry.is_a?(Regexp)
+            warn_non_ascii(entry.source, key, index)
+            return timeout_bounded(entry.source, entry.options, key, index)
+          end
 
           unless entry.is_a?(String) && !entry.empty?
             report("#{key}[#{index}] skipped -- expected a regular expression string, got #{entry.inspect}. This entry will not be applied.")
@@ -263,10 +281,15 @@ module Lich
         # @param pattern [Regexp] the pattern that timed out
         # @return [void]
         def report_timeout(pattern)
-          @reported_timeouts ||= []
-          return if @reported_timeouts.include?(pattern.source)
+          # Guard only the dedup set; do the messaging I/O outside the lock.
+          first_time = @lock.synchronize do
+            next false if @reported_timeouts.include?(pattern.source)
 
-          @reported_timeouts << pattern.source
+            @reported_timeouts << pattern.source
+            true
+          end
+          return unless first_time
+
           report("a custom regular expression #{pattern.source.inspect} took too long (over #{REGEX_TIMEOUT_SECONDS}s) and was skipped for this text. Consider simplifying it.")
         end
       end

--- a/lib/dragonrealms/drinfomon/drdefs.rb
+++ b/lib/dragonrealms/drinfomon/drdefs.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../custom_substitutions'
+
 module Lich
   module DragonRealms
     # Pattern constants for room/NPC parsing
@@ -47,10 +49,14 @@ module Lich
       # Gelapod replacement pattern
       GELAPOD = "<pushBold/>a domesticated gelapod<popBold/>".freeze
       GELAPOD_REPLACEMENT = 'domesticated gelapod'.freeze
-      # Creature name normalization patterns (creatures with variant descriptions)
-      ALFAR_WARRIOR_PATTERN = /.*alfar warrior.*/.freeze
-      SINEWY_LEOPARD_PATTERN = /.*sinewy leopard.*/.freeze
-      LESSER_NAGA_PATTERN = /.*lesser naga.*/.freeze
+      # Canonical creature names whose variant descriptions should collapse to
+      # the bare name (e.g. "a savage alfar warrior" -> "alfar warrior"). Any
+      # room-object string containing one of these is reduced to it. Players
+      # extend this list via the +custom_creature_normalizations+ setting; see
+      # {Lich::DragonRealms#normalize_creature_names}.
+      #
+      # @return [Array<String>] canonical creature names
+      CREATURE_NORMALIZATIONS = ['alfar warrior', 'sinewy leopard', 'lesser naga'].freeze
     end
 
     # Converts an amount and denomination to copper.
@@ -181,15 +187,28 @@ module Lich
       add_ordinals_to_duplicates(normalized_npcs)
     end
 
-    # Normalizes creature names that have variant descriptions.
-    # Maps "a sinewy leopard that..." to just "sinewy leopard".
-    # @param text [String] Text containing creature description
-    # @return [String] Text with normalized creature name
+    # Normalizes creature names that have variant descriptions, collapsing any
+    # string that contains a canonical name to just that name (e.g. "a sinewy
+    # leopard that is prowling" -> "sinewy leopard").
+    #
+    # The canonical list is {DRDefsPattern::CREATURE_NORMALIZATIONS} merged with
+    # the player's +custom_creature_normalizations+ setting, so a player can
+    # teach Lich about their own problematic creature/pet descriptions without a
+    # Lich release. The merged list is memoized; see
+    # {Lich::DragonRealms::CustomSubstitutions}.
+    #
+    # This runs on the hot NPC-parsing path ({find_npcs} fires on every room
+    # update), so it uses a plain substring check rather than compiling a regex
+    # per name per call.
+    #
+    # @param text [String] text containing a creature description
+    # @return [String] the canonical name if +text+ contains one, else +text+
+    # @example
+    #   normalize_creature_names('a massive sinewy leopard') #=> 'sinewy leopard'
+    # @see CustomSubstitutions.resolve
     def normalize_creature_names(text)
-      text
-        .sub(DRDefsPattern::ALFAR_WARRIOR_PATTERN, 'alfar warrior')
-        .sub(DRDefsPattern::SINEWY_LEOPARD_PATTERN, 'sinewy leopard')
-        .sub(DRDefsPattern::LESSER_NAGA_PATTERN, 'lesser naga')
+      names = CustomSubstitutions.resolve(:custom_creature_normalizations, DRDefsPattern::CREATURE_NORMALIZATIONS, type: :names)
+      names.reduce(text) { |current, name| current.include?(name) ? name : current }
     end
 
     # Removes pushBold/popBold XML tags from text.

--- a/lib/dragonrealms/drinfomon/drdefs.rb
+++ b/lib/dragonrealms/drinfomon/drdefs.rb
@@ -208,7 +208,10 @@ module Lich
     # @see CustomSubstitutions.resolve
     def normalize_creature_names(text)
       names = CustomSubstitutions.resolve(:custom_creature_normalizations, DRDefsPattern::CREATURE_NORMALIZATIONS, type: :names)
-      names.reduce(text) { |current, name| current.include?(name) ? name : current }
+      # Longest match against the ORIGINAL text, not a fold over the accumulator:
+      # folding would let a later name that is a substring of an earlier match's
+      # replacement (e.g. 'war yak' after 'grumpy war yak') re-collapse it.
+      names.select { |name| text.include?(name) }.max_by(&:length) || text
     end
 
     # Removes pushBold/popBold XML tags from text.

--- a/lib/dragonrealms/drinfomon/drvariables.rb
+++ b/lib/dragonrealms/drinfomon/drvariables.rb
@@ -319,7 +319,17 @@ module Lich
       'ninety'    => 90
     }.freeze
 
-    BOX_REGEX = /((?:brass|copper|deobar|driftwood|iron|ironwood|mahogany|oaken|pine|steel|wooden) (?:box|caddy|casket|chest|coffer|crate|skippet|strongbox|trunk))/.freeze
+    # Box wood/material adjectives recognized in rummaged box lists. Players
+    # extend this via the +custom_box_woods+ setting; see
+    # {Lich::DragonRealms::DRC.box_list_to_adj_and_noun}.
+    BOX_WOODS = %w[brass copper deobar driftwood iron ironwood mahogany oaken pine steel wooden].freeze
+    # Box container nouns recognized in rummaged box lists. Players extend this
+    # via the +custom_box_containers+ setting.
+    BOX_CONTAINERS = %w[box caddy casket chest coffer crate skippet strongbox trunk].freeze
+    # Recognizes "<wood> <container>" box descriptions. Built from {BOX_WOODS}
+    # and {BOX_CONTAINERS} so both remain a single source of truth; kept as a
+    # global ($box_regex) for third-party scripts.
+    BOX_REGEX = /((?:#{BOX_WOODS.join('|')}) (?:#{BOX_CONTAINERS.join('|')}))/.freeze
 
     MANA_MAP = {
       'weak'       => %w[dim glowing bright].freeze,

--- a/lib/dragonrealms/drinfomon/startup.rb
+++ b/lib/dragonrealms/drinfomon/startup.rb
@@ -99,6 +99,9 @@ module Lich
         warn_obsolete_data_files
         warn_custom_scripts
         $setupfiles.reload if defined?($setupfiles) && $setupfiles
+        # Drop CustomSubstitutions' memoized lists so a fresh login re-reads any
+        # edited custom_* settings (its cache is separate from $setupfiles').
+        Lich::DragonRealms::CustomSubstitutions.reset! if defined?(Lich::DragonRealms::CustomSubstitutions)
       rescue StandardError => e
         safe_message('error', "DRInfomon: post_startup_checks failed: #{e.message}")
         safe_log("DRInfomon: post_startup_checks error: #{e.inspect}\n\t#{e.backtrace&.first(5)&.join("\n\t")}")

--- a/spec/lib/dragonrealms/commons/common_items_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_items_spec.rb
@@ -14,6 +14,32 @@ RSpec.describe Lich::DragonRealms::DRCI do
     allow(DRC).to receive(:bput).and_return(response)
   end
 
+  describe '.trash_storage' do
+    before(:each) do
+      Lich::DragonRealms::CustomSubstitutions.reset!
+      Lich::Messaging.clear_messages!
+    end
+
+    it 'returns the built-in defaults when nothing is configured' do
+      expect(described_class.trash_storage).to include('barrel', 'bucket', 'urn')
+    end
+
+    it 'merges a player-added receptacle from settings' do
+      allow(Lich::DragonRealms::CustomSubstitutions)
+        .to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_trash_storage: ['sarcophagus']))
+      expect(described_class.trash_storage).to include('sarcophagus', 'barrel')
+    end
+
+    it 'skips a malformed addition, warns, and keeps the defaults' do
+      allow(Lich::DragonRealms::CustomSubstitutions)
+        .to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_trash_storage: [['not', 'a', 'string']]))
+      expect(described_class.trash_storage).to include('barrel')
+      expect(Lich::Messaging.messages.map { |m| m[:message] }.join).to include('custom_trash_storage[0] skipped')
+    end
+  end
+
   describe 'constants' do
     describe 'TRASH_STORAGE' do
       it 'is a frozen constant' do

--- a/spec/lib/dragonrealms/commons/common_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_spec.rb
@@ -45,6 +45,9 @@ DRC = Lich::DragonRealms::DRC unless defined?(DRC)
 RSpec.describe Lich::DragonRealms::DRC do
   before(:each) do
     Lich::Messaging.clear_messages!
+    # Rebuild memoized custom-substitution lists so a stub in one example does
+    # not leak its merged list into the next (see CustomSubstitutions.reset!).
+    Lich::DragonRealms::CustomSubstitutions.reset!
     # Stub GameObj with a temporary mock if not already defined by other specs
     stub_const('GameObj', DRC_MOCK_GAME_OBJ) unless defined?(::GameObj)
   end
@@ -104,10 +107,53 @@ RSpec.describe Lich::DragonRealms::DRC do
   end
 
   describe '.scroll_list_to_adj_and_noun' do
+    # Lets an example supply user additions the way get_settings would.
+    def stub_scroll_settings(additions)
+      allow(Lich::DragonRealms::CustomSubstitutions)
+        .to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_scroll_substitutions: additions))
+    end
+
     it('removes article from single scroll') { expect(described_class.scroll_list_to_adj_and_noun(' a blue scroll')).to eq(['blue scroll']) }
     it('removes label text') { expect(described_class.scroll_list_to_adj_and_noun(' a blue scroll labeled with runes')).to eq(['blue scroll']) }
     it('converts papyrus roll to papyrus.roll') { expect(described_class.scroll_list_to_adj_and_noun(' a papyrus roll')).to eq(['papyrus.roll']) }
     it('simplifies icy blue to blue') { expect(described_class.scroll_list_to_adj_and_noun(' an icy blue parchment')).to eq(['blue parchment']) }
+
+    it 'reduces the built-in symbol-torn scale scroll to its gettable noun' do
+      expect(described_class.scroll_list_to_adj_and_noun(' a large midnight-blue scale torn with symbols'))
+        .to eq(['midnight-blue scale'])
+    end
+
+    it 'applies a user-added scroll substitution from settings' do
+      stub_scroll_settings([['weird prismatic scroll of doom', 'doom scroll']])
+      expect(described_class.scroll_list_to_adj_and_noun(' a weird prismatic scroll of doom'))
+        .to eq(['doom scroll'])
+    end
+
+    it 'applies a user addition before the keyword-collapse would mangle it' do
+      # Without a pre-collapse rewrite, "aqua blue vellum scroll" collapses on
+      # the "vellum" keyword to "aqua blue vellum"; the user rule fixes it.
+      stub_scroll_settings([['aqua blue vellum scroll', 'aqua scroll']])
+      expect(described_class.scroll_list_to_adj_and_noun(' an aqua blue vellum scroll'))
+        .to eq(['aqua scroll'])
+    end
+
+    it 'skips a malformed user entry, warns, and still applies the defaults' do
+      stub_scroll_settings([['only one element']])
+      expect(described_class.scroll_list_to_adj_and_noun(' a papyrus roll')).to eq(['papyrus.roll'])
+      warning = Lich::Messaging.messages.find { |m| m[:message].include?('custom_scroll_substitutions[0] skipped') }
+      expect(warning).not_to be_nil
+      expect(warning[:message]).to include('expected a [from, to] pair')
+    end
+
+    it 'falls back to defaults when the settings value is not a list' do
+      allow(Lich::DragonRealms::CustomSubstitutions)
+        .to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_scroll_substitutions: 'not-a-list'))
+      expect(described_class.scroll_list_to_adj_and_noun(' an icy blue parchment')).to eq(['blue parchment'])
+      expect(Lich::Messaging.messages.map { |m| m[:message] }.join)
+        .to include('custom_scroll_substitutions ignored')
+    end
   end
 
   describe '.text2num' do

--- a/spec/lib/dragonrealms/commons/common_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_spec.rb
@@ -103,10 +103,30 @@ RSpec.describe Lich::DragonRealms::DRC do
   end
 
   describe '.remove_flavor_text' do
+    def stub_flavor_patterns(patterns)
+      allow(Lich::DragonRealms::CustomSubstitutions)
+        .to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_flavor_text_patterns: patterns))
+    end
+
     it('returns item unchanged when no flavor text') { expect(described_class.remove_flavor_text('a sword')).to eq('a sword') }
     it('strips "adorned with" flavor text') { expect(described_class.remove_flavor_text('a sword adorned with rubies of deep crimson')).to eq('a sword') }
     it('strips "decorated with" flavor text') { expect(described_class.remove_flavor_text('a shield decorated with a golden crest')).to eq('a shield') }
     it('strips "carved with" flavor text') { expect(described_class.remove_flavor_text('a staff carved with runes of ancient design')).to eq('a staff') }
+
+    it 'strips flavor the built-in pattern misses using a player-added pattern' do
+      # A marker the built-in FLAVOR_TEXT_PATTERN does not touch, so this isolates
+      # the user-pattern path.
+      stub_flavor_patterns(['\s?::.*'])
+      expect(described_class.remove_flavor_text('a sword ::soulbound::')).to eq('a sword')
+    end
+
+    it 'still applies the built-in pattern when a user pattern is invalid, and warns' do
+      stub_flavor_patterns(['(unclosed'])
+      expect(described_class.remove_flavor_text('a sword adorned with rubies of deep crimson')).to eq('a sword')
+      expect(Lich::Messaging.messages.map { |m| m[:message] }.join)
+        .to include('custom_flavor_text_patterns[0] skipped')
+    end
   end
 
   describe '.box_list_to_adj_and_noun' do

--- a/spec/lib/dragonrealms/commons/common_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_spec.rb
@@ -38,6 +38,15 @@ $ENC_MAP = {
 $box_regex = /((?:brass|copper|deobar|driftwood|iron|ironwood|mahogany|oaken|pine|steel|wooden) (?:box|caddy|casket|chest|coffer|crate|skippet|strongbox|trunk))/ unless defined?($box_regex)
 $fake_stormfront = false unless defined?($fake_stormfront)
 
+# Box vocabulary constants normally provided by drvariables.rb (not loaded here);
+# box_list_to_adj_and_noun builds its match regex from these.
+module Lich
+  module DragonRealms
+    BOX_WOODS = %w[brass copper deobar driftwood iron ironwood mahogany oaken pine steel wooden].freeze unless defined?(BOX_WOODS)
+    BOX_CONTAINERS = %w[box caddy casket chest coffer crate skippet strongbox trunk].freeze unless defined?(BOX_CONTAINERS)
+  end
+end
+
 # Load production code
 require File.join(LIB_DIR, 'dragonrealms', 'commons', 'common.rb')
 DRC = Lich::DragonRealms::DRC unless defined?(DRC)
@@ -101,9 +110,34 @@ RSpec.describe Lich::DragonRealms::DRC do
   end
 
   describe '.box_list_to_adj_and_noun' do
+    def stub_box_settings(**values)
+      allow(Lich::DragonRealms::CustomSubstitutions).to receive(:get_settings).and_return(OpenStruct.new(values))
+    end
+
     it('parses a single box') { expect(described_class.box_list_to_adj_and_noun('a wooden strongbox')).to eq(['wooden strongbox']) }
     it('converts ironwood to iron') { expect(described_class.box_list_to_adj_and_noun('an ironwood crate')).to eq(['iron crate']) }
     it('returns empty array for empty string') { expect(described_class.box_list_to_adj_and_noun('')).to eq([]) }
+
+    it 'recognizes a player-added box wood' do
+      stub_box_settings(custom_box_woods: ['faenor'])
+      expect(described_class.box_list_to_adj_and_noun('a polished faenor chest')).to eq(['faenor chest'])
+    end
+
+    it 'recognizes a player-added box container' do
+      stub_box_settings(custom_box_containers: ['reliquary'])
+      expect(described_class.box_list_to_adj_and_noun('a battered steel reliquary')).to eq(['steel reliquary'])
+    end
+
+    it 'applies a player-added box substitution to a recognized box' do
+      stub_box_settings(custom_box_woods: ['faenor'], custom_box_substitutions: [%w[faenor faewood]])
+      expect(described_class.box_list_to_adj_and_noun('a polished faenor chest')).to eq(['faewood chest'])
+    end
+
+    it 'still parses built-in boxes when a custom wood entry is malformed' do
+      stub_box_settings(custom_box_woods: [123])
+      expect(described_class.box_list_to_adj_and_noun('an ironwood crate')).to eq(['iron crate'])
+      expect(Lich::Messaging.messages.map { |m| m[:message] }.join).to include('custom_box_woods[0] skipped')
+    end
   end
 
   describe '.scroll_list_to_adj_and_noun' do

--- a/spec/lib/dragonrealms/commons/common_summoning_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_summoning_spec.rb
@@ -16,6 +16,44 @@ DRCS = Lich::DragonRealms::DRCS unless defined?(DRCS)
 RSpec.describe Lich::DragonRealms::DRCS do
   before(:each) do
     Lich::Messaging.clear_messages!
+    # Rebuild memoized custom-adjective lists between examples.
+    Lich::DragonRealms::CustomSubstitutions.reset!
+  end
+
+  # --- custom_summoned_weapon_adjectives ------------------------------
+
+  describe '.custom_summoned_weapon_adjectives' do
+    def stub_adjective_settings(value)
+      allow(Lich::DragonRealms::CustomSubstitutions).to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_summoned_weapons_adjectives: value))
+    end
+
+    it 'returns an empty list when nothing is configured' do
+      expect(described_class.custom_summoned_weapon_adjectives).to eq([])
+    end
+
+    it 'includes the plural custom list from settings' do
+      stub_adjective_settings(%w[flamewreathed frostbound])
+      expect(described_class.custom_summoned_weapon_adjectives).to eq(%w[flamewreathed frostbound])
+    end
+
+    it 'includes the legacy singular summoned_weapons_adjective setting' do
+      expect(described_class.custom_summoned_weapon_adjectives(OpenStruct.new(summoned_weapons_adjective: 'stormforged')))
+        .to include('stormforged')
+    end
+
+    it 'does not duplicate the legacy value when it is also in the plural list' do
+      stub_adjective_settings(['stormforged'])
+      expect(described_class.custom_summoned_weapon_adjectives(OpenStruct.new(summoned_weapons_adjective: 'stormforged')))
+        .to eq(['stormforged'])
+    end
+
+    it 'skips a malformed plural entry and warns' do
+      stub_adjective_settings([42])
+      expect(described_class.custom_summoned_weapon_adjectives).to eq([])
+      expect(Lich::Messaging.messages.map { |m| m[:message] }.join)
+        .to include('custom_summoned_weapons_adjectives[0] skipped')
+    end
   end
 
   # --- Constants ------------------------------------------------------
@@ -269,6 +307,21 @@ RSpec.describe Lich::DragonRealms::DRCS do
         allow(DRC).to receive(:right_hand).and_return('icy halberd')
         allow(DRCI).to receive(:tap).with('icy halberd').and_return('You tap an icy halberd that you are holding.')
         expect(described_class.identify_summoned_weapon).to eq('icy halberd')
+      end
+
+      it 'identifies a weapon with a player-added custom adjective (plural setting)' do
+        allow(Lich::DragonRealms::CustomSubstitutions).to receive(:get_settings)
+          .and_return(OpenStruct.new(custom_summoned_weapons_adjectives: ['flamewreathed']))
+        allow(DRC).to receive(:right_hand).and_return('flamewreathed sword')
+        allow(DRCI).to receive(:tap).with('flamewreathed sword').and_return('You tap a flamewreathed sword that you are holding.')
+        expect(described_class.identify_summoned_weapon).to eq('flamewreathed sword')
+      end
+
+      it 'still recognizes the legacy singular summoned_weapons_adjective setting' do
+        allow(DRC).to receive(:right_hand).and_return('frostbound sword')
+        allow(DRCI).to receive(:tap).with('frostbound sword').and_return('You tap a frostbound sword that you are holding.')
+        settings = OpenStruct.new(summoned_weapons_adjective: 'frostbound')
+        expect(described_class.identify_summoned_weapon(settings)).to eq('frostbound sword')
       end
 
       it 'handles custom adjective from settings' do

--- a/spec/lib/dragonrealms/commons/common_summoning_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_summoning_spec.rb
@@ -56,6 +56,35 @@ RSpec.describe Lich::DragonRealms::DRCS do
     end
   end
 
+  # --- base_summoned_weapon (adjective stripping) ---------------------
+
+  describe '.base_summoned_weapon' do
+    def stub_adjectives(value)
+      allow(Lich::DragonRealms::CustomSubstitutions).to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_summoned_weapons_adjectives: value))
+    end
+
+    it 'strips a single custom adjective' do
+      stub_adjectives(['flamewreathed'])
+      expect(described_class.base_summoned_weapon('flamewreathed sword')).to eq(' sword')
+    end
+
+    it 'strips the longest adjective when one is a substring of another' do
+      # ['flame','flamewreathed'] must strip 'flamewreathed', not 'flame' (which
+      # would leave a bogus "wreathed sword").
+      [%w[flame flamewreathed], %w[flamewreathed flame]].each do |ordering|
+        Lich::DragonRealms::CustomSubstitutions.reset!
+        stub_adjectives(ordering)
+        expect(described_class.base_summoned_weapon('flamewreathed sword')).to eq(' sword')
+      end
+    end
+
+    it 'returns the weapon unchanged when no custom adjective matches' do
+      stub_adjectives(['frostbound'])
+      expect(described_class.base_summoned_weapon('electric sword')).to eq('electric sword')
+    end
+  end
+
   # --- Constants ------------------------------------------------------
 
   describe 'constants' do

--- a/spec/lib/dragonrealms/custom_substitutions_spec.rb
+++ b/spec/lib/dragonrealms/custom_substitutions_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+require File.join(LIB_DIR, 'dragonrealms', 'custom_substitutions.rb')
+
+# Exercises the shared merge/validate/report/memoize unit that lets players
+# extend Lich's built-in substitution lists from their own settings. Focuses on
+# the adversarial cases: malformed entries, wrong container types, invalid and
+# runaway regexes, and memoization/reset boundaries.
+RSpec.describe Lich::DragonRealms::CustomSubstitutions do
+  before(:each) do
+    described_class.reset!
+    Lich::Messaging.clear_messages!
+  end
+
+  # Supplies user additions the way the real get_settings would.
+  def stub_settings(key, value)
+    allow(described_class).to receive(:get_settings).and_return(OpenStruct.new(key => value))
+  end
+
+  def last_messages
+    Lich::Messaging.messages.map { |m| m[:message] }.join("\n")
+  end
+
+  describe '.resolve merging' do
+    it 'appends valid additions after the defaults' do
+      stub_settings(:custom_pairs, [%w[from-user to-user]])
+      merged = described_class.resolve(:custom_pairs, [%w[from-default to-default]], type: :pairs)
+      expect(merged).to eq([%w[from-default to-default], %w[from-user to-user]])
+    end
+
+    it 'returns the defaults unchanged when there are no additions' do
+      stub_settings(:custom_pairs, nil)
+      expect(described_class.resolve(:custom_pairs, [%w[a b]], type: :pairs)).to eq([%w[a b]])
+    end
+
+    it 'returns the defaults when settings are unavailable (get_settings nil)' do
+      allow(described_class).to receive(:get_settings).and_return(nil)
+      expect(described_class.resolve(:custom_names, %w[goblin], type: :names)).to eq(%w[goblin])
+    end
+
+    it 'deduplicates additions against the defaults and each other' do
+      stub_settings(:custom_names, %w[beta alpha beta])
+      expect(described_class.resolve(:custom_names, %w[beta], type: :names)).to eq(%w[beta alpha])
+    end
+
+    it 'raises for an unsupported type' do
+      expect { described_class.resolve(:custom_x, [], type: :bogus) }.to raise_error(ArgumentError, /unsupported type/)
+    end
+  end
+
+  describe '.resolve memoization' do
+    it 'caches the merged list until reset!' do
+      stub_settings(:custom_pairs, [%w[a b]])
+      first = described_class.resolve(:custom_pairs, [], type: :pairs)
+
+      stub_settings(:custom_pairs, [%w[c d]])
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq(first)
+
+      described_class.reset!
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq([%w[c d]])
+    end
+  end
+
+  describe 'whole-value validation' do
+    it 'ignores a non-list settings value and reports it' do
+      stub_settings(:custom_pairs, 'not-a-list')
+      expect(described_class.resolve(:custom_pairs, [%w[a b]], type: :pairs)).to eq([%w[a b]])
+      expect(last_messages).to include('custom_pairs ignored -- expected a list, got String')
+    end
+  end
+
+  describe ':pairs validation' do
+    it 'skips a non-array entry with a descriptive message' do
+      stub_settings(:custom_pairs, ['oops'])
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq([])
+      expect(last_messages).to include('custom_pairs[0] skipped -- expected a [from, to] pair, got "oops"')
+    end
+
+    it 'skips a wrong-arity entry' do
+      stub_settings(:custom_pairs, [%w[only one three]])
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq([])
+      expect(last_messages).to include('expected a [from, to] pair')
+    end
+
+    it 'skips a pair whose members are not both strings' do
+      stub_settings(:custom_pairs, [['from', 42]])
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq([])
+      expect(last_messages).to include("both 'from' and 'to' must be strings")
+    end
+
+    it 'skips a pair with an empty from (would match everything)' do
+      stub_settings(:custom_pairs, [['', 'to']])
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq([])
+      expect(last_messages).to include("'from' must not be empty")
+    end
+
+    it 'skips a no-op pair where from equals to' do
+      stub_settings(:custom_pairs, [%w[same same]])
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq([])
+      expect(last_messages).to include('would do nothing')
+    end
+
+    it 'keeps valid pairs while dropping the invalid one in the same list' do
+      stub_settings(:custom_pairs, [%w[good rewrite], 'bad'])
+      expect(described_class.resolve(:custom_pairs, [], type: :pairs)).to eq([%w[good rewrite]])
+      expect(last_messages).to include('custom_pairs[1] skipped')
+    end
+  end
+
+  describe ':names validation' do
+    it 'skips a non-string name' do
+      stub_settings(:custom_names, [123])
+      expect(described_class.resolve(:custom_names, [], type: :names)).to eq([])
+      expect(last_messages).to include('expected a non-empty string, got 123')
+    end
+
+    it 'skips an empty string name' do
+      stub_settings(:custom_names, [''])
+      expect(described_class.resolve(:custom_names, [], type: :names)).to eq([])
+      expect(last_messages).to include('expected a non-empty string')
+    end
+
+    it 'warns about non-ASCII but still keeps the entry' do
+      naive = "na" + [0xEF].pack('U') + "ve pet" # non-ASCII value, ASCII source
+      stub_settings(:custom_names, [naive])
+      expect(described_class.resolve(:custom_names, [], type: :names)).to eq([naive])
+      expect(last_messages).to include('contains non-ASCII characters')
+    end
+  end
+
+  describe ':regexes validation' do
+    it 'compiles a valid regex string' do
+      stub_settings(:custom_regexes, ['gilded .* hilt'])
+      compiled = described_class.resolve(:custom_regexes, [], type: :regexes)
+      expect(compiled.first).to be_a(Regexp)
+      expect(compiled.first.source).to eq('gilded .* hilt')
+    end
+
+    it 'rejects an invalid regex and reports the compile error' do
+      stub_settings(:custom_regexes, ['(unclosed'])
+      expect(described_class.resolve(:custom_regexes, [], type: :regexes)).to eq([])
+      expect(last_messages).to include('invalid regular expression "(unclosed"')
+    end
+
+    it 'accepts a pre-compiled Regexp and preserves its flags' do
+      stub_settings(:custom_regexes, [/Encircling/i])
+      compiled = described_class.resolve(:custom_regexes, [], type: :regexes)
+      expect(compiled.first.source).to eq('Encircling')
+      expect(compiled.first.casefold?).to be(true)
+    end
+  end
+
+  describe '.apply_regexes' do
+    it 'strips every matching pattern in order' do
+      patterns = [/ with gems$/, /gaudy /]
+      expect(described_class.apply_regexes('a gaudy scroll with gems', patterns)).to eq('a scroll')
+    end
+
+    # Ruby 3.2+ memoizes match state, defeating classic catastrophic-backtracking
+    # patterns, so we simulate the timeout to test the guard logic itself: that a
+    # Regexp::TimeoutError is caught, the text is left intact, and it is reported
+    # only once per pattern.
+    it 'skips a pattern that times out and reports it once, leaving text intact' do
+      pattern = /(a+)+$/
+      text = +'aaaa' # mutable so the sub stub can define a singleton method
+      allow(text).to receive(:sub).with(pattern, '').and_raise(Regexp::TimeoutError)
+
+      expect(described_class.apply_regexes(text, [pattern])).to eq('aaaa')
+      expect(last_messages).to include('took too long')
+
+      Lich::Messaging.clear_messages!
+      described_class.apply_regexes(text, [pattern])
+      expect(last_messages).not_to include('took too long') # deduplicated by source
+    end
+  end
+end

--- a/spec/lib/dragonrealms/custom_substitutions_spec.rb
+++ b/spec/lib/dragonrealms/custom_substitutions_spec.rb
@@ -150,6 +150,14 @@ RSpec.describe Lich::DragonRealms::CustomSubstitutions do
       expect(compiled.first.source).to eq('Encircling')
       expect(compiled.first.casefold?).to be(true)
     end
+
+    it 'warns about non-ASCII in a pre-compiled Regexp but still keeps it' do
+      non_ascii = Regexp.new("na" + [0xEF].pack('U') + "ve") # non-ASCII source, ASCII spec
+      stub_settings(:custom_regexes, [non_ascii])
+      compiled = described_class.resolve(:custom_regexes, [], type: :regexes)
+      expect(compiled.first).to be_a(Regexp)
+      expect(last_messages).to include('contains non-ASCII characters')
+    end
   end
 
   describe '.apply_regexes' do

--- a/spec/lib/dragonrealms/drinfomon/drdefs_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drdefs_spec.rb
@@ -850,6 +850,18 @@ RSpec.describe Lich::DragonRealms do
       expect(warning).not_to be_nil
       expect(warning[:message]).to include('expected a non-empty string')
     end
+
+    it 'keeps the most specific name when one entry is a substring of another' do
+      # Regardless of list order, the longest containing name wins -- a generic
+      # alias must not re-collapse a more specific one.
+      [['grumpy war yak', 'war yak'], ['war yak', 'grumpy war yak']].each do |ordering|
+        Lich::DragonRealms::CustomSubstitutions.reset!
+        allow(Lich::DragonRealms::CustomSubstitutions)
+          .to receive(:get_settings)
+          .and_return(OpenStruct.new(custom_creature_normalizations: ordering))
+        expect(helper.normalize_creature_names('a grumpy war yak that is charging')).to eq('grumpy war yak')
+      end
+    end
   end
 
   describe '#remove_html_tags' do

--- a/spec/lib/dragonrealms/drinfomon/drdefs_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drdefs_spec.rb
@@ -811,6 +811,13 @@ RSpec.describe Lich::DragonRealms do
   end
 
   describe '#normalize_creature_names' do
+    before(:each) do
+      # Rebuild the memoized merged list so a per-example get_settings stub does
+      # not leak into other examples (see CustomSubstitutions.reset!).
+      Lich::DragonRealms::CustomSubstitutions.reset!
+      Lich::Messaging.clear_messages!
+    end
+
     it 'normalizes alfar warrior variants' do
       expect(helper.normalize_creature_names('a savage alfar warrior')).to eq('alfar warrior')
     end
@@ -825,6 +832,23 @@ RSpec.describe Lich::DragonRealms do
 
     it 'leaves other creatures unchanged' do
       expect(helper.normalize_creature_names('goblin')).to eq('goblin')
+    end
+
+    it 'normalizes a player-added creature from settings' do
+      allow(Lich::DragonRealms::CustomSubstitutions)
+        .to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_creature_normalizations: ['grumpy war yak']))
+      expect(helper.normalize_creature_names('a grumpy war yak that is charging')).to eq('grumpy war yak')
+    end
+
+    it 'skips a malformed user entry, warns, and keeps the built-in defaults' do
+      allow(Lich::DragonRealms::CustomSubstitutions)
+        .to receive(:get_settings)
+        .and_return(OpenStruct.new(custom_creature_normalizations: [42]))
+      expect(helper.normalize_creature_names('a savage alfar warrior')).to eq('alfar warrior')
+      warning = Lich::Messaging.messages.find { |m| m[:message].include?('custom_creature_normalizations[0] skipped') }
+      expect(warning).not_to be_nil
+      expect(warning[:message]).to include('expected a non-empty string')
     end
   end
 


### PR DESCRIPTION
> **Stacked on #1515 (04) → #1514 (03) → #1513 (02) → #1512 (01).** Review/merge those first. Depends on `Lich::DragonRealms::CustomSubstitutions` from #1512.

## Problem

`remove_flavor_text` strips descriptive flavor (`... adorned with ...`) using a single large hardcoded regex, `FLAVOR_TEXT_PATTERN`. When the game introduces a new flavor phrasing the pattern doesn't cover, the flavor leaks into item nouns (and `get_noun` mis-parses) until a Lich release extends the regex. Flavor is open-ended grammar, so a literal-name list can't help — this case genuinely needs pattern power.

## Fix

`remove_flavor_text` applies the built-in `FLAVOR_TEXT_PATTERN` first, then folds any player-defined `custom_flavor_text_patterns` (regular expressions) over the result via `CustomSubstitutions.apply_regexes`. A player can strip a new flavor phrasing without a Lich release; a plain phrase also works since it's a valid regex.

**Strict guards** (this is user-supplied regex on a control-relevant path — all via `CustomSubstitutions`, #1512):
- each pattern is validated and compiled with a per-pattern `Regexp.timeout` before use;
- an invalid pattern is reported with the exact compile error and skipped;
- a pattern that times out at apply time is caught, reported once (deduped), and skipped — never hanging Lich.

The built-in pattern always runs, so behavior is unchanged when nothing is configured.

## Tests

Full suite: **5585 examples, 0 failures.** Existing flavor cases stay green; adds a case where a user pattern strips flavor the built-in misses, and an invalid-regex case asserting the built-in still applies and the warning fires. (Compile/timeout guard internals are covered in the `CustomSubstitutions` unit spec from #1512.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)