### PR TITLE
fix(all): always report missing gems on stderr; only wait on a dialog without a tty

### DIFF
--- a/lib/gemcheck.rb
+++ b/lib/gemcheck.rb
@@ -507,18 +507,44 @@ module Lich
       body.split("\n").map(&:inspect).join(' & return & ')
     end
 
+    # Reports missing gems on stderr, and additionally in a GUI dialog when
+    # there is no terminal that report could have reached.
+    #
+    # The dialog is only ever *waited on*, never merely shown: a launcher start
+    # has no other channel, so {run_with_timeout} keeps the process alive long
+    # enough for the dialog to be read. From a terminal that wait is what makes
+    # the failure look like a hang -- the dialog is easily missed (another
+    # workspace, behind other windows, or not rendering at all), it blocks for
+    # {ALERT_TIMEOUT_SECONDS}, and the child's output is discarded, so the user
+    # waits two minutes and never learns why. Worst for the early-exit CLI
+    # commands (`--help`, `--version`, `--active-sessions`, ...): they are
+    # dispatched well after this check runs, so while it blocks they cannot be
+    # reached at all.
+    #
+    # Both streams are probed because a terminal launch may redirect either
+    # one.
+    #
     # @param body [String]
     # @return [void]
     def alert_linux(body)
+      # Always say it on stderr, whether or not a dialog follows. It costs
+      # nothing, it is the whole message rather than a pointer to it, and when
+      # stderr is captured (a launcher's output, a service log) it is the only
+      # record that survives -- the dialog text goes nowhere else.
+      warn("!!ALERT!! #{body}")
+
+      # Only wait on a dialog when there was no terminal to have said it in.
+      return if $stdout.isatty || $stderr.isatty
+
       if cmd_available?('zenity')
         run_with_timeout(['zenity', '--info', '--title', TITLE, '--text', body], ALERT_TIMEOUT_SECONDS)
       elsif cmd_available?('kdialog')
         run_with_timeout(['kdialog', '--title', TITLE, '--msgbox', body], ALERT_TIMEOUT_SECONDS)
       elsif cmd_available?('xmessage')
         run_with_timeout(['xmessage', '-center', body], ALERT_TIMEOUT_SECONDS)
-      else
-        warn "!!ALERT!! #{body}"
       end
+      # No dialog tool available needs no fallback branch any more -- the
+      # unconditional warn above is the fallback.
     end
 
     # @param cmd [String] executable name to probe

--- a/spec/lib/gemcheck_spec.rb
+++ b/spec/lib/gemcheck_spec.rb
@@ -692,6 +692,58 @@ RSpec.describe Lich::GemCheck do
       allow(described_class).to receive(:cmd_available?).with(tool).and_return(true)
     end
 
+    # The dialog chain is only reached with no terminal attached. Stub both
+    # streams explicitly rather than inheriting whatever the runner happens to
+    # have -- rspec's stdout is a tty when run directly in a terminal and a
+    # pipe under CI, which would otherwise make these pass or fail by accident.
+    before do
+      allow($stdout).to receive(:isatty).and_return(false)
+      allow($stderr).to receive(:isatty).and_return(false)
+      allow(described_class).to receive(:warn)
+    end
+
+    it 'always warns, whether or not a dialog follows' do
+      stub_only_available('zenity')
+      allow(described_class).to receive(:run_with_timeout)
+
+      expect(described_class).to receive(:warn).with(/!!ALERT!!.*body text/m).twice
+
+      described_class.alert_linux('body text')             # no tty: warn + dialog
+      allow($stdout).to receive(:isatty).and_return(true)
+      described_class.alert_linux('body text')             # tty: warn only
+    end
+
+    context 'when a terminal is attached' do
+      it 'does not wait on a dialog, even when zenity is available' do
+        stub_only_available('zenity')
+        allow($stdout).to receive(:isatty).and_return(true)
+
+        expect(described_class).not_to receive(:run_with_timeout)
+        expect(described_class).to receive(:warn).with(/!!ALERT!!.*body text/m)
+
+        described_class.alert_linux('body text')
+      end
+
+      it 'treats a terminal on stderr alone as interactive' do
+        stub_only_available('zenity')
+        allow($stderr).to receive(:isatty).and_return(true)
+
+        expect(described_class).not_to receive(:run_with_timeout)
+
+        described_class.alert_linux('body text')
+      end
+    end
+
+    context 'when no dialog tool is available and no terminal is attached' do
+      it 'still reports on stderr' do
+        allow(described_class).to receive(:cmd_available?).and_return(false)
+
+        expect(described_class).to receive(:warn).with(/!!ALERT!!.*body text/m)
+
+        described_class.alert_linux('body text')
+      end
+    end
+
     context 'when zenity is available' do
       before { stub_only_available('zenity') }
 
