### PR TITLE
fix(dr): make INV LIST refresh atomic and warn on interruption (05 of 05)

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -126,6 +126,13 @@ module Lich
       @@staging_fam_pcs       = nil
       @@staging_contents      = {}
 
+      # True while a full-replacement container refresh (DR +INV LIST+) is open.
+      # While set, +new_inv+ routes every container placement into
+      # +@@staging_contents+ (auto-vivifying per-container buffers) instead of the
+      # live +@@contents+, so an interrupted listing never mutates the published
+      # model. See {.begin_all_containers}.
+      @@staging_all_containers = false
+
       # ---------------------------------------------------------------------------
       # Instance interface
       # ---------------------------------------------------------------------------
@@ -356,7 +363,13 @@ module Lich
       # @return [GameObj]
       def self.new_inv(id, noun, name, container = nil, before = nil, after = nil)
         if container
-          target = @@staging_contents[container] || (@@contents[container] ||= [])
+          target = if @@staging_all_containers
+                     # Full INV LIST refresh: stage every container so nothing
+                     # touches the live model until the listing commits cleanly.
+                     @@staging_contents[container] ||= []
+                   else
+                     @@staging_contents[container] || (@@contents[container] ||= [])
+                   end
           find_or_create(target, id, noun, name, before, after)
         else
           find_or_create(@@staging_inv || @@inv, id, noun, name, before, after)
@@ -420,6 +433,11 @@ module Lich
         @@index_mutex.synchronize do
           @@inv.reject! { |obj| obj.id == str_id }
           @@contents.each_value { |list| list.reject! { |obj| obj.id == str_id } }
+          # Scrub any in-flight staging buffers too: a hand pickup during a full
+          # INV LIST refresh must not be resurrected in its old container when the
+          # staged listing commits.
+          @@staging_inv&.reject! { |obj| obj.id == str_id }
+          @@staging_contents.each_value { |list| list.reject! { |obj| obj.id == str_id } }
         end
         nil
       end
@@ -850,6 +868,46 @@ module Lich
         @@staging_contents.clear
       end
 
+      # Opens a full-replacement refresh of ALL container contents, used by DR's
+      # +INV LIST+ (a complete recursive scrape). While open, +new_inv+ stages
+      # every container placement (see {.new_inv}) and the live +@@contents+ is
+      # left visible to readers. {.commit_all_containers_full} then swaps the
+      # whole hash in one reference assignment, so containers absent from the
+      # listing are dropped -- matching the old clear-then-fill semantics -- while
+      # an interrupted listing that never commits leaves the previous model
+      # intact (see {.discard_inv_refresh}). Pair with {.begin_inv} for worn items.
+      #
+      # @return [void]
+      def self.begin_all_containers
+        @@staging_contents = {}
+        @@staging_all_containers = true
+      end
+
+      # Publishes a full container refresh opened by {.begin_all_containers} with
+      # a single reference swap and closes it. No-op if no full refresh is open,
+      # so an interrupted listing simply keeps the previous published model.
+      #
+      # @return [void]
+      def self.commit_all_containers_full
+        return unless @@staging_all_containers
+
+        @@contents = @@staging_contents
+        @@staging_contents = {}
+        @@staging_all_containers = false
+      end
+
+      # Discards an in-flight INV LIST refresh (worn + full container staging)
+      # without publishing it, leaving the previously published model visible.
+      # Unlike {.discard_staged_refreshes} this touches only the inventory
+      # buffers, so it will not abort an unrelated in-flight room/familiar refresh.
+      #
+      # @return [void]
+      def self.discard_inv_refresh
+        @@staging_inv = nil
+        @@staging_contents = {}
+        @@staging_all_containers = false
+      end
+
       # Discards every in-flight staged refresh without publishing it.
       #
       # Called by +XMLParser#reset+ after a malformed or truncated fragment
@@ -879,6 +937,7 @@ module Lich
         @@staging_fam_npcs      = nil
         @@staging_fam_pcs       = nil
         @@staging_contents.clear
+        @@staging_all_containers = false
       end
 
       # ---------------------------------------------------------------------------

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -867,8 +867,16 @@ module Lich
       # +clearContainer+ ... +inv+ fill sequence (which has no closing tag).
       # No-op when no container refresh is open.
       #
