### PR TITLE
fix(all): dispatch --help and --version before the GTK require

### DIFF
--- a/lib/main/argv_options.rb
+++ b/lib/main/argv_options.rb
@@ -12,7 +12,6 @@ require File.join(LIB_DIR, 'common', 'bind_host_resolver.rb')
 require File.join(LIB_DIR, 'main', 'bind_address_option.rb')
 require File.join(LIB_DIR, 'main', 'arg_normalization.rb')
 require File.join(LIB_DIR, 'main', 'detachable_client_target.rb')
-require File.join(LIB_DIR, 'main', 'help_text.rb')
 require File.join(LIB_DIR, 'main', 'startup_theme.rb')
 
 module Lich
@@ -31,12 +30,6 @@ module Lich
 
           ARGV.each do |arg|
             case arg
-            when '-h', '--help', /^--help=.+$/
-              print_help(HelpText.topic_from_argv(ARGV, arg))
-              exit
-            when '-v', '--version'
-              print_version
-              exit
             when '--link-to-sge'
               result = Lich.link_to_sge
               $stdout.puts(result ? 'Successfully linked to SGE.' : 'Failed to link to SGE.') if $stdout.isatty
@@ -133,22 +126,6 @@ module Lich
         def self.handle_dark_mode(value)
           # Regex returns Integer/nil; force strict boolean for startup handling.
           @argv_options[:dark_mode] = !!(value =~ /^(true|on)$/i)
-        end
-
-        def self.print_help(topic = nil)
-          puts HelpText.render(topic)
-        end
-
-        def self.print_version
-          puts "The Lich, version #{LICH_VERSION}"
-          puts ' (an implementation of the Ruby interpreter by Yukihiro Matsumoto designed to be a \'script engine\' for text-based MUDs)'
-          puts ''
-          puts '- The Lich program and all material collectively referred to as "The Lich project" is copyright (C) 2005-2006 Murray Miron.'
-          puts '- The Gemstone IV and DragonRealms games are copyright (C) Simutronics Corporation.'
-          puts '- The Wizard front-end and the StormFront front-end are also copyrighted by the Simutronics Corporation.'
-          puts '- Ruby is (C) Yukihiro \'Matz\' Matsumoto.'
-          puts ''
-          puts 'Thanks to all those who\'ve reported bugs and helped me track down problems on both Windows and Linux.'
         end
       end
 

