### PR TITLE
feat(dr): opt-in cambrinth charge distribution across configured items

### DIFF
--- a/lib/dragonrealms/commons/common-arcana.rb
+++ b/lib/dragonrealms/commons/common-arcana.rb
@@ -854,7 +854,7 @@ module Lich
             end
           end
           calculate_mana(discern_data['min'], discern_data['more'], discern_data, false, settings)
-        elsif discern_data.empty? || discern_data['time_stamp'].nil? || Time.now - discern_data['time_stamp'] > settings.check_discern_timer_in_hours * 60 * 60 || !discern_data['more'].nil?
+        elsif discern_data.empty? || discern_data['time_stamp'].nil? || Time.now - discern_data['time_stamp'] > settings.check_discern_timer_in_hours * 60 * 60 || !discern_data['more'].nil? || stale_cambrinth_caps?(discern_data, settings)
           discern_data['time_stamp'] = Time.now
           DRC.retreat
           case discern = DRC.bput("discern #{data['abbrev']}", 'The spell requires at minimum \d+ mana streams and you think you can reinforce it with \d+ more', 'You don\'t think you are able to cast this spell', 'You have no idea how to cast that spell', 'You don\'t seem to be able to move to do that')
@@ -881,6 +881,18 @@ module Lich
         normalize_cambrinth_items(settings)
         # Ignore cambrinth if charges to use is nil or 0
         settings.cambrinth_num_charges ||= 0
+        if settings.cambrinth_distribute_charges
+          calculate_mana_by_item(total, remaining, discern_data, cyclic_or_ritual, settings)
+        else
+          calculate_mana_by_ratio(total, remaining, discern_data, cyclic_or_ritual, settings)
+        end
+      end
+
+      # Default. Splits the mana by the cap ratio of each cambrinth item, then gives
+      # every charge of an item the same size. It can charge an item past its cap,
+      # and integer division can drop mana. Kept as the default because a change to
+      # the charge amounts affects every profile.
+      def calculate_mana_by_ratio(total, remaining, discern_data, cyclic_or_ritual, settings)
         settings.cambrinth_items = [] if settings.cambrinth_num_charges == 0
         total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+) || 0
         charges_count_floor = remaining >= settings.cambrinth_num_charges ? settings.cambrinth_num_charges : 1
@@ -902,12 +914,161 @@ module Lich
             charge_amount = (total_cambrinth_mana / total_cambrinth_charges) * item['charges']
             discern_data['cambrinth'][index] = []
             charge_amount.times do |i|
-              discern_data['cambrinth'][index][i % item['charges']] += 1
+              # Lich patches NilClass#+ so that nil + 1 is 1. Spell it out here so
+              # that this does not depend on the patch.
+              slot = i % item['charges']
+              discern_data['cambrinth'][index][slot] = (discern_data['cambrinth'][index][slot] || 0) + 1
             end
           end
         else
           discern_data['cambrinth'] = nil
         end
