### PR TITLE
feat(dr): non-destructive upsert for INV SEARCH / category scrapes (03 of 05)

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -363,6 +363,44 @@ module Lich
         end
       end
 
+      # Upserts an inventory item by id for a PARTIAL (filtered) scrape -- e.g.
+      # +INV SEARCH <word>+ or +INV <category> full+, which list only the
+      # matching items and so must not clear unrelated inventory the way a full
+      # +INV LIST+ refresh does. Any prior placement of +id+ is removed from
+      # +@@inv+ and every +@@contents+ list first, so an item that moved
+      # containers (or whose name changed, e.g. gained "(closed)") is refreshed
+      # in exactly one place with neither a duplicate nor a stale copy left
+      # behind. It is then (re)placed via {.new_inv}: worn (+container+ nil) into
+      # +@@inv+, otherwise into +@@contents[container]+.
+      #
+      # Because a filtered scrape only reports matches, it can add or relocate
+      # items but can never prove an item is gone -- removals are left to the
+      # next full refresh.
+      #
+      # The removal runs under +@@index_mutex+ (the same lock +find_or_create+
+      # holds for registry writes) so it cannot race the off-thread
+      # +prune_index!+ sweep that walks +@@inv+/+@@contents+. It is a separate
+      # acquisition from the +new_inv+ that follows -- Ruby's Mutex is not
+      # reentrant, and +new_inv+ takes the lock itself -- so remove and re-add
+      # are not one atomic step; that is fine because the parser thread is the
+      # sole writer and a reader can at worst momentarily not see the item.
+      #
+      # @param id        [Integer, String]
+      # @param noun      [String, nil]
+      # @param name      [String, nil]
+      # @param container [String, nil]
+      # @param before    [String, nil]
+      # @param after     [String, nil]
+      # @return [GameObj]
+      def self.upsert_inv(id, noun, name, container = nil, before = nil, after = nil)
+        str_id = id.is_a?(Integer) ? id.to_s : id
+        @@index_mutex.synchronize do
+          @@inv.reject! { |obj| obj.id == str_id }
+          @@contents.each_value { |list| list.reject! { |obj| obj.id == str_id } }
+        end
+        new_inv(str_id, noun, name, container, before, after)
+      end
+
       # Creates and registers a new reserve slot item.
       #
       # +@@reserve+ is +nil+ until the first reserve stream is seen; thereafter
@@ -877,8 +915,8 @@ module Lich
           npc = @@npcs.find { |n| n.id == id }
           next unless npc
           next if npc.status.to_s =~ /dead|gone/i
-          next if npc.name  =~ /^animated\b/i && npc.name !~ /^animated slush/i
-          next if npc.noun  =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i &&
+          next if npc.name =~ /^animated\b/i && npc.name !~ /^animated slush/i
+          next if npc.noun =~ /^(?:arm|appendage|claw|limb|pincer|tentacle)s?$|^(?:palpus|palpi)$/i &&
                   npc.name !~ /(?:amaranthine|ghostly|grizzled|ancient) kraken tentacle/i
           npc
         end

