### PR TITLE
fix(all): terminate preserved quiet-state tags with a  newline

### DIFF
--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -114,17 +114,17 @@ module Lich
     #
     # The returned string is newline-terminated even though the matched tags
     # themselves never include one. Every other chunk that reaches this
-    # pipeline is newline/CRLF-terminated as part of GS4's line-oriented
-    # stream framing; a bare, unterminated tag is not a shape of line this
-    # pipeline produced before this method existed. For sentinel-supporting
-    # frontends (currently only Saga -- see Frontend::ORIGIN_SENTINEL and
-    # Game#prefix_origin_sentinel), every forwarded line gets a leading
-    # origin-marker byte that the client is expected to consume as routing
-    # metadata and strip before display. That worked here once the segment
-    # was given the same line termination as everything else the client
-    # already handles; without it, the client had nothing to delimit an
-    # otherwise content-only segment, and the marker byte fell through to
-    # the display as a literal, visible character.
+    # pipeline is newline/CRLF-terminated as part of the game server's
+    # line-oriented stream framing; a bare, unterminated tag is not a shape
+    # of line this pipeline produced before this method existed. For
+    # sentinel-supporting frontends (currently only Saga -- see
+    # Frontend::ORIGIN_SENTINEL and Game#prefix_origin_sentinel), every
+    # forwarded line gets a leading origin-marker byte that the client is
+    # expected to consume as routing metadata and strip before display. That
+    # worked here once the segment was given the same line termination as
+    # everything else the client already handles; without it, the client had
+    # nothing to delimit an otherwise content-only segment, and the marker
+    # byte fell through to the display as a literal, visible character.
     #
     # @param chunk [String] the raw stream chunk being suppressed.
     # @return [String, nil] the concatenated tag matches, in the order they

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -112,13 +112,30 @@ module Lich
     # about to drop, so callers can forward just the tags instead of the
     # whole chunk.
     #
+    # The returned string is newline-terminated even though the matched tags
+    # themselves never include one. Every other chunk that reaches this
+    # pipeline is newline/CRLF-terminated as part of GS4's line-oriented
+    # stream framing; a bare, unterminated tag is not a shape of line this
+    # pipeline produced before this method existed. For sentinel-supporting
+    # frontends (currently only Saga -- see Frontend::ORIGIN_SENTINEL and
+    # Game#prefix_origin_sentinel), every forwarded line gets a leading
+    # origin-marker byte that the client is expected to consume as routing
+    # metadata and strip before display. That worked here once the segment
+    # was given the same line termination as everything else the client
+    # already handles; without it, the client had nothing to delimit an
+    # otherwise content-only segment, and the marker byte fell through to
+    # the display as a literal, visible character.
+    #
     # @param chunk [String] the raw stream chunk being suppressed.
-    # @return [String, nil] the concatenated tag matches in the order they
-    #   appeared, or nil if none were found (signals DownstreamHook to drop
-    #   the chunk entirely, same as before this method existed).
+    # @return [String, nil] the concatenated tag matches, in the order they
+    #   appeared, terminated with a newline; or nil if none were found
+    #   (signals DownstreamHook to drop the chunk entirely, same as before
+    #   this method existed).
     def self.preserve_quiet_state_tags(chunk)
       tags = chunk.to_s.scan(QUIET_STATE_TAG_PATTERN)
-      tags.empty? ? nil : tags.join
+      return nil if tags.empty?
+
+      "#{tags.join}\n"
     end
 
     # Issues a command to the game and captures output between start and end patterns.

--- a/spec/lib/games_spec.rb
+++ b/spec/lib/games_spec.rb
@@ -11,6 +11,9 @@ require "common/detachable_client_registry"
 require "common/sharedbuffer"
 require "common/shutdown_coordinator"
 require "common/xmlparser"
+require "common/downstreamhook"
+require "common/front-end"
+require "util/util"
 require "games"
 require "gemstone/wounds"
 require "gemstone/scars"
@@ -1449,6 +1452,86 @@ RSpec.describe Lich::GameBase::Game do
         expect { described_class.send(:send_to_client, 'test data') }.not_to raise_error
         eventually { expect(Lich).to have_received(:log).with(/client socket write failed.*closed stream/) }
       end