+      # A full INV LIST refresh ({.begin_all_containers}) stages into the same
+      # +@@staging_contents+ hash, but must publish only through its own clean
+      # path ({.commit_all_containers_full}) or be discarded on interruption
+      # ({.discard_inv_refresh}). This runs at every +prompt+ via XMLParser,
+      # which fires before DRParser can discard an interrupted listing, so it
+      # must refuse to publish a partial full refresh here.
+      #
       # @return [void]
       def self.commit_all_containers
+        return if @@staging_all_containers
         return if @@staging_contents.empty?
 
         @@staging_contents.each { |id, staged| @@contents[id] = staged }

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -710,9 +710,18 @@ module Lich
       # Whether a staged refresh for one container's contents is currently open.
       # Same purpose as {.inv_refresh_open?}, scoped to a single container id.
       #
+      # A full INV LIST refresh ({.begin_all_containers}) owns *every* container
+      # the instant it opens, but only allocates a per-container buffer when an
+      # item line for that container arrives. A container not yet seen in the
+      # listing therefore has no key in +@@staging_contents+ and would look
+      # unowned -- letting a second writer publish into or delete it mid-refresh.
+      # Report a full refresh as owning all containers so those writers defer.
+      #
       # @param container_id [String]
       # @return [Boolean]
-      def self.container_refresh_open?(container_id) = @@staging_contents.key?(container_id)
+      def self.container_refresh_open?(container_id)
+        @@staging_all_containers || @@staging_contents.key?(container_id)
+      end
 
       # ---------------------------------------------------------------------------
       # Staged registry refresh - begin/commit pairs

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -126,9 +126,15 @@ module Lich
       @@staging_fam_pcs       = nil
       @@staging_contents      = {}
 
+      # Dedicated buffer for a full-replacement container refresh (DR +INV LIST+),
+      # kept separate from +@@staging_contents+ so the whole-buffer swap/discard of
+      # a full refresh can never clobber an unrelated per-container
+      # +begin_container+ refresh that happens to be in flight at the same time.
+      @@staging_all_contents   = {}
+
       # True while a full-replacement container refresh (DR +INV LIST+) is open.
-      # While set, +new_inv+ routes every container placement into
-      # +@@staging_contents+ (auto-vivifying per-container buffers) instead of the
+      # While set, +new_inv+ routes container placements not already owned by an
+      # open per-container refresh into +@@staging_all_contents+ instead of the
       # live +@@contents+, so an interrupted listing never mutates the published
       # model. See {.begin_all_containers}.
       @@staging_all_containers = false
@@ -363,12 +369,19 @@ module Lich
       # @return [GameObj]
       def self.new_inv(id, noun, name, container = nil, before = nil, after = nil)
         if container
-          target = if @@staging_all_containers
-                     # Full INV LIST refresh: stage every container so nothing
-                     # touches the live model until the listing commits cleanly.
-                     @@staging_contents[container] ||= []
+          target = if @@staging_contents.key?(container)
+                     # An explicit per-container refresh (+begin_container+, e.g. a
+                     # +clearContainer+ fill) already owns this container -- stage
+                     # into it even during a full INV LIST refresh so the two paths
+                     # never share a buffer.
+                     @@staging_contents[container]
+                   elsif @@staging_all_containers
+                     # Full INV LIST refresh: stage every other container into the
+                     # dedicated buffer so nothing touches the live model until the
+                     # listing commits cleanly.
+                     @@staging_all_contents[container] ||= []
                    else
-                     @@staging_contents[container] || (@@contents[container] ||= [])
+                     @@contents[container] ||= []
                    end
           find_or_create(target, id, noun, name, before, after)
         else
@@ -438,6 +451,7 @@ module Lich
           # staged listing commits.
           @@staging_inv&.reject! { |obj| obj.id == str_id }
           @@staging_contents.each_value { |list| list.reject! { |obj| obj.id == str_id } }
+          @@staging_all_contents.each_value { |list| list.reject! { |obj| obj.id == str_id } }
         end
         nil
       end
@@ -675,6 +689,8 @@ module Lich
       # @return [void]
       def self.clear_all_containers
         @@staging_contents.clear
+        @@staging_all_contents.clear
+        @@staging_all_containers = false
         @@contents.clear
       end
 
