### PR TITLE
fix(all): global_def update deprecated method calls to include caller info

### DIFF
--- a/lib/global_defs.rb
+++ b/lib/global_defs.rb
@@ -958,7 +958,7 @@ def checksaturated
 end
 
 def checkmana(num = nil)
-  Lich.deprecated('checkmana', 'Char.mana')
+  Lich.deprecated('checkmana', 'Char.mana', caller[0])
   if num.nil?
     XMLData.mana
   else
@@ -967,12 +967,12 @@ def checkmana(num = nil)
 end
 
 def maxmana
-  Lich.deprecated('maxmana', 'Char.maxmana')
+  Lich.deprecated('maxmana', 'Char.maxmana', caller[0])
   XMLData.max_mana
 end
 
 def percentmana(num = nil)
-  Lich.deprecated('percentmana', 'Char.percent_mana')
+  Lich.deprecated('percentmana', 'Char.percent_mana', caller[0])
   if XMLData.max_mana == 0
     percent = 100
   else
@@ -986,7 +986,7 @@ def percentmana(num = nil)
 end
 
 def checkhealth(num = nil)
-  Lich.deprecated('checkhealth', 'Char.health')
+  Lich.deprecated('checkhealth', 'Char.health', caller[0])
   if num.nil?
     XMLData.health
   else
@@ -995,12 +995,12 @@ def checkhealth(num = nil)
 end
 
 def maxhealth
-  Lich.deprecated('maxhealth', 'Char.max_health')
+  Lich.deprecated('maxhealth', 'Char.max_health', caller[0])
   XMLData.max_health
 end
 
 def percenthealth(num = nil)
-  Lich.deprecated('percenthealth', 'Char.percent_health')
+  Lich.deprecated('percenthealth', 'Char.percent_health', caller[0])
   if num.nil?
     ((XMLData.health.to_f / XMLData.max_health.to_f) * 100).to_i
   else
@@ -1009,7 +1009,7 @@ def percenthealth(num = nil)
 end
 
 def checkspirit(num = nil)
-  Lich.deprecated('checkspirit', 'Char.spirit')
+  Lich.deprecated('checkspirit', 'Char.spirit', caller[0])
   if num.nil?
     XMLData.spirit
   else
@@ -1018,12 +1018,12 @@ def checkspirit(num = nil)
 end
 
 def maxspirit
-  Lich.deprecated('maxspirit', 'Char.max_spirit')
+  Lich.deprecated('maxspirit', 'Char.max_spirit', caller[0])
   XMLData.max_spirit
 end
 
 def percentspirit(num = nil)
-  Lich.deprecated('percentspirit', 'Char.percent_spirit')
+  Lich.deprecated('percentspirit', 'Char.percent_spirit', caller[0])
   if num.nil?
     ((XMLData.spirit.to_f / XMLData.max_spirit.to_f) * 100).to_i
   else
@@ -1032,7 +1032,7 @@ def percentspirit(num = nil)
 end
 
 def checkstamina(num = nil)
-  Lich.deprecated('checkstamina', 'Char.stamina')
+  Lich.deprecated('checkstamina', 'Char.stamina', caller[0])
   if num.nil?
     XMLData.stamina
   else
@@ -1041,12 +1041,12 @@ def checkstamina(num = nil)
 end
 
 def maxstamina()
-  Lich.deprecated('maxstamina', 'Char.max_stamina')
+  Lich.deprecated('maxstamina', 'Char.max_stamina', caller[0])
   XMLData.max_stamina
 end
 
 def percentstamina(num = nil)
-  Lich.deprecated('percentstamina', 'Char.percent_stamina')
+  Lich.deprecated('percentstamina', 'Char.percent_stamina', caller[0])
   if XMLData.max_stamina == 0
     percent = 100
   else
@@ -1077,7 +1077,7 @@ def percentconcentration(num = nil)
 end
 
 def checkstance(num = nil)
-  Lich.deprecated('checkstance', 'Char.stance')
+  Lich.deprecated('checkstance', 'Char.stance', caller[0])
   if num.nil?
     XMLData.stance_text
   elsif (num.is_a?(String)) and (num.to_i == 0)
@@ -1106,7 +1106,7 @@ def checkstance(num = nil)
 end
 
 def percentstance(num = nil)
-  Lich.deprecated('percentstance', 'Char.percent_stance')
+  Lich.deprecated('percentstance', 'Char.percent_stance', caller[0])
   if num.nil?
     XMLData.stance_value
   else
@@ -1115,7 +1115,7 @@ def percentstance(num = nil)
 end
 
 def checkencumbrance(string = nil)
-  Lich.deprecated('checkencumbrance', 'Char.encumbrance')
+  Lich.deprecated('checkencumbrance', 'Char.encumbrance', caller[0])
   if string.nil?
     XMLData.encumbrance_text
   elsif (string.is_a?(Integer)) or (string =~ /^[0-9]+$/ and (string = string.to_i))
@@ -1131,7 +1131,7 @@ def checkencumbrance(string = nil)
 end
 
 def percentencumbrance(num = nil)
-  Lich.deprecated('percentencumbrance', 'Char.percent_encumbrance')
+  Lich.deprecated('percentencumbrance', 'Char.percent_encumbrance', caller[0])
   if num.nil?
     XMLData.encumbrance_value
   else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecation warnings for legacy stat-checking commands now include the location where each command was called, making them easier to trace and resolve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->