@@ -720,15 +772,6 @@ RSpec.describe Lich::GemCheck do
       it 'shows an xmessage dialog bounded by a timeout' do
         expect(described_class).to receive(:run_with_timeout)
           .with(['xmessage', '-center', 'body text'], described_class::ALERT_TIMEOUT_SECONDS)
-        described_class.alert_linux('body text')
-      end
-    end
-
-    context 'when no dialog tool is available' do
-      before { allow(described_class).to receive(:cmd_available?).and_return(false) }
-
-      it 'falls back to warn' do
-        expect(described_class).to receive(:warn).with(/!!ALERT!!/)
         described_class.alert_linux('body text')
       end
     end


### PR DESCRIPTION
## Summary

Fixes #1543.

On Linux, `alert_linux` opened a GUI dialog whenever `zenity`/`kdialog`/`xmessage` was on `PATH`, and `run_with_timeout` then waited on it for up to `ALERT_TIMEOUT_SECONDS` (120) with the child's stdout and stderr sent to `File::NULL`. The message existed *only* inside that dialog. A dialog raised from a terminal launch is easy to miss — another workspace, behind other windows, or not rendering at all — so from the terminal Lich appeared to hang for two minutes and then exit 1 having printed nothing.

It lands hardest on the early-exit CLI commands: `GemCheck.verify!` runs at `lich.rbw:39`, but `lib/main/argv_options.rb` is not required until `lich.rbw:133`. So `--help`, `--version`, `--active-sessions`, `--session-info`, `--link-to-sge` and the rest are all unreachable while the dialog blocks — including the `--help` that would have told the user to run `bundle install`.

Easy to hit right now: following the 4.0.3 → 4.0.5 bump from #1529 with a fresh `rbenv install` leaves you on an empty gem home, which is exactly the triggering condition.

## Change

The reporting and the waiting used to be the same act. Separating them is the whole fix:

- **Always `warn` on stderr**, unconditionally. It costs nothing, it carries the whole message rather than a pointer to it, and when stderr is captured (a launcher's output, a service log) it is the only record that survives. This is the part that makes the failure legible.
- **Only wait on a dialog when there was no terminal that report could reach.** A launcher start has no other channel, so it keeps the dialog and its timeout exactly as before. A terminal launch already has the message and no longer blocks two minutes to deliver it a second time.

So nobody loses information relative to today, and the GUI path is untouched for the launches that actually depend on it. Both `$stdout` and `$stderr` are probed, since a terminal launch may redirect either; `$stdout.isatty` is already the idiom for this in `lib/main/argv_options.rb` (`--link-to-sge`, `--unlink-from-sge`, …).

The trailing no-dialog-tool `else warn` branch is removed — the unconditional warn is now the fallback it used to provide.

One deliberate non-change: a terminal launch no longer *pops* the dialog at all, rather than popping it and not waiting. Firing it off unwaited would leave an orphaned window behind an exited process, which is precisely what `run_with_timeout` was written to avoid ("the spawned child keeps running as an orphan; spawning it ourselves lets us kill it directly"). If you'd rather terminal launches still get a window, the natural shape is a short bounded wait rather than fire-and-forget — happy to switch if you prefer that trade.

Scoped to Linux, matching the issue. `alert_macos` has the same shape and would benefit from the same treatment — happy to extend it here or in a follow-up. I left `alert_windows` alone deliberately: it is bound up with the Ruby4Lich5 self-healing flow and I have no way to test it.

## Test plan

- [x] `bundle exec rspec` (full suite): 6338 examples, 0 failures
- [x] `bundle exec rubocop` on both touched files: no offenses
- [x] New specs: warn happens in both branches, a tty on stdout suppresses the dialog wait, a tty on stderr alone counts as interactive, and the no-dialog-tool case still reports. Confirmed the three key examples **fail against unmodified `main`** and pass with the fix
- [x] Existing `alert_linux` specs now stub both streams explicitly rather than inheriting the runner's — rspec's stdout is a tty when run directly in a terminal but a pipe under CI, so they would otherwise pass or fail by accident
- [x] End-to-end against a simulated desktop (`cmd_available?` always true, `run_with_timeout` sleeping the full timeout): under a pty the message prints in 0.000s and no dialog is spawned; with output redirected the full alert lands on stderr **before** the dialog wait begins, and the process still blocks on the dialog — confirming the launcher path is genuinely unchanged
