### PR TITLE
feat(dr): command broker infra (Stage 1, no callers wired)

### DIFF
--- a/lib/dragonrealms/commons.rb
+++ b/lib/dragonrealms/commons.rb
@@ -1,3 +1,4 @@
+require_relative "./commons/command-broker"
 require_relative "./commons/common"
 require_relative "./commons/common-validation"
 require_relative "./commons/common-items"

--- a/lib/dragonrealms/commons/command-broker.rb
+++ b/lib/dragonrealms/commons/command-broker.rb
@@ -1,0 +1,317 @@
+# frozen_string_literal: true
+
+module Lich
+  module DragonRealms
+    # Command Broker (Stage 1 infra).
+    #
+    # Serializes exclusive access to the single game connection with a *lease*
+    # instead of by pausing peer scripts. A caller that cannot get the lease
+    # parks itself on a condition variable (pausing no one) until the lease
+    # frees or its bounded timeout elapses.
+    #
+    # This is the structural fix for the "$safe_pause_lock deadlock": pausing in
+    # Lich is cooperative, so a paused script is a live thread that keeps every
+    # mutex it holds. Coordinating with a lease -- where waiters park instead of
+    # pausing the holder, and acquisition is bounded -- removes the ability for
+    # one coordination mechanism to suspend the holder of another.
+    #
+    # Design notes (see docs/command-broker-design.md):
+    #   * The critical section is guarded by broker STATE (@owner), not by a
+    #     mutex held across the section. @mutex guards only the acquire/release
+    #     state transitions and is NEVER held across a yield or any call that can
+    #     reach Script.current. This is what makes bounded acquisition,
+    #     dead-holder reclamation, and the watchdog possible.
+    #   * Ownership is keyed by Thread.current (non-blocking, reentrant, and
+    #     supports death detection via Thread#alive?).
+    #   * Bail semantics: #exclusive returns :broker_timeout without running the
+    #     block on acquisition timeout; #exclusive! raises LeaseTimeout instead.
+    #   * Priority is a two-band queue (:high jumps ahead of :normal); there is
+    #     NO preemption of an in-flight lease.
+    #   * Watchdog reclaims leases held by a dead thread and logs (never revokes)
+    #     an over-long live holder.
+    #
+    # Stage 1 wires this into DRC.bput only; direct fput/put remain unbrokered
+    # until a later stage. Callers are migrated off safe_pause_list/pause_script
+    # incrementally.
+    class Broker
+      # Raised by #exclusive! when the lease cannot be acquired in time.
+      class LeaseTimeout < StandardError; end
+
+      # Default bounded wait for a lease, in seconds. Matches the dominant
+      # `pause 30` idiom in the callers being migrated. Override per call.
+      DEFAULT_TIMEOUT = 30
+
+      # How often the watchdog thread wakes, in seconds.
+      WATCHDOG_INTERVAL = 5
+
+      # How long a live holder may hold the lease before the watchdog logs a
+      # (non-fatal) warning, in seconds. Sized to tolerate long roundtimes/casts
+      # and fput's up-to-60s resend loop.
+      WATCHDOG_WARN_AFTER = 90
+
+      VALID_PRIORITIES = %i[high normal].freeze
+
+      class << self
+        # The process-wide default broker instance used by the commons. Tests
+        # construct their own with .new and do not touch this.
+        def instance
+          @instance ||= new
+        end
+
+        # Test/lifecycle hook: drop the memoized default instance.
+        def reset_instance!
+          @instance = nil
+        end
+
+        def exclusive(**opts, &block)
+          instance.exclusive(**opts, &block)
+        end
+
+        def exclusive!(**opts, &block)
+          instance.exclusive!(**opts, &block)
+        end
+
+        def held?
+          instance.held?
+        end
+
+        def mine?
+          instance.mine?
+        end
+
+        def owner_name
+          instance.owner_name
+        end
+      end
+
+      def initialize
+        @mutex = Mutex.new
+        @free = ConditionVariable.new
+        @owner = nil          # Thread currently holding the lease
+        @depth = 0            # reentrancy count for @owner
+        @acquired_at = nil    # monotonic time the lease was taken
+        @holder_name = nil    # script name, for logs
+        @intent = nil         # caller-supplied label, for logs
+        @warned_age = nil     # last age (s) the watchdog warned at
+        @waiters = []         # [{thread:, priority:, seq:}], grant order via #next_token_locked
+        @seq = 0
+        @watchdog = nil
+      end
+
+      # Run the block while holding an exclusive lease on the send channel.
+      #
+      # @param timeout [Numeric] bounded seconds to wait for the lease
+      # @param intent [String, nil] short label for logging/watchdog
+      # @param priority [:high, :normal] queue band; :high jumps ahead
+      # @return the block's value, or :broker_timeout if the lease was not
+      #   acquired in time (in which case the block does NOT run)
+      def exclusive(timeout: DEFAULT_TIMEOUT, intent: nil, priority: :normal)
+        return :broker_timeout unless acquire(timeout, intent, priority)
+
+        guarded { yield }
+      end
+
+      # Like #exclusive but raises LeaseTimeout instead of returning the sentinel.
+      def exclusive!(timeout: DEFAULT_TIMEOUT, intent: nil, priority: :normal)
+        unless acquire(timeout, intent, priority)
+          raise LeaseTimeout, "could not acquire command lease within #{timeout}s (held by #{owner_name || 'nobody'})"
+        end
+
+        guarded { yield }
+      end
+
+      # @return [Boolean] whether any lease is currently held
+      def held?
+        @mutex.synchronize { !@owner.nil? }
+      end
+
+      # @return [Boolean] whether the calling thread holds the lease
+      def mine?
+        @mutex.synchronize { @owner.equal?(Thread.current) }
+      end
+
+      # @return [String, nil] the holder's script name, or nil if free
+      def owner_name
+        @mutex.synchronize { @holder_name }
+      end
+
+      # One watchdog pass: reclaim a dead holder's lease, and warn (without
+      # revoking) when a live holder has held past +warn_after+. Exposed so the
+      # background thread and tests can drive it identically.
+      #
+      # @param warn_after [Numeric] seconds before a live holder is warned about
+      def tick_watchdog(warn_after: WATCHDOG_WARN_AFTER)
+        @mutex.synchronize do
+          reclaim_if_dead_locked
+          break if @owner.nil? || @acquired_at.nil?
+
+          age = now - @acquired_at
+          break if age < warn_after
+          # Warn at most once per warn_after window so we don't spam.
+          break if @warned_age && (age - @warned_age) < warn_after
+
+          @warned_age = age
+          log('bold', "DRC: Broker lease held #{age.round}s by #{describe_holder} -- possible stuck holder")
+        end
+      end
+
+      # Start the background watchdog thread (idempotent). Not called at load;
+      # the bput integration (a later PR) starts it once at runtime.
+      def start_watchdog!(interval: WATCHDOG_INTERVAL)
+        @mutex.synchronize do
+          return @watchdog if @watchdog&.alive?
+
+          @watchdog = Thread.new do
+            loop do
+              sleep interval
+              begin
+                tick_watchdog
+              rescue StandardError => e
+                Lich.log("error: broker watchdog: #{e}") if defined?(Lich) && Lich.respond_to?(:log)
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      # Acquire the lease or time out. Returns true if held on return (including
+      # a reentrant re-acquire), false on timeout.
+      def acquire(timeout, intent, priority)
+        me = Thread.current
+        name = current_script_name
+
+        @mutex.synchronize do
+          reclaim_if_dead_locked
+
+          if @owner.equal?(me) # reentrant: already ours
+            @depth += 1
+            return true
+          end
+
+          deadline = now + timeout
+          token = enqueue_waiter_locked(me, priority)
+          took = false
+          begin
+            until grantable_locked?(token)
+              remaining = deadline - now
+              return false if remaining <= 0
+
+              @free.wait(@mutex, remaining)
+              reclaim_if_dead_locked
+            end
+            take_lease_locked(me, name, intent)
+            took = true
+            return true
+          ensure
+            remove_waiter_locked(token)
+            # If we did not take the lease (timeout/exception), a successor may
+            # now be at the front of the queue -- wake waiters to re-check.
+            @free.broadcast unless took
+          end
+        end
+      end
+
+      # Run a block under an already-held lease, releasing exactly once after.
+      def guarded
+        yield
+      ensure
+        release
+      end
+
+      def release
+        @mutex.synchronize do
+          return unless @owner.equal?(Thread.current)
+
+          @depth -= 1
+          return if @depth.positive?
+
+          log('plain', "DRC: Broker lease released by #{describe_holder}")
+          clear_lease_locked
+          @free.broadcast
+        end
+      end
+
+      def take_lease_locked(thread, name, intent)
+        @owner = thread
+        @depth = 1
+        @acquired_at = now
+        @holder_name = name
+        @intent = intent
+        @warned_age = nil
+        log('plain', "DRC: Broker lease granted to #{describe_holder}")
+      end
+
+      def clear_lease_locked
+        @owner = nil
+        @depth = 0
+        @acquired_at = nil
+        @holder_name = nil
+        @intent = nil
+        @warned_age = nil
+      end
+
+      # Reclaim the lease if its holder thread has died without releasing.
+      def reclaim_if_dead_locked
+        return if @owner.nil? || @owner.alive?
+
+        log('bold', "DRC: Broker reclaiming lease from dead holder #{describe_holder}")
+        clear_lease_locked
+        @free.broadcast
+      end
+
+      def grantable_locked?(token)
+        @owner.nil? && next_token_locked.equal?(token)
+      end
+
+      # The waiter that should be granted next: highest priority first, then
+      # FIFO by arrival sequence within a band.
+      def next_token_locked
+        @waiters.min_by { |w| [w[:priority] == :high ? 0 : 1, w[:seq]] }
+      end
+
+      def enqueue_waiter_locked(thread, priority)
+        @seq += 1
+        token = { thread: thread, priority: normalize_priority(priority), seq: @seq }
+        @waiters << token
+        token
+      end
+
+      def remove_waiter_locked(token)
+        @waiters.delete(token)
+      end
+
+      def normalize_priority(priority)
+        VALID_PRIORITIES.include?(priority) ? priority : :normal
+      end
+
+      def describe_holder
+        @intent ? "#{@holder_name} (#{@intent})" : @holder_name.to_s
+      end
+
+      # Monotonic clock so deadlines/ages are immune to wall-clock jumps.
+      def now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      # Best-effort current script name for logs. Uses Script.self (== the
+      # running script) to match the commons convention; never raises.
+      def current_script_name
+        return '(unknown)' unless defined?(Script) && Script.respond_to?(:self)
+
+        Script.self&.name || '(unknown)'
+      rescue StandardError
+        '(unknown)'
+      end
+
+      def log(style, message)
+        return unless defined?(Lich::Messaging) && Lich::Messaging.respond_to?(:msg)
+
+        Lich::Messaging.msg(style, message)
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/lib/dragonrealms/commons/command-broker.rb
+++ b/lib/dragonrealms/commons/command-broker.rb
@@ -51,16 +51,22 @@ module Lich
 
       VALID_PRIORITIES = %i[high normal].freeze
 
