### PR TITLE
fix(all): enforce Script#pause at every blocking/mutating checkpoint

### DIFF
--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -1019,18 +1019,26 @@ module Lich
         script
       end
 
-      def Script.current
+      # Resolves the script bound to the current thread, without waiting out
+      # any pause. Used by Script.current and by other checkpoints that need
+      # to know "who's calling" before gating on that caller's pause state.
+      #
+      # @return [Script, nil] the script bound to Thread.current, or nil
+      def Script.__resolve_current
         script = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
         script ||= __running_snapshot.find { |candidate| candidate.has_thread?(Thread.current) }
-        if script
-          sleep 0.2 while script.paused? and not script.ignore_pause
-          script
-        else
-          nil
-        end
+        script
+      end
+      private_class_method :__resolve_current
+
+      def Script.current
+        script = __resolve_current
+        script&.wait_while_paused!
+        script
       end
 
       def Script.start(*args)
+        __resolve_current&.wait_while_paused!
         @@elevated_script_start.call(args, nil)
       end
 
@@ -1312,6 +1320,7 @@ module Lich
       private_class_method :__prune_library_waits_locked
 
       def Script.running?(name)
+        __resolve_current&.wait_while_paused!
         __running_snapshot.any? { |i| (i.name =~ /^#{name}$/i) }
       end
 
@@ -1356,6 +1365,8 @@ module Lich
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
 
+        __resolve_current&.wait_while_paused!
+
         running = __running_snapshot
         if (s = (running.find { |i| i.name == name }) || (running.find { |i| i.name =~ /^#{name}$/i }))
           s.killed_externally = true
@@ -1376,6 +1387,8 @@ module Lich
         unless VALID_KILL_CONTEXTS.include?(context)
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
         end
+
+        __resolve_current&.wait_while_paused!
 
         scripts = force ? Script.list : Script.running.reject(&:no_kill_all)
         scripts.each { |script| script.kill(context: context) }
@@ -2739,6 +2752,16 @@ module Lich
 
       def paused?
         @paused
+      end
+
+      # Blocks the calling thread until this script is no longer paused (or
+      # is exempt via ignore_pause). Extracted so every pause checkpoint --
+      # Script.current and any other blocking/mutating call site -- shares
+      # one implementation instead of inlining the sleep loop.
+      #
+      # @return [void]
+      def wait_while_paused!
+        sleep 0.2 while paused? and not ignore_pause
       end
 
       def get_next_label

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -1024,6 +1024,7 @@ module Lich
       # to know "who's calling" before gating on that caller's pause state.
       #
       # @return [Script, nil] the script bound to Thread.current, or nil
+      # @api private
       def Script.__resolve_current
         script = Thread.current.thread_variable_get(CLEANUP_SCRIPT_THREAD_KEY)
         script ||= __running_snapshot.find { |candidate| candidate.has_thread?(Thread.current) }
@@ -1031,18 +1032,46 @@ module Lich
       end
       private_class_method :__resolve_current
 
+      # Returns the script bound to the calling thread.
+      #
+      # Blocks the calling thread while that script is paused (unless it has
+      # opted out via +ignore_pause+) before returning, so callers cannot
+      # observe or act past a pause. This includes indirect callers such as
+      # {.running?}, {.start}, and {.run} that use it (or the equivalent
+      # {#wait_while_paused!} checkpoint) internally.
+      #
+      # @return [Script, nil] the calling script, or nil when called with no
+      #   script bound to the current thread (e.g. from the core/CLI)
       def Script.current
         script = __resolve_current
         script&.wait_while_paused!
         script
       end
 
+      # Starts a script, blocking first if the calling script is paused.
+      #
+      # @param args [Array] arguments forwarded to the underlying script
+      #   start machinery (script name, params, flags -- see callers for the
+      #   accepted shapes)
+      # @return [Script, nil] the started script, or nil on failure
+      # @note Blocks the calling thread while it is itself paused (unless
+      #   exempt via +ignore_pause+) before starting anything; a no-op wait
+      #   when called with no script bound to the current thread.
       def Script.start(*args)
         __resolve_current&.wait_while_paused!
         @@elevated_script_start.call(args, nil)
       end
 
+      # Starts a script and blocks the calling thread until it finishes.
+      #
+      # @param args [Array] arguments forwarded to {.start}
+      # @return [Script, nil] the started script's own return value from
+      #   {Script#join}, or nil if it failed to start
+      # @note Blocks the calling thread while it is itself paused (unless
+      #   exempt via +ignore_pause+) before starting anything, the same as
+      #   {.start}.
       def Script.run(*args)
+        __resolve_current&.wait_while_paused!
         if (s = @@elevated_script_start.call(args, nil))
           s.join
         end
@@ -1319,6 +1348,15 @@ module Lich
       end
       private_class_method :__prune_library_waits_locked
 
+      # Checks whether a script by that name is currently running.
+      #
+      # @param name [String] script name (case-insensitive)
+      # @return [Boolean] true if a running script matches
+      # @note Blocks the calling thread while it is itself paused (unless
+      #   exempt via +ignore_pause+) before checking; a no-op wait when
+      #   called with no script bound to the current thread. A paused caller
+      #   can therefore block here indefinitely -- this is not a plain,
+      #   always-immediate predicate.
       def Script.running?(name)
         __resolve_current&.wait_while_paused!
         __running_snapshot.any? { |i| (i.name =~ /^#{name}$/i) }
@@ -1360,6 +1398,10 @@ module Lich
       # @param context [Symbol] kill context forwarded to {Script#kill}
       #   (:runtime or :shutdown)
       # @return [Boolean] true when a matching running script was found and stopped
+      # @note Blocks the calling thread while it is itself paused (unless
+      #   exempt via +ignore_pause+) before taking effect on the named
+      #   script; a no-op wait when called with no script bound to the
+      #   current thread (e.g. from the core/CLI).
       def Script.kill(name, context: :runtime)
         unless VALID_KILL_CONTEXTS.include?(context)
           raise ArgumentError, "invalid script kill context: #{context.inspect}"
@@ -1383,6 +1425,9 @@ module Lich
       # @param force [Boolean] include hidden and kill-all-protected scripts
       # @param context [Symbol] lifecycle context forwarded to {Script#kill}
       # @return [Integer] number of scripts selected
+      # @note Blocks the calling thread while it is itself paused (unless
+      #   exempt via +ignore_pause+) before selecting scripts to kill; a
+      #   no-op wait when called with no script bound to the current thread.
       def Script.kill_all(force: false, context: :runtime)
         unless VALID_KILL_CONTEXTS.include?(context)
           raise ArgumentError, "invalid script kill context: #{context.inspect}"

--- a/lib/common/script.rb
+++ b/lib/common/script.rb
@@ -2065,13 +2065,19 @@ module Lich
                 __stop_children(children, context)
                 raise cleanup_group_error if cleanup_group_error
 
+                # Clear pause state before die_with propagation: this cleanup
+                # thread identifies as `self` (CLEANUP_SCRIPT_THREAD_KEY), so
+                # Script.kill's calling-script pause checkpoint would
+                # otherwise wait on a paused script's own teardown to unpause
+                # it -- which never happens, deadlocking cleanup and leaving
+                # die_with dependents unstopped.
+                @paused = false
                 @die_with ||= []
                 __run_cleanup_queue(@die_with) do |script_name|
                   failed = true unless __run_cleanup_callback do
                     Script.kill(script_name, context: context)
                   end
                 end
-                @paused = false
                 @at_exit_procs ||= []
                 __run_cleanup_queue(@at_exit_procs) do |callback|
                   failed = true unless __run_cleanup_callback { callback.call }

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -803,10 +803,13 @@ end
 def wait_until(announce = nil)
   priosave = Thread.current.priority
   Thread.current.priority = 0
+  script = Script.current
   unless announce.nil? or yield
     respond(announce)
   end
-  until yield
+  loop do
+    script&.wait_while_paused!
+    break if yield
     sleep 0.25
   end
   Thread.current.priority = priosave
@@ -815,10 +818,13 @@ end
 def wait_while(announce = nil)
   priosave = Thread.current.priority
   Thread.current.priority = 0
+  script = Script.current
   unless announce.nil? or !yield
     respond(announce)
   end
-  while yield
+  loop do
+    script&.wait_while_paused!
+    break unless yield
     sleep 0.25
   end
   Thread.current.priority = priosave

--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -800,6 +800,16 @@ def watchhealth(value, theproc = nil, &block)
   }
 end
 
+# Blocks until the given block returns truthy.
+#
+# @param announce [String, nil] message to respond with if the condition is
+#   not already true on entry
+# @yieldreturn [Boolean] the condition being waited on
+# @return [void]
+# @note Blocks the calling thread while it is itself paused (unless exempt
+#   via +ignore_pause+), both between polls and after the condition becomes
+#   true, before returning control -- so a caller cannot resume past an
+#   active pause here.
 def wait_until(announce = nil)
   priosave = Thread.current.priority
   Thread.current.priority = 0
@@ -809,12 +819,29 @@ def wait_until(announce = nil)
   end
   loop do
     script&.wait_while_paused!
-    break if yield
+    if yield
+      # The predicate may have blocked or yielded control for a while (e.g.
+      # waiting on another thread); re-check pause before honoring its
+      # result and returning to the caller, without re-invoking a
+      # potentially stateful predicate a second time.
+      script&.wait_while_paused!
+      break
+    end
     sleep 0.25
   end
   Thread.current.priority = priosave
 end
 
+# Blocks while the given block returns truthy.
+#
+# @param announce [String, nil] message to respond with if the condition is
+#   already false on entry
+# @yieldreturn [Boolean] the condition being waited on
+# @return [void]
+# @note Blocks the calling thread while it is itself paused (unless exempt
+#   via +ignore_pause+), both between polls and after the condition becomes
+#   false, before returning control -- so a caller cannot resume past an
+#   active pause here.
 def wait_while(announce = nil)
   priosave = Thread.current.priority
   Thread.current.priority = 0
@@ -824,7 +851,12 @@ def wait_while(announce = nil)
   end
   loop do
     script&.wait_while_paused!
-    break unless yield
+    unless yield
+      # See wait_until: re-check pause after the predicate resolves, before
+      # returning control, without re-invoking the predicate.
+      script&.wait_while_paused!
+      break
+    end
     sleep 0.25
   end
   Thread.current.priority = priosave

--- a/spec/lib/common/script_pause_enforcement_spec.rb
+++ b/spec/lib/common/script_pause_enforcement_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'timeout'
+require_relative '../../spec_helper'
+require_relative '../../../lib/common/limitedarray'
+require_relative '../../../lib/common/feature_flags'
+require_relative '../../../lib/common/downstreamhook'
+require_relative '../../../lib/common/upstreamhook'
+
+# wait_while/wait_until live in global_defs.rb, which can't be required
+# wholesale in spec context (it pulls in many unrelated global dependencies).
+# Extract just those two definitions, mirroring the technique used in
+# global_defs_spec.rb.
+global_defs_path = File.join(File.dirname(__FILE__), '..', '..', '..', 'lib', 'global_defs.rb')
+global_defs_lines = File.readlines(global_defs_path)
+%w[wait_until wait_while].each do |method_name|
+  fn_start = global_defs_lines.index { |l| l =~ /^def #{method_name}\(/ }
+  raise "#{method_name} not found in #{global_defs_path}" unless fn_start
+
+  fn_end = global_defs_lines[fn_start + 1..].index { |l| l =~ /^end\s*$/ }
+  # Avoid depending on a top-level `Script` constant alias (only set up by
+  # `include Lich::Common` in the real lich.rbw boot path) -- reference the
+  # real class directly instead.
+  source = global_defs_lines[fn_start..fn_start + 1 + fn_end].join.gsub(/\bScript\./, 'Lich::Common::Script.')
+  eval(source, TOPLEVEL_BINDING, global_defs_path, fn_start + 1)
+end
+
+RSpec.describe 'Lich::Common::Script pause enforcement' do
+  let(:thread_group) { ThreadGroup.new }
+  let(:script_class) { Lich::Common::Script }
+
+  before(:context) do
+    require_relative '../../../lib/common/script'
+  end
+
+  after(:context) do
+    %i[SubScript ExecScript WizardScript Script Scripting TRUSTED_SCRIPT_BINDING].each do |const_name|
+      Lich::Common.send(:remove_const, const_name) if Lich::Common.const_defined?(const_name, false)
+    end
+    $LOADED_FEATURES.delete_if { |path| path.end_with?('/lib/common/script.rb') }
+  end
+
+  before do
+    script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
+    allow(Lich).to receive(:log)
+  end
+
+  after do
+    script_class.class_variable_set(:@@running, [])
+    script_class.class_variable_set(:@@stopping, [])
+  end
+
+  def build_script(name:, paused: false, ignore_pause: false)
+    script_class.allocate.tap do |script|
+      script.instance_variable_set(:@name, name)
+      script.instance_variable_set(:@custom, false)
+      script.instance_variable_set(:@quiet, true)
+      script.instance_variable_set(:@thread_group, thread_group)
+      script.instance_variable_set(:@die_with, [])
+      script.instance_variable_set(:@paused, paused)
+      script.instance_variable_set(:@ignore_pause, ignore_pause)
+      script.instance_variable_set(:@at_exit_procs, [])
+      script.instance_variable_set(:@downstream_buffer, [])
+      script.instance_variable_set(:@upstream_buffer, [])
+      script.instance_variable_set(:@match_stack_labels, [])
+      script.instance_variable_set(:@match_stack_strings, [])
+      script.instance_variable_set(:@killer_mutex, Mutex.new)
+      script.instance_variable_set(:@killed_externally, false)
+      script.instance_variable_set(:@kill_source, nil)
+    end
+  end
+
+  describe '#wait_while_paused!' do
+    it 'blocks while paused and returns once unpaused' do
+      script = build_script(name: 'watcher', paused: true)
+
+      waiter = Thread.new { script.wait_while_paused! }
+      sleep 0.1
+      expect(waiter).to be_alive
+
+      script.paused = false
+      waiter.join(2)
+      expect(waiter).not_to be_alive
+    end
+
+    it 'returns immediately for a paused script with ignore_pause set' do
+      script = build_script(name: 'watcher', paused: true, ignore_pause: true)
+
+      expect(Timeout.timeout(1) { script.wait_while_paused! }).to be_nil
+    end
+  end
+
+  describe 'the bigshot regression: a paused script mutating another script via a helper' do
+    it 'does not let Script.kill take effect until the calling script is unpaused' do
+      caller_script = build_script(name: 'bigshot', paused: true)
+      target_script = build_script(name: 'eloot')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      allow(target_script).to receive(:kill)
+
+      kill_thread = Thread.new do
+        Thread.current.thread_variable_set(Lich::Common::Script::CLEANUP_SCRIPT_THREAD_KEY, caller_script)
+        script_class.kill(target_script.name)
+      end
+
+      sleep 0.1
+      expect(target_script).not_to have_received(:kill)
+      expect(kill_thread).to be_alive
+
+      caller_script.paused = false
+      kill_thread.join(2)
+
+      expect(kill_thread).not_to be_alive
+      expect(target_script).to have_received(:kill)
+    end
+
+    it 'does not let Script.running? observe state changes until the calling script is unpaused' do
+      caller_script = build_script(name: 'bigshot', paused: true)
+      script_class.class_variable_set(:@@running, [caller_script])
+
+      check_thread = Thread.new do
+        Thread.current.thread_variable_set(Lich::Common::Script::CLEANUP_SCRIPT_THREAD_KEY, caller_script)
+        script_class.running?('eloot')
+      end
+
+      sleep 0.1
+      expect(check_thread).to be_alive
+
+      caller_script.paused = false
+      expect(check_thread.value).to eq(false)
+    end
+
+    it 'does not let Script.kill_all take effect until the calling script is unpaused' do
+      caller_script = build_script(name: 'bigshot', paused: true)
+      target_script = build_script(name: 'eloot')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      allow(script_class).to receive(:running).and_return([caller_script, target_script])
+      allow(target_script).to receive(:kill)
+      allow(caller_script).to receive(:kill)
+
+      kill_all_thread = Thread.new do
+        Thread.current.thread_variable_set(Lich::Common::Script::CLEANUP_SCRIPT_THREAD_KEY, caller_script)
+        script_class.kill_all
+      end
+
+      sleep 0.1
+      expect(target_script).not_to have_received(:kill)
+      expect(kill_all_thread).to be_alive
+
+      caller_script.paused = false
+      kill_all_thread.join(2)
+
+      expect(kill_all_thread).not_to be_alive
+      expect(target_script).to have_received(:kill)
+    end
+  end
+
+  describe 'wait_while / wait_until' do
+    it 'wait_while re-checks pause state on every iteration, not just at entry' do
+      script = build_script(name: 'waiter', paused: false)
+      allow(script_class).to receive(:current).and_return(script)
+      condition = true
+
+      wait_thread = Thread.new { wait_while { condition } }
+      sleep 0.1
+
+      script.paused = true
+      sleep 0.1
+      condition = false # condition alone would exit the loop; pause must still hold it
+      sleep 0.1
+      expect(wait_thread).to be_alive
+
+      script.paused = false
+      wait_thread.join(2)
+      expect(wait_thread).not_to be_alive
+    end
+  end
+end

--- a/spec/lib/common/script_pause_enforcement_spec.rb
+++ b/spec/lib/common/script_pause_enforcement_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Lich::Common::Script pause enforcement' do
     script_class.class_variable_set(:@@stopping, [])
   end
 
-  def build_script(name:, paused: false, ignore_pause: false)
+  def build_script(name:, paused: false, ignore_pause: false, no_pause_all: false)
     script_class.allocate.tap do |script|
       script.instance_variable_set(:@name, name)
       script.instance_variable_set(:@custom, false)
@@ -60,6 +60,7 @@ RSpec.describe 'Lich::Common::Script pause enforcement' do
       script.instance_variable_set(:@die_with, [])
       script.instance_variable_set(:@paused, paused)
       script.instance_variable_set(:@ignore_pause, ignore_pause)
+      script.instance_variable_set(:@no_pause_all, no_pause_all)
       script.instance_variable_set(:@at_exit_procs, [])
       script.instance_variable_set(:@downstream_buffer, [])
       script.instance_variable_set(:@upstream_buffer, [])
@@ -151,6 +152,57 @@ RSpec.describe 'Lich::Common::Script pause enforcement' do
       kill_all_thread.join(2)
 
       expect(kill_all_thread).not_to be_alive
+      expect(target_script).to have_received(:kill)
+    end
+  end
+
+  describe 'no_pause_all is preserved and not conflated with a checkpoint bypass' do
+    it 'is still excluded from the bulk pause-all/unpause-all selection, unaffected by this change' do
+      normal = build_script(name: 'normal-script')
+      exempt = build_script(name: 'exempt-script', no_pause_all: true)
+      script_class.class_variable_set(:@@running, [normal, exempt])
+
+      # Mirrors the `pause all` selection in global_defs.rb / DRC common.rb:
+      # `Script.running.find_all { |s| not s.paused? and not s.no_pause_all }`
+      to_pause = script_class.running.find_all { |s| !s.paused? && !s.no_pause_all }
+      expect(to_pause).to contain_exactly(normal)
+
+      to_pause.each(&:pause)
+      expect(normal.paused?).to be true
+      expect(exempt.paused?).to be false
+    end
+
+    it 'does not exempt a no_pause_all script from wait_while_paused! if it is individually paused' do
+      script = build_script(name: 'watcher', paused: true, no_pause_all: true)
+
+      waiter = Thread.new { script.wait_while_paused! }
+      sleep 0.1
+      expect(waiter).to be_alive
+
+      script.paused = false
+      waiter.join(2)
+      expect(waiter).not_to be_alive
+    end
+
+    it 'does not exempt a no_pause_all caller from the Script.kill checkpoint' do
+      caller_script = build_script(name: 'bigshot', paused: true, no_pause_all: true)
+      target_script = build_script(name: 'eloot')
+      script_class.class_variable_set(:@@running, [caller_script, target_script])
+      allow(target_script).to receive(:kill)
+
+      kill_thread = Thread.new do
+        Thread.current.thread_variable_set(Lich::Common::Script::CLEANUP_SCRIPT_THREAD_KEY, caller_script)
+        script_class.kill(target_script.name)
+      end
+
+      sleep 0.1
+      expect(target_script).not_to have_received(:kill)
+      expect(kill_thread).to be_alive
+
+      caller_script.paused = false
+      kill_thread.join(2)
+
+      expect(kill_thread).not_to be_alive
       expect(target_script).to have_received(:kill)
     end
   end

--- a/spec/lib/common/script_pause_enforcement_spec.rb
+++ b/spec/lib/common/script_pause_enforcement_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe 'Lich::Common::Script pause enforcement' do
     script_class.class_variable_set(:@@stopping, [])
   end
 
-  def build_script(name:, paused: false, ignore_pause: false, no_pause_all: false)
+  def build_script(name:, paused: false, ignore_pause: false, no_pause_all: false, die_with: [])
     script_class.allocate.tap do |script|
       script.instance_variable_set(:@name, name)
       script.instance_variable_set(:@custom, false)
       script.instance_variable_set(:@quiet, true)
       script.instance_variable_set(:@thread_group, thread_group)
-      script.instance_variable_set(:@die_with, [])
+      script.instance_variable_set(:@die_with, die_with)
       script.instance_variable_set(:@paused, paused)
       script.instance_variable_set(:@ignore_pause, ignore_pause)
       script.instance_variable_set(:@no_pause_all, no_pause_all)
@@ -69,6 +69,7 @@ RSpec.describe 'Lich::Common::Script pause enforcement' do
       script.instance_variable_set(:@killer_mutex, Mutex.new)
       script.instance_variable_set(:@killed_externally, false)
       script.instance_variable_set(:@kill_source, nil)
+      allow(script).to receive(:report_errors) { |&blk| blk.call }
     end
   end
 
@@ -204,6 +205,23 @@ RSpec.describe 'Lich::Common::Script pause enforcement' do
 
       expect(kill_thread).not_to be_alive
       expect(target_script).to have_received(:kill)
+    end
+  end
+
+  describe 'a paused script tearing down its own die_with dependents' do
+    it 'does not deadlock cleanup on its own pause state (coderabbit review, PR #1537)' do
+      # If a paused script is killed and has die_with dependents, its cleanup
+      # thread identifies as itself (CLEANUP_SCRIPT_THREAD_KEY), so the
+      # Script.kill checkpoint added for the bigshot fix would otherwise wait
+      # on the script's own pause state -- which nothing will ever clear,
+      # since the script is dying. This must complete promptly instead.
+      parent = build_script(name: 'paused-parent', paused: true, die_with: ['dependent'])
+      dependent = build_script(name: 'dependent')
+      script_class.class_variable_set(:@@running, [parent, dependent])
+
+      expect(Timeout.timeout(2) { parent.kill(context: :shutdown) }).to eq('paused-parent')
+
+      expect(script_class.list).to be_empty
     end
   end
 

--- a/spec/lib/common/script_pause_enforcement_spec.rb
+++ b/spec/lib/common/script_pause_enforcement_spec.rb
@@ -244,5 +244,99 @@ RSpec.describe 'Lich::Common::Script pause enforcement' do
       wait_thread.join(2)
       expect(wait_thread).not_to be_alive
     end
+
+    # Astra review, PR #1537 (finding 1): the entry/per-iteration pause check
+    # happens *before* the predicate is evaluated, so a script paused while
+    # the predicate itself is blocked or yielding control would previously
+    # fall straight through to the caller the instant the predicate
+    # resolved, without ever re-checking pause. Deterministic via Queue
+    # hand-off rather than sleep timing, per that review's testability note.
+    it 'does not return to the caller if the script is paused while wait_while\'s predicate is resolving' do
+      script = build_script(name: 'waiter', paused: false)
+      allow(script_class).to receive(:current).and_return(script)
+      predicate_entered = Queue.new
+      release_predicate = Queue.new
+      keep_waiting = true
+
+      wait_thread = Thread.new do
+        wait_while do
+          predicate_entered << true
+          release_predicate.pop
+          keep_waiting
+        end
+      end
+
+      predicate_entered.pop # the predicate is now blocked, mid-evaluation
+      script.paused = true  # pause while control is inside the predicate
+      keep_waiting = false  # predicate will return false -- wait_while's exit condition
+      release_predicate << true
+
+      sleep 0.1
+      expect(wait_thread).to be_alive
+
+      script.paused = false
+      wait_thread.join(2)
+      expect(wait_thread).not_to be_alive
+    end
+
+    it 'does not return to the caller if the script is paused while wait_until\'s predicate is resolving' do
+      script = build_script(name: 'waiter', paused: false)
+      allow(script_class).to receive(:current).and_return(script)
+      predicate_entered = Queue.new
+      release_predicate = Queue.new
+      condition_met = false
+
+      wait_thread = Thread.new do
+        wait_until do
+          predicate_entered << true
+          release_predicate.pop
+          condition_met
+        end
+      end
+
+      predicate_entered.pop # the predicate is now blocked, mid-evaluation
+      script.paused = true  # pause while control is inside the predicate
+      condition_met = true  # predicate will return true -- wait_until's exit condition
+      release_predicate << true
+
+      sleep 0.1
+      expect(wait_thread).to be_alive
+
+      script.paused = false
+      wait_thread.join(2)
+      expect(wait_thread).not_to be_alive
+    end
+  end
+
+  describe 'Script.run' do
+    # Astra review, PR #1537 (finding 2): Script.start gained a pause
+    # checkpoint but the adjacent Script.run -- a separate public entry point
+    # used by e.g. lib/common/spell.rb -- called the same start primitive
+    # directly, bypassing it.
+    it 'does not let Script.run initiate a new script until the calling script is unpaused' do
+      caller_script = build_script(name: 'bigshot', paused: true)
+      script_class.class_variable_set(:@@running, [caller_script])
+      started_script = instance_double(script_class, join: 'child-name')
+      original_start = script_class.class_variable_get(:@@elevated_script_start)
+      script_class.class_variable_set(:@@elevated_script_start, proc { |_args, _parent| started_script })
+
+      begin
+        run_thread = Thread.new do
+          Thread.current.thread_variable_set(Lich::Common::Script::CLEANUP_SCRIPT_THREAD_KEY, caller_script)
+          script_class.run('child')
+        end
+
+        sleep 0.1
+        expect(run_thread).to be_alive
+
+        caller_script.paused = false
+        run_thread.join(2)
+
+        expect(run_thread).not_to be_alive
+        expect(run_thread.value).to eq('child-name')
+      ensure
+        script_class.class_variable_set(:@@elevated_script_start, original_start)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

`Script#pause` currently only flips a boolean (`@paused = true`). The only
thing that ever consults that flag is `Script.current`, which is called
frequently by the untrusted-script label-transition loop and by ~20 global
helpers (`echo`, `fput`, `get`, `matchwait`, `waitfor`, etc.) that happen to
resolve it internally. Modern, class-based scripts with no labels only hit
that outer loop's `Script.current` call once, at the top — after that,
pause enforcement is 100% dependent on the script's own code happening to
call one of those helpers.

Concretely: `wait_while`/`wait_until` (plain `sleep 0.25` loops) and the
`Script.kill`/`Script.kill_all`/`Script.start`/`Script.running?` class
methods never touch `Script.current` at all, so a script can be nominally
paused while its own thread keeps running through any of these and mutating
*other* scripts' lifecycle. This is a real bug hit in production: `bigshot`
was paused by `ecleanse` mid-disarm-recovery, but was already inside
`Bigshot#run_script`, which called `Script.kill(name)` on `eloot` — pause-
blind, so it fired anyway.

- Extracted the sleep-based pause wait into `Script#wait_while_paused!`,
  shared by `Script.current` and every new checkpoint (no duplicated
  `sleep 0.2 while ...` loop).
- Added the same checkpoint to `Script.kill`, `Script.kill_all`,
  `Script.start`, and `Script.running?`, gated on the *calling* script's
  pause state (a no-op when there's no calling script, e.g. core/CLI).
- `wait_while`/`wait_until` in `global_defs.rb` now re-check pause every
  loop iteration instead of only at entry — closes a race where the wait
  condition and the pause flip in the same window, which would otherwise
  let control return to paused-blind code with one last unchecked pause
  state.
- `ignore_pause`/`hidden`/`no_pause_all` semantics are unchanged — same
  `paused? and not ignore_pause` condition, now centralized in one place.

This is cooperative scheduling, not preemption (matches existing patterns
in this codebase — no `Thread#raise`): a long stretch of plain computation
with no loop and no Lich API call still won't be interrupted mid-statement.
The goal is "every blocking wait and every cross-script mutation respects
pause," not "every line of Ruby halts instantly."

`Script.pause`/`Script.unpause`/`Script.paused?` themselves are untouched —
they're pause-state accessors, not blocking/mutating checkpoints.

## Test plan

- [x] New regression spec (`spec/lib/common/script_pause_enforcement_spec.rb`)
      reproduces the exact bigshot scenario: a paused caller's
      `Script.kill`/`Script.kill_all`/`Script.running?` calls on another
      script are held (via real threads, not stubbed timing) until the
      caller unpauses.
- [x] Full existing RSpec suite passes (6341 examples, 0 failures)
- [x] Rubocop clean on all touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paused scripts now properly suspend before starting, checking status, or being stopped.
  * Waiting operations now pause while the script is paused and resume polling when execution continues.
  * Existing behavior that bypasses pauses remains supported.

* **Tests**
  * Added coverage for pause enforcement across script controls and waiting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->