### PR TITLE
fix(dr): refresh before_name/after_name on a name-preserving container move

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -529,8 +529,9 @@ module Lich
       # based garbage collection.
       #
       # When a matching entry is found, +before_name+ and +after_name+ are
-      # backfilled if they were previously +nil+ and the incoming values are
-      # non-nil. Existing non-nil values are never overwritten.
+      # refreshed from a differing non-nil incoming value; a nil observation
+      # never clobbers a known value. (Hand slots pass no before/after, so in
+      # practice this path only ever backfills.)
       #
       # @example Replace a bare GameObj.new call
       #   # Before:
@@ -1368,8 +1369,8 @@ module Lich
         # and it is re-added to the cleared registry - no allocation required.
         #
         # When a duplicate is found, +before_name+ and +after_name+ are
-        # backfilled if they were previously +nil+ and the incoming values are
-        # non-nil. Existing non-nil values are never overwritten.
+        # refreshed from a differing non-nil observation; a nil observation
+        # never clobbers a known value.
         #
         # @param registry [Array<GameObj>]  the target registry array
         # @param id       [Integer, String]

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -542,8 +542,8 @@ module Lich
       # @param id     [Integer, String]
       # @param noun   [String, nil]
       # @param name   [String, nil]
-      # @param before [String, nil]   backfills +before_name+ if previously unset
-      # @param after  [String, nil]   backfills +after_name+ if previously unset
+      # @param before [String, nil]   sets +before_name+ from a differing non-nil observation
+      # @param after  [String, nil]   sets +after_name+ from a differing non-nil observation
       # @return [GameObj]
       # @api private Internal identity-index plumbing. No compatibility guarantee.
       def self.index_or_create(id, noun, name, before = nil, after = nil)
@@ -555,8 +555,13 @@ module Lich
           if (entry = @@index[key])
             existing, _ts        = entry
             @@index[key]         = [existing, now]
-            existing.before_name = before if existing.before_name.nil? && !before.nil?
-            existing.after_name  = after  if existing.after_name.nil?  && !after.nil?
+            # Refresh command metadata whenever a differing non-nil observation
+            # arrives -- e.g. a name-preserving move updates +before_name+ from
+            # "get #id in #old" to "get #id in #new". A nil observation never
+            # clobbers a known value (a sighting from a source that carries no
+            # command, such as the hand slot, must not blank it).
+            existing.before_name = before if !before.nil? && existing.before_name != before
+            existing.after_name  = after  if !after.nil?  && existing.after_name  != after
             existing
           else
             new_obj      = GameObj.new(id, noun, name, before, after)
@@ -1370,8 +1375,8 @@ module Lich
         # @param id       [Integer, String]
         # @param noun     [String, nil]
         # @param name     [String, nil]
-        # @param before   [String, nil]   backfills +before_name+ if previously unset
-        # @param after    [String, nil]   backfills +after_name+ if previously unset
+        # @param before   [String, nil]   sets +before_name+ from a differing non-nil observation
+        # @param after    [String, nil]   sets +after_name+ from a differing non-nil observation
         # @return [GameObj]
         def find_or_create(registry, id, noun, name, before = nil, after = nil)
           str_id = id.is_a?(Integer) ? id.to_s : id
@@ -1382,8 +1387,13 @@ module Lich
             if (entry = @@index[key])
               existing, _ts        = entry
               @@index[key]         = [existing, now] # refresh last-seen timestamp
-              existing.before_name = before if existing.before_name.nil? && !before.nil?
-              existing.after_name  = after  if existing.after_name.nil?  && !after.nil?
+              # Refresh command metadata whenever a differing non-nil observation
+              # arrives -- e.g. a name-preserving move updates +before_name+ from
+              # "get #id in #old" to "get #id in #new". A nil observation never
+              # clobbers a known value (a sighting from a source that carries no
+              # command must not blank it).
+              existing.before_name = before if !before.nil? && existing.before_name != before
+              existing.after_name  = after  if !after.nil?  && existing.after_name  != after
               registry.push(existing) unless registry.include?(existing)
               existing
             else

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -139,6 +139,24 @@ module Lich
       # model. See {.begin_all_containers}.
       @@staging_all_containers = false
 
