### PR TITLE
feat(all): add --active-session-dir to decouple Active Sessions coordination from --temp

### DIFF
--- a/lib/common/authentication/login_helpers.rb
+++ b/lib/common/authentication/login_helpers.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../front-end'
-require_relative '../ruby_executable'
 
 # login_helpers.rb: Core lich file for collection of utilities to extend Lich capabilities.
 # Entries added here should always be accessible from Lich::Common::Authentication::LoginHelpers.method namespace.
@@ -603,52 +602,6 @@ module Lich
             when 'DRT' then '--drt'
             else nil
             end
-          end
-        end
-
-        # Spawns a Lich login session using a saved entry.
-        #
-        # This constructs and launches a Ruby + Lich command line with proper login arguments.
-        # It is aware of the Lich version and formats launch flags (e.g., `--gst`, `--GSX`) accordingly.
-        # Only the character name and game instance are passed - all sensitive data is handled by Lich internally.
-        #
-        # @param entry [Hash] the login entry (must include :char_name and :game_code)
-        # @param lich_path [String, nil] optional path to lich.rbw; defaults to LICH_DIR/lich.rbw
-        # @param startup_scripts [Array<String>] optional scripts to autostart post-login
-        # @param instance_override [String, Symbol, nil] optional instance override (e.g., 'GST', 'GSX')
-        # @param frontend_override [String, nil] optional frontend (e.g., 'avalon', 'wizard')
-        # @param custom_launch_filter [String, nil] optional custom launch filter for entry selection
-        # @return [Process::Waiter, nil] detached process handle if successful, nil otherwise
-        def self.spawn_login(entry, lich_path: nil, startup_scripts: [], instance_override: nil, frontend_override: nil, custom_launch_filter: nil)
-          ruby_path = Lich::Common::RubyExecutable.resolve
-          lich_path ||= File.join(LICH_DIR, 'lich.rbw')
-
-          spawn_cmd = [
-            "#{ruby_path}",
-            "#{lich_path}",
-            '--login', entry[:char_name]
-          ]
-          if instance_override
-            flag = format_launch_flag(instance_override)
-            spawn_cmd << flag if flag
-          end
-          spawn_cmd << "--#{frontend_override}" unless frontend_override.nil?
-          spawn_cmd << "--custom-launch=#{custom_launch_filter}" if custom_launch_filter
-          spawn_cmd << "--start-scripts=#{startup_scripts.join(',')}" if startup_scripts.any?
-
-          Lich::Messaging.msg('info', "Spawning login: #{spawn_cmd}")
-
-          begin
-            pid = Process.spawn(*spawn_cmd)
-            Process.detach(pid)
-          rescue Errno::ENOENT => e
-            Lich::Messaging.msg('error', "Executable not found: #{e.message}")
-            Lich.log "error: Executable not found: #{e.message}"
-            nil
-          rescue StandardError => e
-            Lich::Messaging.msg('error', "Failed to launch login session: #{e.class} - #{e.message}")
-            Lich.log "error: Failed to launch login session: #{e.class} - #{e.message}"
-            nil
           end
         end
       end

--- a/lib/common/session_launcher.rb
+++ b/lib/common/session_launcher.rb
@@ -16,7 +16,8 @@ module Lich
         { option: 'maps', key: :map_dir, constant: :MAP_DIR },
         { option: 'logs', key: :log_dir, constant: :LOG_DIR },
         { option: 'backup', key: :backup_dir, constant: :BACKUP_DIR },
-        { option: 'lib', key: :lib_dir, constant: :LIB_DIR }
+        { option: 'lib', key: :lib_dir, constant: :LIB_DIR },
+        { option: 'active-session-dir', key: :active_session_dir, constant: :ACTIVE_SESSION_DIR }
       ].freeze
 
       class << self
