### PR TITLE
fix(dr): make $safe_pause_lock holder immune to pause

### DIFF
--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -971,6 +971,18 @@ module Lich
       def safe_pause_list
         return false unless $safe_pause_lock.try_lock
 
+        # Pausing is cooperative: a paused script is a live thread that keeps
+        # every mutex it holds (Ruby frees a mutex on thread death, not on
+        # pause). So a script that gets pause_script'd while holding
+        # $safe_pause_lock never releases it, and every peer spins forever on
+        # try_lock -> false. Make the lock-holder immune to pause for as long as
+        # it owns the lock, so this deadlock cannot form. Save the prior value
+        # (and the holder itself) so we restore exactly what was there for a
+        # caller that was already ignoring pauses, e.g. mid-travel.
+        @safe_pause_holder = Script.self
+        @safe_pause_prev_ignore_pause = @safe_pause_holder&.ignore_pause
+        @safe_pause_holder&.ignore_pause = true
+
         paused_script_list = []
         Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != Script.self.name }.each do |s|
           s.pause
@@ -989,6 +1001,11 @@ module Lich
           Lich::Messaging.msg("plain", "DRC: Unpausing #{scripts_to_unpause}, #{Script.self.name} has finished.")
           Script.running.find_all { |s| s.paused? && !s.no_pause_all && scripts_to_unpause.include?(s.name) }.each(&:unpause)
         end
+        # Restore the holder's pre-lock pause immunity before releasing the lock,
+        # so we never leave a script permanently unpausable.
+        @safe_pause_holder&.ignore_pause = @safe_pause_prev_ignore_pause
+        @safe_pause_holder = nil
+        @safe_pause_prev_ignore_pause = nil
         $safe_pause_lock.unlock
       end
 

--- a/spec/lib/dragonrealms/commons/common_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_spec.rb
@@ -1077,6 +1077,41 @@ RSpec.describe Lich::DragonRealms::DRC do
         end
       end
     end
+
+    # Regression: a script that gets pause_script'd while holding
+    # $safe_pause_lock is a live-but-suspended thread that keeps the mutex, so
+    # every peer deadlocks on try_lock. The holder must be made immune to pause
+    # (ignore_pause) for as long as it owns the lock, then restored.
+    describe 'lock holder pause immunity' do
+      let(:holder) { Script.new.tap { |s| s.name = 'holder'; s.ignore_pause = false } }
+
+      before { allow(Script).to receive(:self).and_return(holder) }
+
+      it 'makes the lock holder immune to pause while it holds the lock' do
+        described_class.safe_pause_list
+        expect(holder.ignore_pause).to be true
+      end
+
+      it 'restores the holder pause setting when the lock is released' do
+        described_class.safe_pause_list
+        described_class.safe_unpause_list(['other'])
+        expect(holder.ignore_pause).to be false
+      end
+
+      it 'restores a pre-existing ignore_pause=true rather than clobbering it' do
+        holder.ignore_pause = true
+        described_class.safe_pause_list
+        expect(holder.ignore_pause).to be true
+        described_class.safe_unpause_list([])
+        expect(holder.ignore_pause).to be true
+      end
+
+      it 'does not grant immunity when the lock cannot be acquired' do
+        $safe_pause_lock.lock
+        expect(described_class.safe_pause_list).to be false
+        expect(holder.ignore_pause).to be false
+      end
+    end
   end
 
   describe '.log_window' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -604,7 +604,7 @@ end
 # Represents running scripts. Full implementation for testing pause/unpause.
 
 class Script
-  attr_accessor :paused, :no_pause_all, :name
+  attr_accessor :paused, :no_pause_all, :name, :ignore_pause
 
   def paused?
     @paused || false


### PR DESCRIPTION
## Problem

Scripts coordinate access to the single game connection by pausing each other. `DRC.safe_pause_list` takes `$safe_pause_lock` (fail-fast `try_lock`), pauses peers, and callers hand-roll the wait with `until (x = DRC.safe_pause_list); pause N; end`.

Pausing in Lich is **cooperative**: `Script#pause` only sets a flag, honored the next time the script calls `Script.current` (`sleep 0.2 while paused?`, `lib/common/script.rb:1026`). A paused script is therefore a **live thread that keeps every mutex it holds** — Ruby frees a mutex on thread *death*, not on pause.

So if a script is `pause_script`'d **by name** while it holds `$safe_pause_lock`, it parks at its next I/O call still holding the lock, and every peer spins forever on `try_lock -> false`. Real incident: a lock-holder studying its almanac was paused from inside another script's heal; the lock was never released and the character froze.

## Fix

`safe_pause_list` sets `ignore_pause` on the lock holder for as long as it owns `$safe_pause_lock`, so a raw `pause_script` can no longer suspend the holder mid-section. `safe_unpause_list` restores the **previous** value (saved, not forced to `false`) before releasing the lock, so a caller that was already ignoring pauses (e.g. mid-travel) is not clobbered.

This reuses an existing, tested mechanism — `ignore_pause` is already used for a critical section by GemStone travel (`lib/common/map/map_gs.rb:190,260`).

## Scope / non-goals

Targeted hotfix for the deadlock. It intentionally does **not** remove the two-mechanism coordination structure (lock-guarded pause vs. raw `pause_script`) or the unbounded spin loops in the ~18 dr-scripts callers. A lease-based command broker is planned separately to retire pausing-as-coordination; this buys safety now and is independently valuable.

## Testing

- New regression specs in `spec/lib/dragonrealms/commons/common_spec.rb`: holder made immune while holding the lock, restored on release, pre-existing `ignore_pause=true` not clobbered, no immunity granted when the lock can't be acquired.
- Added `ignore_pause` to the central `Script` double in `spec/spec_helper.rb` (additive).
- Full suite green (6285 examples, 0 failures) and `rubocop -A` clean on Ruby 4.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)