+      # Deferred +before_name+/+after_name+ refreshes for objects observed while a
+      # staged registry refresh is open. +find_or_create+ returns the shared,
+      # still-published instance, so mutating its metadata mid-refresh would leak
+      # an uncommitted value to readers and could not be rolled back if the refresh
+      # is discarded. Instead the change is recorded here and applied by the
+      # matching +commit_*+ (see {.apply_pending_metadata}), or dropped by every
+      # discard path (+abort_*+, {.delete_container}, {.clear_all_containers}, an
+      # +begin_inv+/+begin_container+ restart, {.discard_inv_refresh}, and
+      # {.discard_staged_refreshes}).
+      #
+      # Scoped PER staging buffer: the outer hash is keyed by the buffer Array's
+      # identity (+compare_by_identity+ -- two empty Arrays are +==+, so content
+      # keying would collide), the inner by GameObj identity. Buffer scoping is
+      # what keeps two concurrently-open refreshes of the same object from
+      # overwriting each other's pending values and lets a discard drop exactly
+      # its own buffer's entries and no others.
+      @@pending_metadata = {}.compare_by_identity
+
       # ---------------------------------------------------------------------------
       # Instance interface
       # ---------------------------------------------------------------------------
@@ -368,24 +386,31 @@ module Lich
       # @param after     [String, nil]
       # @return [GameObj]
       def self.new_inv(id, noun, name, container = nil, before = nil, after = nil)
+        # A write is "staged" when it targets an open staging buffer rather than
+        # the live registry. Metadata refreshes are then deferred into that same
+        # buffer so an uncommitted (or later discarded) value is never published
+        # on the shared instance -- see +@@pending_metadata+.
         if container
-          target = if @@staging_contents.key?(container)
-                     # An explicit per-container refresh (+begin_container+, e.g. a
-                     # +clearContainer+ fill) already owns this container -- stage
-                     # into it even during a full INV LIST refresh so the two paths
-                     # never share a buffer.
-                     @@staging_contents[container]
-                   elsif @@staging_all_containers
-                     # Full INV LIST refresh: stage every other container into the
-                     # dedicated buffer so nothing touches the live model until the
-                     # listing commits cleanly.
-                     @@staging_all_contents[container] ||= []
-                   else
-                     @@contents[container] ||= []
-                   end
-          find_or_create(target, id, noun, name, before, after)
+          staged =
+            if @@staging_contents.key?(container)
+              # An explicit per-container refresh (+begin_container+, e.g. a
+              # +clearContainer+ fill) already owns this container -- stage into
+              # it even during a full INV LIST refresh so the two paths never
+              # share a buffer.
+              @@staging_contents[container]
+            elsif @@staging_all_containers
+              # Full INV LIST refresh: stage every other container into the
+              # dedicated buffer so nothing touches the live model until the
+              # listing commits cleanly.
+              @@staging_all_contents[container] ||= []
+            end
+          # +staged+ is the target staging buffer (either kind) or nil for a live
+          # write; either way it is both the placement target and the deferral
+          # scope, so an uncommitted metadata change lands in that same buffer.
+          target = staged || (@@contents[container] ||= [])
+          find_or_create(target, id, noun, name, before, after, defer_to: staged)
         else
-          find_or_create(@@staging_inv || @@inv, id, noun, name, before, after)
+          find_or_create(@@staging_inv || @@inv, id, noun, name, before, after, defer_to: @@staging_inv)
         end
       end
 
@@ -710,6 +735,8 @@ module Lich
       #
       # @return [void]
       def self.clear_all_containers
