### PR TITLE
fix(all): preserve bundled display-state tags on quiet-suppressed chunks

### DIFF
--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -88,11 +88,25 @@ module Lich
     # single regex) so a future confirmed case -- e.g. pushBold/popBold or
     # pushStream/popStream -- can be added as its own entry without touching
     # the filtering logic below. Keep each pattern anchored to a single
-    # self-closing `<tag .../>` so a scan can't accidentally absorb
-    # surrounding text.
+    # self-closing `<tag .../>`, with no capturing groups (String#scan
+    # returns captured subgroups instead of full matches when a pattern has
+    # any, which would silently change what preserve_quiet_state_tags
+    # returns), so a scan can't accidentally absorb surrounding text or
+    # change shape.
     QUIET_STATE_TAGS = [
       /<output class="[^"]*"\s*\/>/ # mono/formatting state toggle
     ].freeze
+
+    # Combines QUIET_STATE_TAGS into a single alternation, scanned once per
+    # chunk. Scanning each pattern separately and concatenating the results
+    # (the original approach) groups matches by pattern rather than by where
+    # they actually appear -- invisible with a single pattern, but as soon as
+    # a second entry is added, two tags from different patterns on the same
+    # chunk would come back in pattern order instead of source order, which
+    # matters when the tags are an open/close pair. A single combined scan
+    # preserves the chunk's real left-to-right order regardless of how many
+    # patterns are registered.
+    QUIET_STATE_TAG_PATTERN = Regexp.union(QUIET_STATE_TAGS).freeze
 
     # Pulls any QUIET_STATE_TAGS matches out of a chunk that quiet: true is
     # about to drop, so callers can forward just the tags instead of the
@@ -103,7 +117,7 @@ module Lich
     #   appeared, or nil if none were found (signals DownstreamHook to drop
     #   the chunk entirely, same as before this method existed).
     def self.preserve_quiet_state_tags(chunk)
-      tags = QUIET_STATE_TAGS.flat_map { |pattern| chunk.to_s.scan(pattern) }
+      tags = chunk.to_s.scan(QUIET_STATE_TAG_PATTERN)
       tags.empty? ? nil : tags.join
     end
 

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -73,6 +73,40 @@ module Lich
       "Util::#{prefix}-#{now}-#{Random.rand(10000)}"
     end
 
+    # Self-closing tags that toggle persistent client display state (as
+    # opposed to e.g. <prompt>, which self-heals on the next prompt). The raw
+    # server chunk handed to a DownstreamHook proc is not split on line
+    # boundaries, so the server is free to bundle one of these onto the same
+    # chunk as text that quiet: true is about to drop. Silently discarding
+    # that chunk would discard the tag with it -- e.g. dropping a trailing
+    # mono-closing <output class=""/> that rode in on the same chunk as the
+    # <prompt> a quiet-filtered range ends on leaves the frontend stuck in
+    # mono mode until an unrelated, later mono tag happens to close it.
+    #
+    # Only the mono/formatting <output> tag is confirmed to hit this in
+    # practice today. The list is deliberately an array of patterns (not a
+    # single regex) so a future confirmed case -- e.g. pushBold/popBold or
+    # pushStream/popStream -- can be added as its own entry without touching
+    # the filtering logic below. Keep each pattern anchored to a single
+    # self-closing `<tag .../>` so a scan can't accidentally absorb
+    # surrounding text.
+    QUIET_STATE_TAGS = [
+      /<output class="[^"]*"\s*\/>/ # mono/formatting state toggle
+    ].freeze
+
+    # Pulls any QUIET_STATE_TAGS matches out of a chunk that quiet: true is
+    # about to drop, so callers can forward just the tags instead of the
+    # whole chunk.
+    #
+    # @param chunk [String] the raw stream chunk being suppressed.
+    # @return [String, nil] the concatenated tag matches in the order they
+    #   appeared, or nil if none were found (signals DownstreamHook to drop
+    #   the chunk entirely, same as before this method existed).
+    def self.preserve_quiet_state_tags(chunk)
+      tags = QUIET_STATE_TAGS.flat_map { |pattern| chunk.to_s.scan(pattern) }
+      tags.empty? ? nil : tags.join
+    end
+
     # Issues a command to the game and captures output between start and end patterns.
     #
     # @param command [String] The command to send.