@@ -876,12 +892,12 @@ module Lich
       # +clearContainer+ ... +inv+ fill sequence (which has no closing tag).
       # No-op when no container refresh is open.
       #
-      # A full INV LIST refresh ({.begin_all_containers}) stages into the same
-      # +@@staging_contents+ hash, but must publish only through its own clean
-      # path ({.commit_all_containers_full}) or be discarded on interruption
-      # ({.discard_inv_refresh}). This runs at every +prompt+ via XMLParser,
-      # which fires before DRParser can discard an interrupted listing, so it
-      # must refuse to publish a partial full refresh here.
+      # A full INV LIST refresh ({.begin_all_containers}) uses its own dedicated
+      # buffer (+@@staging_all_contents+) and is published only through its clean
+      # path ({.commit_all_containers_full}) or discarded on interruption
+      # ({.discard_inv_refresh}) -- never here. While one is open this defers the
+      # ordinary per-container publish until the listing closes, so the two commit
+      # paths never interleave at an interrupting +prompt+.
       #
       # @return [void]
       def self.commit_all_containers
@@ -893,17 +909,21 @@ module Lich
       end
 
       # Opens a full-replacement refresh of ALL container contents, used by DR's
-      # +INV LIST+ (a complete recursive scrape). While open, +new_inv+ stages
-      # every container placement (see {.new_inv}) and the live +@@contents+ is
-      # left visible to readers. {.commit_all_containers_full} then swaps the
-      # whole hash in one reference assignment, so containers absent from the
-      # listing are dropped -- matching the old clear-then-fill semantics -- while
-      # an interrupted listing that never commits leaves the previous model
-      # intact (see {.discard_inv_refresh}). Pair with {.begin_inv} for worn items.
+      # +INV LIST+ (a complete recursive scrape). Staging goes into a dedicated
+      # buffer (+@@staging_all_contents+), separate from the ordinary per-container
+      # +@@staging_contents+, so an unrelated +begin_container+ refresh in flight
+      # at the same time is never clobbered by this refresh's discard/commit. While
+      # open, +new_inv+ stages every not-already-owned container placement (see
+      # {.new_inv}) and the live +@@contents+ is left visible to readers.
+      # {.commit_all_containers_full} then swaps the whole buffer in one reference
+      # assignment, so containers absent from the listing are dropped -- matching
+      # the old clear-then-fill semantics -- while an interrupted listing that
+      # never commits leaves the previous model intact (see {.discard_inv_refresh}).
+      # Pair with {.begin_inv} for worn items.
       #
       # @return [void]
       def self.begin_all_containers
-        @@staging_contents = {}
+        @@staging_all_contents = {}
         @@staging_all_containers = true
       end
 
@@ -915,20 +935,22 @@ module Lich
       def self.commit_all_containers_full
         return unless @@staging_all_containers
 
-        @@contents = @@staging_contents
-        @@staging_contents = {}
+        @@contents = @@staging_all_contents
+        @@staging_all_contents = {}
         @@staging_all_containers = false
       end
 
       # Discards an in-flight INV LIST refresh (worn + full container staging)
       # without publishing it, leaving the previously published model visible.
-      # Unlike {.discard_staged_refreshes} this touches only the inventory
-      # buffers, so it will not abort an unrelated in-flight room/familiar refresh.
+      # Unlike {.discard_staged_refreshes} this touches only the INV LIST buffers,
+      # so it will not abort an unrelated in-flight room/familiar refresh -- nor an
+      # unrelated per-container +begin_container+ refresh, which lives in the
+      # separate +@@staging_contents+ hash and commits on its own at the next prompt.
       #
       # @return [void]
       def self.discard_inv_refresh
         @@staging_inv = nil
-        @@staging_contents = {}
+        @@staging_all_contents = {}
         @@staging_all_containers = false
       end
 
@@ -961,6 +983,7 @@ module Lich
         @@staging_fam_npcs      = nil
         @@staging_fam_pcs       = nil
         @@staging_contents.clear
+        @@staging_all_contents.clear
         @@staging_all_containers = false
       end
 
@@ -1536,6 +1559,7 @@ module Lich
             *Array(@@staging_fam_loot), *Array(@@staging_fam_npcs),
             *Array(@@staging_fam_pcs), *Array(@@staging_fam_room_desc),
             *@@staging_contents.values.flatten,