+    end
+  end
+
+  describe '.process_downstream_hooks with a sentinel-supporting frontend' do
+    # Regression coverage for the reported production bug: a Saga session
+    # (the only frontend with :sentinel) saw a literal, visible 0x1F Unit
+    # Separator character during quiet-suppressed issue_command output.
+    # util_spec.rb confirms Lich::Util.preserve_quiet_state_tags itself
+    # returns a newline-terminated tag; this confirms that value survives
+    # end-to-end through DownstreamHook.run, Game#process_downstream_hooks,
+    # and Game#prefix_origin_sentinel to the actual client write, which is
+    # where the bug actually manifested -- a passing unit test on the
+    # util.rb side alone would not have caught a regression introduced at
+    # this layer (e.g. a future change to prefix_origin_sentinel's line
+    # matching, or to how/when it's invoked).
+    def eventually(timeout: 1)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        begin
+          return yield
+        rescue RSpec::Expectations::ExpectationNotMetError
+          raise if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+          sleep 0.005
+        end
+      end
+    end
+
+    before do
+      allow(Lich).to receive(:log)
+      # games.rb calls DownstreamHook/Frontend as bare top-level constants
+      # (production relies on `include Lich::Common` at boot for that to
+      # resolve). spec_helper.rb separately defines lightweight top-level
+      # mocks for both, guarded by `unless defined?`, for specs that don't
+      # need real behavior -- neither mock implements .add/.remove
+      # (DownstreamHook) or supports_sentinel? (Frontend). Rebind both to
+      # the real classes for this block, independent of file load order
+      # across the suite (see util_spec.rb for the load-order failure this
+      # protects against).
+      stub_const('DownstreamHook', Lich::Common::DownstreamHook)
+      stub_const('Frontend', Lich::Common::Frontend)
+
+      @raw_socket = instance_double('raw_client_socket', closed?: false, write: nil, close: nil)
+      $_DETACHABLE_CLIENT_REGISTRY_ = nil
+      $_DETACHABLE_CLIENT_ = nil
+      $_CLIENT_ = Lich::Common::SynchronizedSocket.new(@raw_socket)
+      $frontend = 'saga' # the only registered :sentinel frontend
+    end
+
+    after do
+      $_CLIENT_.close rescue nil
+      $_CLIENT_ = nil
+      $frontend = nil
+      DownstreamHook.remove('spec_quiet_hook')
+    end
+
+    it 'delivers a quiet-preserved tag to the client with the sentinel and terminator intact' do
+      # Mirrors exactly what Lich::Util.issue_command registers for
+      # quiet: true.
+      DownstreamHook.add('spec_quiet_hook', proc { |line| Lich::Util.preserve_quiet_state_tags(line) })
+
+      # The exact bundled chunk from the original bug report: the game
+      # bundles the mono-closing tag onto the same raw chunk as the prompt
+      # a quiet-filtered range ends on.
+      bundled_end_chunk = %(<output class=""/>\n<prompt time="1787075465">H&gt;</prompt>)
+
+      described_class.send(:process_downstream_hooks, bundled_end_chunk)
+
+      eventually { expect(@raw_socket).to have_received(:write).with(%(\x1F<output class=""/>\n)) }
+    end
+
+    it 'does not sentinel-prefix the tag for a frontend without the :sentinel capability' do
+      $frontend = 'wrayth' # xml + mono, but no :sentinel
+      DownstreamHook.add('spec_quiet_hook', proc { |line| Lich::Util.preserve_quiet_state_tags(line) })
+
+      bundled_end_chunk = %(<output class=""/>\n<prompt time="1787075465">H&gt;</prompt>)
+
+      described_class.send(:process_downstream_hooks, bundled_end_chunk)
+
+      eventually { expect(@raw_socket).to have_received(:write).with(%(<output class=""/>\n)) }
     end
   end
 end

--- a/spec/lib/util/util_spec.rb
+++ b/spec/lib/util/util_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Lich::Util do
 
     it 'terminates the returned tags with a newline, even though the matched tags never include one' do
       # Every other chunk that reaches this pipeline is newline/CRLF-
-      # terminated (GS4's stream is line-oriented); a preserved-tag string
+      # terminated (the game server's stream is line-oriented); a preserved-tag string
       # with no terminator is not a shape of line the pipeline produced
       # before this method existed. For sentinel-supporting frontends
       # (currently only Saga), every forwarded line gets a leading

