### PR TITLE
feat(dr): reconcile GameObj containers on hand pickup (04 of 05)

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -394,11 +394,34 @@ module Lich
       # @return [GameObj]
       def self.upsert_inv(id, noun, name, container = nil, before = nil, after = nil)
         str_id = id.is_a?(Integer) ? id.to_s : id
+        remove_inv_item(str_id)
+        new_inv(str_id, noun, name, container, before, after)
+      end
+
+      # Removes every placement of +id+ from the worn inventory (+@@inv+) and
+      # from all container contents (+@@contents+). Used as the removal half of
+      # {.upsert_inv} and to reconcile the model when an item leaves inventory
+      # for a hand (a held item is neither worn nor in a container). Leaves
+      # +@@right_hand+/+@@left_hand+ and the shared identity index untouched.
+      #
+      # A +nil+ or empty id is an explicit no-op: empty hands stream a hand tag
+      # with no +exist+ id, so this is called constantly with +nil+, and matching
+      # +obj.id == nil+ would wrongly wipe any (future) nil-id entry -- and also
+      # scan the whole inventory for nothing. The +reject!+ runs under
+      # +@@index_mutex+ (the lock +find_or_create+ holds for registry writes) so
+      # it cannot race the off-thread prune sweep that walks these registries.
+      #
+      # @param id [Integer, String, nil]
+      # @return [void]
+      def self.remove_inv_item(id)
+        str_id = id.is_a?(Integer) ? id.to_s : id
+        return if str_id.nil? || str_id.empty?
+
         @@index_mutex.synchronize do
           @@inv.reject! { |obj| obj.id == str_id }
           @@contents.each_value { |list| list.reject! { |obj| obj.id == str_id } }
         end
-        new_inv(str_id, noun, name, container, before, after)
+        nil
       end
 
       # Creates and registers a new reserve slot item.

--- a/lib/common/xmlparser.rb
+++ b/lib/common/xmlparser.rb
@@ -1045,9 +1045,17 @@ module Lich
             @prompt = text_string
           elsif @active_tags.include?('right')
             GameObj.new_right_hand(@obj_exist, @obj_noun, text_string)
+            # DR only: an item now held in hand is no longer worn or in a
+            # container, so drop any stale placement of it. DR has no passive
+            # container stream to self-correct this, and its containers are
+            # rebuilt only on an explicit INV LIST/SEARCH. Gated so GemStone
+            # (which relies on its own inv stream) is unaffected. Empty hands
+            # carry no exist id (@obj_exist nil), making this a safe no-op.
+            GameObj.remove_inv_item(@obj_exist) if XMLData.game =~ /^DR/
             $_CLIENT_.puts "\034GSm#{sprintf('%-45s', text_string)}\r\n" if @send_fake_tags
           elsif @active_tags.include?('left')
             GameObj.new_left_hand(@obj_exist, @obj_noun, text_string)
+            GameObj.remove_inv_item(@obj_exist) if XMLData.game =~ /^DR/ # see 'right' above
             $_CLIENT_.puts "\034GSl#{sprintf('%-45s', text_string)}\r\n" if @send_fake_tags
           elsif @active_tags.include?('spell')
             @prepared_spell = text_string

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -185,6 +185,76 @@ RSpec.describe Lich::Common::GameObj do
     end
   end
 
+  describe '.remove_inv_item' do
+    it 'removes the id from a container' do
+      described_class.new_inv('123', 'gem', 'ruby', 'container1')
+      described_class.new_inv('999', 'gem', 'opal', 'container1') # bystander stays
+
+      described_class.remove_inv_item('123')
+
+      expect(described_class.containers['container1'].map(&:id)).to eq(['999'])
+    end
+
+    it 'removes the id from worn inv' do
+      described_class.new_inv('123', 'gem', 'ruby')
+
+      described_class.remove_inv_item('123')
+
+      expect(described_class.inv.to_a.map(&:id)).to eq([])
+    end
+
+    it 'removes every placement across containers' do
+      described_class.new_inv('123', 'gem', 'ruby', 'container1')
+      described_class.new_inv('123', 'gem', 'ruby', 'container2') # stale duplicate elsewhere
+
+      described_class.remove_inv_item('123')
+
+      expect(described_class.containers['container1'].map(&:id)).to eq([])
+      expect(described_class.containers['container2'].map(&:id)).to eq([])
+    end
+
+    it 'is a no-op for an unknown id' do
+      described_class.new_inv('999', 'gem', 'opal', 'container1')
+
+      described_class.remove_inv_item('123')
+
+      expect(described_class.containers['container1'].map(&:id)).to eq(['999'])
+    end
+
+    it 'is a no-op for nil' do
+      described_class.new_inv('999', 'gem', 'opal', 'container1')
+
+      expect { described_class.remove_inv_item(nil) }.not_to raise_error
+      expect(described_class.containers['container1'].map(&:id)).to eq(['999'])
+    end
+
+    # Adversarial: empty hands fire remove_inv_item(nil) constantly. The nil
+    # guard must not let that match and wipe a nil-id entry (obj.id == nil).
+    it 'does NOT remove a nil-id entry when called with nil' do
+      described_class.new_inv(nil, 'thing', 'a mysterious idless thing', 'container1')
+
+      described_class.remove_inv_item(nil)
+
+      expect(described_class.containers['container1'].map(&:name)).to eq(['a mysterious idless thing'])
+    end
+
+    it 'is a no-op for an empty-string id' do
+      described_class.new_inv('999', 'gem', 'opal', 'container1')
+
+      described_class.remove_inv_item('')
+
+      expect(described_class.containers['container1'].map(&:id)).to eq(['999'])
+    end
+
+    it 'accepts an integer id' do
+      described_class.new_inv('123', 'gem', 'ruby', 'container1')
+
+      described_class.remove_inv_item(123)
+
+      expect(described_class.containers['container1'].map(&:id)).to eq([])
+    end
+  end
+
   describe '.clear_inv' do
     it 'clears the @@inv array' do
       described_class.new_inv('123', 'gem', 'ruby')