+      end
+
+      # Opt in with cambrinth_distribute_charges. Splits the mana into whole charges,
+      # then fills each item up to its cap before it uses the next, the same way
+      # cast.lic does. No item goes over its cap and no mana is dropped.
+      def calculate_mana_by_item(total, remaining, discern_data, cyclic_or_ritual, settings)
+        cambrinth_items = settings.cambrinth_num_charges == 0 ? [] : settings.cambrinth_items
+        discern_data['cambrinth_caps'] = cambrinth_caps(settings)
+        total_cambrinth_cap = cambrinth_items.map { |item| item['cap'].to_i }.sum
+        if remaining > total_cambrinth_cap
+          discern_data['mana'] = discern_data['mana'] + (remaining - total_cambrinth_cap)
+          remaining = total - discern_data['mana']
+        end
+        if cyclic_or_ritual || cambrinth_items.empty?
+          discern_data['cambrinth'] = nil
+          discern_data['mana'] = discern_data['mana'] + remaining
+        elsif remaining > 0
+          num_charges = remaining >= settings.cambrinth_num_charges ? settings.cambrinth_num_charges : 1
+          distribution, leftover = allocate_cambrinth_charges(remaining, cambrinth_items, num_charges)
+          # Mana that fits in no cambrinth item goes into the base prep instead.
+          discern_data['mana'] = discern_data['mana'] + leftover
+          discern_data['cambrinth'] = distribution.empty? ? nil : distribution
+        else
+          discern_data['cambrinth'] = nil
+        end
+      end
+
+      # The mana capacity of one cambrinth item. An unset or non-positive cap means
+      # the config never declared a limit, so do not enforce one.
+      def cambrinth_item_cap(item)
+        cap = item['cap'].to_i
+        cap <= 0 ? Float::INFINITY : cap
+      end
+
+      # Works out how to charge an amount of mana into the cambrinth items.
+      #
+      # Each item takes as much as its cap allows, in the order the config lists
+      # them, so a small worn item fills before a large stored one. Each item then
+      # splits its own share into charges. Returns the per-item nested array and
+      # the mana that fits in no item.
+      def allocate_cambrinth_charges(mana, cambrinth_items, num_charges)
+        return [[], mana] if mana <= 0 || num_charges <= 0
+        return [[], mana] if cambrinth_items.nil? || cambrinth_items.empty?
+
+        allocations = Array.new(cambrinth_items.length, 0)
+        unallocated = mana
+        usable_cambrinth_indexes(cambrinth_items, num_charges).each do |index|
+          allocations[index] = [unallocated, cambrinth_item_cap(cambrinth_items[index])].min
+          unallocated -= allocations[index]
+        end
+
+        counts = cambrinth_charge_counts(allocations, num_charges)
+        distribution = allocations.each_with_index.map do |allocation, index|
+          split_cambrinth_charges(allocation, counts[index])
+        end
+        # Drop trailing empty entries so unused items are skipped entirely.
+        [distribution.reverse.drop_while(&:empty?).reverse, unallocated]
+      end
+
+      # Every item that holds mana needs at least one charge, so the charge budget
+      # limits how many items can be used. When there are more items than charges,
+      # keep the items with the largest caps.
+      def usable_cambrinth_indexes(cambrinth_items, num_charges)
+        indexes = (0...cambrinth_items.length).to_a
+        return indexes if indexes.length <= num_charges
+
+        indexes.max_by(num_charges) { |index| cambrinth_item_cap(cambrinth_items[index]) }.sort
+      end
+
+      # Gives one charge to every item that holds mana, then spends what is left of
+      # the charge budget on the largest charge, while that makes it smaller. This
+      # keeps each charge inside what the character can channel at once.
+      def cambrinth_charge_counts(allocations, num_charges)
+        counts = allocations.map { |allocation| allocation > 0 ? 1 : 0 }
+        funded = allocations.each_index.select { |index| allocations[index] > 0 }
+        spare = num_charges - funded.length
+        while spare > 0
+          index = funded.max_by { |i| [allocations[i].to_f / counts[i], allocations[i]] }
+          break if counts[index] >= allocations[index]
+
+          largest = funded.map { |i| allocations[i].to_f / counts[i] }.max
+          split = funded.map { |i| allocations[i].to_f / (i == index ? counts[i] + 1 : counts[i]) }.max
+          break if split >= largest
+
+          counts[index] += 1
+          spare -= 1
+        end
+        counts
+      end
+
+      # Splits an amount of mana into num_charges charge values, largest first.
+      # For example, 53 mana over 4 charges becomes [14, 13, 13, 13].
+      def split_cambrinth_charges(total_mana, num_charges)
+        return [] if total_mana <= 0 || num_charges <= 0
+
+        charge_values = []
+        rest = total_mana
+        charges_left = num_charges
+        while rest > 0 && charges_left > 0
+          next_charge = (rest * 1.0 / charges_left).ceil
+          charge_values << next_charge
+          rest -= next_charge
+          charges_left -= 1
+        end
+        charge_values
+      end
+
+      # Packs a flat list of charge values into the cambrinth items. Each item is
+      # filled up to its cap before the next item is used. Returns the per-item
+      # nested array and the mana that fits in no item.
+      def distribute_cambrinth_charges(charge_values, cambrinth_items)
+        pending = Array(charge_values).flatten.map(&:to_i).reject { |value| value <= 0 }
+        return [[], pending.sum] if cambrinth_items.nil? || cambrinth_items.empty?
+
+        distribution = Array.new(cambrinth_items.length) { [] }
+        charged = Array.new(cambrinth_items.length, 0)
+        leftover = 0
+        pending.each do |charge_value|
+          index = cambrinth_items.each_index.find do |i|
+            charged[i] + charge_value <= cambrinth_item_cap(cambrinth_items[i])
+          end
+          if index
+            distribution[index] << charge_value
+            charged[index] += charge_value
+          else
+            leftover += charge_value
+          end
+        end
+        # Drop trailing empty entries so unused items are skipped entirely.
+        [distribution.reverse.drop_while(&:empty?).reverse, leftover]
+      end
+
+      # Signature of the configured cambrinth items. A change to it invalidates any
+      # cached discern data, because the cached charges are split per item.
+      def cambrinth_caps(settings)
+        normalize_cambrinth_items(settings)
+        settings.cambrinth_items.map { |item| item['cap'].to_i }
+      end
+
+      # True when cached discern data was calculated against a different set of
+      # cambrinth items. Only the cambrinth_distribute_charges path records the
+      # signature, so the default path never invalidates on it.
+      def stale_cambrinth_caps?(discern_data, settings)
+        return false unless settings.cambrinth_distribute_charges
+
+        discern_data['cambrinth_caps'] != cambrinth_caps(settings)
       end
 
       def check_to_harness(should_harness)