--- a/spec/lib/util/util_spec.rb
+++ b/spec/lib/util/util_spec.rb
@@ -35,14 +35,30 @@ RSpec.describe Lich::Util do
     it 'extracts a single bundled mono tag from surrounding text' do
       chunk = %(Some Spell.....................  10:00\n<output class=""/>\n<prompt time="1787075465">H&gt;</prompt>)
 
-      expect(described_class.preserve_quiet_state_tags(chunk)).to eq('<output class=""/>')
+      expect(described_class.preserve_quiet_state_tags(chunk)).to eq(%(<output class=""/>\n))
     end
 
     it 'extracts every matching tag, in order, when more than one is present' do
       chunk = %(<output class="mono"/>text<output class=""/>)
 
       expect(described_class.preserve_quiet_state_tags(chunk))
-        .to eq('<output class="mono"/><output class=""/>')
+        .to eq(%(<output class="mono"/><output class=""/>\n))
+    end
+
+    it 'terminates the returned tags with a newline, even though the matched tags never include one' do
+      # Every other chunk that reaches this pipeline is newline/CRLF-
+      # terminated (GS4's stream is line-oriented); a preserved-tag string
+      # with no terminator is not a shape of line the pipeline produced
+      # before this method existed. For sentinel-supporting frontends
+      # (currently only Saga), every forwarded line gets a leading
+      # Frontend::ORIGIN_SENTINEL byte the client consumes as routing
+      # metadata and strips before display. An unterminated segment gave
+      # the client nothing to delimit it by, and the sentinel byte fell
+      # through to the display as a literal, visible character instead of
+      # being consumed.
+      chunk = '<output class="mono"/>'
+
+      expect(described_class.preserve_quiet_state_tags(chunk)).to eq(%(<output class="mono"/>\n))
     end
 
     it 'preserves the chunk\'s real left-to-right order across two distinct patterns' do
@@ -61,7 +77,7 @@ RSpec.describe Lich::Util do
       chunk = %(<output class="mono"/>text<popBold/>more<output class=""/>)
 
       expect(described_class.preserve_quiet_state_tags(chunk))
-        .to eq('<output class="mono"/><popBold/><output class=""/>')
+        .to eq(%(<output class="mono"/><popBold/><output class=""/>\n))
     end
   end
 
@@ -143,7 +159,7 @@ RSpec.describe Lich::Util do
       bundled_end_chunk = %(<output class=""/>\n<prompt time="1787075465">H&gt;</prompt>)
       forwarded = captured_proc[:action].call(bundled_end_chunk)
 
-      expect(forwarded).to eq('<output class=""/>')
+      expect(forwarded).to eq(%(<output class=""/>\n))
     end
 
     it 'forwards a bundled tag on an intermediate suppressed chunk, not just the end chunk' do
@@ -153,7 +169,7 @@ RSpec.describe Lich::Util do
       mid_range_chunk = %(<output class="mono"/>Some Spell.....................  10:00)
       forwarded = captured_proc[:action].call(mid_range_chunk)
 
-      expect(forwarded).to eq('<output class="mono"/>')
+      expect(forwarded).to eq(%(<output class="mono"/>\n))
     end
 
     it 'does not alter non-quiet behavior (lines are forwarded unchanged)' do


### PR DESCRIPTION
Every chunk that normally reaches DownstreamHook.run is newline/CRLF- terminated, since GS4's stream is fundamentally line-oriented. preserve_quiet_state_tags returned just the matched tag text with no terminator at all -- a shape of line this pipeline never produced before this method existed.

For sentinel-supporting frontends (currently only Saga -- see Frontend::ORIGIN_SENTINEL / Frontend.supports_sentinel? / Game#prefix_origin_sentinel in lib/games.rb), every forwarded line gets a leading \x1f origin-marker byte that the client consumes as routing metadata and strips before display. Confirmed in production: with an unterminated preserved-tag chunk, that byte was rendering on screen as a literal, visible 'US' character during quiet-suppressed output -- reported as a regression starting with the tag-preservation fix, since previously these chunks returned nil and never reached prefix_origin_sentinel at all.

Append a trailing newline to the returned tag string, matching the termination every other line in this pipeline already has. Confirmed this resolves the reported symptom.

Updated all affected spec assertions in spec/lib/util/util_spec.rb to expect the trailing newline, and added a dedicated regression case for the termination itself. Verified against the prior no-newline implementation: reverting produces the same 6 targeted failures this patch fixes, and no others.