### PR TITLE
fix(dr): pin capped skills to 34 in DRSkill.clear_mind

### DIFF
--- a/lib/dragonrealms/drinfomon/drskill.rb
+++ b/lib/dragonrealms/drinfomon/drskill.rb
@@ -129,12 +129,11 @@ module Lich
 
       # BUG FIX: Added nil guard - find_skill can return nil if skill not found
       #
-      # Mastered skills (rank >= 1750) are pinned to 34/34 the same way
-      # `initialize` and `update` do it. The game continuously streams an empty
-      # exp component for a capped skill (its mindstate sits at clear/0), which
-      # routes here; without the cap guard that pulse would reset exp to 0 and
-      # defeat the "capped == 34" convention that trainer scripts rely on to
-      # avoid re-training a maxed skill.
+      # Capped skills (rank >= 1750) are pinned to 34/34 the same way
+      # `initialize` and `update` do it. Without the cap guard, clearing the
+      # mindstate here would reset exp to 0 and defeat the "capped == 34"
+      # convention that trainer scripts rely on to avoid re-training a capped
+      # skill.
       def self.clear_mind(val)
         skill = find_skill(val)
         return unless skill

--- a/lib/dragonrealms/drinfomon/drskill.rb
+++ b/lib/dragonrealms/drinfomon/drskill.rb
@@ -128,9 +128,18 @@ module Lich
       end
 
       # BUG FIX: Added nil guard - find_skill can return nil if skill not found
+      #
+      # Mastered skills (rank >= 1750) are pinned to 34/34 the same way
+      # `initialize` and `update` do it. The game continuously streams an empty
+      # exp component for a capped skill (its mindstate sits at clear/0), which
+      # routes here; without the cap guard that pulse would reset exp to 0 and
+      # defeat the "capped == 34" convention that trainer scripts rely on to
+      # avoid re-training a maxed skill.
       def self.clear_mind(val)
         skill = find_skill(val)
-        skill.exp = 0 if skill
+        return unless skill
+
+        skill.exp = skill.rank.to_i >= 1750 ? 34 : 0
       end
 
       # BUG FIX: Added nil guard - find_skill can return nil if skill not found

--- a/spec/lib/dragonrealms/drinfomon/drskill_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drskill_spec.rb
@@ -258,6 +258,29 @@ RSpec.describe Lich::DragonRealms::DRSkill do
     end
   end
 
+  describe '.clear_mind cap guard (BUG FIX)' do
+    it 'zeroes mindstate for a non-capped skill' do
+      described_class.new('Athletics', 500, 20, 50)
+
+      described_class.clear_mind('Athletics')
+
+      expect(described_class.getxp('Athletics')).to eq(0)
+    end
+
+    # A mastered skill (rank >= 1750) permanently sits at a clear mindstate, so
+    # the game keeps streaming an empty exp component that routes to clear_mind.
+    # It must stay pinned to 34/34 like initialize/update do, otherwise trainer
+    # scripts (e.g. t2, athletics) see a 0 mindstate and re-train a maxed skill.
+    it 'keeps a mastered skill (rank >= 1750) pinned to 34' do
+      described_class.new('Athletics', 1750, 34, 0)
+      expect(described_class.getxp('Athletics')).to eq(34)
+
+      described_class.clear_mind('Athletics')
+
+      expect(described_class.getxp('Athletics')).to eq(34)
+    end
+  end
+
   describe '#lookup_skillset nil guard (BUG FIX)' do
     it 'returns nil for unknown skill without crashing' do
       # Create a skill with an unknown name directly

--- a/spec/lib/dragonrealms/drinfomon/drskill_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drskill_spec.rb
@@ -267,11 +267,10 @@ RSpec.describe Lich::DragonRealms::DRSkill do
       expect(described_class.getxp('Athletics')).to eq(0)
     end
 
-    # A mastered skill (rank >= 1750) permanently sits at a clear mindstate, so
-    # the game keeps streaming an empty exp component that routes to clear_mind.
-    # It must stay pinned to 34/34 like initialize/update do, otherwise trainer
-    # scripts (e.g. t2, athletics) see a 0 mindstate and re-train a maxed skill.
-    it 'keeps a mastered skill (rank >= 1750) pinned to 34' do
+    # A capped skill (rank >= 1750) must stay pinned to 34/34 through clear_mind
+    # like initialize/update do, otherwise trainer scripts (e.g. t2, athletics)
+    # see a 0 mindstate and re-train a capped skill.
+    it 'keeps a capped skill (rank >= 1750) pinned to 34' do
       described_class.new('Athletics', 1750, 34, 0)
       expect(described_class.getxp('Athletics')).to eq(34)
 


### PR DESCRIPTION
## Problem

`DRSkill` pins a capped skill (rank ≥ 1750) to a `34/34` mindstate in both `initialize` and `update`. Trainer scripts that gate on `DRSkill.getxp(skill)` — e.g. `t2`, `athletics` — rely on that convention: a capped skill reads as "fully learning," so it's skipped and never re-trained.

`clear_mind` was the **one exp writer missing that guard** — it unconditionally set `exp = 0`:

```ruby
def self.clear_mind(val)
  skill = find_skill(val)
  skill.exp = 0 if skill
end
```

The parser routes clear-mindstate events for a skill to `clear_mind` ([drparser.rb](https://github.com/elanthia-online/lich-5/blob/main/lib/dragonrealms/drinfomon/drparser.rb) `ExpClearMindstate`). When that fired for a capped skill, it reset the pinned `34` back to `0`.

### Observed impact

With a 1750-Athletics character, `t2` saw `getxp('Athletics') == 0` (below its start threshold of 10) and launched `athletics max` on a capped skill. Because a capped skill's mindstate can never climb, `athletics`'s `done_training?` (`getxp >= 32`) is never satisfied, so it looped indefinitely (climbing wyvern cliffs) — training that should have been impossible to start.

Verified end-to-end against the real `DRSkill` code:

| Step | `getxp('Athletics')` |
|---|---|
| `update('Athletics', 1750, clear, 0)` (the exp-dump parse path) | `34` ✅ guard works |
| `clear_mind('Athletics')` | `0` ❌ bug |
| `clear_mind('Forging')` (rank 910, non-capped) | `0` ✅ correct |

## Fix

Apply the same `rank >= 1750 ? 34 : 0` guard used by `initialize`/`update`, and keep the existing nil guard.

## Tests

Adds regression specs to `drskill_spec.rb`:
- a non-capped skill still zeroes on `clear_mind`
- a capped skill (rank ≥ 1750) stays pinned to `34` after `clear_mind`

The capped-skill spec fails on `main` and passes with this change. Full `drskill_spec.rb` is green (40 examples), and `rubocop` reports no offenses on the changed files.

**Manually tested in game** on this branch and confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)