+        @@staging_contents.each_value { |staged| drop_pending_metadata(staged) }
+        @@staging_all_contents.each_value { |staged| drop_pending_metadata(staged) }
         @@staging_contents.clear
         @@staging_all_contents.clear
         @@staging_all_containers = false
@@ -733,7 +760,8 @@ module Lich
       # @param container_id [String]
       # @return [GameObj, nil]
       def self.delete_container(container_id)
-        @@staging_contents.delete(container_id)
+        staged = @@staging_contents.delete(container_id)
+        drop_pending_metadata(staged) if staged
         @@contents.delete(container_id)
       end
 
@@ -780,13 +808,50 @@ module Lich
       # staged part.
       # ---------------------------------------------------------------------------
 
+      # Applies the metadata deferred for one staging +buffer+ to its objects and
+      # clears that buffer's pending entries. Called by each +commit_*+ just before
+      # it publishes the buffer, so the new +before_name+/+after_name+ become
+      # visible together with the new membership rather than mid-refresh. No-op for
+      # a buffer that deferred nothing.
+      #
+      # @param buffer [Array, nil] the staging buffer being committed
+      # @return [void]
+      def self.apply_pending_metadata(buffer)
+        pending = @@pending_metadata.delete(buffer)
+        return unless pending
+
+        pending.each do |obj, (before, after)|
+          obj.before_name = before unless before.nil?
+          obj.after_name  = after  unless after.nil?
+        end
+      end
+
+      # Drops the metadata deferred for one staging +buffer+ without applying it --
+      # the abort counterpart to {.apply_pending_metadata}. Called by every path
+      # that discards a buffer so a rolled-back refresh cannot later publish its
+      # staged values. No-op for a buffer that deferred nothing.
+      #
+      # @param buffer [Array, nil] the staging buffer being discarded
+      # @return [void]
+      def self.drop_pending_metadata(buffer)
+        @@pending_metadata.delete(buffer)
+      end
+
+      # Opens a refresh of worn inventory. Restarting an already-open refresh (a
+      # second +begin_inv+ before commit) discards the prior buffer, so drop its
+      # deferred metadata too rather than orphan it (mirrors {.begin_container}).
+      #
       # @return [Array]
-      def self.begin_inv = @@staging_inv = []
+      def self.begin_inv
+        drop_pending_metadata(@@staging_inv)
+        @@staging_inv = []
+      end
 
       # @return [void]
       def self.commit_inv
         return if @@staging_inv.nil?
 
+        apply_pending_metadata(@@staging_inv)
         @@inv         = @@staging_inv
         @@staging_inv = nil
       end
@@ -798,7 +863,12 @@ module Lich
       # open. Symmetric with {.commit_inv}.
       #
       # @return [void]
-      def self.abort_inv = @@staging_inv = nil
+      def self.abort_inv
+        return if @@staging_inv.nil?
+
+        drop_pending_metadata(@@staging_inv)
+        @@staging_inv = nil
+      end
 
       # @return [Array]
       def self.begin_reserve = @@staging_reserve = []
@@ -885,11 +955,16 @@ module Lich
         @@staging_fam_pcs       = nil
       end
 
-      # Opens a refresh of a single container's contents.
+      # Opens a refresh of a single container's contents. Restarting an
+      # already-open refresh (a second +begin_container+ before commit) discards
+      # the prior buffer, so drop its deferred metadata too rather than orphan it.
       #
       # @param container_id [String]
       # @return [Array]
-      def self.begin_container(container_id) = @@staging_contents[container_id] = []
+      def self.begin_container(container_id)
+        drop_pending_metadata(@@staging_contents[container_id])
+        @@staging_contents[container_id] = []
+      end
 
       # @param container_id [String]
       # @return [void]
@@ -897,6 +972,7 @@ module Lich
         staged = @@staging_contents.delete(container_id)
         return if staged.nil?
 
+        apply_pending_metadata(staged)
         @@contents[container_id] = staged
       end
 