@@ -26,7 +27,8 @@ module Lich
         # @param launch_context [Hash, nil] Optional context keys:
         #   :char_name, :game_code, :frontend, :custom_launch, :dark_mode
         #   and optional directory overrides (:home_dir, :data_dir, :script_dir,
-        #   :temp_dir, :map_dir, :log_dir, :backup_dir, :lib_dir).
+        #   :temp_dir, :map_dir, :log_dir, :backup_dir, :lib_dir,
+        #   :active_session_dir).
         # @return [Hash] Structured result:
         #   - success: { ok: true, pid: Integer }
         #   - failure: { ok: false, error: String }
@@ -177,6 +179,14 @@ module Lich
           if option_name == 'home'
             return Object.const_defined?(:LICH_DIR) ? File.expand_path(Object.const_get(:LICH_DIR).to_s) : nil
           end
+
+          # active-session-dir has no constants.rb default of its own (see
+          # ActiveSessions.coordination_dir): an unset child falls back to its
+          # own TEMP_DIR, not to this process's ACTIVE_SESSION_DIR. There is no
+          # default here to compare against, so never suppress this flag --
+          # doing so would silently drop it whenever the requested value
+          # happens to match the parent's own coordination dir.
+          return nil if option_name == 'active-session-dir'
 
           home_override = context[:home_dir]
           if !home_override.to_s.empty?

--- a/lib/common/session_launcher.rb
+++ b/lib/common/session_launcher.rb
@@ -17,7 +17,10 @@ module Lich
         { option: 'logs', key: :log_dir, constant: :LOG_DIR },
         { option: 'backup', key: :backup_dir, constant: :BACKUP_DIR },
         { option: 'lib', key: :lib_dir, constant: :LIB_DIR },
-        { option: 'active-session-dir', key: :active_session_dir, constant: :ACTIVE_SESSION_DIR }
+        # :inherit marks a flag with no constants.rb default of its own, which a
+        # child therefore cannot re-derive from its own ARGV. Such a flag falls
+        # back to this process's constant when the launch context omits it.
+        { option: 'active-session-dir', key: :active_session_dir, constant: :ACTIVE_SESSION_DIR, inherit: true }
       ].freeze
 
       class << self
@@ -96,8 +99,10 @@ module Lich
         end
 
         # Builds optional CLI flags for child launches.
-        # Emits path flags only when explicitly overridden to a non-default value.
-        # This keeps child ARGV concise and avoids passing parent default directories.
+        # Emits path flags only when explicitly overridden to a non-default value,
+        # or, for :inherit flags, when this process holds a value the child cannot
+        # re-derive. This keeps child ARGV concise and avoids passing parent
+        # default directories.
         #
         # @param context [Hash] Optional launch context from GUI callbacks.
         # @return [Array<String>] Optional flags (possibly empty).
@@ -157,8 +162,10 @@ module Lich
         def overridden_path_value(context, path_flag)
           context_key = path_flag[:key]
           constant_name = path_flag[:constant]
-          return nil unless context.key?(context_key)
+          return inherited_path_value(path_flag) unless context.key?(context_key)
 
+          # An explicitly empty value is an opt-out: the caller named the key and
+          # asked for nothing, so don't fall back to this process's own value.
           value = context[context_key]
           return nil if value.to_s.empty?
 
@@ -167,6 +174,29 @@ module Lich
           return nil if default_value && value_expanded == default_value
 
           value
+        end
+
+        # Returns this process's own value for an :inherit flag the launch context
+        # did not mention.
+        #
+        # Production launch contexts (see GuiLogin#handle_play_action) carry
+        # account and frontend keys only -- never directory overrides. For flags
+        # backed by a constants.rb default that is harmless, since the child
+        # re-derives the same path. An :inherit flag has no such default: a child
+        # spawned without it coordinates through its own TEMP_DIR instead, so
+        # every GUI-launched session would build an isolated Active Sessions
+        # registry and defeat the point of --active-session-dir.
+        #
+        # @param path_flag [Hash]
+        # @return [String, nil]
+        def inherited_path_value(path_flag)
+          return nil unless path_flag[:inherit]
+
+          constant_name = path_flag[:constant]
+          return nil unless Object.const_defined?(constant_name)
+
+          value = Object.const_get(constant_name).to_s
+          value.empty? ? nil : value
         end
 
         # Resolves the path value that the child would derive without an explicit flag.