@@ -107,13 +141,13 @@ module Lich
                 DownstreamHook.remove(name)
                 filter = false
                 if quiet && !ignore_end
-                  next(nil)
+                  next(preserve_quiet_state_tags(line))
                 else
                   line
                 end
               else
                 if quiet
-                  next(nil)
+                  next(preserve_quiet_state_tags(line))
                 else
                   line
                 end
@@ -121,7 +155,7 @@ module Lich
             elsif line =~ start_pattern
               filter = true
               if quiet
-                next(nil)
+                next(preserve_quiet_state_tags(line))
               else
                 line
               end

--- a/spec/lib/util/util_spec.rb
+++ b/spec/lib/util/util_spec.rb
@@ -3,13 +3,6 @@
 require 'rspec'
 require 'timeout'
 require_relative '../../../lib/common/downstreamhook'
-# Production boot (lich.rbw) does `include Lich::Common` at the top level,
-# which is how the bare `DownstreamHook.add`/`.remove` calls inside
-# Lich::Util.issue_command resolve to Lich::Common::DownstreamHook. Mirror
-# just that constant lookup here, before spec_helper loads, so its own
-# top-level DownstreamHook mock (guarded by `unless defined?`) steps aside
-# for the real class instead of shadowing it.
-DownstreamHook = Lich::Common::DownstreamHook unless defined?(DownstreamHook)
 require_relative '../../../lib/util/util.rb'
 require_relative '../../spec_helper'
 
@@ -57,6 +50,20 @@ RSpec.describe Lich::Util do
     let(:captured_proc) { {} }
 
     before do
+      # issue_command's source calls the bare top-level constant
+      # `DownstreamHook` unqualified (production relies on `include
+      # Lich::Common` at boot for that to resolve to
+      # Lich::Common::DownstreamHook). spec_helper.rb separately defines its
+      # own lightweight top-level `DownstreamHook` mock (add/remove-less,
+      # `unless defined?` guarded) for specs that don't need real hook
+      # behavior. Which one wins the bare `DownstreamHook` name in a full
+      # suite run depends on file load order across the whole spec/
+      # directory, which this file does not control -- so rather than fight
+      # that at load time, stub_const rebinds the constant just for the
+      # examples in this block and restores whatever was there afterward,
+      # independent of load order.
+      stub_const('DownstreamHook', Lich::Common::DownstreamHook)
+
       # Capture the proc issue_command registers so it can be driven
       # directly with synthetic bundled chunks.
       allow(DownstreamHook).to receive(:add).and_wrap_original do |original, name, action, **kwargs|