@@ -907,7 +983,10 @@ module Lich
       #
       # @param container_id [String]
       # @return [void]
-      def self.abort_container(container_id) = @@staging_contents.delete(container_id)
+      def self.abort_container(container_id)
+        staged = @@staging_contents.delete(container_id)
+        drop_pending_metadata(staged) if staged
+      end
 
       # Publishes every open container staging buffer. Called at the +prompt+
       # that terminates a command burst, the reliable close signal for the
@@ -926,7 +1005,10 @@ module Lich
         return if @@staging_all_containers
         return if @@staging_contents.empty?
 
-        @@staging_contents.each { |id, staged| @@contents[id] = staged }
+        @@staging_contents.each do |id, staged|
+          apply_pending_metadata(staged)
+          @@contents[id] = staged
+        end
         @@staging_contents.clear
       end
 
@@ -945,6 +1027,9 @@ module Lich
       #
       # @return [void]
       def self.begin_all_containers
+        # Restarting an already-open full refresh discards the prior buffers, so
+        # drop their deferred metadata rather than orphan it (mirrors begin_inv).
+        @@staging_all_contents.each_value { |buf| drop_pending_metadata(buf) }
         @@staging_all_contents = {}
         @@staging_all_containers = true
       end
@@ -957,6 +1042,7 @@ module Lich
       def self.commit_all_containers_full
         return unless @@staging_all_containers
 
+        @@staging_all_contents.each_value { |buf| apply_pending_metadata(buf) }
         @@contents = @@staging_all_contents
         @@staging_all_contents = {}
         @@staging_all_containers = false
@@ -971,6 +1057,8 @@ module Lich
       #
       # @return [void]
       def self.discard_inv_refresh
+        drop_pending_metadata(@@staging_inv)
+        @@staging_all_contents.each_value { |buf| drop_pending_metadata(buf) }
         @@staging_inv = nil
         @@staging_all_contents = {}
         @@staging_all_containers = false
@@ -1007,6 +1095,9 @@ module Lich
         @@staging_contents.clear
         @@staging_all_contents.clear
         @@staging_all_containers = false
+        # Every open buffer is being discarded, so no deferred metadata can still
+        # belong to a refresh that will commit; drop all of it.
+        @@pending_metadata.clear
       end
 
       # ---------------------------------------------------------------------------
@@ -1500,8 +1591,11 @@ module Lich
         # @param name     [String, nil]
         # @param before   [String, nil]   sets +before_name+ from a differing non-nil observation
         # @param after    [String, nil]   sets +after_name+ from a differing non-nil observation
+        # @param defer_to [Array, nil]    the open staging buffer this write targets, or +nil+ for a
+        #                                  live write; when set, the metadata refresh is deferred into
+        #                                  that buffer's +@@pending_metadata+ and applied at commit
         # @return [GameObj]
-        def find_or_create(registry, id, noun, name, before = nil, after = nil)
+        def find_or_create(registry, id, noun, name, before = nil, after = nil, defer_to: nil)
           str_id = id.is_a?(Integer) ? id.to_s : id
           key    = "#{str_id}|#{noun}|#{name}"
           now    = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -1515,8 +1609,23 @@ module Lich
               # "get #id in #old" to "get #id in #new". A nil observation never
               # clobbers a known value (a sighting from a source that carries no
               # command must not blank it).
-              existing.before_name = before if !before.nil? && existing.before_name != before
-              existing.after_name  = after  if !after.nil?  && existing.after_name  != after
+              #
+              # During a staged refresh the shared instance is still published, so
+              # the change is deferred into the buffer's pending map instead of
+              # mutated in place. Each field is merged independently against the
+              # effective pending value (seeded from the currently published one),
+              # so a before-only then after-only observation keeps both, and a
+              # value that returns to the published one supersedes an earlier
+              # intermediate. commit_* applies it; any discard drops it.
+              if defer_to
+                pending      = (@@pending_metadata[defer_to] ||= {}.compare_by_identity)
+                current      = (pending[existing] ||= [existing.before_name, existing.after_name])
+                current[0]   = before unless before.nil?
+                current[1]   = after  unless after.nil?
+              else
+                existing.before_name = before if !before.nil? && existing.before_name != before
+                existing.after_name  = after  if !after.nil?  && existing.after_name  != after
+              end
               registry.push(existing) unless registry.include?(existing)
               existing
             else

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -1253,6 +1253,171 @@ RSpec.describe Lich::Common::GameObj do
       end
     end
 