--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'json'
 require 'securerandom'
 require 'tmpdir'
@@ -402,6 +403,12 @@ module Lich
       # @note The caller must hold {@mutex}.
       # @return [Boolean] true when the lock was acquired by this process
       def self.acquire_ownership_lock
+        # coordination_dir has no boot-time mkdir the way TEMP_DIR does (see
+        # lib/init.rb) -- ACTIVE_SESSION_DIR in particular may point at a path
+        # that has never been created. Without this, File.open below raises
+        # Errno::ENOENT, which the rescue clause quietly turns into "service
+        # unavailable" with no actionable trace for the caller.
+        FileUtils.mkdir_p(coordination_dir)
         file = File.open(lock_path, File::RDWR | File::CREAT, 0o600)
         if file.flock(File::LOCK_EX | File::LOCK_NB)
           @lock_file = file
@@ -440,8 +447,16 @@ module Lich
       # Returns the base directory shared by local coordination files
       # (the discovery record and the ownership lock).
       #
+      # Prefers an explicit ACTIVE_SESSION_DIR override (set via the
+      # --active-session-dir=PATH CLI flag) so coordination can be pointed at a
+      # directory shared across characters independently of TEMP_DIR, which is
+      # often overridden per-character to separate debug logs. Falls back to
+      # today's behavior -- TEMP_DIR, or Dir.tmpdir -- when unset.
+      #
       # @return [String]
       def self.coordination_dir
+        return ACTIVE_SESSION_DIR if defined?(ACTIVE_SESSION_DIR) && !ACTIVE_SESSION_DIR.to_s.empty?
+
         defined?(TEMP_DIR) ? TEMP_DIR : Dir.tmpdir
       end
       private_class_method :coordination_dir

--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -73,11 +73,19 @@ module Lich
 
       # Indicates whether the active sessions API is enabled.
       #
-      # Until feature-flag plumbing is present in core, this API remains safely
-      # dormant and returns empty snapshots.
+      # An explicit --active-session-dir=PATH CLI flag implies opt-in for this
+      # process only -- passing a coordination directory is a clear enough
+      # signal of intent that requiring the persisted feature_flag:
+      # active_sessions_api row too would just be friction. This never writes
+      # to lich_settings; removing the flag on a later launch reverts to
+      # whatever the persisted flag says (false by default).
+      #
+      # Until feature-flag plumbing is present in core, this API otherwise
+      # remains safely dormant and returns empty snapshots.
       #
       # @return [Boolean]
       def self.enabled?
+        return true if defined?(ACTIVE_SESSION_DIR) && !ACTIVE_SESSION_DIR.to_s.empty?
         return false unless defined?(Lich::Common::FeatureFlags)
 
         Lich::Common::FeatureFlags.enabled?(FEATURE_FLAG)

--- a/lib/main/help_text.rb
+++ b/lib/main/help_text.rb
@@ -183,6 +183,12 @@ module Lich
             each character uses a separate --temp-dir, pass a shared
             --active-session-dir=PATH so all characters coordinate through one
             directory instead of isolated per-character ones.
+
+            Passing --active-session-dir=PATH also enables the active sessions
+            service for that launch, even if it isn't persistently enabled.
+            This is a per-launch opt-in only -- it writes nothing to disk, and
+            omitting the flag on a later launch reverts to the persisted
+            setting (disabled by default).
         TEXT
       end
 

--- a/lib/main/help_text.rb
+++ b/lib/main/help_text.rb
@@ -177,6 +177,12 @@ module Lich
           Examples:
             lich --active-sessions
             lich --session-info Mychar