--- a/lib/main/early_exit.rb
+++ b/lib/main/early_exit.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative 'help_text'
+
+module Lich
+  module Main
+    # Commands that print to stdout and exit without starting a session.
+    #
+    # lich.rbw dispatches these before Lich::GemCheck.verify! and before
+    # lib/init.rb requires GTK, so they stay usable on a runtime that cannot
+    # load a toolkit. Without that ordering, `--help` cannot report the very
+    # options that make a headless launch work.
+    #
+    # The allow-list is deliberately syntactic. It reads ARGV and nothing else.
+    # DISPLAY, TTY, and cron state never select a launch mode here, which keeps
+    # the guarantee that #1439 introduced.
+    #
+    # Membership is limited to commands that need no directory, no log file,
+    # and no database. lib/init.rb creates all three after the GTK require, so
+    # a command that needs any of them cannot move into this module.
+    module EarlyExit
+      HELP_FLAGS = ['-h', '--help'].freeze
+      HELP_TOPIC_PREFIX = '--help='
+      VERSION_FLAGS = ['-v', '--version'].freeze
+
+      module_function
+
+      # Prints the first selected command and exits. Returns when the arguments
+      # select no command handled here.
+      #
+      # @param argv [Array<String>] command-line arguments
+      # @return [void]
+      def dispatch!(argv = ARGV)
+        argv = Array(argv)
+        argv.each do |arg|
+          if help?(arg)
+            print_help(HelpText.topic_from_argv(argv, arg))
+            exit
+          elsif version?(arg)
+            print_version
+            exit
+          end
+        end
+      end
+
+      # @param argv [Array<String>] command-line arguments
+      # @return [Boolean] whether the arguments select a command handled here
+      def requested?(argv = ARGV)
+        Array(argv).any? { |arg| help?(arg) || version?(arg) }
+      end
+
+      # @param arg [String] one command-line argument
+      # @return [Boolean]
+      def help?(arg)
+        HELP_FLAGS.include?(arg) || arg.to_s.start_with?(HELP_TOPIC_PREFIX)
+      end
+
+      # @param arg [String] one command-line argument
+      # @return [Boolean]
+      def version?(arg)
+        VERSION_FLAGS.include?(arg)
+      end
+
+      # @param topic [String, nil] optional help topic
+      # @return [void]
+      def print_help(topic = nil)
+        puts HelpText.render(topic)
+      end
+
+      # @return [void]
+      def print_version
+        puts "The Lich, version #{LICH_VERSION}"
+        puts ' (an implementation of the Ruby interpreter by Yukihiro Matsumoto designed to be a \'script engine\' for text-based MUDs)'
+        puts ''
+        puts '- The Lich program and all material collectively referred to as "The Lich project" is copyright (C) 2005-2006 Murray Miron.'
+        puts '- The Gemstone IV and DragonRealms games are copyright (C) Simutronics Corporation.'
+        puts '- The Wizard front-end and the StormFront front-end are also copyrighted by the Simutronics Corporation.'
+        puts '- Ruby is (C) Yukihiro \'Matz\' Matsumoto.'
+        puts ''
+        puts 'Thanks to all those who\'ve reported bugs and helped me track down problems on both Windows and Linux.'
+      end
+    end
+  end
+end

--- a/lich.rbw
+++ b/lich.rbw
@@ -33,6 +33,14 @@ else
   require_relative('./lib/constants.rb')
 end
 require File.join(LIB_DIR, 'version.rb')
+
+# --help and --version print to stdout and exit. They read ARGV, and they touch
+# no gem, no directory, and no database. Dispatch them here, before the gem
+# check and before lib/init.rb's `require 'gtk3'`, so a runtime that cannot
+# load a toolkit can still report how to launch without one.
+require File.join(LIB_DIR, 'main', 'early_exit.rb')
+Lich::Main::EarlyExit.dispatch!
+
 require File.join(LIB_DIR, 'gemcheck.rb')
 Lich::GemCheck.verify!(*Lich::GemCheck.startup_groups)
 