@@ -1073,6 +1234,16 @@ module Lich
       end
 
       def charge_cambrinth_items(data, settings)
+        if settings.cambrinth_distribute_charges
+          charge_cambrinth_items_by_item(data, settings)
+        else
+          charge_cambrinth_items_repeated(data, settings)
+        end
+      end
+
+      # Default. A nested cambrinth list gives one entry to each item. A flat list
+      # goes to every item in full, so several items each charge the whole list.
+      def charge_cambrinth_items_repeated(data, settings)
         settings.cambrinth_items.each_with_index do |item, index|
           case data['cambrinth'].first
           when Array
@@ -1081,6 +1252,48 @@ module Lich
             find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'], settings.cambrinth_invoke_exact_amount)
           end
         end
+      end
+
+      # Opt in with cambrinth_distribute_charges. A flat list is spread over the
+      # items instead of charged into every one of them.
+      def charge_cambrinth_items_by_item(data, settings)
+        charges = data['cambrinth']
+        return unless charges.is_a?(Array) && !charges.empty?
+
+        unless charges.first.is_a?(Array)
+          return unless charges.first.is_a?(Integer)
+
+          charges = spread_flat_cambrinth_charges(charges, settings.cambrinth_items)
+        end
+
+        settings.cambrinth_items.each_with_index do |item, index|
+          item_charges = charges[index]
+          next if item_charges.nil? || item_charges.empty?
+
+          find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, item_charges, settings.cambrinth_invoke_exact_amount)
+        end
+      end
+
+      # Turns one flat list of charge values, as written in a spell config, into one
+      # list for each cambrinth item.
+      #
+      # A single item takes the list unchanged. In this path cambrinth_cap feeds the
+      # arcana check in skilled_to_charge_while_worn?, not a charge limit, and many
+      # configs charge well past it on purpose.
+      #
+      # Several items need the list spread over them, because the whole list into
+      # every item charges the same mana again for each item.
+      def spread_flat_cambrinth_charges(charge_values, cambrinth_items)
+        return [charge_values] if cambrinth_items.nil? || cambrinth_items.length <= 1
+
+        distribution, leftover = distribute_cambrinth_charges(charge_values, cambrinth_items)
+        return distribution if leftover <= 0
+
+        # Never drop mana. What fits nowhere goes to the item with the largest cap.
+        largest = cambrinth_items.each_with_index.max_by { |item, _index| item['cap'].to_i }.last
+        distribution[largest] = (distribution[largest] || []) + [leftover]
+        Lich::Messaging.msg("bold", "DRCA: #{leftover} mana does not fit your cambrinth_items caps and went into your #{cambrinth_items[largest]['name']}. Check those caps.")
+        distribution
       end
     end
   end

--- a/spec/lib/dragonrealms/commons/common_arcana_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_arcana_spec.rb
@@ -838,4 +838,401 @@ RSpec.describe Lich::DragonRealms::DRCA do
       DRCA.find_charge_invoke_stow('armband', false, 50, nil, [10])
     end
   end