+
+          Notes:
+            Active session discovery coordinates through TEMP_DIR by default. If
+            each character uses a separate --temp-dir, pass a shared
+            --active-session-dir=PATH so all characters coordinate through one
+            directory instead of isolated per-character ones.
         TEXT
       end
 
@@ -198,10 +204,12 @@ module Lich
             --lib-dir=PATH
             --hosts-dir=PATH
             --hosts-file=PATH
+            --active-session-dir=PATH
 
           Examples:
             lich --script-dir=/my/scripts
             lich --data-dir=/my/data --temp-dir=/tmp/lich
+            lich --temp-dir=/tmp/lich-Mychar --active-session-dir=/tmp/lich-sessions
         TEXT
       end
 

--- a/lib/main/help_text.rb
+++ b/lib/main/help_text.rb
@@ -186,9 +186,11 @@ module Lich
 
             Passing --active-session-dir=PATH also enables the active sessions
             service for that launch, even if it isn't persistently enabled.
-            This is a per-launch opt-in only -- it writes nothing to disk, and
+            This is a per-launch opt-in only -- it persists no setting, so
             omitting the flag on a later launch reverts to the persisted
-            setting (disabled by default).
+            setting (disabled by default). The service itself still writes
+            coordination files (a lock and a discovery record) into the
+            directory while it runs.
         TEXT
       end
 

--- a/lich.rbw
+++ b/lich.rbw
@@ -24,6 +24,8 @@ for arg in ARGV
     DATA_DIR = $1
   elsif arg =~ /^--(?:lib|lib-dir)=(.+)[\\\/]?$/i
     LIB_DIR = $1
+  elsif arg =~ /^--(?:active-session-dir)=(.+)[\\\/]?$/i
+    ACTIVE_SESSION_DIR = $1
   end
 end
 

--- a/spec/lib/common/authentication/login_helpers_spec.rb
+++ b/spec/lib/common/authentication/login_helpers_spec.rb
@@ -596,26 +596,4 @@ RSpec.describe Lich::Common::Authentication::LoginHelpers do
       expect(result).to match(/--G?S?3?/i)
     end
   end
-
-  describe '.spawn_login' do
-    it 'uses the shared checked Ruby executable for a child CLI login' do
-      allow(Lich::Common::RubyExecutable).to receive(:resolve).and_return('/checked/ruby')
-      allow(Process).to receive(:spawn).and_return(12_345)
-      waiter = double('process waiter')
-      allow(Process).to receive(:detach).with(12_345).and_return(waiter)
-
-      result = described_class.spawn_login(
-        { char_name: 'Tsetem', game_code: 'GS3' },
-        lich_path: '/lich/lich.rbw'
-      )
-
-      expect(result).to equal(waiter)
-      expect(Process).to have_received(:spawn).with(
-        '/checked/ruby',
-        '/lich/lich.rbw',
-        '--login',
-        'Tsetem'
-      )
-    end
-  end
 end

--- a/spec/lib/common/session_launcher_spec.rb
+++ b/spec/lib/common/session_launcher_spec.rb
@@ -163,6 +163,61 @@ RSpec.describe Lich::Common::SessionLauncher do
     )
   end
 