+      # Guards creation/reset of the process-wide default instance so a first-use
+      # race between script threads cannot construct two brokers -- which would
+      # split serialization across two independent leases.
+      CLASS_MUTEX = Mutex.new
+
       class << self
         # The process-wide default broker instance used by the commons. Tests
-        # construct their own with .new and do not touch this.
+        # construct their own with .new and do not touch this. Double-checked so
+        # the hot path stays lock-free once initialized.
         def instance
-          @instance ||= new
+          @instance || CLASS_MUTEX.synchronize { @instance ||= new }
         end
 
         # Test/lifecycle hook: drop the memoized default instance.
         def reset_instance!
-          @instance = nil
+          CLASS_MUTEX.synchronize { @instance = nil }
         end
 
         def exclusive(**opts, &block)
@@ -151,7 +157,7 @@ module Lich
           break if @warned_age && (age - @warned_age) < warn_after
 
           @warned_age = age
-          log('bold', "DRC: Broker lease held #{age.round}s by #{describe_holder} -- possible stuck holder")
+          log('bold', "DRC: Broker lease held #{age.round}s by #{describe_holder} -- possible stuck holder#{holder_backtrace}")
         end
       end
 
@@ -288,6 +294,17 @@ module Lich
 
       def describe_holder
         @intent ? "#{@holder_name} (#{@intent})" : @holder_name.to_s