+
+  # ----------------------------------------------
+  # Cambrinth charge distribution
+  # ----------------------------------------------
+  # A three item setup where the first two items are far too small to hold a
+  # full charge. This is the shape that exposed the old distribution bugs.
+  def three_cambrinth_items
+    [
+      { 'name' => 'cambrinth earcuff', 'cap' => 4, 'stored' => false },
+      { 'name' => 'cambrinth anklet', 'cap' => 4, 'stored' => false },
+      { 'name' => 'sea urchin', 'cap' => 48, 'stored' => true }
+    ]
+  end
+
+  describe '.split_cambrinth_charges' do
+    it 'returns no charges when there is no mana' do
+      expect(DRCA.split_cambrinth_charges(0, 3)).to eq([])
+    end
+
+    it 'returns no charges when the charge count is zero' do
+      expect(DRCA.split_cambrinth_charges(30, 0)).to eq([])
+    end
+
+    it 'puts the remainder in the first charge' do
+      expect(DRCA.split_cambrinth_charges(53, 4)).to eq([14, 13, 13, 13])
+    end
+
+    it 'splits evenly when the mana divides exactly' do
+      expect(DRCA.split_cambrinth_charges(36, 3)).to eq([12, 12, 12])
+    end
+
+    it 'uses a single charge when asked for one' do
+      expect(DRCA.split_cambrinth_charges(40, 1)).to eq([40])
+    end
+
+    it 'never loses mana and never exceeds the charge count' do
+      (1..40).each do |mana|
+        (1..5).each do |count|
+          charges = DRCA.split_cambrinth_charges(mana, count)
+          expect(charges.sum).to eq(mana)
+          expect(charges.length).to be <= count
+        end
+      end
+    end
+  end
+
+  describe '.distribute_cambrinth_charges' do
+    it 'fills each item up to its cap before it uses the next item' do
+      expect(DRCA.distribute_cambrinth_charges([3, 3, 40], three_cambrinth_items))
+        .to eq([[[3], [3], [40]], 0])
+    end
+
+    it 'skips an item that is too small for the next charge' do
+      expect(DRCA.distribute_cambrinth_charges([14, 13, 13], three_cambrinth_items))
+        .to eq([[[], [], [14, 13, 13]], 0])
+    end
+
+    it 'never charges an item past its cap' do
+      distribution, = DRCA.distribute_cambrinth_charges([11, 11, 11], three_cambrinth_items)
+      distribution.each_with_index do |charges, index|
+        expect(charges.sum).to be <= three_cambrinth_items[index]['cap']
+      end
+    end
+
+    it 'puts each charge in the first item with room for it' do
+      expect(DRCA.distribute_cambrinth_charges([5, 4, 4], three_cambrinth_items))
+        .to eq([[[4], [4], [5]], 0])
+    end
+
+    it 'reports mana that fits in no item' do
+      expect(DRCA.distribute_cambrinth_charges([19, 19, 18], three_cambrinth_items))
+        .to eq([[[], [], [19, 19]], 18])
+    end
+
+    it 'drops trailing empty entries so unused items are skipped' do
+      expect(DRCA.distribute_cambrinth_charges([2], three_cambrinth_items))
+        .to eq([[[2]], 0])
+    end
+
+    it 'reports everything as leftover when there are no items' do
+      expect(DRCA.distribute_cambrinth_charges([5, 5], [])).to eq([[], 10])
+    end
+
+    it 'ignores zero and negative charge values' do
+      expect(DRCA.distribute_cambrinth_charges([0, 3, -2], three_cambrinth_items))
+        .to eq([[[3]], 0])
+    end
+
+    it 'treats an unset cap as no limit' do
+      items = [{ 'name' => 'armband', 'cap' => nil, 'stored' => false }]
+      expect(DRCA.distribute_cambrinth_charges([10, 10], items)).to eq([[[10, 10]], 0])
+    end
+  end
+
+  # ----------------------------------------------
+  # calculate_mana
+  # ----------------------------------------------
+  describe '.calculate_mana' do
+    let(:settings) do
+      OpenStruct.new(
+        prep_scaling_factor: 0.8,
+        cambrinth_num_charges: 3,
+        cambrinth_items: three_cambrinth_items,
+        cambrinth_distribute_charges: true
+      )
+    end
+
+    it 'fills the small items before the large one' do
+      discern_data = {}
+      DRCA.calculate_mana(5, 12, discern_data, false, settings)
+      expect(discern_data['mana']).to eq(5)
+      expect(discern_data['cambrinth']).to eq([[4], [4]])
+    end
+
+    it 'uses every item when there is mana for all of them' do
+      discern_data = {}
+      DRCA.calculate_mana(20, 50, discern_data, false, settings)
+      expect(discern_data['cambrinth']).to eq([[4], [4], [28]])
+      discern_data['cambrinth'].each_with_index do |charges, index|
+        expect(charges.sum).to be <= three_cambrinth_items[index]['cap']
+      end
+    end
+
+    it 'moves mana that fits in no item into the prep instead of losing it' do
+      discern_data = {}
+      DRCA.calculate_mana(40, 80, discern_data, false, settings)
+      total = (120 * 0.8).floor
+      charged = discern_data['cambrinth'].flatten.sum
+      expect(discern_data['mana'] + charged).to eq(total)
+    end
+
+    it 'never loses mana for any discern result' do
+      (1..60).each do |min|
+        discern_data = {}
+        DRCA.calculate_mana(min, min * 2, discern_data, false, OpenStruct.new(
+                                                                 prep_scaling_factor: 0.8,
+                                                                 cambrinth_num_charges: 3,
+                                                                 cambrinth_items: three_cambrinth_items,
+                                                                 cambrinth_distribute_charges: true
+                                                               ))
+        charged = (discern_data['cambrinth'] || []).flatten.sum
+        expect(discern_data['mana'] + charged).to eq(((min * 3) * 0.8).floor)
+      end
+    end
+
+    it 'puts everything in the prep for a cyclic or ritual spell' do
+      discern_data = {}
+      DRCA.calculate_mana(20, 50, discern_data, true, settings)
+      expect(discern_data['cambrinth']).to be_nil
+      expect(discern_data['mana']).to eq((70 * 0.8).floor)
+    end
+
+    it 'skips cambrinth when the charge count is zero' do
+      settings.cambrinth_num_charges = 0
+      discern_data = {}
+      DRCA.calculate_mana(20, 50, discern_data, false, settings)
+      expect(discern_data['cambrinth']).to be_nil
+      expect(discern_data['mana']).to eq((70 * 0.8).floor)
+    end
+
+    it 'keeps the configured items when the charge count is zero' do
+      settings.cambrinth_num_charges = 0
+      DRCA.calculate_mana(20, 50, {}, false, settings)
+      expect(settings.cambrinth_items.length).to eq(3)
+    end
+
+    it 'records the cambrinth caps it calculated against' do
+      discern_data = {}
+      DRCA.calculate_mana(20, 50, discern_data, false, settings)
+      expect(discern_data['cambrinth_caps']).to eq([4, 4, 48])
+    end
+  end
+
+  # ----------------------------------------------
+  # check_discern cambrinth cache
+  # ----------------------------------------------
+  describe '.check_discern cambrinth cache' do
+    let(:settings) do
+      OpenStruct.new(
+        check_discern_timer_in_hours: 24,
+        prep_scaling_factor: 0.8,
+        cambrinth_num_charges: 3,
+        cambrinth_items: three_cambrinth_items,
+        cambrinth_distribute_charges: true
+      )
+    end
+
+    it 'discerns again when the cambrinth items changed' do
+      UserVars.discerns = {
+        'bs' => { 'time_stamp' => Time.now, 'mana' => 5, 'cambrinth' => [[3, 3, 3]], 'cambrinth_caps' => [32] }
+      }
+      allow(DRC).to receive(:bput).and_return('The spell requires at minimum 20 mana streams and you think you can reinforce it with 50 more')
+      data = DRCA.check_discern({ 'abbrev' => 'bs' }, settings)
+      expect(data['cambrinth']).to eq([[4], [4], [28]])
+      expect(UserVars.discerns['bs']['cambrinth_caps']).to eq([4, 4, 48])
+    end
+
+    it 'keeps the cache when the cambrinth items are unchanged' do
+      UserVars.discerns = {
+        'bs' => { 'time_stamp' => Time.now, 'mana' => 5, 'cambrinth' => [[2], [2], [4]], 'cambrinth_caps' => [4, 4, 48] }
+      }
+      expect(DRC).not_to receive(:bput)
+      data = DRCA.check_discern({ 'abbrev' => 'bs' }, settings)
+      expect(data['cambrinth']).to eq([[2], [2], [4]])
+    end
+  end
+
+  # ----------------------------------------------
+  # charge_cambrinth_items
+  # ----------------------------------------------
+  describe '.charge_cambrinth_items' do
+    let(:settings) do
+      OpenStruct.new(
+        cambrinth_items: three_cambrinth_items,
+        dedicated_camb_use: nil,
+        cambrinth_invoke_exact_amount: true,
+        cambrinth_distribute_charges: true
+      )
+    end
+
+    it 'spreads a flat charge list over the items instead of repeating it' do
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth earcuff', false, 4, nil, [3], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth anklet', false, 4, nil, [3], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('sea urchin', true, 48, nil, [40], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [3, 3, 40] }, settings)
+    end
+
+    it 'never charges an item past its cap from a flat list' do
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('sea urchin', true, 48, nil, [10, 10], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [10, 10] }, settings)
+    end
+
+    it 'puts mana that fits nowhere into the largest item and warns' do
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('sea urchin', true, 48, nil, [60], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [60] }, settings)
+      expect(bold_messages.join).to include('60 mana does not fit')
+      expect(bold_messages.join).to include('sea urchin')
+    end
+
+    it 'never loses mana from a flat list' do
+      charged = []
+      allow(DRCA).to receive(:find_charge_invoke_stow) { |*args| charged.concat(args[4]) }
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [30, 30, 30] }, settings)
+      expect(charged.sum).to eq(90)
+    end
+
+    it 'uses a nested list as one entry per item' do
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth earcuff', false, 4, nil, [1], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth anklet', false, 4, nil, [2], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('sea urchin', true, 48, nil, [3], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [[1], [2], [3]] }, settings)
+    end
+
+    it 'skips items that have no charges' do
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth earcuff', false, 4, nil, [4], true)
+      expect(DRCA).not_to receive(:find_charge_invoke_stow).with('cambrinth anklet', any_args)
+      expect(DRCA).not_to receive(:find_charge_invoke_stow).with('sea urchin', any_args)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [[4], [], []] }, settings)
+    end
+
+    it 'keeps the old behaviour for a flat list and a single item' do
+      settings.cambrinth_items = [{ 'name' => 'armband', 'cap' => 32, 'stored' => false }]
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('armband', false, 32, nil, [10, 10], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [10, 10] }, settings)
+    end
+
+    # cambrinth_cap drives the arcana check in this path, not a charge limit. Many
+    # profiles charge well past it on purpose, so a single item must not be capped.
+    it 'charges a single item past its cap when the config asks for it' do
+      settings.cambrinth_items = [{ 'name' => 'cam armband', 'cap' => 32, 'stored' => false }]
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cam armband', false, 32, nil, [25, 25], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [25, 25] }, settings)
+    end
+
+    it 'charges a single item with a value larger than its cap' do
+      settings.cambrinth_items = [{ 'name' => 'cambrinth ring', 'cap' => 5, 'stored' => false }]
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth ring', false, 5, nil, [48], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [48] }, settings)
+    end
+
+    it 'does nothing when there are no charges' do
+      expect(DRCA).not_to receive(:find_charge_invoke_stow)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => nil }, settings)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [] }, settings)
+    end
+  end
+
+  # ----------------------------------------------
+  # cambrinth_distribute_charges off: the default path must not change
+  # ----------------------------------------------
+  describe 'default cambrinth behaviour (cambrinth_distribute_charges unset)' do
+    let(:settings) do
+      OpenStruct.new(
+        prep_scaling_factor: 0.8,
+        cambrinth_num_charges: 3,
+        cambrinth_items: three_cambrinth_items,
+        dedicated_camb_use: nil,
+        cambrinth_invoke_exact_amount: true
+      )
+    end
+
+    it 'splits discern mana by cap ratio, cap overflow included' do
+      discern_data = {}
+      DRCA.calculate_mana(20, 50, discern_data, false, settings)
+      expect(discern_data['mana']).to eq(20)
+      expect(discern_data['cambrinth']).to eq([[7], [7], [7, 7, 7]])
+    end
+
+    it 'records no cambrinth caps signature' do
+      discern_data = {}
+      DRCA.calculate_mana(20, 50, discern_data, false, settings)
+      expect(discern_data).not_to have_key('cambrinth_caps')
+    end
+
+    it 'charges a flat list into every item' do
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth earcuff', false, 4, nil, [3, 3, 40], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth anklet', false, 4, nil, [3, 3, 40], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('sea urchin', true, 48, nil, [3, 3, 40], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [3, 3, 40] }, settings)
+    end
+
+    it 'gives a nested list one entry per item' do
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth earcuff', false, 4, nil, [1], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('cambrinth anklet', false, 4, nil, [2], true)
+      expect(DRCA).to receive(:find_charge_invoke_stow).with('sea urchin', true, 48, nil, [3], true)
+      DRCA.charge_cambrinth_items({ 'cambrinth' => [[1], [2], [3]] }, settings)
+    end
+
+    it 'ignores a changed cambrinth item list and keeps the cache' do
+      UserVars.discerns = {
+        'bs' => { 'time_stamp' => Time.now, 'mana' => 5, 'cambrinth' => [[3, 3, 3]] }
+      }
+      settings.check_discern_timer_in_hours = 24
+      expect(DRC).not_to receive(:bput)
+      data = DRCA.check_discern({ 'abbrev' => 'bs' }, settings)
+      expect(data['cambrinth']).to eq([[3, 3, 3]])
+    end
+  end
+
+  describe '.allocate_cambrinth_charges' do
+    it 'fills each item up to its cap in configured order' do
+      expect(DRCA.allocate_cambrinth_charges(20, three_cambrinth_items, 3))
+        .to eq([[[4], [4], [12]], 0])
+    end
+
+    it 'uses the small items at every size of discern' do
+      [13, 20, 26, 36, 50, 56].each do |mana|
+        distribution, = DRCA.allocate_cambrinth_charges(mana, three_cambrinth_items, 3)
+        expect(distribution[0]).to eq([4])
+        expect(distribution[1]).to eq([4])
+      end
+    end
+
+    it 'spends spare charges on the largest charge' do
+      # One item, two charges: 22 mana becomes two charges of 11, not one of 22.
+      items = [{ 'name' => 'armband', 'cap' => 32 }]
+      expect(DRCA.allocate_cambrinth_charges(22, items, 2)).to eq([[[11, 11]], 0])
+    end
+
+    it 'leaves a spare charge unused when it would not make any charge smaller' do
+      expect(DRCA.allocate_cambrinth_charges(8, three_cambrinth_items, 3))
+        .to eq([[[4], [4]], 0])
+    end
+
+    it 'reports mana that fits in no item' do
+      expect(DRCA.allocate_cambrinth_charges(60, three_cambrinth_items, 3))
+        .to eq([[[4], [4], [48]], 4])
+    end
+
+    it 'keeps the largest items when there are more items than charges' do
+      expect(DRCA.allocate_cambrinth_charges(40, three_cambrinth_items, 1))
+        .to eq([[[], [], [40]], 0])
+    end
+
+    it 'returns nothing when there is no mana or no charge budget' do
+      expect(DRCA.allocate_cambrinth_charges(0, three_cambrinth_items, 3)).to eq([[], 0])
+      expect(DRCA.allocate_cambrinth_charges(20, three_cambrinth_items, 0)).to eq([[], 20])
+      expect(DRCA.allocate_cambrinth_charges(20, [], 3)).to eq([[], 20])
+    end
+
+    it 'conserves mana, respects every cap and the charge budget' do
+      configs = [three_cambrinth_items,
+                 [{ 'name' => 'ring', 'cap' => 4 }, { 'name' => 'armband', 'cap' => 32 }],
+                 [{ 'name' => 'armband', 'cap' => 32 }]]
+      configs.each do |items|
+        (0..120).each do |mana|
+          (1..6).each do |num_charges|
+            distribution, leftover = DRCA.allocate_cambrinth_charges(mana, items, num_charges)
+            expect(distribution.flatten.sum + leftover).to eq(mana)
+            expect(distribution.flatten.length).to be <= num_charges
+            expect(distribution.flatten).to all(be > 0)
+            distribution.each_with_index { |c, i| expect(c.sum).to be <= items[i]['cap'] }
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`DRCA` charges cambrinth incorrectly when `cambrinth_items` lists more than one item. There are two separate faults.