+  it 'forwards an explicit active_session_dir override' do
+    allow(described_class).to receive(:optional_spawn_flags).and_call_original
+    allow(Lich).to receive(:track_dark_mode).and_return(nil)
+    stub_const('LICH_DIR', '/tmp/lich-home')
+
+    described_class.launch(
+      launch_data + ['CHARACTER=Tsetem'],
+      launch_context: {
+        frontend: 'stormfront',
+        active_session_dir: '/tmp/shared-active-sessions'
+      }
+    )
+
+    expect(described_class).to have_received(:spawn).with(
+      '/usr/bin/ruby',
+      File.expand_path($PROGRAM_NAME),
+      '--login', 'Tsetem',
+      '--GST',
+      '--stormfront',
+      '--custom-launch=/path/to/custom',
+      '--active-session-dir=/tmp/shared-active-sessions',
+      hash_including(chdir: '/tmp/lich-home')
+    )
+  end
+
+  it 'still forwards active_session_dir even when it matches this process own constant' do
+    # active-session-dir has no constants.rb default the way DATA_DIR/SCRIPT_DIR
+    # do, so a spawned child cannot re-derive the parent's ACTIVE_SESSION_DIR on
+    # its own -- unlike the other path flags, "matches the current value" must
+    # never be treated as "the child would get this anyway" and suppressed.
+    allow(described_class).to receive(:optional_spawn_flags).and_call_original
+    allow(Lich).to receive(:track_dark_mode).and_return(nil)
+    stub_const('LICH_DIR', '/tmp/lich-home')
+    stub_const('ACTIVE_SESSION_DIR', '/tmp/shared-active-sessions')
+
+    described_class.launch(
+      launch_data + ['CHARACTER=Tsetem'],
+      launch_context: {
+        frontend: 'stormfront',
+        active_session_dir: '/tmp/shared-active-sessions'
+      }
+    )
+
+    expect(described_class).to have_received(:spawn).with(
+      '/usr/bin/ruby',
+      File.expand_path($PROGRAM_NAME),
+      '--login', 'Tsetem',
+      '--GST',
+      '--stormfront',
+      '--custom-launch=/path/to/custom',
+      '--active-session-dir=/tmp/shared-active-sessions',
+      hash_including(chdir: '/tmp/lich-home')
+    )
+  end
+
   it 'uses per-launch home_dir for chdir when provided in launch_context' do
     launch_data_with_name = launch_data + ['CHARACTER=Tsetem']
 

--- a/spec/lib/common/session_launcher_spec.rb
+++ b/spec/lib/common/session_launcher_spec.rb
@@ -218,6 +218,104 @@ RSpec.describe Lich::Common::SessionLauncher do
     )
   end
 