+    describe 'deferred metadata during a staged refresh' do
+      # find_or_create returns the shared, still-published instance, so a
+      # differing before_name/after_name observed mid-refresh must NOT mutate it
+      # until the refresh commits, must roll back if the refresh is discarded, and
+      # must stay scoped to its own staging buffer.
+
+      it 'does not publish a changed after_name until the container refresh commits' do
+        described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+
+        described_class.begin_container('20')
+        described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(new detail)')
+
+        expect(described_class.containers['20'].first.after_name).to eq('(old detail)')
+
+        described_class.commit_container('20')
+        expect(described_class.containers['20'].first.after_name).to eq('(new detail)')
+      end
+
+      it 'defers a worn-inv metadata change until commit_inv' do
+        described_class.new_inv('10', 'gem', 'ruby', nil, 'get #10')
+
+        described_class.begin_inv
+        described_class.new_inv('10', 'gem', 'ruby', nil, 'get #10 fast')
+        expect(described_class.inv.first.before_name).to eq('get #10')
+
+        described_class.commit_inv
+        expect(described_class.inv.first.before_name).to eq('get #10 fast')
+      end
+
+      it 'still refreshes metadata immediately for a non-staged observation' do
+        described_class.new_inv('30', 'gem', 'opal', '40', nil, '(det A)')
+        described_class.new_inv('30', 'gem', 'opal', '40', nil, '(det B)')
+
+        expect(described_class.containers['40'].first.after_name).to eq('(det B)')
+      end
+
+      %i[abort_container discard_staged_refreshes clear_all_containers].each do |discard|
+        it "leaves the published metadata intact when the refresh ends via #{discard}" do
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+
+          described_class.begin_container('20')
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(new detail)')
+          discard == :abort_container ? described_class.abort_container('20') : described_class.public_send(discard)
+
+          # ...and a later unrelated committing refresh of the same instance must
+          # not resurrect the discarded value (the pending entry is dropped, not
+          # merely detached from its buffer).
+          described_class.begin_inv
+          described_class.new_inv('10', 'gem', 'ruby', nil, nil, nil)
+          described_class.commit_inv
+
+          obj = described_class['10']
+          expect(obj.after_name).to eq('(old detail)')
+        end
+      end
+
+      it 'drops the prior buffer\'s deferral when a container refresh is restarted' do
+        # The restart replaces container 20's contents (obj 10 is not re-observed),
+        # so hold the instance directly -- it is no longer in any registry.
+        obj = described_class.new_inv('10', 'gem', 'ruby', '20', 'get #10 in #20')
+
+        described_class.begin_container('20')
+        described_class.new_inv('10', 'gem', 'ruby', '20', 'get #10 in #30') # deferred
+        described_class.begin_container('20')                                # restart drops it
+        described_class.new_inv('99', 'gem', 'other', '20', nil)
+        described_class.commit_container('20')
+
+        expect(obj.before_name).to eq('get #10 in #20')
+      end
+
+      it 'drops the prior buffer\'s deferral when a worn-inv refresh is restarted' do
+        obj = described_class.new_inv('10', 'gem', 'ruby', nil, 'get #10')
+
+        described_class.begin_inv
+        described_class.new_inv('10', 'gem', 'ruby', nil, 'get #10 fast') # deferred
+        described_class.begin_inv                                         # restart drops it
+        described_class.new_inv('10', 'gem', 'ruby', nil, nil)
+        described_class.commit_inv
+
+        expect(obj.before_name).to eq('get #10')
+        # the orphaned entry must not linger (no unbounded @@pending_metadata growth)
+        expect(described_class.class_variable_get(:@@pending_metadata)).to be_empty
+      end
+
+      it 'keeps each open container\'s deferral scoped to its own buffer' do
+        described_class.new_inv('10', 'gem', 'ruby', '20', 'get #10 in #20')
+
+        described_class.begin_container('20')
+        described_class.begin_container('30')
+        described_class.new_inv('10', 'gem', 'ruby', '20', 'get #10 in #20b')
+        described_class.new_inv('10', 'gem', 'ruby', '30', 'get #10 in #30')
+
+        described_class.commit_container('20')
+        expect(described_class.containers['20'].first.before_name).to eq('get #10 in #20b')
+
+        described_class.commit_container('30')
+        expect(described_class.containers['30'].first.before_name).to eq('get #10 in #30')
+      end
+
+      it 'merges before and after fields independently within one refresh' do
+        described_class.new_inv('10', 'gem', 'ruby', '20', 'old ruby', '(old tail)')
+
+        described_class.begin_container('20')
+        described_class.new_inv('10', 'gem', 'ruby', '20', 'new ruby', nil) # before only
+        described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(new tail)') # after only
+        described_class.commit_container('20')
+
+        obj = described_class.containers['20'].first
+        expect(obj.before_name).to eq('new ruby')
+        expect(obj.after_name).to eq('(new tail)')
+      end
+
+      it 'lets an observation that returns to the published value supersede an intermediate one' do
+        described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+
+        described_class.begin_container('20')
+        described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(intermediate detail)')
+        described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+        described_class.commit_container('20')
+
+        expect(described_class.containers['20'].first.after_name).to eq('(old detail)')
+      end
+
+      context 'during a full INV LIST refresh (begin_all_containers)' do
+        it 'defers metadata until commit_all_containers_full' do
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+
+          described_class.begin_inv
+          described_class.begin_all_containers
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(new detail)')
+
+          expect(described_class.containers['20'].first.after_name).to eq('(old detail)')
+
+          described_class.commit_all_containers_full
+          described_class.commit_inv
+          expect(described_class.containers['20'].first.after_name).to eq('(new detail)')
+        end
+
+        it 'rolls the metadata back when the listing is discarded via discard_inv_refresh' do
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+
+          described_class.begin_inv
+          described_class.begin_all_containers
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(new detail)')
+          described_class.discard_inv_refresh
+
+          expect(described_class.containers['20'].first.after_name).to eq('(old detail)')
+          expect(described_class.class_variable_get(:@@pending_metadata)).to be_empty
+        end
+
+        it 'drops the prior buffers\' deferral when the listing is restarted' do
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+
+          described_class.begin_all_containers
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(new detail)') # deferred
+          described_class.begin_all_containers                                    # restart drops it
+          described_class.new_inv('10', 'gem', 'ruby', '20', nil, '(old detail)')
+          described_class.commit_all_containers_full
+
+          expect(described_class.containers['20'].first.after_name).to eq('(old detail)')
+          expect(described_class.class_variable_get(:@@pending_metadata)).to be_empty
+        end
+      end
+    end
+
     describe 'prune safety during a refresh' do
       it 'never prunes an object held only in an open staging buffer' do
         described_class.begin_room_objs

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -113,6 +113,23 @@ RSpec.describe Lich::Common::GameObj do
 
         expect(obj.after_name).to eq('after text')
       end