**`charge_cambrinth_items` repeats a flat list on every item.** A spell configured as `cambrinth: [4, 10]` reaches `charge_cambrinth_items` as a flat `Array` of `Integer`. The `when Integer` branch passes the whole list to every item, so a 14 mana plan charges 14 into the first item and 14 more into the second.

**`calculate_mana` ignores each item's cap.** The `use_auto_mana` path uses `cap` only as a ratio to pick a charge count, then gives every charge of an item the same size. Nothing checks that an item's total fits its cap, and the remainder of an integer division is dropped. With caps 4/4/48 and 3 charges it produces `[[7], [7], [7, 7, 7]]` — 7 mana into a cap-4 item, and 1 mana lost.

`cast.lic` is unaffected, because it calculates the split itself before it calls `DRCA`.

## Change

A new per-character setting, `cambrinth_distribute_charges`, selects a second code path. It is unset by default.

With the setting on, `allocate_cambrinth_charges` gives each item as much as its cap allows, in the order the profile lists them, so a small worn item fills before a large stored one. Each item then splits its own share into charges. Spare charges go to the largest charge while that makes it smaller, which keeps each charge inside what the character can channel at once. Mana that fits in no item returns to the base prep.

```
caps 4/4/48, cambrinth_num_charges: 3, discern minimum 20

  to charge   before                   charged   after              charged
  13          [[2], [2], [2, 2, 2]]    10        [[4], [4], [5]]    13
  20          [[4], [4], [4, 4, 4]]    20        [[4], [4], [12]]   20
  36          [[7], [7], [7, 7, 7]]    35        [[4], [4], [28]]   36
```