+  it 'inherits this process active_session_dir when the launch context omits it' do
+    # Production GUI launch contexts (GuiLogin#handle_play_action) carry account
+    # and frontend keys only, never directory overrides. Without inheritance the
+    # parent's --active-session-dir is dropped on every child, and each one
+    # coordinates through its own TEMP_DIR instead of the shared registry.
+    allow(described_class).to receive(:optional_spawn_flags).and_call_original
+    allow(Lich).to receive(:track_dark_mode).and_return(nil)
+    stub_const('LICH_DIR', '/tmp/lich-home')
+    stub_const('ACTIVE_SESSION_DIR', '/tmp/shared-active-sessions')
+
+    described_class.launch(
+      launch_data + ['CHARACTER=Tsetem'],
+      launch_context: {
+        frontend: 'stormfront',
+        user_id: 'someaccount',
+        saved_entry: true
+      }
+    )
+
+    expect(described_class).to have_received(:spawn).with(
+      '/usr/bin/ruby',
+      File.expand_path($PROGRAM_NAME),
+      '--login', 'Tsetem',
+      '--GST',
+      '--stormfront',
+      '--custom-launch=/path/to/custom',
+      '--active-session-dir=/tmp/shared-active-sessions',
+      hash_including(chdir: '/tmp/lich-home')
+    )
+  end
+
+  it 'inherits this process active_session_dir when no launch_context is given at all' do
+    allow(described_class).to receive(:optional_spawn_flags).and_call_original
+    allow(Lich).to receive(:track_dark_mode).and_return(nil)
+    stub_const('LICH_DIR', '/tmp/lich-home')
+    stub_const('ACTIVE_SESSION_DIR', '/tmp/shared-active-sessions')
+
+    described_class.launch(launch_data + ['CHARACTER=Tsetem'])
+
+    expect(described_class).to have_received(:spawn).with(
+      '/usr/bin/ruby',
+      File.expand_path($PROGRAM_NAME),
+      '--login', 'Tsetem',
+      '--GST',
+      '--stormfront',
+      '--custom-launch=/path/to/custom',
+      '--active-session-dir=/tmp/shared-active-sessions',
+      hash_including(chdir: '/tmp/lich-home')
+    )
+  end
+
+  it 'treats an explicitly empty active_session_dir as an opt-out rather than inheriting' do
+    allow(described_class).to receive(:optional_spawn_flags).and_call_original
+    allow(Lich).to receive(:track_dark_mode).and_return(nil)
+    stub_const('LICH_DIR', '/tmp/lich-home')
+    stub_const('ACTIVE_SESSION_DIR', '/tmp/shared-active-sessions')
+
+    described_class.launch(
+      launch_data + ['CHARACTER=Tsetem'],
+      launch_context: {
+        frontend: 'stormfront',
+        active_session_dir: nil
+      }
+    )
+
+    expect(described_class).to have_received(:spawn).with(
+      '/usr/bin/ruby',
+      File.expand_path($PROGRAM_NAME),
+      '--login', 'Tsetem',
+      '--GST',
+      '--stormfront',
+      '--custom-launch=/path/to/custom',
+      hash_including(chdir: '/tmp/lich-home')
+    )
+  end
+
+  it 'emits no active-session-dir flag when this process has none' do
+    allow(described_class).to receive(:optional_spawn_flags).and_call_original
+    allow(Lich).to receive(:track_dark_mode).and_return(nil)
+    stub_const('LICH_DIR', '/tmp/lich-home')
+    hide_const('ACTIVE_SESSION_DIR') if Object.const_defined?(:ACTIVE_SESSION_DIR)
+
+    described_class.launch(
+      launch_data + ['CHARACTER=Tsetem'],
+      launch_context: { frontend: 'stormfront' }
+    )
+
+    expect(described_class).to have_received(:spawn).with(
+      '/usr/bin/ruby',
+      File.expand_path($PROGRAM_NAME),
+      '--login', 'Tsetem',
+      '--GST',
+      '--stormfront',
+      '--custom-launch=/path/to/custom',
+      hash_including(chdir: '/tmp/lich-home')
+    )
+  end
+
   it 'uses per-launch home_dir for chdir when provided in launch_context' do
     launch_data_with_name = launch_data + ['CHARACTER=Tsetem']
 

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'tmpdir'
 
 require_relative '../../spec_helper'
+require_relative '../../../lib/common/feature_flags'
 require_relative '../../../lib/internal_api/active_sessions'
 
 RSpec.describe Lich::InternalAPI::ActiveSessions do
@@ -73,6 +74,40 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
       ensure
         FileUtils.rm_rf(active_session_dir)
       end
+    end
+  end
+
+  describe '.enabled?' do
+    before do
+      # The file-level `before` above stubs .enabled? to always return true so
+      # every other example doesn't have to think about the feature flag --
+      # restore the real implementation to actually test it here.
+      allow(described_class).to receive(:enabled?).and_call_original
+    end
+
+    it 'is true when ACTIVE_SESSION_DIR is set, even if the persisted flag is off' do
+      stub_const('ACTIVE_SESSION_DIR', temp_dir)
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?).and_return(false)
+
+      expect(described_class.enabled?).to be(true)
+      expect(Lich::Common::FeatureFlags).not_to have_received(:enabled?)
+    end
+
+    it 'does not persist anything when ACTIVE_SESSION_DIR implies opt-in' do
+      stub_const('ACTIVE_SESSION_DIR', temp_dir)
+      expect(Lich::Common::FeatureFlags).not_to receive(:set)
+
+      described_class.enabled?
+    end
+
+    it 'falls back to the persisted feature flag when ACTIVE_SESSION_DIR is unset' do
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?)
+        .with(described_class::FEATURE_FLAG).and_return(true)
+      expect(described_class.enabled?).to be(true)
+
+      allow(Lich::Common::FeatureFlags).to receive(:enabled?)
+        .with(described_class::FEATURE_FLAG).and_return(false)
+      expect(described_class.enabled?).to be(false)
     end
   end
 

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -56,6 +56,44 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
     JSON.parse(File.read(discovery_file), symbolize_names: true)
   end
 