--- a/spec/lib/common/xmlparser_spec.rb
+++ b/spec/lib/common/xmlparser_spec.rb
@@ -509,6 +509,63 @@ RSpec.describe Lich::Common::XMLParser do
     end
   end
 
+  # DragonRealms only: an item taken into a hand is no longer worn or in a
+  # container, so the <right>/<left> handler drops any stale placement of it.
+  # GemStone is unaffected (its own inv stream is authoritative), which these
+  # cover via the game gate.
+  describe 'DragonRealms hand-pickup container reconciliation' do
+    let(:gameobj) { Lich::Common::GameObj }
+
+    def feed_hand(side, exist:, noun: 'pouch', name: 'a soft gem pouch')
+      attrs = exist.nil? ? {} : { 'exist' => exist, 'noun' => noun }
+      parser.tag_start(side, attrs)
+      parser.text(name)
+      parser.tag_end(side)
+    end
+
+    context 'when the game is DragonRealms' do
+      before { XMLData.game = 'DR' }
+
+      it 'removes a picked-up item from its container when it appears in the right hand' do
+        gameobj.new_inv('123', 'pouch', 'a soft gem pouch', 'cid')
+        gameobj.new_inv('999', 'gem', 'a ruby', 'cid') # bystander stays
+
+        feed_hand('right', exist: '123')
+
+        expect(gameobj.containers['cid'].map(&:id)).to eq(['999'])
+        expect(gameobj.right_hand.id).to eq('123')
+      end
+
+      it 'reconciles the left hand the same way' do
+        gameobj.new_inv('123', 'pouch', 'a soft gem pouch', 'cid')
+
+        feed_hand('left', exist: '123')
+
+        expect(gameobj.containers['cid'].map(&:id)).to eq([])
+        expect(gameobj.left_hand.id).to eq('123')
+      end
+
+      it 'is a safe no-op for an empty hand (no exist id)' do
+        gameobj.new_inv('999', 'gem', 'a ruby', 'cid')
+
+        expect { feed_hand('right', exist: nil, noun: nil, name: 'Empty') }.not_to raise_error
+        expect(gameobj.containers['cid'].map(&:id)).to eq(['999'])
+      end
+    end
+
+    context 'when the game is GemStone (gated off)' do
+      before { XMLData.game = 'GSIV' }
+
+      it 'leaves the container untouched on a hand update' do
+        gameobj.new_inv('123', 'pouch', 'a soft gem pouch', 'cid')
+
+        feed_hand('right', exist: '123')
+
+        expect(gameobj.containers['cid'].map(&:id)).to eq(['123'])
+      end
+    end
+  end
+
   # DragonRealms now emits <nav rm='NNNN'/> on every arrival (a plain <nav/> with no rm for
   # a room that has no UID). The parser takes room_id from that tag as the primary source, and
   # falls back to the streamWindow subtitle's "(NNNNN)" only when nav did not supply a UID this


### PR DESCRIPTION
**Part 04 of 05** — DR inventory-model series. **Depends on #1556** (which is stacked on #1554 → #1555); review/merge those first, in order: #1555 → #1554 → #1556 → #1557 → #1563.

> Diff is cumulative until the predecessors merge; this PR's own change is the hand-pickup commit.

## What

When an item is taken into a hand it's no longer worn or in a container, but nothing removed its stale placement from GameObj — the shared `<right>`/`<left>` handler only set the hand slot. On DragonRealms (no passive container stream; containers rebuilt only on an explicit `INV LIST`/`SEARCH`) a picked-up item stayed double-counted in its old container.

- `GameObj.remove_inv_item(id)` — removes every placement of `id` from `@@inv`/`@@contents`. Shared removal half of `upsert_inv` (#1556).
- Called from `<right>`/`<left>`, **gated `XMLData.game =~ /^DR/`** so GemStone is byte-for-byte unaffected.

## Hardening from adversarial review

- **nil/empty-id guard**: empty hands stream a hand tag with no `exist` id, firing `remove_inv_item(nil)` constantly — explicit early-return so it can't match/wipe a nil-id entry and skips a pointless full scan.
- **`@@index_mutex`-guarded** removal, matching `find_or_create`'s registry-write discipline.

## GemStone safety

Only shared-parser change is a single DR-gated call after each existing `new_*_hand`; non-DR runs nothing new. Verified DR emits `<right exist="…">` (id) and `<right>Empty</right>` (no id).

## Testing

DR pickup removes item from container (right+left); GS gate leaves it; empty-hand no-op; **nil-id entry is NOT wiped by `remove_inv_item(nil)`**; empty-string no-op; move/dedup/cross-container unit coverage. Full suite: **6365 examples, 0 failures**. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