+      end
+
+      # A bounded snapshot of the holder thread's stack, appended to the stuck-
+      # holder warning so an operator can see where it is wedged. Empty when
+      # unavailable (e.g. the holder just died). Runs under @mutex, so it never
+      # races the holder into a nil @owner.
+      def holder_backtrace
+        frames = Array(@owner&.backtrace).first(15)
+        return '' if frames.empty?
+
+        "\n    #{frames.join("\n    ")}"
       end
 
       # Monotonic clock so deadlines/ages are immune to wall-clock jumps.

--- a/spec/lib/dragonrealms/commons/command_broker_spec.rb
+++ b/spec/lib/dragonrealms/commons/command_broker_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+
+require File.join(LIB_DIR, 'dragonrealms', 'commons', 'command-broker.rb')
+
+RSpec.describe Lich::DragonRealms::Broker do
+  subject(:broker) { described_class.new }
+
+  # Keep a helper thread alive until released, so it can stand in as a foreign
+  # (live) lease holder without racing the test.
+  def live_holder
+    gate = Queue.new
+    thread = Thread.new { gate.pop }
+    Thread.pass until thread.status == 'sleep' || !thread.alive?
+    [thread, gate]
+  end
+
+  def dead_thread
+    t = Thread.new {}
+    t.join
+    t
+  end
+
+  def hold_lease_with(thread, name: 'peer', intent: nil, acquired_at: 0.0)
+    broker.instance_variable_set(:@owner, thread)
+    broker.instance_variable_set(:@depth, 1)
+    broker.instance_variable_set(:@acquired_at, acquired_at)
+    broker.instance_variable_set(:@holder_name, name)
+    broker.instance_variable_set(:@intent, intent)
+  end
+
+  def messages
+    Lich::Messaging.messages.map { |m| m[:message] }
+  end
+
+  describe '#exclusive (happy path)' do
+    it 'yields, returns the block value, and frees the lease' do
+      result = broker.exclusive(intent: 'study') { 42 }
+      expect(result).to eq(42)
+      expect(broker.held?).to be false
+    end
+
+    it 'returns a falsey block value faithfully (not confused with timeout)' do
+      expect(broker.exclusive { false }).to be false
+      expect(broker.exclusive { nil }).to be_nil
+    end
+
+    it 'reports ownership while inside the block' do
+      broker.exclusive do
+        expect(broker.held?).to be true
+        expect(broker.mine?).to be true
+        expect(broker.owner_name).not_to be_nil
+      end
+      expect(broker.held?).to be false
+      expect(broker.mine?).to be false
+      expect(broker.owner_name).to be_nil
+    end
+
+    it 'releases the lease even when the block raises' do
+      expect { broker.exclusive { raise 'boom' } }.to raise_error('boom')
+      expect(broker.held?).to be false
+    end
+
+    it 'logs grant and release mirroring the DRC pause messages' do
+      broker.exclusive(intent: 'study') { :ok }
+      expect(messages).to include(a_string_matching(/DRC: Broker lease granted to .*\(study\)/))
+      expect(messages).to include(a_string_matching(/DRC: Broker lease released by .*\(study\)/))
+    end
+  end
+
+  describe '#exclusive reentrancy' do
+    it 'lets the same thread re-enter without deadlocking and frees once' do
+      inner_ran = false
+      broker.exclusive(intent: 'outer') do
+        broker.exclusive(intent: 'inner') { inner_ran = true }
+        # inner release must NOT free the lease the outer call still holds
+        expect(broker.held?).to be true
+        expect(broker.mine?).to be true
+      end
+      expect(inner_ran).to be true
+      expect(broker.held?).to be false
+    end
+  end
+
+  describe '#exclusive timeout' do
+    it 'returns :broker_timeout without running the block when held by a live peer' do
+      thread, gate = live_holder
+      hold_lease_with(thread)
+      allow(broker).to receive(:now).and_return(0.0, 100.0)
+
+      ran = false
+      result = broker.exclusive(timeout: 30) { ran = true }
+
+      expect(result).to eq(:broker_timeout)
+      expect(ran).to be false
+    ensure
+      gate << :go
+      thread.join
+    end
+  end
+
+  describe '#exclusive!' do
+    it 'returns the block value on success' do
+      expect(broker.exclusive!(timeout: 5) { 7 }).to eq(7)
+      expect(broker.held?).to be false
+    end
+
+    it 'raises LeaseTimeout when the lease cannot be acquired in time' do
+      thread, gate = live_holder
+      hold_lease_with(thread)
+      allow(broker).to receive(:now).and_return(0.0, 100.0)
+
+      expect { broker.exclusive!(timeout: 30) { :never } }
+        .to raise_error(described_class::LeaseTimeout, /could not acquire command lease/)
+    ensure
+      gate << :go
+      thread.join
+    end
+  end
+
+  describe 'dead-holder reconciliation' do
+    it 'reclaims a lease whose holder thread has died, on the next acquire' do
+      hold_lease_with(dead_thread, name: 'zombie')
+
+      expect(broker.exclusive(timeout: 5) { :ran }).to eq(:ran)
+      expect(broker.held?).to be false
+      expect(messages).to include(a_string_matching(/reclaiming lease from dead holder zombie/))
+    end
+  end
+
+  describe '#tick_watchdog' do
+    it 'reclaims a dead holder proactively' do
+      hold_lease_with(dead_thread, name: 'zombie')
+      broker.tick_watchdog
+      expect(broker.held?).to be false
+    end
+
+    it 'warns about an over-long LIVE holder but does not revoke it' do
+      thread, gate = live_holder
+      hold_lease_with(thread, name: 'slow', acquired_at: 0.0)
+      allow(broker).to receive(:now).and_return(1000.0)
+
+      broker.tick_watchdog(warn_after: 90)
+
+      expect(broker.held?).to be true
+      expect(messages).to include(a_string_matching(/lease held 1000s by slow -- possible stuck holder/))
+    ensure
+      gate << :go
+      thread.join
+    end
+
+    it 'does not warn before the threshold' do
+      thread, gate = live_holder
+      hold_lease_with(thread, name: 'slow', acquired_at: 0.0)
+      allow(broker).to receive(:now).and_return(10.0)
+
+      broker.tick_watchdog(warn_after: 90)
+
+      expect(messages).not_to include(a_string_matching(/possible stuck holder/))
+    ensure
+      gate << :go
+      thread.join
+    end
+  end
+
+  describe 'waiter ordering (#next_token_locked)' do
+    it 'grants highest priority first, FIFO within a band' do
+      broker.instance_variable_set(:@waiters, [
+                                     { thread: :a, priority: :normal, seq: 1 },
+                                     { thread: :b, priority: :high,   seq: 2 },
+                                     { thread: :c, priority: :normal, seq: 3 },
+                                     { thread: :d, priority: :high,   seq: 4 },
+                                   ])
+      expect(broker.send(:next_token_locked)[:thread]).to eq(:b)
+    end
+
+    it 'falls back to FIFO when no high-priority waiters remain' do
+      broker.instance_variable_set(:@waiters, [
+                                     { thread: :c, priority: :normal, seq: 3 },
+                                     { thread: :a, priority: :normal, seq: 1 },
+                                   ])
+      expect(broker.send(:next_token_locked)[:thread]).to eq(:a)
+    end
+  end
+
+  describe 'priority normalization' do
+    it 'coerces an unknown priority to :normal' do
+      expect(broker.send(:normalize_priority, :bogus)).to eq(:normal)
+      expect(broker.send(:normalize_priority, :high)).to eq(:high)
+      expect(broker.send(:normalize_priority, :normal)).to eq(:normal)
+    end
+  end
+
+  describe 'class-level facade' do
+    after { described_class.reset_instance! }
+
+    it 'delegates to a shared singleton instance' do
+      expect(described_class.exclusive(timeout: 5) { :ok }).to eq(:ok)
+      expect(described_class.held?).to be false
+      expect(described_class.instance).to be(described_class.instance)
+    end
+  end
+
+  # End-to-end with real threads: exercises the actual ConditionVariable park
+  # and broadcast (the stubbed timeout/ordering tests above never wait). Bounded
+  # spins/joins so a regression fails fast instead of hanging the suite.
+  describe 'concurrency (real threads)' do
+    def wait_for_waiters(target)
+      200.times do
+        return if broker.instance_variable_get(:@waiters).length >= target
+
+        sleep 0.005
+      end
+      raise "waiters never reached #{target}"
+    end
+
+    def join_all(*threads)
+      threads.each { |t| raise 'broker thread hung' unless t.join(2) }
+    end
+
+    it 'parks a waiter (pausing no one) and grants it on release' do
+      order = Queue.new
+      holding = Queue.new
+      release_now = Queue.new
+
+      holder = Thread.new do
+        broker.exclusive(intent: 'holder') do
+          holding << :held
+          release_now.pop
+          order << :holder_done
+        end
+      end
+      holding.pop # holder now owns the lease
+
+      waiter = Thread.new { broker.exclusive(intent: 'waiter') { order << :waiter_ran } }
+      wait_for_waiters(1) # waiter is parked, not pausing the holder
+
+      release_now << :go
+      join_all(holder, waiter)
+
+      expect([order.pop, order.pop]).to eq(%i[holder_done waiter_ran])
+      expect(broker.held?).to be false
+    end
+
+    it 'grants a high-priority waiter ahead of an earlier normal waiter' do
+      order = Queue.new
+      holding = Queue.new
+      release_now = Queue.new
+
+      holder = Thread.new do
+        broker.exclusive(intent: 'holder') do
+          holding << :held
+          release_now.pop
+        end
+      end
+      holding.pop
+
+      normal = Thread.new { broker.exclusive(priority: :normal) { order << :normal } }
+      wait_for_waiters(1)
+      high = Thread.new { broker.exclusive(priority: :high) { order << :high } }
+      wait_for_waiters(2)
+
+      release_now << :go
+      join_all(holder, normal, high)
+
+      expect([order.pop, order.pop]).to eq(%i[high normal])
+    end
+  end
+end

