### PR TITLE
ci(dr): clear DRRoom mock through accessors to stop cross-process state leak (fixes #1567)

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -59,6 +59,10 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # The suite normally finishes in well under a minute; cap the job so a hung
+    # example (see the DRRoom cross-process state leak fixed in spec_helper) fails
+    # fast instead of occupying a runner up to GitHub's 6h default.
+    timeout-minutes: 15
     env:
       BUNDLE_WITHOUT: 'gtk:vscode:profanity'
     name: Run tests on Ruby

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1678,11 +1678,20 @@ class DRRoom
   class << self
     attr_accessor :npcs, :pcs, :group_members, :room_objs
 
+    # Clear through the accessors, not the mock's instance variables. When the
+    # production DRRoom (lib/dragonrealms/drinfomon/drroom.rb) is loaded in the
+    # same process it reopens DRRoom and redefines the accessors to read/write
+    # class variables (@@npcs, ...), while this mock's reset! kept assigning the
+    # class-level instance variables (@npcs, ...). The two no longer refer to the
+    # same storage, so reset! silently failed to clear production state and NPCs
+    # leaked between examples (a later cambrinth spec would spin in an endless
+    # retreat loop). Routing through the setters writes to whichever storage the
+    # live accessor uses; respond_to? guards attributes the mock lacks.
     def reset!
-      @npcs = []
-      @pcs = []
-      @group_members = []
-      @room_objs = []
+      %i[npcs pcs group_members room_objs pcs_prone pcs_sitting dead_npcs].each do |attribute|
+        setter = :"#{attribute}="
+        public_send(setter, []) if respond_to?(setter)
+      end
     end
   end
 end unless defined?(DRRoom)


### PR DESCRIPTION
Fixes #1567.

## Root cause

The intermittent CI hang was a **test-isolation bug**, not a code hang and not the socket/keychain paths my earlier issue triage suspected.

The `spec/spec_helper.rb` `DRRoom` mock's `reset!` assigned class-level **instance** variables:

```ruby
def reset!
  @npcs = []
  @pcs = []
  ...
end
```

But the production `DRRoom` (`lib/dragonrealms/drinfomon/drroom.rb`) is reopened onto the **same object** (spec_helper aliases `Lich::DragonRealms::DRRoom = DRRoom`, then a spec loads the production file) and redefines the accessors to use class **variables**:

```ruby
def self.npcs; @@npcs; end
def self.npcs=(val); @@npcs = val; end
```

Production defines **no** `reset!`, so the mock's `reset!` stays active but now writes to storage (`@npcs`) that the live accessors (`@@npcs`) no longer read. `reset!` silently stopped clearing room state → **NPCs leaked between examples**, and under an unlucky ordering a later cambrinth spec spun in an endless retreat loop. That is the 25–52 min "hang" before the run was cancelled. The password/STDIN lines were just the last output flushed before the buffered hang, which made them look responsible.

## Fix

- **`reset!` clears through the setters** (`public_send(:npcs=, [])`), so it writes to whichever storage the live accessor uses; `respond_to?` guards attributes the pure mock lacks. Also covers `pcs_prone`/`pcs_sitting`/`dead_npcs`.
- **`timeout-minutes: 15` on the rspec job** so any future hang fails fast instead of occupying a runner up to GitHub's 6h default.

## Verification

Reproduced with the exact mock → alias → production load order:

- Old `reset!`: `DRRoom.npcs` still `["Bob the wraith"]` after reset → **leak confirmed**.
- New `reset!`: `DRRoom.npcs == []` after reset → **cleared**.

Full suite green (7011 examples, 0 failures) across multiple seeds; rubocop clean; workflow YAML validated.

Credit for isolating the root cause (exact failed seed, cambrinth retreat loop) to @MahtraDR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)