In the first and third rows the old code drops mana. In the third it also
asks a cap-4 item to hold 7.

A flat charge list written in a profile is placed one charge at a time into the first item with room, rather than skipping an item for good once a charge has passed it by.

Cached discern data records the cambrinth caps it was calculated against, so a change to `cambrinth_items` invalidates the cache. Without that, a distribution built for the old item list is replayed for up to `check_discern_timer_in_hours`, which charges one item and silently skips the rest.

## A single cambrinth item is left alone

Even with the setting on, one item takes its charge list unchanged. In that path `cambrinth_cap` feeds the arcana check in `skilled_to_charge_while_worn?` rather than a charge limit, and many profiles charge well past it on purpose. Enforcing it there would quietly reduce charging for a large number of existing setups.

## Evidence that the default path is unchanged

I ran the patched module with the setting off against a verbatim copy of `main`'s algorithms and made any difference raise.

- `charge_cambrinth_items`: all 1638 spell entries carrying a `cambrinth` list, across the 270 profiles in `dr-scripts/profiles` and my own runtime profile directory. No divergence.
- `calculate_mana`: 55 distinct cambrinth configurations over 180 discern results each. No divergence.

With the setting on, 13 of those 1638 entries change. All 13 belong to the three profiles that configure several items, including `Samples/WarriorMage/Dartellum-setup.yaml`, which today charges 240 mana for a 60 mana plan.

