### PR TITLE
feat(dr): [DRCC] add shared private-forge helpers

### DIFF
--- a/lib/dragonrealms/commons/common-crafting.rb
+++ b/lib/dragonrealms/commons/common-crafting.rb
@@ -736,6 +736,80 @@ module Lich
         DRCC.get_crafting_item("#{material} ingot", nil, nil, nil, true)
         DRCC.stow_crafting_item("#{material} ingot", settings.crafting_container, nil) if DRC.right_hand
       end
+
+      # --- Private forge helpers ---------------------------------------------
+      # Shared settings resolution and navigation for the blacksmithing private
+      # forge, so smith / forge / makesteel behave identically. Callers should
+      # prefer these over inlining the logic.
+
+      # Default copper reserved to rent/enter a private forge when the
+      # forge_private_forge_cost setting is unset.
+      DEFAULT_PRIVATE_FORGE_COST = 50_000
+
+      # Patterns for entering a private forge through its door/sentry.
+      PRIVATE_FORGE_ENTRY_SUCCESS = ['You head through', 'You walk', 'You go', 'Obvious exits'].freeze
+      PRIVATE_FORGE_ENTRY_BLOCKED = ["You don't have enough", 'The sentry blocks', 'cannot enter', 'You need to pay'].freeze
+
+      # Resolve the town a crafter should work in: the crafting-specific override
+      # if set, otherwise their hometown. Mirrors the convention used by every
+      # crafting script.
+      #
+      # @param settings the character settings object
+      # @return [String] the town name
+      def crafting_hometown(settings)
+        settings.force_crafting_town || settings.hometown
+      end
+
+      # Whether the character wants to use a private forge. Accepts the legacy
+      # forge-only setting name for backward compatibility.
+      #
+      # @param settings the character settings object
+      # @return [Boolean]
+      def use_private_forge?(settings)
+        settings.use_private_forge || settings.forge_use_private_forge || false
+      end
+
+      # Copper to reserve for private forge rental/entry.
+      #
+      # @param settings the character settings object
+      # @return [Integer]
+      def private_forge_cost(settings)
+        settings.forge_private_forge_cost || DEFAULT_PRIVATE_FORGE_COST
+      end
+
+      # The room id of a town's private forge, or nil when it has none.
+      #
+      # @param hometown [String]
+      # @return [Integer, nil]
+      def private_forge_room(hometown)
+        get_data('crafting')['blacksmithing'][hometown]['private_forge']
+      end
+
+      # Blacksmithing towns that define a private forge.
+      #
+      # @return [Array<String>]
+      def towns_with_private_forge
+        get_data('crafting')['blacksmithing'].select { |_town, data| data['private_forge'] }.keys
+      end
+
+      # Ensure funds and navigate into the town's private forge.
+      #
+      # @param hometown [String]
+      # @param settings the character settings object
+      # @return [Boolean] true if we ended up in the private forge, false when the
+      #   town has no private forge, funds could not be secured, or entry was blocked.
+      def go_to_private_forge(hometown, settings)
+        room = private_forge_room(hometown)
+        return false unless room
+        return false unless DRCM.ensure_copper_on_hand(private_forge_cost(settings), settings, hometown)
+
+        DRCT.walk_to(room)
+        return true if Room.current.id == room
+
+        # Not in the room yet -- try to enter through the door/sentry.
+        DRC.bput('go door', *PRIVATE_FORGE_ENTRY_SUCCESS, *PRIVATE_FORGE_ENTRY_BLOCKED, 'What were you')
+        Room.current.id == room
+      end
     end
   end
 end

--- a/spec/lib/dragonrealms/commons/common_crafting_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_crafting_spec.rb
@@ -155,4 +155,115 @@ describe DRCC do
       end
     end
   end