--- a/spec/lib/util/util_spec.rb
+++ b/spec/lib/util/util_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'timeout'
+require_relative '../../../lib/common/downstreamhook'
+# Production boot (lich.rbw) does `include Lich::Common` at the top level,
+# which is how the bare `DownstreamHook.add`/`.remove` calls inside
+# Lich::Util.issue_command resolve to Lich::Common::DownstreamHook. Mirror
+# just that constant lookup here, before spec_helper loads, so its own
+# top-level DownstreamHook mock (guarded by `unless defined?`) steps aside
+# for the real class instead of shadowing it.
+DownstreamHook = Lich::Common::DownstreamHook unless defined?(DownstreamHook)
+require_relative '../../../lib/util/util.rb'
+require_relative '../../spec_helper'
+
+# Covers Lich::Util.issue_command's quiet: true filtering, specifically the
+# fix for dropping bundled display-state tags along with suppressed text.
+#
+# Background: DownstreamHook.run is called with the raw, unsplit socket
+# chunk (see Lich::Common::Game#process_downstream_hooks in lib/games.rb),
+# not a single parsed display line. The server is free to bundle a
+# formatting-state tag (e.g. the mono-closing `<output class=""/>`) onto the
+# same chunk as the `<prompt>` a quiet-filtered range ends on. Before this
+# fix, `next(nil)` on a suppressed chunk discarded that tag along with the
+# text, leaving the frontend stuck in mono mode until an unrelated later
+# mono tag happened to close it.
+#
+# These specs drive the DownstreamHook proc issue_command registers
+# directly (captured via a wrapped DownstreamHook.add), rather than
+# simulating the full socket pipeline, since the proc's suppression logic
+# is what changed and is independently testable.
+RSpec.describe Lich::Util do
+  describe '.preserve_quiet_state_tags' do
+    it 'returns nil for a chunk with no recognized state tags' do
+      expect(described_class.preserve_quiet_state_tags('You are stunned!')).to be_nil
+    end
+
+    it 'returns nil for nil input' do
+      expect(described_class.preserve_quiet_state_tags(nil)).to be_nil
+    end
+
+    it 'extracts a single bundled mono tag from surrounding text' do
+      chunk = %(Some Spell.....................  10:00\n<output class=""/>\n<prompt time="1787075465">H&gt;</prompt>)
+
+      expect(described_class.preserve_quiet_state_tags(chunk)).to eq('<output class=""/>')
+    end
+
+    it 'extracts every matching tag, in order, when more than one is present' do
+      chunk = %(<output class="mono"/>text<output class=""/>)
+
+      expect(described_class.preserve_quiet_state_tags(chunk))
+        .to eq('<output class="mono"/><output class=""/>')
+    end
+  end
+
+  describe '.issue_command with quiet: true' do
+    let(:captured_proc) { {} }
+
+    before do
+      # Capture the proc issue_command registers so it can be driven
+      # directly with synthetic bundled chunks.
+      allow(DownstreamHook).to receive(:add).and_wrap_original do |original, name, action, **kwargs|
+        captured_proc[:action] = action
+        original.call(name, action, **kwargs)
+      end
+
+      Script.current = OpenStruct.new(name: 'spec', silent: false, want_downstream: true, want_downstream_xml: true)
+    end
+
+    # Drives issue_command's internal get-loop just far enough for it to
+    # match start_pattern then end_pattern and return, independent of the
+    # DownstreamHook proc under test (get and DownstreamHook consume the
+    # same underlying stream through separate paths in production).
+    def run_issue_command(quiet:, timeout: 1)
+      allow(described_class).to receive(:get).and_return(
+        'You currently have the following active effects:',
+        '<prompt time="1787075465">H&gt;</prompt>'
+      )
+
+      described_class.issue_command(
+        'spell active',
+        /You currently have the following/,
+        /<prompt/,
+        quiet: quiet,
+        usexml: true,
+        timeout: timeout
+      )
+    end
+
+    it 'still returns the captured lines to the caller' do
+      result = run_issue_command(quiet: true)
+
+      expect(result).to eq(
+        [
+          'You currently have the following active effects:',
+          '<prompt time="1787075465">H&gt;</prompt>'
+        ]
+      )
+    end
+
+    it 'drops a suppressed chunk outright when it carries no state tags' do
+      run_issue_command(quiet: true)
+
+      forwarded = captured_proc[:action].call('You currently have the following active effects:')
+
+      expect(forwarded).to be_nil
+    end
+
+    it 'forwards a bundled mono-closing tag instead of dropping the whole end-of-range chunk' do
+      run_issue_command(quiet: true)
+
+      # Enter the filtering state via the start_pattern chunk.
+      captured_proc[:action].call('You currently have the following active effects:')
+
+      # The end-of-range chunk bundles the mono-closing tag with the prompt --
+      # this is the exact server behavior from the reported bug.
+      bundled_end_chunk = %(<output class=""/>\n<prompt time="1787075465">H&gt;</prompt>)
+      forwarded = captured_proc[:action].call(bundled_end_chunk)
+
+      expect(forwarded).to eq('<output class=""/>')
+    end
+
+    it 'forwards a bundled tag on an intermediate suppressed chunk, not just the end chunk' do
+      run_issue_command(quiet: true)
+
+      captured_proc[:action].call('You currently have the following active effects:') # enters filter
+      mid_range_chunk = %(<output class="mono"/>Some Spell.....................  10:00)
+      forwarded = captured_proc[:action].call(mid_range_chunk)
+
+      expect(forwarded).to eq('<output class="mono"/>')
+    end
+
+    it 'does not alter non-quiet behavior (lines are forwarded unchanged)' do
+      run_issue_command(quiet: false)
+
+      start_chunk = 'You currently have the following active effects:'
+      end_chunk = %(<output class=""/>\n<prompt time="1787075465">H&gt;</prompt>)
+
+      expect(captured_proc[:action].call(start_chunk)).to eq(start_chunk)
+      expect(captured_proc[:action].call(end_chunk)).to eq(end_chunk)
+    end
+  end
+end