--- a/spec/lib/dragonrealms/commons/command_broker_spec.rb
+++ b/spec/lib/dragonrealms/commons/command_broker_spec.rb
@@ -144,7 +144,10 @@ RSpec.describe Lich::DragonRealms::Broker do
       broker.tick_watchdog(warn_after: 90)
 
       expect(broker.held?).to be true
-      expect(messages).to include(a_string_matching(/lease held 1000s by slow -- possible stuck holder/))
+      warning = messages.find { |m| m.include?('possible stuck holder') }
+      expect(warning).to match(/lease held 1000s by slow/)
+      # The holder thread's backtrace is appended so the wedge is diagnosable.
+      expect(warning).to match(/\.rb:\d+/)
     ensure
       gate << :go
       thread.join
@@ -199,6 +202,16 @@ RSpec.describe Lich::DragonRealms::Broker do
       expect(described_class.exclusive(timeout: 5) { :ok }).to eq(:ok)
       expect(described_class.held?).to be false
       expect(described_class.instance).to be(described_class.instance)
+    end
+
+    it 'hands every thread the same instance under concurrent first use' do
+      described_class.reset_instance!
+      ids = Queue.new
+      threads = Array.new(24) { Thread.new { ids << described_class.instance.object_id } }
+      threads.each(&:join)
+      seen = []
+      seen << ids.pop until ids.empty?
+      expect(seen.uniq.length).to eq(1)
     end
   end
 