+
+  describe '.crafting_hometown' do
+    it 'prefers force_crafting_town when set' do
+      settings = OpenStruct.new(force_crafting_town: 'Shard', hometown: 'Crossing')
+      expect(DRCC.crafting_hometown(settings)).to eq('Shard')
+    end
+
+    it 'falls back to hometown when force_crafting_town is unset' do
+      settings = OpenStruct.new(force_crafting_town: nil, hometown: 'Crossing')
+      expect(DRCC.crafting_hometown(settings)).to eq('Crossing')
+    end
+  end
+
+  describe '.use_private_forge?' do
+    it 'is true when use_private_forge is set' do
+      expect(DRCC.use_private_forge?(OpenStruct.new(use_private_forge: true))).to be true
+    end
+
+    it 'is true when the legacy forge_use_private_forge is set' do
+      expect(DRCC.use_private_forge?(OpenStruct.new(forge_use_private_forge: true))).to be true
+    end
+
+    it 'is false (not nil) when neither is set' do
+      expect(DRCC.use_private_forge?(OpenStruct.new)).to be false
+    end
+  end
+
+  describe '.private_forge_cost' do
+    it 'uses forge_private_forge_cost when present' do
+      expect(DRCC.private_forge_cost(OpenStruct.new(forge_private_forge_cost: 12_345))).to eq(12_345)
+    end
+
+    it 'defaults to DEFAULT_PRIVATE_FORGE_COST (50_000)' do
+      expect(DRCC::DEFAULT_PRIVATE_FORGE_COST).to eq(50_000)
+      expect(DRCC.private_forge_cost(OpenStruct.new)).to eq(50_000)
+    end
+  end
+
+  describe '.private_forge_room' do
+    before do
+      allow(DRCC).to receive(:get_data).with('crafting').and_return(
+        'blacksmithing' => {
+          'Shard'      => { 'private_forge' => 51_058 },
+          'Riverhaven' => {}
+        }
+      )
+    end
+
+    it 'returns the room id for a town with a private forge' do
+      expect(DRCC.private_forge_room('Shard')).to eq(51_058)
+    end
+
+    it 'returns nil for a town without one' do
+      expect(DRCC.private_forge_room('Riverhaven')).to be_nil
+    end
+  end
+
+  describe '.towns_with_private_forge' do
+    it 'lists only blacksmithing towns that define a private forge' do
+      allow(DRCC).to receive(:get_data).with('crafting').and_return(
+        'blacksmithing' => {
+          'Shard'      => { 'private_forge' => 51_058 },
+          'Crossing'   => { 'private_forge' => 16_936 },
+          'Riverhaven' => {}
+        }
+      )
+      expect(DRCC.towns_with_private_forge).to contain_exactly('Shard', 'Crossing')
+    end
+  end
+
+  describe '.go_to_private_forge' do
+    # Reference the modules the way production resolves them (Lich::DragonRealms::*),
+    # so stubs hit the same object whether or not the real commons are loaded by
+    # other specs in the full-suite run.
+    let(:money) { Lich::DragonRealms::DRCM }
+    let(:travel) { Lich::DragonRealms::DRCT }
+    let(:settings) { OpenStruct.new(hometown: 'Shard') }
+
+    before do
+      allow(DRCC).to receive(:private_forge_room).with('Shard').and_return(51_058)
+      allow(DRCC).to receive(:private_forge_cost).and_return(50_000)
+      allow(money).to receive(:ensure_copper_on_hand).and_return(true)
+      allow(travel).to receive(:walk_to)
+      allow(DRC).to receive(:bput)
+      allow(Room).to receive(:current).and_return(OpenStruct.new(id: 51_058))
+    end
+
+    it 'returns false and does not spend when the town has no private forge' do
+      allow(DRCC).to receive(:private_forge_room).with('Shard').and_return(nil)
+      expect(money).not_to receive(:ensure_copper_on_hand)
+      expect(DRCC.go_to_private_forge('Shard', settings)).to be false
+    end
+
+    it 'returns false and does not walk when funds cannot be secured' do
+      allow(money).to receive(:ensure_copper_on_hand).and_return(false)
+      expect(travel).not_to receive(:walk_to)
+      expect(DRCC.go_to_private_forge('Shard', settings)).to be false
+    end
+
+    it 'walks to the forge and returns true on arrival without trying the door' do
+      expect(travel).to receive(:walk_to).with(51_058)
+      expect(DRC).not_to receive(:bput)
+      expect(DRCC.go_to_private_forge('Shard', settings)).to be true
+    end
+
+    it 'tries the door when walk_to did not arrive, then confirms arrival' do
+      allow(Room).to receive(:current).and_return(OpenStruct.new(id: 999), OpenStruct.new(id: 51_058))
+      expect(DRC).to receive(:bput).with('go door', any_args)
+      expect(DRCC.go_to_private_forge('Shard', settings)).to be true
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1710,6 +1710,21 @@ module DRCT
 end unless defined?(DRCT)
 
 # -----------------------------------------------------------------------------