+
+      it 'refreshes before_name on a name-preserving move to a new container' do
+        # Same id/noun/name -> same identity-index entry, so the instance is
+        # reused. A move must update its command metadata, not keep the stale one.
+        first  = described_class.new_inv('10', 'gem', 'ruby', '20', 'get #10 in #20')
+        second = described_class.new_inv('10', 'gem', 'ruby', '30', 'get #10 in #30')
+
+        expect(second).to equal(first) # reused instance
+        expect(second.before_name).to eq('get #10 in #30')
+      end
+
+      it 'does not let a nil observation blank a known before_name' do
+        obj = described_class.new_inv('11', 'gem', 'opal', '20', 'get #11 in #20')
+        described_class.new_inv('11', 'gem', 'opal', '20', nil) # e.g. a source with no command
+
+        expect(obj.before_name).to eq('get #11 in #20')
+      end
     end
 
     context 'with integer id' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,6 +124,8 @@ RSpec.configure do |config|
       # committed/discarded) by one example never leaks into the next, where it
       # would silently route new_inv into staging instead of the live registry.
       g.class_variable_set(:@@staging_all_containers, false) if g.class_variable_defined?(:@@staging_all_containers)
+      # Identity-keyed like the production initializer; a plain {} would break buffer scoping.
+      g.class_variable_set(:@@pending_metadata, {}.compare_by_identity) if g.class_variable_defined?(:@@pending_metadata)
     end
 
     # DR mocks from spec_helper - these have reset! defined in the mock (not production)


