### PR TITLE
fix(all): Linux WINE and Wrayth FE detection

### DIFF
--- a/lib/common/frontend_locator.rb
+++ b/lib/common/frontend_locator.rb
@@ -161,7 +161,7 @@ module Lich
         candidates.concat(path_candidates(definition).map { |path| [path, :path] })
 
         candidates.each do |path, source|
-          next unless executable?(path)
+          next unless executable?(path, definition)
 
           resolved = resolution(definition, path, source)
           return resolved if resolved
@@ -171,7 +171,7 @@ module Lich
 
       def resolve_override(definition, override)
         path = expand_path(override)
-        unless executable?(path)
+        unless executable?(path, definition)
           raise ArgumentError, "frontend override is not executable: #{override}"
         end
 
@@ -352,11 +352,20 @@ module Lich
         nil
       end
 
-      def executable?(path)
-        !path.to_s.empty? && File.file?(path) && File.executable?(path)
+      def executable?(path, definition)
+        return false if path.to_s.empty? || !File.file?(path)
+
+        wine_managed_executable?(path, definition) || File.executable?(path)
       rescue SystemCallError => e
         log_discovery_error(path, e)
         false
+      end
+
+      def wine_managed_executable?(path, definition)
+        platform_key == :linux &&
+          @wine &&
+          definition.dig(:metadata, :launcher_adapter) == :simutronics &&
+          File.extname(path).casecmp?('.exe')
       end
 
       def resolution(definition, path, source)

--- a/lib/wine.rb
+++ b/lib/wine.rb
@@ -72,7 +72,7 @@ unless $wine_bin.nil?
             end
             lookin = result = false
             File.open(PREFIX + '/system.reg') { |f| f.readlines }.each { |line|
-              if line[0...subkey.length] == subkey
+              if line[0...subkey.length].casecmp?(subkey)
                 lookin = true
               elsif line =~ /^\[/
                 lookin = false

--- a/spec/lib/common/frontend_locator_spec.rb
+++ b/spec/lib/common/frontend_locator_spec.rb
@@ -397,6 +397,28 @@ RSpec.describe Lich::Common::FrontendLocator do
     end
   end
 
+  it 'accepts a Wine frontend override without requiring a Unix execute bit' do
+    Dir.mktmpdir do |directory|
+      wrayth = File.join(directory, 'Wrayth.exe')
+      File.write(wrayth, 'PE executable')
+      FileUtils.chmod(0o644, wrayth)
+      locator = described_class.new(
+        platform_key: :linux,
+        environment: { 'PATH' => '' },
+        wine: Module.new
+      )
+
+      expect(File.executable?(wrayth)).to be(false)
+      expect(locator.resolve('stormfront', override: wrayth)).to eq(
+        described_class::Resolution.new(
+          frontend_id: 'stormfront',
+          executable_path: File.realpath(wrayth),
+          source: :override
+        )
+      )
+    end
+  end
+
   it 'does not consult ambient Wine when the injected provider is nil' do
     stub_const('Wine', Module.new)
     locator = described_class.new(

--- a/spec/lib/common/frontend_locator_spec.rb
+++ b/spec/lib/common/frontend_locator_spec.rb
@@ -369,13 +369,16 @@ RSpec.describe Lich::Common::FrontendLocator do
     end
   end
 
-  it 'converts Wine registry directories before executable discovery' do
+  it 'discovers a Wine frontend without requiring a Unix execute bit' do
     Dir.mktmpdir do |prefix|
-      wrayth = executable(File.join(prefix, 'drive_c', 'Simutronics', 'Wrayth.exe'))
+      wrayth = File.join(prefix, 'drive_c', 'Simutronics', 'Wrayth.exe')
+      FileUtils.mkdir_p(File.dirname(wrayth))
+      File.write(wrayth, 'PE executable')
+      FileUtils.chmod(0o644, wrayth)
       wine = Module.new
       wine.const_set(:PREFIX, prefix)
       wine.define_singleton_method(:registry_gets) do |key|
-        key.include?('STORM32') ? 'C:\\Simutronics' : nil
+        key == 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Simutronics\\STORM32\\Directory' ? 'C:\\Simutronics' : nil
       end
       stub_const('Wine', wine)
       locator = described_class.new(

--- a/spec/lib/wine_spec.rb
+++ b/spec/lib/wine_spec.rb
@@ -194,6 +194,12 @@ RSpec.describe 'wine.rb' do
         expect(result).to eq('C:\\Program Files\\Launcher')
       end
 
+      it 'matches registry key paths case-insensitively' do
+        File.write("#{temp_wine_prefix}/system.reg", system_reg_content)
+        result = Wine.registry_gets('HKEY_LOCAL_MACHINE\\SOFTWARE\\SIMUTRONICS\\LAUNCHER\\Directory')
+        expect(result).to eq('C:\\Program Files\\Launcher')
+      end
+
       it 'reads default (@) registry values' do
         File.write("#{temp_wine_prefix}/system.reg", system_reg_content)
         result = Wine.registry_gets('HKEY_LOCAL_MACHINE\\Software\\Classes\\Test\\')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Wine-managed Windows frontends on Linux, including valid files without Unix execute permissions.
  * Made Wine registry lookups case-insensitive for more reliable frontend discovery.
  * Preserved validation for other executable paths and continued handling system-call errors safely.

* **Tests**
  * Added coverage for non-executable Windows frontend files and case-insensitive registry keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->