+  describe '.coordination_dir' do
+    it 'falls back to TEMP_DIR when ACTIVE_SESSION_DIR is unset' do
+      expect(described_class.send(:coordination_dir)).to eq(temp_dir)
+    end
+
+    it 'uses ACTIVE_SESSION_DIR instead of TEMP_DIR when explicitly set' do
+      active_session_dir = Dir.mktmpdir('active-session-dir-spec')
+
+      begin
+        stub_const('ACTIVE_SESSION_DIR', active_session_dir)
+
+        expect(described_class.send(:coordination_dir)).to eq(active_session_dir)
+        expect(described_class.send(:lock_path)).to eq(File.join(active_session_dir, 'lich-active-sessions.lock'))
+        expect(described_class.send(:discovery_path)).to eq(File.join(active_session_dir, 'lich-active-sessions.json'))
+      ensure
+        FileUtils.rm_rf(active_session_dir)
+      end
+    end
+  end
+
+  describe '.acquire_ownership_lock' do
+    it 'creates a missing coordination_dir before opening the lock file' do
+      base_dir = Dir.mktmpdir('active-session-dir-missing-spec')
+      nested_dir = File.join(base_dir, 'nested', 'coordination')
+
+      begin
+        stub_const('ACTIVE_SESSION_DIR', nested_dir)
+        expect(File.directory?(nested_dir)).to be(false)
+
+        expect(described_class.send(:acquire_ownership_lock)).to be(true)
+
+        expect(File.directory?(nested_dir)).to be(true)
+      ensure
+        FileUtils.rm_rf(base_dir)
+      end
+    end
+  end
+
   describe 'ownership election' do
     it 'acquires the lock, binds an ephemeral port, and publishes it in discovery' do
       dead_client = instance_double(Lich::InternalAPI::ActiveSessions::Client, ping: false)

--- a/spec/lib/internal_api/active_sessions_spec.rb
+++ b/spec/lib/internal_api/active_sessions_spec.rb
@@ -124,6 +124,11 @@ RSpec.describe Lich::InternalAPI::ActiveSessions do
 
         expect(File.directory?(nested_dir)).to be(true)
       ensure
+        # Release before rm_rf: acquire_ownership_lock retains the open, flocked
+        # handle for the process lifetime, and the outer after hook only drops it
+        # after this deletion. Platforms that refuse to remove open locked files
+        # would leak the temporary directory.
+        described_class.send(:release_ownership_lock)
         FileUtils.rm_rf(base_dir)
       end
     end

--- a/spec/lib/main/help_text_spec.rb
+++ b/spec/lib/main/help_text_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Lich::Main::HelpText do
       expect(output).to include('Lich Help: automation')
       expect(output).to include('--active-sessions')
       expect(output).to include('--session-info NAME')
+      expect(output).to include('--active-session-dir=PATH')
     end
 
     it 'requires an explicit flag to suppress the default GTK GUI' do
@@ -60,6 +61,7 @@ RSpec.describe Lich::Main::HelpText do
       expect(output).to include('--lib-dir=PATH')
       expect(output).to include('--hosts-dir=PATH')
       expect(output).to include('--hosts-file=PATH')
+      expect(output).to include('--active-session-dir=PATH')
     end
   end
 


### PR DESCRIPTION
## Summary