### PR DESCRIPTION
## What

Adds `Lich::DragonRealms::Broker`, a **lease-based** serializer for exclusive access to the single game connection, plus its design doc. This is the structural replacement for the "scripts pause each other" coordination that can deadlock `$safe_pause_lock` (mechanism write-up in the doc). A caller that can't get the lease **parks on a condition variable — pausing no one** — until the lease frees or a bounded timeout elapses.

**This PR is infra only: nothing calls the broker yet.** `bput` integration and the per-script migrations off `safe_pause_list`/`pause_script` land in separate PRs, per the phased plan.

Related: the Stage-0 `ignore_pause` hotfix is #1525.

## Design (full detail in `docs/command-broker-design.md`)

- **State-guarded lease, not a held mutex.** The critical section is guarded by broker *state* (`@owner`); `@mutex` guards only the acquire/release transitions and is **never** held across a `yield` or `Script.current`. That's what makes bounded acquisition, dead-holder reclamation, and the watchdog possible — a mutex held across the section would recreate the "uninterruptible wait on a suspended holder" bug.
- **Thread-keyed, reentrant** ownership, so a nested `bput`/`fput` under a lease can't self-deadlock.
- **Bail semantics:** `#exclusive` returns `:broker_timeout` without running the block on acquisition timeout; `#exclusive!` raises `Broker::LeaseTimeout`.
- **Two-band priority** (`:high` jumps `:normal`); **no preemption** of an in-flight lease.
- **Watchdog:** reclaims a dead holder's lease and **logs (never revokes)** an over-long live holder. Grant/release logging mirrors today's `DRC: Pausing/Unpausing` messages.
- **Defaults:** 30s acquisition timeout (per-call override), 90s watchdog warn threshold (sized for long RT/casts and `fput`'s resend loop).

## Testing

`spec/lib/dragonrealms/commons/command_broker_spec.rb` — 19 examples:
- happy path, falsey-return fidelity, ownership introspection, release-on-raise, grant/release logging;
- reentrancy; `#exclusive` timeout + `#exclusive!` (raise vs value);
- dead-holder reconciliation on acquire and via the watchdog; over-long-live warn-but-don't-revoke; below-threshold silence;
- priority/FIFO ordering + normalization;
- **real-thread integration:** a waiter parks and is granted on release, and a high-priority waiter is granted ahead of an earlier normal waiter (bounded spins/joins so a regression fails fast rather than hanging CI).

Full suite green (6300 examples, 0 failures) and `rubocop -A` clean on Ruby 4.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command broker that coordinates exclusive command access without pausing other scripts.
  - Supports reentrant access, priority ordering, timed acquisition, ownership checks, and automatic recovery from abandoned leases.
  - Added optional watchdog diagnostics for long-held command access.

- **Documentation**
  - Added design documentation covering broker behavior, rollout considerations, migration, and operational decisions.

- **Tests**
  - Added comprehensive coverage for concurrency, timeouts, ordering, cleanup, logging, and watchdog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->