+            *@@staging_all_contents.values.flatten,
             @@right_hand, @@left_hand
           ].compact
           defined?(Set) ? Set.new(objs) : objs

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -624,8 +624,15 @@ module Lich
       # @return [Array<GameObj>, nil]
       def self.fam_pcs     = registry_or_nil(@@fam_pcs)
 
+      # Returns a snapshot of all container contents: the outer hash and every
+      # inner array are duplicated, so a caller iterating +containers[id]+ is not
+      # affected by concurrent in-place mutation of the live registry (e.g. a hand
+      # pickup's +remove_inv_item+ +reject!+, or +new_inv+'s +push+). Matches the
+      # dup-on-read contract of the other registry accessors and instance
+      # +#contents+. The GameObj elements themselves are shared, not copied.
+      #
       # @return [Hash{String => Array<GameObj>}]
-      def self.containers  = @@contents.dup
+      def self.containers  = @@contents.transform_values(&:dup)
 
       # ---------------------------------------------------------------------------
       # Class-level clear methods

--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -193,6 +193,13 @@ module Lich
         case server_string
         when Pattern::OutputClassEmpty
           if @@parsing_inventory_get
+            # Clean terminator: a COMPLETE INV LIST finished, so publish the
+            # staged full replacement atomically. PARTIAL scrapes upsert as they
+            # go and stage nothing, so there is nothing to commit for them.
+            unless @@inventory_partial
+              GameObj.commit_inv
+              GameObj.commit_all_containers_full
+            end
             @@parsing_inventory_get = false
             @@inventory_partial = false
           end
@@ -529,9 +536,12 @@ module Lich
         begin
           check_game_shutdown(line)
           if Pattern::InventoryListStart.match?(line)
-            # COMPLETE inventory (INV LIST): wipe and repopulate from scratch.
-            GameObj.clear_inv
-            GameObj.clear_all_containers
+            # COMPLETE inventory (INV LIST): stage a full replacement and publish
+            # it only on the clean terminator (see populate_inventory_get). The
+            # live model stays visible until then, so an interrupted listing keeps
+            # the previous inventory instead of wiping it.
+            GameObj.begin_inv
+            GameObj.begin_all_containers
             @@parsing_inventory_get = true
             @@inventory_partial = false
           elsif Pattern::InventorySearchStart.match?(line)
@@ -672,6 +682,15 @@ module Lich
           # <d cmd> links in ordinary output. Any <prompt> ends the exchange, so
           # reset there. In normal flow the flag is already false by the prompt.
           if @@parsing_inventory_get && line.start_with?('<prompt')
+            # Reaching the prompt with the flag still set means the closing tag was
+            # never seen -- the listing was interrupted/truncated. For a COMPLETE
+            # INV LIST that means the staged full replacement is incomplete, so
+            # discard it (keeping the previously published model) and tell the user
+            # rather than silently leaving inventory half-updated.
+            unless @@inventory_partial
+              GameObj.discard_inv_refresh
+              Lich::Messaging.msg('warn', "DRParser: 'inv list' did not finish; keeping previous inventory. Re-run 'inv list' to refresh.")
+            end
             @@parsing_inventory_get = false
             @@inventory_partial = false
           end

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -1282,4 +1282,50 @@ RSpec.describe Lich::Common::GameObj do
       end
     end
   end