## One behaviour-preserving cleanup

`calculate_mana` built its charge array with `arr[i] += 1` on a `nil` slot, which works only because Lich patches `NilClass#+`. It is now written as `(arr[i] || 0) + 1`. Identical result, and the default path is testable without the global patch — which is why it had no coverage before.

## Testing

- `bundle exec rspec` — 6383 examples, 0 failures. 60 new examples in `spec/lib/dragonrealms/commons/common_arcana_spec.rb`, five of which pin the default path so a later change cannot quietly flip the gate.
- A property test sweeps three cambrinth configurations against every mana value from 0 to 120 and charge budgets 1 to 6, asserting that mana is conserved, no cap is exceeded, the charge budget holds, and no zero-sized charge is produced.
- `bundle exec rubocop` — clean.

## Companion change

elanthia-online/dr-scripts documents the new setting in `profiles/base.yaml` and teaches `cast.lic` to call `DRCA.allocate_cambrinth_charges`, so `,cast` and the waggle scripts share one implementation. That PR checks the method exists and falls back to its own split on an older Lich, so it does not depend on this one landing first.

## Test plan

- [ ] Existing profiles with one cambrinth item behave exactly as before, with and without the setting.
- [ ] A profile with several `cambrinth_items` and a flat `cambrinth:` list charges each item its own share instead of the full list.
- [ ] `use_auto_mana` with several items never charges an item past its `cap`.
- [ ] Changing `cambrinth_items` causes the next cast to discern again rather than reuse the old distribution.