--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -37,17 +37,24 @@ module Lich
         Rested_EXP_F2P = %r{^<component id='exp rexp'>\[Unlock Rested Experience}.freeze
         TDPValue_XPWindow = %r{^<component id='exp tdp'>\s*TDPs:\s*(?<tdp>\d+)</component>}.freeze
         FavorValue_XPWindow = %r{^<component id='exp favor'>\s*Favors:\s*(?<favor>\d+)</component>}.freeze
-        # Header line emitted by the DR inventory verbs whose <d> output we
-        # scrape for item IDs. Two verbs share this scrape:
-        #   INV SEARCH <text> => "You rummage about your person, looking for ..."
-        #   INV LIST          => "You take a moment and rummage about your
-        #                          person, taking stock of your possessions..."
-        # Anchored to the start of the stream line, allowing only the optional
-        # leading <roundTime/> the search verbs emit, so quoted/chat/book text
-        # containing the phrase mid-line cannot open a scrape (cf. GameShutdown).
-        # Logs confirm the header is never otherwise prefixed: INV LIST is bare at
-        # line start; the "looking for" verbs carry exactly one <roundTime/>.
-        InventoryGetStart = %r{^(?:<roundTime[^>]*/>)?You (?:take a moment and )?rummage about your person, (?:taking stock of your possessions|looking for)}.freeze
+        # Headers that open a DR inventory scrape whose <d> output we mine for
+        # item IDs. The two differ in completeness, which decides how we write
+        # GameObj (see .parse):
+        #   INV LIST -> COMPLETE: lists everything, so we clear and repopulate.
+        #     "You take a moment and rummage about your person, taking stock of
+        #      your possessions..."
+        #   INV SEARCH <word> / INV <category> full -> PARTIAL: lists only the
+        #     matching items, so we upsert without clearing. The header's trailing
+        #     phrase is a per-category friendly name (e.g. "looking for gems...",
+        #     "looking for armor and shields...") and is not matched here.
+        #
+        # Both are anchored to the start of the stream line so quoted/chat/book
+        # text containing the phrase mid-line cannot open a (mutating) scrape
+        # (cf. GameShutdown). Logs confirm the exact prefixes: INV LIST is bare at
+        # line start; the "looking for" verbs carry exactly one leading
+        # <roundTime/>, which is allowed optionally.
+        InventoryListStart   = %r{^You take a moment and rummage about your person, taking stock of your possessions}.freeze
+        InventorySearchStart = %r{^(?:<roundTime[^>]*/>)?You rummage about your person, looking for}.freeze
 
         # Scheduled shutdown announcement, e.g. "Announcement: DragonRealms will
         # be shutting down in 15 minutes for routine maintenance." Anchored to
@@ -87,6 +94,9 @@ module Lich
       # Class variables for parsing state (must be @@ not @ for module-level state)
       @@parsing_exp_mods_output = false
       @@parsing_inventory_get = false
+      # true while the active inventory scrape is PARTIAL (INV SEARCH / category)
+      # -> items are upserted; false for a COMPLETE INV LIST -> items replace.
+      @@inventory_partial = false
 
       # Wall-clock time the game is expected to go down for maintenance, set
       # from a shutdown announcement. nil when no shutdown is pending.
@@ -184,6 +194,7 @@ module Lich
         when Pattern::OutputClassEmpty
           if @@parsing_inventory_get
             @@parsing_inventory_get = false
+            @@inventory_partial = false
           end
         else
           # This block parses a single line from the output of the `inv search <string>` verb,
@@ -232,7 +243,7 @@ module Lich
               # single placement each line establishes. The regex still captures
               # container2 (the grandparent in a doubly-nested line) because it is
               # needed to bound container1 correctly, but we do not read it: see
-              # the note below new_inv.
+              # the note below store_inv_item.
               container1 = id_match[:container1].strip.delete('#') if id_match[:container1]
               container = container1 || nil
               before = cmd
@@ -241,23 +252,41 @@ module Lich
               # Store the parsed item into its immediate container (or worn inv).
               # DRItems.update_item(item, id, cmd, full_description)
               Lich.log("DRParser: Adding inventory item - ID: #{id}, Noun: #{noun}, Name: #{name}, Container: #{container}, Before: #{before}, After: #{after}")
-              GameObj.new_inv(id, noun, name, container, before, after)
+              store_inv_item(id, noun, name, container, before, after)
               # A doubly-nested line (get #item in #mid in <parent>) also reveals
               # that the middle container #mid sits inside <parent>, but we do NOT
-              # synthesize that placement here. INV LIST is a complete, recursive
+              # synthesize that placement here. A COMPLETE INV LIST is a recursive
               # scrape, and #mid always carries its own id (the only idless item in
               # DR is the portal, which only ever appears as <parent>), so #mid is
               # always emitted on its own line -- "get #mid in <parent>" -- which
-              # registers it into <parent> with its REAL name via new_inv above.
-              # Re-deriving that edge from a child line could only add a second
-              # copy of #mid with name=nil (the child line never carries the middle
-              # container's name); because find_or_create keys on "id|noun|name",
-              # the nil-name copy never collides with the real one, leaving a
-              # phantom duplicate in GameObj.containers[<parent>].
+              # registers it into <parent> with its REAL name via store_inv_item
+              # above. Re-deriving that edge from a child line could only add a
+              # second copy of #mid with name=nil (the child line never carries the
+              # middle container's name); because find_or_create keys on
+              # "id|noun|name", the nil-name copy never collides with the real one,
+              # leaving a phantom duplicate in GameObj.containers[<parent>]. A
+              # PARTIAL (INV SEARCH / category) scrape never listed the middle
+              # container either -- routing it through upsert_inv would blank its
+              # name and yank a worn parent out of GameObj.inv -- so both modes
+              # agree: only an item's own line establishes its placement.
             end
           end
         end
         server_string
+      end
+
+      # Routes a parsed inventory item into GameObj according to the active
+      # scrape's completeness: a COMPLETE INV LIST replaces (items were cleared
+      # up front, so a plain add rebuilds the model), while a PARTIAL INV SEARCH /
+      # category scrape upserts by id so it refreshes only the matched items and
+      # never wipes unrelated inventory.
+      # @return [void]
+      def self.store_inv_item(id, noun, name, container, before, after)
+        if @@inventory_partial
+          GameObj.upsert_inv(id, noun, name, container, before, after)
+        else
+          GameObj.new_inv(id, noun, name, container, before, after)
+        end
       end
 
       # Parses 'exp mods' output and updates DRSkill.exp_modifiers.
@@ -499,10 +528,18 @@ module Lich
         check_events(line)
         begin
           check_game_shutdown(line)
-          if Pattern::InventoryGetStart.match?(line)
+          if Pattern::InventoryListStart.match?(line)
+            # COMPLETE inventory (INV LIST): wipe and repopulate from scratch.
             GameObj.clear_inv
             GameObj.clear_all_containers
             @@parsing_inventory_get = true
+            @@inventory_partial = false
+          elsif Pattern::InventorySearchStart.match?(line)
+            # PARTIAL inventory (INV SEARCH <word> / INV <category> full): only
+            # matching items are listed, so upsert them and leave the rest of the
+            # GameObj model intact -- no clear.
+            @@parsing_inventory_get = true
+            @@inventory_partial = true
           elsif (match = line.match(Pattern::GenderAgeCircle))
             DRStats.gender = match[:gender]
             DRStats.age = match[:age].to_i
@@ -636,6 +673,7 @@ module Lich
           # reset there. In normal flow the flag is already false by the prompt.
           if @@parsing_inventory_get && line.start_with?('<prompt')
             @@parsing_inventory_get = false
+            @@inventory_partial = false
           end
 
           populate_inventory_get(line) if @@parsing_inventory_get

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -136,6 +136,55 @@ RSpec.describe Lich::Common::GameObj do
     end
   end
 
+  describe '.upsert_inv' do
+    it 'adds a new item like new_inv when nothing pre-exists' do
+      described_class.upsert_inv('123', 'gem', 'ruby', 'container1')
+
+      expect(described_class.containers['container1'].map(&:id)).to eq(['123'])
+    end
+
+    it 'refreshes an item in place without duplicating it' do
+      described_class.new_inv('123', 'gem', 'ruby', 'container1')
+      described_class.upsert_inv('123', 'gem', 'ruby', 'container1')
+
+      expect(described_class.containers['container1'].count { |o| o.id == '123' }).to eq(1)
+    end
+
+    it 'moves an item to its new container, leaving no stale copy' do
+      described_class.new_inv('123', 'gem', 'ruby', 'container1')
+      described_class.new_inv('999', 'gem', 'opal', 'container1') # bystander stays
+
+      described_class.upsert_inv('123', 'gem', 'ruby', 'container2')
+
+      expect(described_class.containers['container1'].map(&:id)).to eq(['999'])
+      expect(described_class.containers['container2'].map(&:id)).to eq(['123'])
+    end
+
+    it 'removes a prior copy even when the name changed (e.g. gained "(closed)")' do
+      described_class.new_inv('123', nil, 'soft gem pouch', 'container1')
+      described_class.upsert_inv('123', nil, 'soft gem pouch (closed)', 'container1')
+
+      list = described_class.containers['container1']
+      expect(list.map(&:id)).to eq(['123'])
+      expect(list.first.name).to eq('soft gem pouch (closed)')
+    end
+
+    it 'relocates a contained item to worn inv when container is nil' do
+      described_class.new_inv('123', 'gem', 'ruby', 'container1')
+
+      described_class.upsert_inv('123', 'gem', 'ruby', nil)
+
+      expect(described_class.containers['container1'].map(&:id)).to eq([])
+      expect(described_class.inv.map(&:id)).to eq(['123'])
+    end
+
+    it 'converts an integer id to string' do
+      obj = described_class.upsert_inv(12345, 'gem', 'ruby')
+
+      expect(obj.id).to eq('12345')
+    end
+  end
+
   describe '.clear_inv' do
     it 'clears the @@inv array' do
       described_class.new_inv('123', 'gem', 'ruby')

--- a/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
@@ -673,85 +673,81 @@ RSpec.describe Lich::DragonRealms::DRParser do
     end
   end
 
-  describe 'inventory search parsing' do
+  describe 'inventory scrape parsing' do
     before(:each) do
       allow(GameObj).to receive(:clear_inv)
       allow(GameObj).to receive(:clear_all_containers)
+      described_class.class_variable_set(:@@parsing_inventory_get, false)
+      described_class.class_variable_set(:@@inventory_partial, false)
     end
 
-    describe 'when InventoryGetStart pattern matches' do
-      let(:inv_search_line) { 'You rummage about your person, looking for' }
-
-      it 'calls GameObj.clear_inv' do
-        expect(GameObj).to receive(:clear_inv)
-
-        described_class.parse(inv_search_line)
+    describe 'headers' do
+      it 'InventoryListStart matches the INV LIST header only' do
+        expect('You take a moment and rummage about your person, taking stock of your possessions...')
+          .to match(described_class::Pattern::InventoryListStart)
+        expect('You rummage about your person, looking for pouch...')
+          .not_to match(described_class::Pattern::InventoryListStart)
       end
 
-      it 'calls GameObj.clear_all_containers' do
-        expect(GameObj).to receive(:clear_all_containers)
-
-        described_class.parse(inv_search_line)
+      it 'InventorySearchStart matches the INV SEARCH / category header' do
+        expect('You rummage about your person, looking for pouch...')
+          .to match(described_class::Pattern::InventorySearchStart)
+        expect('You rummage about your person, looking for armor and shields...')
+          .to match(described_class::Pattern::InventorySearchStart)
       end
 
-      it 'sets @@parsing_inventory_get to true' do
-        described_class.parse(inv_search_line)
-
-        # NOTE: class_variable_get is acceptable here - we're verifying the parser
-        # correctly transitions to inventory parsing state after matching the trigger line.
-        expect(described_class.class_variable_get(:@@parsing_inventory_get)).to be true
-      end
-    end
-
-    describe 'InventoryGetStart pattern' do
-      it 'matches inv search command output' do
-        line = 'You rummage about your person, looking for'
-        expect(line).to match(described_class::Pattern::InventoryGetStart)
+      it 'InventorySearchStart matches the real <roundTime/>-prefixed header' do
+        expect("<roundTime value='1788496743'/>You rummage about your person, looking for pouch...")
+          .to match(described_class::Pattern::InventorySearchStart)
       end
 
-      it 'matches partial inv search output' do
-        line = 'You rummage about your person, looking for all items'
-        expect(line).to match(described_class::Pattern::InventoryGetStart)
-      end
-
-      it 'matches inv list command output' do
-        line = 'You take a moment and rummage about your person, taking stock of your possessions...'
-        expect(line).to match(described_class::Pattern::InventoryGetStart)
-      end
-
-      it 'matches a search header carrying the real <roundTime/> prefix' do
-        line = "<roundTime value='1788496743'/>You rummage about your person, looking for pouch..."
-        expect(line).to match(described_class::Pattern::InventoryGetStart)
-      end
-
-      # Adversarial: the phrase quoted mid-line (speech/thought/book) must NOT
-      # open a mutating scrape. This is why the pattern is anchored.
-      it 'does NOT match the phrase quoted mid-line in speech' do
+      # Adversarial: a header quoted mid-line (speech/thought/book) must NOT open
+      # a scrape -- for the SEARCH header this would open a *mutating* upsert.
+      # This is why both patterns are anchored to the stream-line start.
+      it 'neither header matches the phrase quoted mid-line in speech' do
         line = %(Someone says, "You rummage about your person, looking for trouble.")
-        expect(line).not_to match(described_class::Pattern::InventoryGetStart)
+        expect(line).not_to match(described_class::Pattern::InventorySearchStart)
+        expect(line).not_to match(described_class::Pattern::InventoryListStart)
       end
 
-      it 'does NOT match the phrase embedded after other prose' do
+      it 'neither header matches the phrase embedded after prose' do
         line = 'She watched as you take a moment and rummage about your person, taking stock of your possessions.'
-        expect(line).not_to match(described_class::Pattern::InventoryGetStart)
+        expect(line).not_to match(described_class::Pattern::InventoryListStart)
       end
 
-      it 'does NOT match an arbitrary tag glued before the header' do
-        line = "<pushStream id='thought'/>You rummage about your person, looking for pouch..."
-        expect(line).not_to match(described_class::Pattern::InventoryGetStart)
+      it 'does NOT match an arbitrary non-roundTime tag glued before the search header' do
+        expect("<pushStream id='thought'/>You rummage about your person, looking for pouch...")
+          .not_to match(described_class::Pattern::InventorySearchStart)
       end
     end
 
-    describe 'when the inv list header matches' do
+    describe 'when the INV LIST (complete) header matches' do
       let(:inv_list_line) { 'You take a moment and rummage about your person, taking stock of your possessions...' }
 
-      it 'clears inv and containers and enters parsing state' do
+      it 'clears inv and containers, enters parsing, and is NOT partial' do
         expect(GameObj).to receive(:clear_inv)
         expect(GameObj).to receive(:clear_all_containers)
 
         described_class.parse(inv_list_line)
 
+        # NOTE: class_variable_get is acceptable here - we're verifying the parser
+        # correctly transitions to inventory parsing state after the trigger line.
         expect(described_class.class_variable_get(:@@parsing_inventory_get)).to be true
+        expect(described_class.class_variable_get(:@@inventory_partial)).to be false
+      end
+    end
+
+    describe 'when the INV SEARCH (partial) header matches' do
+      let(:inv_search_line) { 'You rummage about your person, looking for pouch...' }
+
+      it 'enters parsing in partial mode WITHOUT clearing the model' do
+        expect(GameObj).not_to receive(:clear_inv)
+        expect(GameObj).not_to receive(:clear_all_containers)
+
+        described_class.parse(inv_search_line)
+
+        expect(described_class.class_variable_get(:@@parsing_inventory_get)).to be true
+        expect(described_class.class_variable_get(:@@inventory_partial)).to be true
       end
     end
 
@@ -767,6 +763,20 @@ RSpec.describe Lich::DragonRealms::DRParser do
 
         # A later stray get-link in ordinary output must NOT be parsed as inventory.
         expect(GameObj).not_to receive(:new_inv)
+        described_class.parse("<d cmd='get #999'>a random link</d>")
+      end
+
+      it 'also clears PARTIAL mode when a prompt ends an interrupted search scrape' do
+        described_class.parse("<roundTime value='1'/>You rummage about your person, looking for pouch...")
+        expect(described_class.class_variable_get(:@@inventory_partial)).to be true
+
+        described_class.parse('<prompt time="123">&gt;</prompt>')
+
+        expect(described_class.class_variable_get(:@@parsing_inventory_get)).to be false
+        expect(described_class.class_variable_get(:@@inventory_partial)).to be false
+
+        # A stray get-link afterward must NOT be upserted into the live model.
+        expect(GameObj).not_to receive(:upsert_inv)
         described_class.parse("<d cmd='get #999'>a random link</d>")
       end
     end
@@ -927,7 +937,10 @@ RSpec.describe Lich::DragonRealms::DRParser do
   describe '.populate_inventory_get' do
     before(:each) do
       allow(GameObj).to receive(:new_inv)
+      allow(GameObj).to receive(:upsert_inv)
       described_class.class_variable_set(:@@parsing_inventory_get, true)
+      # Default to COMPLETE (INV LIST) mode for the existing add cases.
+      described_class.class_variable_set(:@@inventory_partial, false)
     end
 
     it 'parses a top-level item, stripping a leading article' do
@@ -974,9 +987,39 @@ RSpec.describe Lich::DragonRealms::DRParser do
       described_class.populate_inventory_get("        -<d cmd='get #10956111 in #10956107 in a watery portal'>a rosemary-dusted pumpkin and apple tart drizzled with an amber glaze</d>")
     end
 
-    it 'stops parsing on the output-class-empty tag' do
+    it 'stops parsing and clears partial mode on the output-class-empty tag' do
+      described_class.class_variable_set(:@@inventory_partial, true)
       described_class.populate_inventory_get('<output class=""/>')
       expect(described_class.class_variable_get(:@@parsing_inventory_get)).to be false
+      expect(described_class.class_variable_get(:@@inventory_partial)).to be false
+    end
+
+    context 'in PARTIAL (INV SEARCH / category) mode' do
+      before(:each) { described_class.class_variable_set(:@@inventory_partial, true) }
+
+      it 'upserts a matched item instead of a plain add' do
+        expect(GameObj).to receive(:upsert_inv).with('11404650', nil, 'soft gem pouch', '11404639', 'get #11404650 in #11404639', nil)
+        expect(GameObj).not_to receive(:new_inv)
+        described_class.populate_inventory_get("  <d cmd='get #11404650 in #11404639'>A soft gem pouch</d> is in a sky blue thigh quiver.")
+      end
+
+      it 'upserts a matched worn item (remove link) into inv' do
+        expect(GameObj).to receive(:upsert_inv).with('11404268', nil, 'red pouch embroidered with a pork chop', nil, 'remove #11404268', nil)
+        described_class.populate_inventory_get("  <d cmd='remove #11404268'>A red pouch embroidered with a pork chop</d> is being worn.")
+      end
+
+      # Adversarial (#5): a filtered scrape of a deeply-nested item must NOT touch
+      # the intermediate container. Routing it through upsert_inv with name=nil
+      # would blank that container's real name and pull a worn parent out of
+      # GameObj.inv. So the middle container is left alone in partial mode.
+      it 'does NOT upsert the intermediate container for a doubly-nested match' do
+        # Only the matched item itself is upserted...
+        expect(GameObj).to receive(:upsert_inv).with('10956111', nil, 'rosemary-dusted pumpkin and apple tart drizzled with an amber glaze', '10956107', 'get #10956111 in #10956107 in a watery portal', nil)
+        # ...never the middle container (#10956107) with a nil name.
+        expect(GameObj).not_to receive(:upsert_inv).with('10956107', anything, anything, anything, anything, anything)
+        expect(GameObj).not_to receive(:new_inv)
+        described_class.populate_inventory_get("        -<d cmd='get #10956111 in #10956107 in a watery portal'>a rosemary-dusted pumpkin and apple tart drizzled with an amber glaze</d>")
+      end
     end
   end
 


### PR DESCRIPTION
**Part 03 of 05** — DR inventory-model series. Stacked on #1554 → #1555; review/merge those first. (Cumulative diff until predecessors merge.)

## What

`INV LIST` is complete, so it clears+repopulates GameObj. `INV SEARCH <word>` and `INV <category> full` are **filtered** listings, yet shared the clear-everything path — so `inv search pouch` wiped the whole model down to the matches. Split the trigger by header completeness; the `looking for …` scrapes now **upsert** via `GameObj.upsert_inv` (removes any prior placement of an id, then re-places) instead of clearing.

## Hardening from adversarial review

- **Anchored triggers**: `InventoryListStart`/`InventorySearchStart` are anchored to the stream-line start (search allows its one real leading `<roundTime/>`), so quoted/chat/book text can't open a mutating scrape. Prefixes verified against logs.
- **Non-destructive nesting (#5)**: a filtered scrape of a deeply-nested item no longer routes the intermediate container through `upsert_inv` with `name=nil` (which blanked its name and pulled a worn parent out of `@@inv`); the middle container is left alone in partial mode.
- **Mutex-guarded removal**: `upsert_inv`'s `reject!` runs under `@@index_mutex` so it can't race the off-thread prune sweep.
- **Interrupted-scrape guard**: an unclosed scrape resets on the next `<prompt>` so stray `<d cmd>` links aren't hijacked/upserted.

## Testing

Adversarial specs: quoted-line rejection, `<roundTime/>` acceptance, deep-nested partial non-destruction, prompt-reset (both flags), partial-vs-full routing, upsert move/dedup/`(closed)`. Header classification verified across all ~90 `inv` verbs. Full suite green; rubocop clean (also fixed two pre-existing `ExtraSpacing` offenses in `gameobj.rb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
