### PR TITLE
fix(all): normalize colons in Lich::Util.normalize_lookup

### DIFF
--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -12,9 +12,13 @@ module Lich
     # Normalizes and performs a lookup for an effect based on the provided value.
     #
     # Depending on the type of `val`, this method will:
-    # - For String: Check if the normalized string matches any key in the effect's hash (case-insensitive, underscores replaced with spaces).
+    # - For String: Check if the normalized string matches any key in the effect's hash (case-insensitive, underscores/colons replaced with spaces).
     # - For Integer: Check if the effect is active for the given integer value.
-    # - For Symbol: Check if the normalized symbol matches any key in the effect's hash (case-insensitive, underscores replaced with spaces).
+    # - For Symbol: Check if the normalized symbol matches any key in the effect's hash (case-insensitive, underscores/colons replaced with spaces).
+    #
+    # Both the lookup value and the effect's hash keys are normalized the same way, so a
+    # punctuation-free lookup (e.g. PSM feat names like "covert_art_escape_artist") still
+    # matches an effect key that contains punctuation (e.g. "Covert Art: Escape Artist").
     #
     # @param effect [String] The name of the effect class (without the "Effects::" prefix).
     # @param val [String, Integer, Symbol] The value to look up; can be a string, integer, or symbol.
@@ -23,13 +27,12 @@ module Lich
     def self.normalize_lookup(effect, val)
       caller_type = "Effects::#{effect}"
       case val
-      when String
-        (eval caller_type).to_h.transform_keys(&:to_s).transform_keys(&:downcase).include?(val.downcase.gsub('_', ' '))
+      when String, Symbol
+        normalize = ->(str) { str.to_s.downcase.gsub(':', ' ').gsub('_', ' ').squeeze(' ').strip }
+        (eval caller_type).to_h.transform_keys { |k| normalize.call(k) }.include?(normalize.call(val))
       when Integer
         #      seek = mappings.fetch(val, nil)
         (eval caller_type).active?(val)
-      when Symbol
-        (eval caller_type).to_h.transform_keys(&:to_s).transform_keys(&:downcase).include?(val.to_s.downcase.gsub('_', ' '))
       else
         fail "invalid lookup case #{val.class.name}"
       end

--- a/spec/lib/util/util_spec.rb
+++ b/spec/lib/util/util_spec.rb
@@ -182,4 +182,60 @@ RSpec.describe Lich::Util do
       expect(captured_proc[:action].call(end_chunk)).to eq(end_chunk)
     end
   end
+
+  describe '.normalize_lookup' do
+    # normalize_lookup evals "Effects::#{effect}" to reach a
+    # Lich::Gemstone::Effects::Registry (Effects::Cooldowns, Effects::Debuffs, ...).
+    # Production resolves the bare `Effects` constant via `include Lich::Gemstone`
+    # at the top level (see lib/main/main.rb), so stub a bare top-level
+    # Effects::<name> double here rather than pulling in the full
+    # Registry/XMLData.dialogs dependency chain.
+    def stub_effect(name, hash)
+      registry = Object.new
+      registry.define_singleton_method(:to_h) { hash }
+      registry.define_singleton_method(:active?) { |val| hash.key?(val) }
+      stub_const('Effects', Module.new)
+      stub_const("Effects::#{name}", registry)
+    end
+
+    it 'matches an underscored PSM lookup value against an effect key containing a colon' do
+      # Regression: PSM feat names never encode punctuation ("covert_art_escape_artist"),
+      # but some effect keys do ("Covert Art: Escape Artist"). Underscore-to-space
+      # substitution alone can't reconstruct the colon, so both the lookup value and the
+      # effect keys must be normalized the same way (colons included) before comparing.
+      stub_effect('Cooldowns', 'Covert Art: Escape Artist' => Time.now)
+
+      expect(described_class.normalize_lookup('Cooldowns', 'covert_art_escape_artist')).to be true
+    end
+
+    it 'still matches a plain underscored lookup against a punctuation-free effect key' do
+      stub_effect('Cooldowns', 'Bulwark' => Time.now)
+
+      expect(described_class.normalize_lookup('Cooldowns', 'bulwark')).to be true
+    end
+
+    it 'matches a Symbol lookup value the same way as an equivalent String' do
+      stub_effect('Cooldowns', 'Covert Art: Escape Artist' => Time.now)
+
+      expect(described_class.normalize_lookup('Cooldowns', :covert_art_escape_artist)).to be true
+    end
+
+    it 'returns false when no effect key matches' do
+      stub_effect('Cooldowns', 'Bulwark' => Time.now)
+
+      expect(described_class.normalize_lookup('Cooldowns', 'nonexistent_maneuver')).to be false
+    end
+
+    it 'delegates to the effect registry\'s active? for an Integer lookup value' do
+      stub_effect('Cooldowns', 119_818_740 => Time.now)
+
+      expect(described_class.normalize_lookup('Cooldowns', 119_818_740)).to be true
+    end
+
+    it 'raises for an unsupported lookup value type' do
+      stub_effect('Cooldowns', {})
+
+      expect { described_class.normalize_lookup('Cooldowns', 1.5) }.to raise_error(RuntimeError, /invalid lookup case/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `Lich::Util.normalize_lookup` normalized underscores to spaces on the lookup value but did nothing about colons in effect hash keys (e.g. `"Covert Art: Escape Artist"`), so `PSMS.available?("covert_art_escape_artist")` never matched that cooldown entry and reported the maneuver as unavailable/on cooldown even when it wasn't.
- Both the lookup value and the effect registry's hash keys are now normalized the same way (colons and underscores both collapsed to spaces, then squeezed/stripped) before comparing, so punctuation-free PSM feat names correctly match punctuated effect keys.
- Merged the previously-identical `String`/`Symbol` branches and updated the method's doc comment to describe the new normalization and why both sides need it.

## Test plan
- [x] Added specs in `spec/lib/util/util_spec.rb` covering: a punctuated effect key matched by an underscored PSM-style lookup, a plain punctuation-free match, `Symbol` lookup values, a non-matching lookup, the `Integer`/`active?` delegation path, and the `RuntimeError` for unsupported types.
- [x] `bundle exec rspec spec/lib/util/util_spec.rb` — 17 examples, 0 failures
- [x] `bundle exec rspec` (full suite) — 6341 examples, 0 failures
- [x] `rubocop lib/util/util.rb spec/lib/util/util_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lookup matching for names containing colons, underscores, or repeated whitespace.
  - String and Symbol lookups now behave consistently.
  - Unmatched and unsupported lookup values continue to return clear results or errors as appropriate.

- **Tests**
  - Added coverage for punctuation, whitespace normalization, Symbol lookups, unmatched values, numeric lookups, and unsupported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->