--- a/spec/lib/main/early_exit_spec.rb
+++ b/spec/lib/main/early_exit_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+require_relative '../../../lib/main/early_exit'
+
+RSpec.describe Lich::Main::EarlyExit do
+  before { stub_const('LICH_VERSION', '5.20.1') }
+
+  describe '.requested?' do
+    it 'recognizes every help and version spelling' do
+      ['-h', '--help', '--help=login', '-v', '--version'].each do |flag|
+        expect(described_class.requested?([flag])).to be(true), "expected #{flag} to be recognized"
+      end
+    end
+
+    it 'ignores arguments that start a session' do
+      expect(described_class.requested?(['--login', 'Someone', '--no-gtk'])).to be(false)
+    end
+
+    it 'ignores an empty argument list' do
+      expect(described_class.requested?([])).to be(false)
+    end
+
+    # PR #1439 removed the inference of a headless launch from DISPLAY, TTY,
+    # and cron state. This allow-list must never bring it back.
+    it 'decides from the arguments alone, not from the environment' do
+      original = ENV['DISPLAY']
+      [nil, ':0'].each do |display|
+        ENV['DISPLAY'] = display
+        expect(described_class.requested?(['--help'])).to be(true)
+        expect(described_class.requested?(['--login', 'Someone'])).to be(false)
+      end
+    ensure
+      ENV['DISPLAY'] = original
+    end
+  end
+
+  describe '.dispatch!' do
+    it 'prints the overview and exits for --help' do
+      expect { described_class.dispatch!(['--help']) }
+        .to output(/Lich 5/).to_stdout
+        .and raise_error(SystemExit)
+    end
+
+    it 'prints the requested topic for --help=login' do
+      expect { described_class.dispatch!(['--help=login']) }
+        .to output(/Lich Help: login/).to_stdout
+        .and raise_error(SystemExit)
+    end
+
+    it 'prints the requested topic for a separated help argument' do
+      expect { described_class.dispatch!(['--help', 'advanced']) }
+        .to output(/Lich Help: advanced/).to_stdout
+        .and raise_error(SystemExit)
+    end
+
+    it 'prints the version and exits for --version' do
+      expect { described_class.dispatch!(['--version']) }
+        .to output(/The Lich, version 5\.20\.1/).to_stdout
+        .and raise_error(SystemExit)
+    end
+
+    it 'handles the first selected command when several are present' do
+      expect { described_class.dispatch!(['--version', '--help']) }
+        .to output(/The Lich, version 5\.20\.1/).to_stdout
+        .and raise_error(SystemExit)
+    end
+
+    it 'returns without output when no early-exit command is present' do
+      expect { described_class.dispatch!(['--login', 'Someone']) }.not_to output.to_stdout
+    end
+
+    it 'does not exit when no early-exit command is present' do
+      expect { described_class.dispatch!(['--login', 'Someone']) }.not_to raise_error
+    end
+  end
+
+  describe 'load isolation' do
+    # The module runs before GemCheck and before lib/init.rb requires GTK, so
+    # it must not reach the heavy CLI require chain or any optional gem.
+    it 'loads without gtk3, sqlite3, or the ARGV pipeline' do
+      source = File.read(File.expand_path('../../../lib/main/early_exit.rb', __dir__))
+
+      expect(source).not_to match(/require.*gtk3/)
+      expect(source).not_to match(/require.*sqlite3/)
+      expect(source).not_to match(/require.*argv_options/)
+      expect(source).not_to match(/require.*cli_orchestration/)
+    end
+  end
+
+  describe 'lich.rbw boot ordering' do
+    # The whole point of this module is where it runs. Guard the order so a
+    # later edit to lich.rbw cannot silently reintroduce elanthia-online/lich-5#1545.
+    let(:boot) { File.read(File.expand_path('../../../lich.rbw', __dir__)) }
+
+    def index_of(pattern)
+      match = boot.index(pattern)
+      raise "lich.rbw no longer contains #{pattern.inspect}" if match.nil?
+
+      match
+    end
+
+    it 'dispatches early-exit commands before the gem check' do
+      expect(index_of('Lich::Main::EarlyExit.dispatch!')).to be < index_of('Lich::GemCheck.verify!')
+    end
+
+    it 'dispatches early-exit commands before init.rb requires GTK' do
+      expect(index_of('Lich::Main::EarlyExit.dispatch!')).to be < index_of("require File.join(LIB_DIR, 'init.rb')")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1545.

## Problem

`ruby lich.rbw --help` aborts on any runtime without the `gtk3` gem. The cause is load order in `lich.rbw`:

| line | what happens |
| --- | --- |
| 37 | `Lich::GemCheck.verify!` |
| 68 | `require .../init.rb` -> `require 'gtk3'` at `lib/init.rb:417` |
| 131 | `require .../main/argv_options.rb` -> CLI dispatch |

The GTK require sits 60 lines above the dispatcher, so an early-exit command never gets to handle itself. That makes it chicken-and-egg: `--no-gtk` avoids the problem, but `--help` is the command that reports `--no-gtk` exists.

## Approach

This takes option (1) from the issue, limited to the two commands that qualify.