### PR DESCRIPTION
## What

`find_or_create` / `index_or_create` only backfilled `before_name`/`after_name` when the stored value was `nil`. After a **name-preserving container move** (same `id|noun|name`, e.g. `#10` from `#20` to `#30`) the identity index reused the instance but kept its **stale** `before_name`. A consumer building a GET from `before_name` would target the item's old container; the fields also compose `full_name`, which feeds `type`/`sellable` classification.

## How

Refresh `before_name`/`after_name` whenever a **differing non-nil** observation arrives; a `nil` observation never blanks a known value. Both `find_or_create` and `index_or_create` are updated, and their stale doc summaries corrected.

Because `find_or_create` returns the shared, still-published instance, refreshing it **during an open staged refresh** (a `clearContainer`/container fill, `begin_inv`, or a full `INV LIST` refresh) would publish an uncommitted value and could not be rolled back on discard. So a staged refresh **defers** the metadata change into `@@pending_metadata` and applies it at the matching `commit_*`; non-staged observations still refresh immediately.

The pending map is scoped **per staging buffer** (outer hash keyed by the buffer Array's identity via `compare_by_identity`, inner by GameObj identity), which is what makes it correct:

- two concurrently-open refreshes of the same object can't clobber each other's pending values; a commit publishes only its own buffer's changes;
- `before`/`after` merge **independently** (a before-only then after-only observation keeps both), seeded from the published value so an observation returning to the published value supersedes an earlier intermediate one;
- **every** discard path drops exactly its buffer's entries — `abort_inv`, `abort_container`, `delete_container`, `clear_all_containers`, a `begin_inv` / `begin_container` / `begin_all_containers` restart, `discard_inv_refresh`, and `discard_staged_refreshes` — so a rolled-back refresh can't leak onto the shared instance and the map never grows unbounded.

The deferral integrates with the full `INV LIST` staging path (`begin_all_containers` / `commit_all_containers_full` / `discard_inv_refresh`) added by #1563.

## Scope / history

The nil-only backfill dates to #1234 and reproduces on `main`; independent of the DR inventory-model series. An earlier revision of this PR shipped the deferral with correctness gaps (cross-buffer leakage, whole-pair overwrite, missed discard paths); a follow-up review then showed that simply removing it reintroduced the premature-publication/rollback regression vs. `main`. This revision keeps the deferral but makes it correct and buffer-scoped, and closes the gaps.

## Testing

New regression specs cover: staged isolation until commit; rollback on every discard path; per-buffer scoping; independent field merge; return-to-published superseding an intermediate; both `begin_inv`/`begin_container` restart leaks; and the full `INV LIST` path (defer → `commit_all_containers_full`, and `discard_inv_refresh`/restart rollback). Full suite green (7042 examples). Rubocop clean (pinned 1.86.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
