### PR TITLE
fix(dr): evict orphaned identity-index entries on a name-changing upsert

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -395,7 +395,23 @@ module Lich
       def self.upsert_inv(id, noun, name, container = nil, before = nil, after = nil)
         str_id = id.is_a?(Integer) ? id.to_s : id
         remove_inv_item(str_id)
-        new_inv(str_id, noun, name, container, before, after)
+        obj = new_inv(str_id, noun, name, container, before, after)
+
+        # A name change keys a NEW index entry ("id|noun|newname"); the prior
+        # "id|noun|oldname" instance was just pulled from every registry by
+        # remove_inv_item, but its index key lingers until the TTL prune. On the
+        # cold scrape path, evict any index entry for this id whose instance is no
+        # longer live so a frequently-renamed item (e.g. a pouch toggling
+        # "(closed)") can't accumulate orphaned variants between sweeps. Guarded by
+        # object identity via +live_registry_objects+ (computed outside the lock,
+        # matching +sweep_stale!+) so a variant still held anywhere -- the instance
+        # just re-added, or a hand slot -- is kept.
+        live = live_registry_objects
+        @@index_mutex.synchronize do
+          @@index.delete_if { |_key, (indexed, _ts)| indexed.id == str_id && !live.include?(indexed) }
+        end
+
+        obj
       end
 
       # Removes every placement of +id+ from the worn inventory (+@@inv+) and

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -169,6 +169,32 @@ RSpec.describe Lich::Common::GameObj do
       expect(list.first.name).to eq('soft gem pouch (closed)')
     end
 
+    it 'evicts the orphaned index entry for the old name immediately (no wait for TTL prune)' do
+      index = described_class.class_variable_get(:@@index)
+      described_class.new_inv('123', nil, 'soft gem pouch', 'container1')
+      expect(index).to have_key('123||soft gem pouch') # noun is nil -> empty segment
+
+      described_class.upsert_inv('123', nil, 'soft gem pouch (closed)', 'container1')
+
+      # The renamed entry is live; the old-name entry is a dead orphan and must be
+      # gone right away rather than lingering until the next prune sweep.
+      expect(index).to have_key('123||soft gem pouch (closed)')
+      expect(index).not_to have_key('123||soft gem pouch')
+    end
+
+    it 'keeps a same-id variant that is still live in another registry' do
+      index = described_class.class_variable_get(:@@index)
+      described_class.new_right_hand('123', 'pouch', 'a soft gem pouch') # live in a hand
+      described_class.new_inv('123', 'pouch', 'a soft gem pouch', 'container1')
+
+      described_class.upsert_inv('123', 'pouch', 'a soft gem pouch (closed)', 'container1')
+
+      # The hand variant shares the id but is a distinct, still-held instance;
+      # eviction is by object identity, so it must survive.
+      expect(index).to have_key('123|pouch|a soft gem pouch') # held in the hand
+      expect(index).to have_key('123|pouch|a soft gem pouch (closed)')
+    end
+
     it 'relocates a contained item to worn inv when container is nil' do
       described_class.new_inv('123', 'gem', 'ruby', 'container1')
 


### PR DESCRIPTION
**Depends on #1557 → #1563** (branched off the inventory-model series head; `upsert_inv`/`remove_inv_item` are introduced by that stack). Merge the stack first.

## What

A name-changing `upsert_inv` (the review's own example: `"soft gem pouch"` → `"soft gem pouch (closed)"`) keys a **new** `id|noun|newname` entry in the shared identity index. The prior `id|noun|oldname` instance was just pulled from every registry by `remove_inv_item`, but `remove_inv_item` deliberately leaves `@@index` alone — so the old key lingers, unreachable from any live registry, until the 15-minute TTL prune (`prune_index!`) sweeps it. Under heavy `INV SEARCH` of frequently-renamed items the index accumulates dead orphans between sweeps.

## How

On the **cold** scrape path (`upsert_inv`), evict any index entry for the id whose instance is no longer live, right after the re-add:

```ruby
live = live_registry_objects
@@index_mutex.synchronize do
  @@index.delete_if { |_key, (indexed, _ts)| indexed.id == str_id && !live.include?(indexed) }
end
```

Guarded by **object identity** via `live_registry_objects` (computed outside the lock, matching `sweep_stale!`), so a same-id variant still held anywhere — the just-re-added instance, or a hand slot — survives.

The **hot** hand-pickup path (`remove_inv_item`, called on every DR `<right>`/`<left>` update) is deliberately left untouched to avoid an O(index) scan on every hand event; the TTL prune remains the backstop there. This targets exactly the review's scenario (name-changing INV SEARCH re-observe).

## Scope / attribution

Pre-existing index-lifecycle characteristic (how the index already treats any object leaving a registry), flagged in review as non-blocking — this makes the common scrape case self-clean immediately rather than waiting for the sweep. Not a regression introduced by the stack.

## Testing

Regression tests: the old-name entry is evicted immediately after a name-changing upsert (verified to fail on the old code, where it lingered), and a live same-id variant held in a hand slot is kept. Rubocop clean (pinned 1.86.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)