`--help` and `--version` move into a new `Lich::Main::EarlyExit` module. `lich.rbw` dispatches it before **both** `GemCheck.verify!` and the `init.rb` require. Both commands read `ARGV`, print, and exit. They touch no gem, no directory, no log file, and no database, so they are safe that early.

Dispatch runs before `verify!` as well as before the GTK require. On Windows `startup_groups` adds `:gtk` to the verified groups, so a `--help` run on a machine with no GTK would otherwise stop at the gem check instead. Placing the dispatch first makes `--help` work on any incomplete runtime, which is the point of the report.

### The allow-list stays syntactic

`EarlyExit.requested?` reads `ARGV` and nothing else. It is not a "is this a GUI launch" classifier, and that is deliberate: #1439 removed the inference of a headless launch from `DISPLAY`, `TTY`, and cron state, and this must not bring it back. A spec asserts the answer does not change when `DISPLAY` is set or unset.

GTK stays required for every session launch that does not pass `--no-gtk` or `--no-gui`. #1439's strictness is unchanged.

### Why only two commands

`lib/init.rb` creates the Lich directory, performs `Dir.chdir`, opens the debug log, and calls `Lich.init_db` **after** the GTK require, at lines 456-570. The remaining early-exit commands depend on that state:

- `--install` and `--uninstall` call `Lich.log`, which needs the file opened at `lib/init.rb:492`.
- The account and password handlers reach `EntryStore`, which needs `DATA_DIR` from `lib/init.rb:515`.

Those keep their current behaviour and still require GTK. This also matches @OSXLich-Doug's read in the issue thread: `--link-to-sge` and `--install` target Windows, where GTK is present anyway.

### Removed rather than left unreachable

`lich.rbw:131` is the only caller of `ArgvOptions`, so the `-h`/`--help` and `-v`/`--version` branches there became dead once the dispatch moved. This deletes them and the two now-unused print methods instead of leaving a second copy of the version text to drift. `HelpText` is now required by `early_exit.rb`; `argv_options.rb` no longer references it, so that require goes too.

An ordering spec reads `lich.rbw` and asserts the dispatch precedes both `verify!` and the `init.rb` require, so a later edit cannot quietly reintroduce the fault.

## Not in scope

Two points from the issue stay open, and I am happy to take either as a separate PR:

- The `UNIX_MESSAGE` "run `bundle install`" text is wrong when `:gtk` sits in `BUNDLE_WITHOUT`. Naming `--no-gtk` there would make this self-service.
- Self-healing on Linux, which @OSXLich-Doug raised in the thread. Worth doing on its own merits, but it does not close this issue: the `gtk3` gem on Linux builds from source against system GTK development packages, and Ruby4Lich5 publishes `x64-mingw-ucrt` assets only. There is nothing for a Linux manifest to point at. macOS is in the same position today; `BundlerRecovery` excludes the `gtk` group at `lib/bundler_recovery.rb:18`, so a Mac without the `gtk3` gem hits this identical `--help` failure. Even with a working Linux repair, `--help` opening a consent dialog to install a toolkit before printing text would be the wrong outcome.

## Test plan

- [x] `bundle exec rspec` passes (6349 examples, 0 failures locally)
- [x] `bundle exec rubocop` reports no offences on the changed files
- [ ] With `bundle config set --local without 'gtk:vscode:profanity'` (no `gtk3` installed):
  - [ ] `ruby lich.rbw --help` prints the overview and exits 0
  - [ ] `ruby lich.rbw --version` prints the version banner
  - [ ] `ruby lich.rbw --help login` and `ruby lich.rbw --help=advanced` print the right topic
  - [ ] `ruby lich.rbw --no-gtk --help` still works
- [ ] Tier-2 behaviour is unchanged: `ruby lich.rbw --change-master-password` still shows the missing-gem alert, and `ruby lich.rbw --no-gtk --change-master-password` still reaches its own usage output
- [ ] On a machine **with** `gtk3`: a normal session launch still loads GTK, and `--no-gtk` still suppresses it

