### PR TITLE
fix(dr): match lowercase "it's already open" when opening a container

### DIFF
--- a/lib/dragonrealms/commons/common-items.rb
+++ b/lib/dragonrealms/commons/common-items.rb
@@ -523,7 +523,7 @@ module Lich
         /^You slowly open/,
         /^The .* opens/,
         /^You unbutton/,
-        /(It's|is) already open/,
+        /([Ii]t's|is) already open/,
         /^You spread your arms, carefully holding your bag well away from your body/
       ].freeze
 

--- a/spec/lib/dragonrealms/commons/common_items_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_items_spec.rb
@@ -937,6 +937,11 @@ RSpec.describe Lich::DragonRealms::DRCI do
         stub_bput("It's already open.")
         expect(described_class.open_container?('pack')).to be true
       end
+
+      it 'returns true when the already open message is mid-sentence and lowercase' do
+        stub_bput("Using slow movements so as to not compromise your invisibility, you slide your hand into your backpack.  Oh, I guess it's already open.")
+        expect(described_class.open_container?('backpack')).to be true
+      end
     end
 
     context 'when open fails' do


### PR DESCRIPTION
## Problem

`DRCI.open_container?` times out on the invisibility variant of the already-open message. Observed while running `pick.lic`:

```
[pick]>open backpack
Using slow movements so as to not compromise your invisibility, you slide your hand into your backpack.  Oh, I guess it's already open.
DRC: No match was found after 15 seconds for command 'open backpack'
```

`OPEN_CONTAINER_SUCCESS_PATTERNS` contains `/(It's|is) already open/`. That matches a capitalized `It's` at the start of a line, or a separate word `is` ("That is already open"). The lowercase `it's` in the message above matches neither alternative, so the call falls through to the 15 second `bput` timeout every time an invisible character opens a container that is already open.

## Fix

Widen the alternation to `/([Ii]t's|is) already open/`.

The pattern is unanchored, so it still matches mid-sentence. All three known forms are covered:

| Message | Before | After |
| --- | --- | --- |
| `It's already open.` | match | match |
| `That is already open.` | match | match |
| `... Oh, I guess it's already open.` | no match | match |

## Test plan

- [ ] `bundle exec rspec spec/lib/dragonrealms/commons/common_items_spec.rb` passes (335 examples, 0 failures)
- [ ] `bundle exec rubocop lib/dragonrealms/commons/common-items.rb spec/lib/dragonrealms/commons/common_items_spec.rb` reports no offenses
- [ ] New spec covers the mid-sentence lowercase form and fails without the pattern change
- [ ] In game, an invisible character running `open <container>` on an open container returns at once instead of waiting 15 seconds