+
+  # A full INV LIST refresh (begin_all_containers) stages into its own dedicated
+  # buffer, so an unrelated per-container refresh (begin_container -- e.g. a
+  # clearContainer fill) that is in flight at the same time must never be
+  # clobbered by the full refresh's whole-buffer discard or commit.
+  describe 'INV LIST full refresh isolation from per-container refreshes' do
+    it 'does not drop an unrelated in-flight container when the listing is discarded' do
+      described_class.begin_all_containers          # INV LIST opens
+      described_class.begin_container('backpack')   # unrelated clearContainer refresh
+      described_class.new_inv('55', 'gem', 'a gem', 'backpack')
+
+      described_class.discard_inv_refresh           # listing interrupted -- must not wipe backpack
+      described_class.commit_all_containers         # next prompt publishes the per-container refresh
+
+      expect(described_class.containers['backpack'].map(&:id)).to eq(['55'])
+    end
+
+    it 'does not publish an unrelated half-filled container when the listing commits' do
+      described_class.begin_all_containers
+      described_class.new_inv('99', 'ring', 'a ring', 'pouch') # a real INV LIST container
+      described_class.begin_container('backpack')              # unrelated, still filling
+      described_class.new_inv('55', 'gem', 'a gem', 'backpack')
+
+      described_class.commit_all_containers_full # clean INV LIST terminator
+
+      # The full commit publishes only its own containers, never the half-filled backpack.
+      expect(described_class.containers).to have_key('pouch')
+      expect(described_class.containers).not_to have_key('backpack')
+
+      described_class.commit_all_containers         # prompt publishes the per-container refresh
+      expect(described_class.containers['backpack'].map(&:id)).to eq(['55'])
+    end
+
+    it 'preserves an already-open per-container refresh when a full refresh starts' do
+      described_class.begin_container('backpack')
+      described_class.new_inv('55', 'gem', 'a gem', 'backpack')
+
+      described_class.begin_all_containers          # INV LIST opens AFTER the per-container refresh
+      described_class.new_inv('99', 'ring', 'a ring', 'pouch')
+      described_class.commit_all_containers_full
+      described_class.commit_all_containers
+
+      expect(described_class.containers['backpack'].map(&:id)).to eq(['55'])
+      expect(described_class.containers['pouch'].map(&:id)).to eq(['99'])
+    end
+  end
 end

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -134,6 +134,24 @@ RSpec.describe Lich::Common::GameObj do
       # Original should not be affected
       expect(described_class.containers['container1']).not_to be_empty
     end
+
+    it 'returns duplicated inner arrays so a reader iterating one is unaffected by in-place mutation' do
+      described_class.new_inv('10', 'gem', 'ruby', 'container1')
+      described_class.new_inv('11', 'gem', 'opal', 'container1')
+      described_class.new_inv('12', 'gem', 'jade', 'container1')
+
+      snapshot = described_class.containers['container1']
+      visited = []
+      snapshot.each do |item|
+        visited << item.id
+        # Simulate a hand pickup reconciling the live model mid-iteration: this
+        # reject!s the live inner array. A shared inner array would shift the
+        # iterator and silently skip '11'.
+        described_class.remove_inv_item('11') if item.id == '10'
+      end
+
+      expect(visited).to eq(%w[10 11 12])
+    end
   end
 
   describe '.upsert_inv' do

--- a/spec/lib/common/inventory_spec.rb
+++ b/spec/lib/common/inventory_spec.rb
@@ -649,6 +649,50 @@ RSpec.describe Lich::Common::Inventory do
       expect(game_obj.containers['ca'].map(&:id)).to eq(['classic-child'])
     end
 
