### PR TITLE
fix(dr): do not re-add a held item as worn inventory on inv scrape

### DIFF
--- a/lib/dragonrealms/drinfomon/drparser.rb
+++ b/lib/dragonrealms/drinfomon/drparser.rb
@@ -239,6 +239,16 @@ module Lich
               id = id_match[:itemID].strip.delete('#').to_s
               noun = nil # This isn't exposed in the DR XML stream
               name = item_name
+              # An item reported "... is in your right/left hand" is held, not worn
+              # or in a container: its placement is the hand slot, tracked
+              # separately by the <right>/<left> stream. Storing it here (cmd has no
+              # "in #container", so container=nil -> worn inv) would recreate the
+              # held/worn duplicate that hand reconciliation removes on pickup. Drop
+              # any stale placement and skip the worn/container store.
+              if stripped =~ /\bis in your (?:right|left) hand\b/i
+                GameObj.remove_inv_item(id)
+                return server_string
+              end
               # Only container1 (the item's immediate parent) is used -- it is the
               # single placement each line establishes. The regex still captures
               # container2 (the grandparent in a doubly-nested line) because it is

--- a/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
+++ b/spec/lib/dragonrealms/drinfomon/drparser_spec.rb
@@ -958,9 +958,24 @@ RSpec.describe Lich::DragonRealms::DRParser do
       described_class.populate_inventory_get("<d cmd='get #1 in #2'>a sack</d>")
     end
 
-    it 'parses an item line with trailing location prose' do
-      expect(GameObj).to receive(:new_inv).with('8761784', nil, 'seagull feather quill', nil, 'get #8761784', nil)
+    it 'parses an item line with trailing location prose after the </d> element' do
+      expect(GameObj).to receive(:new_inv).with('8286821', nil, 'papyrus parchment', '8286816', 'get #8286821 in #8286816', nil)
+      described_class.populate_inventory_get("<d cmd='get #8286821 in #8286816'>a papyrus parchment</d> is in a black winter cloak.")
+    end
+
+    it 'does NOT store a held item ("... is in your right hand") as worn inventory' do
+      # The item is in a hand, tracked by the <right> stream -- storing it here
+      # (cmd has no container -> worn inv) would recreate the held/worn duplicate.
+      expect(GameObj).not_to receive(:new_inv)
+      expect(GameObj).not_to receive(:upsert_inv)
+      expect(GameObj).to receive(:remove_inv_item).with('8761784')
       described_class.populate_inventory_get("<d cmd='get #8761784'>a seagull feather quill</d> is in your right hand.")
+    end
+
+    it 'also skips the worn store for a left-hand item' do
+      expect(GameObj).not_to receive(:new_inv)
+      expect(GameObj).to receive(:remove_inv_item).with('8761784')
+      described_class.populate_inventory_get("<d cmd='get #8761784'>a seagull feather quill</d> is in your left hand.")
     end
 
     it 'parses an inv list worn item linked with a remove command into inv' do


### PR DESCRIPTION
**Depends on #1557 → #1563** (branched off the inventory-model series head; the INV scrape/parse path this touches was reworked by that stack). Merge the stack first.

## What

An `INV SEARCH` / `INV LIST` line for an item in a hand looks like:

```
<d cmd='get #8761784'>a seagull feather quill</d> is in your right hand.
```

The parser only reads the `<d>` element's `cmd`, which for a held item is just `get #8761784` — no `in #container`. So it routed the item to **worn inventory** (`container = nil` → `GameObj.inv`), with no awareness of the "is in your right hand" tail. That recreates the **held/worn duplicate** that #1557's `<right>`/`<left>` reconciliation removes on pickup: pick up an item, then `inv search` for it, and the model shows it as simultaneously in-hand *and* worn.

## How

Detect the `"... is in your right/left hand"` trailing prose — still present on the full line after the `</d>` element — and skip the worn/container store, dropping any stale placement via `remove_inv_item`. The item's real placement is the hand slot, tracked separately by the `<right>`/`<left>` stream.

## Scope / attribution

Pre-existing behavior of the INV scrape (reproduces both before and after the inventory-model series) — the reverse direction of #1557's pickup reconciliation. DR-only path; GemStone's inventory stream is untouched.

## Testing

Repurposed the old "trailing location prose" test (which had codified the buggy hand behavior) to a realistic nested-container line, and added tests asserting a held item is **not** stored as worn for both right and left hand (verified to fail on the old code). Full DR parser suite green; rubocop clean (pinned 1.86.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)