+# DRCM - Money module
+# -----------------------------------------------------------------------------
+module DRCM
+  class << self
+    def ensure_copper_on_hand(_copper, _settings = nil, _hometown = nil)
+      true
+    end
+
+    def town_currency(_hometown)
+      'Kronars'
+    end
+  end
+end unless defined?(DRCM)
+
+# -----------------------------------------------------------------------------
 # DRCMM - Moon mage module
 # -----------------------------------------------------------------------------
 module DRCMM
@@ -1768,6 +1783,7 @@ Lich::DragonRealms::DRSpells = DRSpells unless defined?(Lich::DragonRealms::DRSp
 Lich::DragonRealms::DRRoom = DRRoom unless defined?(Lich::DragonRealms::DRRoom)
 Lich::DragonRealms::DRExpMonitor = DRExpMonitor unless defined?(Lich::DragonRealms::DRExpMonitor)
 Lich::DragonRealms::DRCA = DRCA unless defined?(Lich::DragonRealms::DRCA)
+Lich::DragonRealms::DRCM = DRCM unless defined?(Lich::DragonRealms::DRCM)
 Lich::DragonRealms::DRCT = DRCT unless defined?(Lich::DragonRealms::DRCT)
 Lich::DragonRealms::DRCMM = DRCMM unless defined?(Lich::DragonRealms::DRCMM)
 Lich::DragonRealms::DRCTH = DRCTH unless defined?(Lich::DragonRealms::DRCTH)


### PR DESCRIPTION
## Summary

Blacksmithing private-forge logic is duplicated and **divergent** across the DR crafting scripts (`smith`, `forge`, `makesteel`): different setting names (`use_private_forge` vs `forge_use_private_forge`), different town resolution (`force_crafting_town || hometown` vs `hometown` alone), and a hardcoded `50_000` cost in one place vs a configurable `5_000` default in another. This adds a single shared home for that logic in `DRCC` so the scripts can converge on identical behavior.

This is the lich-5 half; a companion dr-scripts PR wires `smith`/`forge`/`makesteel` to these helpers (with local fallbacks gated on `DRCC.respond_to?`, so the scripts keep working on older lich-5 until this ships).

## New `DRCC` module functions

| Method | Behavior |
|---|---|
| `crafting_hometown(settings)` | `force_crafting_town \|\| hometown` |
| `use_private_forge?(settings)` | `use_private_forge \|\| forge_use_private_forge \|\| false` (accepts the legacy name) |
| `private_forge_cost(settings)` | `forge_private_forge_cost \|\| DEFAULT_PRIVATE_FORGE_COST` (50_000) |
| `private_forge_room(hometown)` | room id, or `nil` when the town has none |
| `towns_with_private_forge` | blacksmithing towns that define a private forge |
| `go_to_private_forge(hometown, settings)` | ensure funds + walk + door entry; returns `Boolean` (false on no-room / no-funds / blocked) |

## Testing

- `rspec` — full suite green (**6349 examples, 0 failures**).
- `rubocop` — clean on changed files.
- Adds a guarded `DRCM` test double to `spec_helper` (mirroring `DRCT`) and aliases it into the `Lich::DragonRealms` namespace, so stubs resolve to the object production uses in both isolated and full-suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)