- Active Sessions coordination (the lock + discovery files that let independent Lich processes find each other) previously always lived under `TEMP_DIR`. Anyone overriding `--temp` per-character to keep debug logs separate ends up with an isolated Active Sessions registry per character instead of one shared one, defeating the point of a cross-process session list.
- Adds `--active-session-dir=PATH` to point coordination at a shared directory independently of `--temp`. Unset, behavior is unchanged (falls back to `TEMP_DIR`, or `Dir.tmpdir` if that's undefined).
- Fixes two gaps caught in review before this landed: `coordination_dir` had no boot-time `mkdir` the way `TEMP_DIR` does, so a not-yet-existing `--active-session-dir` path silently degraded to "service unavailable" with no trace of the real cause; and `SessionLauncher`'s optional-flag forwarding assumed every path flag has a `constants.rb` default a spawned child re-derives on its own, which isn't true for this one and caused it to be silently dropped when forwarded value matched the parent's.
- Second commit: an explicit `--active-session-dir` also implicitly enables the Active Sessions service for that launch, without persisting anything to `lich_settings` — removing the flag on a later launch reverts to the persisted default (disabled). Kept as a separate commit in case the "implicit enable" behavior specifically needs to be reverted independently.

### Review round 2 (@OSXLich-Doug)

Four follow-up commits, one per finding:

- **[P1] Propagate the parent's active-session directory to GUI children** — confirmed, and broader than the report: *no* production caller populates any of the nine `OPTIONAL_PATH_FLAGS` context keys, since GUI launch contexts are login entries (account/frontend), not directory overrides. For the other eight that's harmless — a child re-derives them from `constants.rb`. `--active-session-dir` has no such default by design, so it was dropped on every GUI-launched child. Marked `:inherit` and now falls back to this process's `ACTIVE_SESSION_DIR` when the context omits the key; an explicitly empty value stays an opt-out.
- **[P2] Correct the "writes nothing to disk" claim** — the service does create the coordination dir, the lock, and the discovery record. Help text now says it persists no *setting*, and spells out that coordination files are still written. Corrected in the summary above too.
- **[P3] Unused `:active_session_dir` launch-context path** — resolved by the P1 fix, which makes the path reachable from production.
- **[P3] Release the ownership lock before deleting its temp dir** — done in the example's own `ensure`, ahead of `rm_rf`.
- **[P3] Remove the uncalled `spawn_login` helper** — removed, along with its now-unused `ruby_executable` require (both remaining `RubyExecutable` callers require it themselves). Predates this branch; folded in here since it's a second child-launch path already drifted from `SessionLauncher`. Happy to split it out if you'd rather keep the branch narrow.

## Test plan

- [x] `bundle exec rspec` (full suite): 6346 examples, 0 failures (rebased onto `main` through #1532 / 5.20.1)
- [x] `bundle exec rubocop` on all touched files: no offenses
- [x] Manually reproduced both review findings (ENOENT on a missing coordination dir; flag silently dropped when forwarded value matches the parent's own) before and after the fix
- [x] Manually verified the implicit-enable behavior against a real `lich_settings` row forced to `false`, confirming it stays untouched on disk
- [x] Round 2: new specs cover inheriting `ACTIVE_SESSION_DIR` when the context omits it, when no context is passed at all, the explicit-empty opt-out, and the no-constant case
- [x] Re-ran every manual verification against the post-rebase base, driving the real library code rather than specs:
  - missing coordination dir is created and the lock acquired; with the `mkdir_p` removed the same call raises `Errno::ENOENT` and degrades to "service unavailable"
  - real detached child processes spawned via `SessionLauncher`, asserting on the child's actual `ARGV`: inherits the parent's `--active-session-dir` from a production-shaped GUI context, still forwards it when the explicit value equals the parent's, honours the explicit-empty opt-out, and emits nothing when the parent has no `ACTIVE_SESSION_DIR`. `--data` matching its `constants.rb` default is still suppressed in the same run, confirming the suppression logic is live and only bypassed for this flag
  - against a real SQLite `lich_settings` row forced to `false`: `ActiveSessions.enabled?` returns true with the flag set, the row still reads `false`, no rows are added, the db file is byte-identical, and dropping the flag reverts to the persisted `false`


