### PR TITLE
fix(gs): correct messaging drift in 13 crit table patterns

### DIFF
--- a/lib/gemstone/critranks/acid_critical_table.rb
+++ b/lib/gemstone/critranks/acid_critical_table.rb
@@ -434,7 +434,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 1,
                                   :secondary_wound => nil,
-                                  :regex           => /^Drop of acid gets in .*? eye. Better flush it out./ },
+                                  :regex           => /^Drop of acid gets in .*? eye.  Better flush it out./ },
                            2 =>
                                 { :type            => "acid",
                                   :location        => "left eye",
@@ -511,7 +511,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 3,
                                   :secondary_wound => nil,
-                                  :regex           => /^Hit to eye empties the socket. How can something missing be so painful./ },
+                                  :regex           => /^Hit to eye empties the socket.  How can something missing be so painful./ },
                            6 =>
                                 { :type            => "acid",
                                   :location        => "left eye",
@@ -589,7 +589,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 3,
                                   :secondary_wound => { :location => "head", :wound_rank => 3 },
-                                  :regex           => /^Acid Flush! The .*? brains get washed right out the mouth./ } },
+                                  :regex           => /^Acid Flush!  The .*? brains get washed right out the mouth./ } },
           :right_eye  =>
                          { 4 =>
                                 { :type            => "acid",
@@ -1345,7 +1345,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 2,
                                   :secondary_wound => nil,
-                                  :regex           => /^Burn to the elbow eats through tendons. Muscles snap free./ },
+                                  :regex           => /^Burn to the elbow eats through tendons.  Muscles snap free./ },
                            6 =>
                                 { :type            => "acid",
                                   :location        => "left arm",
@@ -1364,7 +1364,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 2,
                                   :secondary_wound => nil,
-                                  :regex           => /^Acid dissolves the elbow ligaments. Arm swings in a very odd manner./ },
+                                  :regex           => /^Acid dissolves the elbow ligaments.  Arm swings in a very odd manner./ },
                            7 =>
                                 { :type            => "acid",
                                   :location        => "left arm",
@@ -1383,7 +1383,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 3,
                                   :secondary_wound => nil,
-                                  :regex           => /^The .*? arm is drenched in acid. Flesh and bones are reduced to a smoking slime./ },
+                                  :regex           => /^The .*? arm is drenched in acid.  Flesh and bones are reduced to a smoking slime./ },
                            8 =>
                                 { :type            => "acid",
                                   :location        => "left arm",

--- a/lib/gemstone/critranks/crush_critical_table.rb
+++ b/lib/gemstone/critranks/crush_critical_table.rb
@@ -700,7 +700,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 2,
                                   :secondary_wound => nil,
-                                  :regex           => /^Whoosh. Several ribs driven into lungs./ },
+                                  :regex           => /^Whoosh.  Several ribs driven into lungs./ },
                            6 =>
                                 { :type            => "crush",
                                   :location        => "chest",
@@ -1157,7 +1157,7 @@ module Lich
                                   :silenced        => false,
                                   :slowed          => false,
                                   :wound_rank      => 3,
-                                  :secondary_wound => { :location => "nerves", "wound_rank" => 3 },
+                                  :secondary_wound => { :location => "nerves", :wound_rank => 3 },
                                   :regex           => /^A mighty blow cleaves a swath through .*? back, taking the spine with it./ } },
           :right_arm  =>
                          { 0 =>

--- a/lib/gemstone/critranks/fire_critical_table.rb
+++ b/lib/gemstone/critranks/fire_critical_table.rb
@@ -163,7 +163,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 3,
                                   :secondary_wound => nil,
-                                  :regex           => /^Flame sets a .*? head alight like a torch./ },
+                                  :regex           => /^Flame sets an? .*? head alight like a torch./ },
                            8 =>
                                 { :type            => "fire",
                                   :location        => "head",

--- a/lib/gemstone/critranks/impact_critical_table.rb
+++ b/lib/gemstone/critranks/impact_critical_table.rb
@@ -2036,7 +2036,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 2,
                                   :secondary_wound => nil,
-                                  :regex           => /^Hard blow to left hand breaking bones./ },
+                                  :regex           => /^Hard blow to(?: the)? left hand breaking bones./ },
                            7 =>
                                 { :type            => "impact",
                                   :location        => "left hand",

--- a/lib/gemstone/critranks/lightning_critical_table.rb
+++ b/lib/gemstone/critranks/lightning_critical_table.rb
@@ -1348,7 +1348,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 3,
                                   :secondary_wound => { :location => "nerves", :wound_rank => 3 },
-                                  :regex           => /^Massive electrical bolt burns a hole through the back and kidneys./ } },
+                                  :regex           => /^Massive electrical bolt burns a hole through the back and kidneys.?/ } },
           :right_arm  =>
                          { 0 =>
                                 { :type            => "lightning",

--- a/lib/gemstone/critranks/plasma_critical_table.rb
+++ b/lib/gemstone/critranks/plasma_critical_table.rb
@@ -1428,7 +1428,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 1,
                                   :secondary_wound => nil,
-                                  :regex           => /^Light burns to .*? leg./ },
+                                  :regex           => /^Light burns to .*? leg.?/ },
                            2 =>
                                 { :type            => "plasma",
                                   :location        => "left leg",
@@ -1619,7 +1619,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 1,
                                   :secondary_wound => nil,
-                                  :regex           => /^Stinging burn to .*? hand./ },
+                                  :regex           => /^Stinging burn to .*? hand.?/ },
                            2 =>
                                 { :type            => "plasma",
                                   :location        => "left hand",

--- a/lib/gemstone/critranks/puncture_critical_table.rb
+++ b/lib/gemstone/critranks/puncture_critical_table.rb
@@ -584,7 +584,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 3,
                                   :secondary_wound => nil,
-                                  :regex           => /^Perfect strike to the abdomen./ } },
+                                  :regex           => /^Perfect strike to (?:the )?abdomen./ } },
           :back       =>
                          { 0 =>
                                 { :type            => "puncture",

--- a/lib/gemstone/critranks/unbalance_critical_table.rb
+++ b/lib/gemstone/critranks/unbalance_critical_table.rb
@@ -719,7 +719,7 @@ module Lich
                                   :slowed          => false,
                                   :wound_rank      => 2,
                                   :secondary_wound => nil,
-                                  :regex           => /^.*? knocked back and stunned./ },
+                                  :regex           => /^.*? [Kk]nocked back and stunned./ },
                            8 =>
                                 { :type            => "unbalance",
                                   :location        => "chest",


### PR DESCRIPTION
## Summary

The crit tables were transcribed from the wiki. Live messaging has since drifted, so a number of patterns no longer match what the game actually sends and those crits are silently lost.

Found by scanning **200,341,002 lines** of session logs: build a relaxed variant of each of the 2,394 table regexes (flexible whitespace, optional articles/punctuation), then report lines that match the relaxed form but fail `CritRanks.parse`. Every hit is a message we already have a table entry for, just with drifted wording.

## Drift classes

**1. Two spaces between sentences, table had one**

```
table: /^Burn to the elbow eats through tendons. Muscles snap free./
live:  "Burn to the elbow eats through tendons.  Muscles snap free!"
```

Affects `acid` (elbow tendons, elbow ligaments, arm drenched, eye socket, drop of acid, Acid Flush) and `crush` (Whoosh).

**2. Trailing punctuation absent in live messaging**

```
table: /^Stinging burn to .*? hand./
live:  "Stinging burn to the basalt grotesque's hand"
```

Occurs when the crit is followed by another damage line, e.g. a plasma DoT tick:

```
The whip of plasma continues to wreathe a hapless charmed corsair in its sizzling embrace!
   ... 7 points of damage!
   Light burns to the charmed corsair's leg
   ... 18 points of damage!
```

Present in Prime (1,463 of 4,066 instances) as well as Shattered, so not realm-specific.

**3. Article mismatch**

```
table: /^Perfect strike to the abdomen./
live:  "Perfect strike to abdomen.  The steelwing harpy howls in pain and drops quite dead!"
```

```
table: /^Flame sets a .*? head alight like a torch./
live:  "Flame sets an eyeless black valravn's head alight like a torch."
```

**4. Capitalised variant unreachable**

The tables are case-sensitive, so a leading `.*?` cannot match a capitalised word:

```
table: /^.*? knocked back and stunned./
live:  "Chest strike.  Knocked back and stunned!"   (vs "The triton brawler knocked back and stunned!")
```

## Also included

`crush_critical_table.rb` had a malformed `secondary_wound` key — the string `"wound_rank"` instead of the symbol `:wound_rank`. `Processor#apply_secondary_wound` reads `secondary[:wound_rank]`, so that nerves wound was silently dropped.

## Changes

| Table | Change |
|---|---|
| puncture | `to (?:the )?abdomen` |
| plasma | `leg.?`, `hand.?` |
| lightning | `kidneys.?` |
| acid | two spaces ×6 |
| crush | `Whoosh.  Several`, `secondary_wound` key |
| fire | `Flame sets an?` |
| impact | `Hard blow to(?: the)? left hand` |
| unbalance | `[Kk]nocked back and stunned` |

## Testing

- 19 targeted assertions covering every changed pattern, including **both** the old and new wording where a form was made optional, confirming no existing match was broken
- `bundle exec rubocop lib/gemstone/critranks/` — 21 files, no offenses
- Re-scanning the corpus after the fixes drops near-misses to zero (the only remaining hits are second-person lines, which are out of scope — these tables describe crits against creatures)

## Scope note

Second-person crits (a crit landing on the player) are deliberately **not** addressed. All 22 existing "you" patterns in the tables have the player as *attacker* ("your well placed strike"), never as recipient, so 2p messaging is out of scope by design.