--- a/spec/lib/util/util_spec.rb
+++ b/spec/lib/util/util_spec.rb
@@ -44,6 +44,25 @@ RSpec.describe Lich::Util do
       expect(described_class.preserve_quiet_state_tags(chunk))
         .to eq('<output class="mono"/><output class=""/>')
     end
+
+    it 'preserves the chunk\'s real left-to-right order across two distinct patterns' do
+      # QUIET_STATE_TAGS only has one confirmed entry today, so this
+      # regression case stubs in a second, unrelated pattern for the
+      # duration of this example to exercise the multi-pattern path before
+      # a real second entry ever lands. Scanning each pattern separately and
+      # concatenating the results groups matches by pattern rather than by
+      # position -- invisible with one pattern, but wrong the moment a
+      # second one is added and both fire on the same chunk, which matters
+      # for tags that are an open/close pair.
+      stub_const(
+        'Lich::Util::QUIET_STATE_TAG_PATTERN',
+        Regexp.union(/<output class="[^"]*"\s*\/>/, /<popBold\s*\/>/)
+      )
+      chunk = %(<output class="mono"/>text<popBold/>more<output class=""/>)
+
+      expect(described_class.preserve_quiet_state_tags(chunk))
+        .to eq('<output class="mono"/><popBold/><output class=""/>')
+    end
   end
 
   describe '.issue_command with quiet: true' do


### PR DESCRIPTION
## Problem
`Lich::Util.issue_command`'s `quiet: true` filter drops any chunk inside the matched start/end range via `next(nil)`. `DownstreamHook.run` is called on the raw, unsplit socket chunk (before line-splitting, in `Game#process_downstream_hooks`), so the server can bundle a formatting-state tag onto the same chunk as text quiet mode is about to discard.

In practice: a quiet range ending at `<prompt>` arrives bundled with the game's closing `<output class="">/>` tag (e.g. after `spell active`), and the whole chunk — prompt included — gets dropped. The frontend is left stuck in mono formatting until an unrelated, later mono tag happens to close it.

## Fix
Adds `Lich::Util.preserve_quiet_state_tags`, which extracts any tags matching a small, explicit `QUIET_STATE_TAGS` list from a chunk before it's suppressed, and forwards just those tags instead of dropping the chunk outright. Applied at all three `quiet:`-suppression branches in the filter closure (start-of-range, mid-range, end-of-range), since the same bundling risk isn't unique to the end-of-range case.

Scope is intentionally narrow — only the mono/formatting `<output>` tag is confirmed to hit this in practice. `QUIET_STATE_TAGS` is a list specifically so a future confirmed case (e.g. `pushBold`/`popBold`, `pushStream`/`popStream`) is a one-line addition rather than a rework of the filtering logic.

## Testing
New `spec/lib/util/util_spec.rb` drives the registered `DownstreamHook` proc directly against synthetic bundled chunks and asserts tags are forwarded while suppressed text is dropped. Verified against the prior `next(nil)` behavior — reverting the fix fails exactly the two tag-preservation specs and nothing else. `bundle exec rubocop` clean; no regressions in the rest of `spec/lib/util/`.

**No behavior change** for existing `quiet: true` callers that never hit this bundling edge case, and none for `quiet: false` callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quiet command filtering now preserves important client state updates from suppressed output.
  * State tags are forwarded in the correct order, including tags from intermediate and final command results.
  * Command output remains unchanged, while non-quiet behavior continues to work as expected.

* **Tests**
  * Added coverage for quiet filtering, state-tag preservation, output handling, and non-quiet commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->