+    # A full INV LIST refresh owns EVERY container the instant it opens, but only
+    # allocates a per-container staging buffer once an item line for that
+    # container streams. A container the listing has not reached yet therefore
+    # has no @@staging_contents key -- container_refresh_open? must still report
+    # it as owned, or the observer publishes into / deletes it mid-refresh.
+    it 'skips a container during an open full INV LIST refresh before it is streamed' do
+      first_snapshot
+      expect(game_obj.containers['ca'].map(&:id)).to eq(['x'])
+
+      # INV LIST opens: owns all containers, but ca has not streamed yet.
+      game_obj.begin_all_containers
+
+      # A snapshot arrives mid-refresh reporting ca with different contents.
+      described_class.observe(
+        "<inventoryManager id='s2' room='1'>" \
+        "<i id='ca' loc='worn,player' name=\"a,leather,pack\" weight='10' in_max='1000'/>" \
+        "<i id='z' loc='in,ca' name=\"a,brass,key\" weight='1'/>" \
+        "</inventoryManager>"
+      )
+
+      # The observer must defer to the open full refresh, leaving the live model
+      # untouched rather than replacing ca's contents with z.
+      expect(game_obj.container_refresh_open?('ca')).to be(true)
+      expect(game_obj.containers['ca'].map(&:id)).to eq(['x'])
+    end
+
+    it 'defers deleting a container during an open full INV LIST refresh before it is streamed' do
+      first_snapshot
+      expect(game_obj.containers).to have_key('ca')
+
+      # INV LIST opens: owns ca, but has not streamed it yet.
+      game_obj.begin_all_containers
+
+      # A snapshot omits ca entirely; the deletion loop must not drop it while the
+      # full refresh (which will re-report ca) is still in flight.
+      described_class.observe(
+        "<inventoryManager id='s2' room='1'>" \
+        "<i id='cb' loc='worn,player' name=\"a,canvas,sack\" weight='8' in_max='1000'/>" \
+        "</inventoryManager>"
+      )
+      expect(game_obj.container_refresh_open?('ca')).to be(true)
+      expect(game_obj.containers).to have_key('ca')
+    end
+
     it 'preserves a descendant hidden behind an ancestor that turned opaque' do
       # A(pk) -> B(pouch) -> gem, all visible.
       described_class.observe(

--- a/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
@@ -841,6 +841,30 @@ RSpec.describe Lich::DragonRealms::DRParser do
         expect(ids(GameObj.containers['10'])).to contain_exactly('11')
       end
 
+      # Regression: in production Game.process_xml_data runs XMLParser BEFORE
+      # DRParser, so the interrupting <prompt> first fires
+      # GameObj.commit_all_containers (the ordinary per-container publish) and
+      # only afterwards does DRParser discard the refresh. commit_all_containers
+      # must refuse to publish while a full refresh is open, or it commits the
+      # partial listing before the discard can run -- corrupting the model while
+      # still warning that the previous inventory was kept.
+      it 'does not commit a partial full refresh when XMLParser commits at the prompt first' do
+        described_class.parse('You take a moment and rummage about your person, taking stock of your possessions...')
+        # Listing streams the cloak with a DIFFERENT child (#12) than published (#11).
+        described_class.parse("  <d cmd='remove #10'>a cloak</d>")
+        described_class.parse("     -<d cmd='get #12 in #10'>a coin</d>")
+
+        expect(Lich::Messaging).to receive(:msg).with('warn', /inv list.*did not finish/i)
+        # Production order at the prompt: XMLParser publishes containers first...
+        GameObj.commit_all_containers
+        # ...then DRParser sees the interrupted scrape and discards it.
+        described_class.parse('<prompt time="123">&gt;</prompt>')
+
+        # The premature commit must NOT have replaced #11 with #12.
+        expect(ids(GameObj.containers['10'])).to contain_exactly('11')
+        expect(ids(GameObj.inv)).to contain_exactly('10')
+      end
+
       it 'does not resurrect an item picked into a hand mid-listing when the staged list commits' do
         described_class.parse('You take a moment and rummage about your person, taking stock of your possessions...')
         # The listing streams the gem (#11) as still inside the cloak...

--- a/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
@@ -724,9 +724,13 @@ RSpec.describe Lich::DragonRealms::DRParser do
     describe 'when the INV LIST (complete) header matches' do
       let(:inv_list_line) { 'You take a moment and rummage about your person, taking stock of your possessions...' }
 
-      it 'clears inv and containers, enters parsing, and is NOT partial' do
-        expect(GameObj).to receive(:clear_inv)
-        expect(GameObj).to receive(:clear_all_containers)
+      it 'opens a staged full refresh (NOT a destructive clear), enters parsing, and is NOT partial' do
+        # The full replacement is now staged so the live model stays visible until
+        # a clean terminator commits it -- the header must not wipe anything.
+        expect(GameObj).not_to receive(:clear_inv)
+        expect(GameObj).not_to receive(:clear_all_containers)
+        expect(GameObj).to receive(:begin_inv)
+        expect(GameObj).to receive(:begin_all_containers)
 
         described_class.parse(inv_list_line)
 
@@ -778,6 +782,76 @@ RSpec.describe Lich::DragonRealms::DRParser do
         # A stray get-link afterward must NOT be upserted into the live model.
         expect(GameObj).not_to receive(:upsert_inv)
         described_class.parse("<d cmd='get #999'>a random link</d>")
+      end
+    end
+
+    # Non-mocked, drives the REAL GameObj end-to-end to prove the COMPLETE INV
+    # LIST path is atomic: the previous model stays visible until a clean
+    # terminator commits the staged replacement, and an interrupted listing
+    # keeps the old model instead of leaving it half-updated.
+    describe 'atomic full INV LIST refresh (real GameObj)' do
+      before do
+        GameObj.class_variable_set(:@@inv, [])
+        GameObj.class_variable_set(:@@contents, {})
+        GameObj.class_variable_set(:@@staging_inv, nil)
+        GameObj.class_variable_set(:@@staging_contents, {})
+        GameObj.class_variable_set(:@@staging_all_containers, false)
+        GameObj.class_variable_set(:@@index, {})
+        described_class.class_variable_set(:@@parsing_inventory_get, false)
+        described_class.class_variable_set(:@@inventory_partial, false)
+        allow(Lich::Messaging).to receive(:msg)
+
+        # Seed a known model: a worn cloak (#10) holding a gem (#11).
+        GameObj.new_inv('10', nil, 'cloak', nil, 'remove #10')
+        GameObj.new_inv('11', nil, 'gem', '10', 'get #11 in #10')
+      end
+
+      def ids(list) = Array(list).map(&:id)
+
+      it 'leaves the previous model visible while the listing streams (no up-front wipe)' do
+        described_class.parse('You take a moment and rummage about your person, taking stock of your possessions...')
+        described_class.parse("  <d cmd='remove #20'>a backpack</d>")
+
+        # Nothing committed yet: the old cloak+gem are still the published model.
+        expect(ids(GameObj.inv)).to contain_exactly('10')
+        expect(GameObj.containers).to have_key('10')
+        expect(ids(GameObj.containers['10'])).to contain_exactly('11')
+      end
+
+      it 'atomically replaces the model on the clean terminator, dropping absent containers' do
+        described_class.parse('You take a moment and rummage about your person, taking stock of your possessions...')
+        described_class.parse("  <d cmd='remove #20'>a backpack</d>")
+        described_class.parse('<output class=""/>')
+
+        expect(ids(GameObj.inv)).to contain_exactly('20')
+        # The cloak was not in the new listing, so its container entry is dropped.
+        expect(GameObj.containers).not_to have_key('10')
+      end
+
+      it 'keeps the previous model and warns when the listing is interrupted by a prompt' do
+        described_class.parse('You take a moment and rummage about your person, taking stock of your possessions...')
+        described_class.parse("  <d cmd='remove #20'>a backpack</d>")
+
+        expect(Lich::Messaging).to receive(:msg).with('warn', /inv list.*did not finish/i)
+        # Interrupted: a prompt arrives with no closing <output class=""/>.
+        described_class.parse('<prompt time="123">&gt;</prompt>')
+
+        # Old model intact; the half-streamed backpack was discarded.
+        expect(ids(GameObj.inv)).to contain_exactly('10')
+        expect(ids(GameObj.containers['10'])).to contain_exactly('11')
+      end
+
+      it 'does not resurrect an item picked into a hand mid-listing when the staged list commits' do
+        described_class.parse('You take a moment and rummage about your person, taking stock of your possessions...')
+        # The listing streams the gem (#11) as still inside the cloak...
+        described_class.parse("  <d cmd='remove #10'>a cloak</d>")
+        described_class.parse("     -<d cmd='get #11 in #10'>a gem</d>")
+        # ...but it is then picked into a hand before the list commits.
+        GameObj.remove_inv_item('11')
+        described_class.parse('<output class=""/>')
+
+        # The commit must not re-add the picked-up gem to the cloak.
+        expect(ids(GameObj.containers['10'] || [])).not_to include('11')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,6 +119,7 @@ RSpec.configure do |config|
         g.class_variable_set(cv, nil) if g.class_variable_defined?(cv)
       end
       g.class_variable_set(:@@staging_contents, {}) if g.class_variable_defined?(:@@staging_contents)
+      g.class_variable_set(:@@staging_all_contents, {}) if g.class_variable_defined?(:@@staging_all_contents)
       # Full-container INV LIST refresh flag: reset so a refresh opened (and not
       # committed/discarded) by one example never leaks into the next, where it
       # would silently route new_inv into staging instead of the live registry.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,6 +119,10 @@ RSpec.configure do |config|
         g.class_variable_set(cv, nil) if g.class_variable_defined?(cv)
       end
       g.class_variable_set(:@@staging_contents, {}) if g.class_variable_defined?(:@@staging_contents)
+      # Full-container INV LIST refresh flag: reset so a refresh opened (and not
+      # committed/discarded) by one example never leaks into the next, where it
+      # would silently route new_inv into staging instead of the live registry.
+      g.class_variable_set(:@@staging_all_containers, false) if g.class_variable_defined?(:@@staging_all_containers)
     end
 
     # DR mocks from spec_helper - these have reset! defined in the mock (not production)


### PR DESCRIPTION
**Part 05 of 05 — DR inventory-model series. Depends on #1557** (stack order: #1555 → #1554 → #1556 → #1557 → this). Review/merge the stack first; this PR builds on #1554's `INV LIST` path and #1556's staging mechanism, so its diff will only be minimal once the stack has merged.

Two related robustness fixes surfaced by an adversarial audit of the series, both in the shared `GameObj` inventory model.

## 1. Atomic `INV LIST` refresh + interruption notice

The COMPLETE `INV LIST` path added in the series cleared `GameObj.inv` and every container **up front**, then repopulated. An interrupted or truncated listing — a `<prompt>` arriving before the closing `<output class=""/>`, the exact case the existing safety valve at the prompt was added for — left the model wiped and only half-filled, **silently**, until the next successful scrape. Nothing here is persisted, so this is a torn/partial read of the in-memory model rather than true data loss — but a consumer reading `GameObj` between the interruption and the next refresh sees an incomplete inventory with no signal that the listing didn't finish.

Route `INV LIST` through the staged-refresh mechanism `GameObj` already provides (the same "leave the published snapshot in place until a clean commit" pattern documented on `begin_*`/`commit_*`), instead of clear-then-fill:

- **`GameObj.begin_all_containers` / `commit_all_containers_full`** — a full-replacement container refresh. While open, `new_inv` stages every container placement instead of touching live `@@contents`; commit swaps the whole hash in one reference assignment, so containers absent from the listing are dropped (matching the old clear-then-fill semantics), and an interrupted listing that never commits leaves the previous model intact.
- **`GameObj.discard_inv_refresh`** — drops only the inventory staging buffers (worn + full container) without aborting an unrelated in-flight room/familiar refresh.
- **`remove_inv_item`** now also scrubs the staging buffers, so an item picked into a hand mid-listing is not resurrected in its old container when the staged list commits.
- **drparser** — begin staging on the `INV LIST` header, commit on the clean `<output class=""/>` terminator, and on an interrupted `<prompt>` discard staging (keeping the previous model) and emit a `Lich::Messaging` warn: `"DRParser: 'inv list' did not finish; keeping previous inventory. Re-run 'inv list' to refresh."`

## 2. `GameObj.containers` dup-on-read

`GameObj.containers` duplicated only the outer hash, handing callers the **live inner arrays**. That was safe pre-stack — container arrays were only ever replaced wholesale, never mutated in place — but not once this series began mutating them in place: `remove_inv_item`'s `reject!` (hand pickup / upsert) and `new_inv`'s `push`. A script iterating `GameObj.containers[id]` across a hand pickup would have its array shifted under it and **silently skip an item**.

Fixed by returning duplicated inner arrays (`transform_values(&:dup)`), matching the dup-on-read contract every other registry accessor and instance `#contents` already honor. The `GameObj` elements are shared, not copied. The two in-tree callers (`stash.rb`, `readylist.rb`) are one-shot per-command reads with no write-through dependency, so cost and behavior are unaffected.

## GemStone safety

Byte-for-byte unaffected. The full-refresh mode is only ever entered from the DR `INV LIST` path, so `@@staging_all_containers` stays `false` for GS and `new_inv` behaves exactly as before; `remove_inv_item` is only reached from DR-gated paths. The `containers` accessor change is a read-side snapshot with no behavioral effect on any writer.

## Known limitation

An `XMLParser#reset` resync landing *mid*-`INV LIST` is a double-fault edge: `discard_staged_refreshes` now also clears the full-refresh flag, so subsequent item lines (before the next header) would route to the live model. This remains bounded by the existing prompt safety valve and is no worse than the prior clear-then-fill behavior; not staged around here.

## Testing

- Updated the one test asserting the old `clear_*` behavior; added 4 real-`GameObj` INV LIST scenario tests (model stays visible mid-stream; atomic replace + absent-container drop on a clean finish; previous model kept + warn emitted on interruption; picked-up item not resurrected on commit).
- Added a `GameObj.containers` regression test that drives a real `reject!` mid-iteration and asserts no item is skipped (verified to fail on the old shallow dup).
- Full suite: **5772 examples, 0 failures**. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
