### PR TITLE
feat(all): add HTTPS web-login fallback for when EAccess (7910) is unreachable

### DIFF
--- a/docs/eaccess-failure-diagnostics.md
+++ b/docs/eaccess-failure-diagnostics.md
@@ -1,0 +1,67 @@
+# EAccess Failure Diagnostics
+
+## Overview
+
+`EAccess.auth` is a single linear exchange -- TCP connect, TLS handshake, then a
+K/A/M/F/G/P/C/L command sequence over one blocking socket (see
+[eaccess-protocol-analysis.md](eaccess-protocol-analysis.md) for the protocol itself). Historically,
+a failure anywhere in that chain surfaced as one of a handful of generic exception types
+(`Errno::*`, `OpenSSL::SSL::SSLError`, `AuthenticationError`, a bare `StandardError`, or just "timed
+out after 30s" from the outer watchdog) with no indication of *which* stage failed. Two very
+different root causes -- "the load balancer in front of 7910 is dropping packets" and "the account's
+password is wrong" -- could both eventually surface as "authentication failed," several layers away
+from the log line a responder would actually need.
+
+This document defines the failure-stage taxonomy `EAccess` now logs on, so a log line's stage name
+maps to a specific, actionable probable cause instead of requiring someone to re-read the protocol
+exchange from scratch during an incident.
+
+## Design
+
+Each stage is wrapped so that on failure, `EAccess` logs (at `warn`, `Lich.log`):
+
+```
+warn: EAccess stage '<stage>' failed after <duration>s (<ExceptionClass>: <message>) -- likely cause: <probable cause>
+```
+
+**Never logged:** the account password (obfuscated or not), the session `KEY`, or the account's
+character list (the `C` response). `M`/`F`/`L`'s raw response text IS included in their exception
+messages (and therefore in the stage log line) -- these are short, low-sensitivity protocol status
+tokens (`NEW_TO_GAME`, `PROBLEM\t1`, etc.), not secrets, and the exact token is genuinely useful for
+diagnosis. The `A` response is different: it can be a real Simutronics rejection token or an
+unrecognized/garbled response, and only the *derived classification* (recognized-rejection vs.
+divergence, see `.classify_a_response_failure`) is logged, not the raw text -- an unrecognized
+response is exactly the case most likely to contain something unexpected (an HTML intercept page
+from a WAF, a truncated fragment, etc.) that shouldn't be assumed safe to log verbatim.
+
+## Stage Taxonomy
+
+| # | Stage | Trigger (code) | Confirmed cause(s) | Probable cause hint |
+|---|---|---|---|---|
+| 1 | `dns_resolve` | `Socket.tcp` raises `SocketError` from `getaddrinfo` before any TCP attempt | Hostname doesn't resolve | Upstream DNS or local resolver -- not a Simutronics-side issue |
+| 2 | `tcp_connect` | `Socket.tcp(..., connect_timeout:)` raises `Errno::ETIMEDOUT` | SYN sent, no response (dropped, not refused) | Firewall/routing/load-balancer silently dropping packets (probable) |
+| 3 | `tcp_connect` | `Socket.tcp` raises `Errno::ECONNREFUSED` | Host reachable, nothing listening on 7910 | Service down, or wrong port, on an otherwise-reachable host (distinct from #2 -- different remediation) |
+| 4 | `tls_handshake` | `ssl_socket.connect` raises `OpenSSL::SSL::SSLError` | TLS negotiation failure (protocol/cipher mismatch, handshake timeout) | TLS termination misconfiguration (not probable on its own -- rare relative to #2/#3) |
+| 5 | `cert_pin_mismatch` | `verify_pem`: peer cert != locally pinned `simu.pem` | Certificate changed since last pin | **Ambiguous by design today** -- a legitimate Simutronics cert rotation and a MITM presenting a different cert look identical; currently auto-re-pins with only a log line, no alert. Flagged loudly as its own stage rather than folded into a generic warning. |
+| 6 | `k_response` | No response to `K`, or response received but empty/implausibly short | Connection closed immediately post-handshake, or a malformed hash key | A relay or the EAccess target itself behind 7910 (possible) -- previously indistinguishable from a stage-7 (`a_response`) failure, since a malformed K silently produced garbage password bytes that only failed two steps later |
+| 7 | `a_response` | `K` succeeded; `A` response doesn't match `/KEY\t.../ ` | Two distinct sub-cases, now classified separately (see below) | (a) recognized rejection token (`REJECT`/`NORECORD`/`INVALID`/`PASSWORD`) -- normal, expected, not a backend issue; (b) unrecognized/empty/malformed response -- application/backend divergence (possible) |
+| 8 | `m_response` | `A` succeeded; `M` response doesn't match `/^M\t/` | Session accepted, but the very next command fails | Session-affinity issue on a load-balanced backend (possible) -- credentials are known-good at this point, which rules out #7 entirely |
+| 9 | `entitlement_response` | Any of `F`/`G`/`P`/`C` fails or times out (non-legacy path) | Valid session, valid `M`, but the per-game entitlement pipeline breaks for the requested `game_code` | A backend/DB dependency specific to entitlements, not the auth path itself |
+| 10 | `l_response` | `L` response isn't `/^L\t/` at all (distinct from a well-formed `L\tPROBLEM\t...`) | Protocol/backend divergence at the final step | Same "unrecognized response" class as #7b, at the last step instead of the first |
+| 11 | *(cross-cutting)* | The outer 30s `auth_with_timeout` watchdog fires | A hang with no exception at all | Answers "which stage" using the last-entered-stage marker rather than nothing, the actual gap this taxonomy closes -- see `auth_with_timeout`'s log line |
+
+Stages 2-3 refine the reviewer's original "TCP timeout/refusal" bucket; 7's (a)/(b) split refines
+"K succeeds, but authentication command fails." Stages 1, 5, 6, 8, 9, 10, and 11 are new relative to
+the original 4-stage list.
+
+**Not implemented (out of scope for this pass):** distinguishing a truncated/partial `sysread` from
+a genuine short response -- `EAccess.read` remains a single `sysread(PACKET_SIZE)` call. If a
+response is ever found to legitimately span multiple TCP segments in practice, this would need a
+read-until-delimiter loop, not just better logging.
+
+## Where this shows up
+
+- `EAccess.socket` / `EAccess.download_pem` -- stages 1-5 (connect through cert verification)
+- `EAccess.auth` -- stages 6-10 (the K/A/M/F/G/P/C/L exchange)
+- `EAccess.auth_with_timeout` -- stage 11 (reports the last stage that was entered when the
+  watchdog fires, if the thread was killed mid-stage)

--- a/docs/eaccess-failure-diagnostics.md
+++ b/docs/eaccess-failure-diagnostics.md
@@ -36,23 +36,21 @@ from a WAF, a truncated fragment, etc.) that shouldn't be assumed safe to log ve
 
 ## Stage Taxonomy
 
-| # | Stage | Trigger (code) | Confirmed cause(s) | Probable cause hint |
+| # | Stage (exact log name) | Trigger (code) | Confirmed cause(s) | Probable cause hint |
 |---|---|---|---|---|
-| 1 | `dns_resolve` | `Socket.tcp` raises `SocketError` from `getaddrinfo` before any TCP attempt | Hostname doesn't resolve | Upstream DNS or local resolver -- not a Simutronics-side issue |
-| 2 | `tcp_connect` | `Socket.tcp(..., connect_timeout:)` raises `Errno::ETIMEDOUT` | SYN sent, no response (dropped, not refused) | Firewall/routing/load-balancer silently dropping packets (probable) |
-| 3 | `tcp_connect` | `Socket.tcp` raises `Errno::ECONNREFUSED` | Host reachable, nothing listening on 7910 | Service down, or wrong port, on an otherwise-reachable host (distinct from #2 -- different remediation) |
-| 4 | `tls_handshake` | `ssl_socket.connect` raises `OpenSSL::SSL::SSLError` | TLS negotiation failure (protocol/cipher mismatch, handshake timeout) | TLS termination misconfiguration (not probable on its own -- rare relative to #2/#3) |
-| 5 | `cert_pin_mismatch` | `verify_pem`: peer cert != locally pinned `simu.pem` | Certificate changed since last pin | **Ambiguous by design today** -- a legitimate Simutronics cert rotation and a MITM presenting a different cert look identical; currently auto-re-pins with only a log line, no alert. Flagged loudly as its own stage rather than folded into a generic warning. |
-| 6 | `k_response` | No response to `K`, or response received but empty/implausibly short | Connection closed immediately post-handshake, or a malformed hash key | A relay or the EAccess target itself behind 7910 (possible) -- previously indistinguishable from a stage-7 (`a_response`) failure, since a malformed K silently produced garbage password bytes that only failed two steps later |
-| 7 | `a_response` | `K` succeeded; `A` response doesn't match `/KEY\t.../ ` | Two distinct sub-cases, now classified separately (see below) | (a) recognized rejection token (`REJECT`/`NORECORD`/`INVALID`/`PASSWORD`) -- normal, expected, not a backend issue; (b) unrecognized/empty/malformed response -- application/backend divergence (possible) |
-| 8 | `m_response` | `A` succeeded; `M` response doesn't match `/^M\t/` | Session accepted, but the very next command fails | Session-affinity issue on a load-balanced backend (possible) -- credentials are known-good at this point, which rules out #7 entirely |
-| 9 | `entitlement_response` | Any of `F`/`G`/`P`/`C` fails or times out (non-legacy path) | Valid session, valid `M`, but the per-game entitlement pipeline breaks for the requested `game_code` | A backend/DB dependency specific to entitlements, not the auth path itself |
-| 10 | `l_response` | `L` response isn't `/^L\t/` at all (distinct from a well-formed `L\tPROBLEM\t...`) | Protocol/backend divergence at the final step | Same "unrecognized response" class as #7b, at the last step instead of the first |
-| 11 | *(cross-cutting)* | The outer 30s `auth_with_timeout` watchdog fires | A hang with no exception at all | Answers "which stage" using the last-entered-stage marker rather than nothing, the actual gap this taxonomy closes -- see `auth_with_timeout`'s log line |
+| 1 | `tcp_connect:main` (the auth connection) or `tcp_connect:pem_bootstrap` (the separate connection `download_pem` makes when no cert is pinned yet) | `Socket.tcp(..., connect_timeout:)` raises `SocketError` (DNS resolution failure from `getaddrinfo`, before any TCP attempt), `Errno::ETIMEDOUT` (SYN sent, no response), or `Errno::ECONNREFUSED` (connection actively refused) | Hostname doesn't resolve, packets are being dropped, or the host is reachable but nothing is listening on 7910 | `SocketError`: upstream DNS or local resolver, not Simutronics-side. `ETIMEDOUT`: firewall/routing/load-balancer silently dropping packets (probable). `ECONNREFUSED`: service down, or wrong port, on an otherwise-reachable host -- distinct from `ETIMEDOUT`, different remediation |
+| 2 | `tls_handshake:main` or `tls_handshake:pem_bootstrap` | `ssl_socket.connect` (or `ssl.connect` for the bootstrap path) raises `OpenSSL::SSL::SSLError` | TLS negotiation failure (protocol/cipher mismatch, handshake timeout) | TLS termination misconfiguration (not probable on its own -- rare relative to #1) |
+| 3 | `cert_pin_mismatch` | `verify_pem`: peer cert != locally pinned `simu.pem` | Certificate changed since last pin | **Ambiguous by design today** -- a legitimate Simutronics cert rotation and a MITM presenting a different cert look identical; currently auto-re-pins with only a log line, no alert. Flagged loudly as its own stage rather than folded into a generic warning. |
+| 4 | `k_response` | No response to `K`, or response received but empty/implausibly short | Connection closed immediately post-handshake, or a malformed hash key | A relay or the EAccess target itself behind 7910 (possible) -- previously indistinguishable from a stage-5 (`a_response`) failure, since a malformed K silently produced garbage password bytes that only failed two steps later |
+| 5 | `a_response` | `K` succeeded; `A` response doesn't match `/KEY\t.../ ` | Two distinct sub-cases, now classified separately (see below) | (a) recognized rejection token (`REJECT`/`NORECORD`/`INVALID`/`PASSWORD`) -- normal, expected, not a backend issue; (b) unrecognized/empty/malformed response -- application/backend divergence (possible) |
+| 6 | `m_response` | `A` succeeded; `M` response doesn't match `/^M\t/` | Session accepted, but the very next command fails | Session-affinity issue on a load-balanced backend (possible) -- credentials are known-good at this point, which rules out #5 entirely |
+| 7 | `entitlement_response` | Any of `F`/`G`/`P`/`C` fails or times out (non-legacy path) | Valid session, valid `M`, but the per-game entitlement pipeline breaks for the requested `game_code` | A backend/DB dependency specific to entitlements, not the auth path itself |
+| 8 | `l_response` | `L` response isn't `/^L\t/` at all (distinct from a well-formed `L\tPROBLEM\t...`) | Protocol/backend divergence at the final step | Same "unrecognized response" class as #5b, at the last step instead of the first |
+| 9 | *(cross-cutting, not its own `stage` call)* | The outer 30s `auth_with_timeout` watchdog fires | A hang with no exception at all | Answers "which stage" using the last-entered-stage marker rather than nothing, the actual gap this taxonomy closes -- see `auth_with_timeout`'s log line |
 
-Stages 2-3 refine the reviewer's original "TCP timeout/refusal" bucket; 7's (a)/(b) split refines
-"K succeeds, but authentication command fails." Stages 1, 5, 6, 8, 9, 10, and 11 are new relative to
-the original 4-stage list.
+Stage 1 refines the reviewer's original "TCP timeout/refusal" bucket (three causes -- DNS,
+timeout, refusal -- rather than one); 5's (a)/(b) split refines "K succeeds, but authentication
+command fails." Stages 3, 4, 6, 7, 8, and 9 are new relative to the original 4-stage list.
 
 **Not implemented (out of scope for this pass):** distinguishing a truncated/partial `sysread` from
 a genuine short response -- `EAccess.read` remains a single `sysread(PACKET_SIZE)` call. If a
@@ -61,7 +59,7 @@ read-until-delimiter loop, not just better logging.
 
 ## Where this shows up
 
-- `EAccess.socket` / `EAccess.download_pem` -- stages 1-5 (connect through cert verification)
-- `EAccess.auth` -- stages 6-10 (the K/A/M/F/G/P/C/L exchange)
-- `EAccess.auth_with_timeout` -- stage 11 (reports the last stage that was entered when the
+- `EAccess.socket` / `EAccess.download_pem` -- stages 1-3 (connect through cert verification)
+- `EAccess.auth` -- stages 4-8 (the K/A/M/F/G/P/C/L exchange)
+- `EAccess.auth_with_timeout` -- stage 9 (reports the last stage that was entered when the
   watchdog fires, if the thread was killed mid-stage)

--- a/docs/web-login-protocol-analysis.md
+++ b/docs/web-login-protocol-analysis.md
@@ -21,8 +21,10 @@ A `Lich::Common::Authentication::WebLogin` module implementing this flow has bee
 (`lib/common/authentication/web_login.rb`) and exercised live end-to-end: DR, DR Test, GemStone
 Prime (`GS3`->`GS4` mapping), GemStone Test, GemStone Shattered, and a bad-password failure all
 confirmed working against the real play.net servers, matching the browser-captured hosts/ports
-exactly. Several things were only discovered by building and running a non-browser HTTP client,
-or by testing a second account, not by watching a single browser session:
+exactly. `DRX` (Platinum) and `DRF` (Fallen) are wired in end-to-end too, but as *unverified*
+entries pending an account with real entitlement to confirm the actual host/port -- see
+`CONFIRMED_INSTANCES`. Several things were only discovered by building and running a non-browser
+HTTP client, or by testing more than one account, not by watching a single browser session:
 
 1. **A browser-like `User-Agent` header is required on every request, including the very first
    GET.** play.net's front end (CloudFront/WAF) returns a bare `500` for Ruby's default
@@ -59,8 +61,15 @@ or by testing a second account, not by watching a single browser session:
    response's status: a redirect to `subscription_needed.asp` raises a distinct `NO_SUBSCRIPTION`
    (classified fatal in `Authenticator::FATAL_ERROR_CODES` -- retrying won't help), and any other
    non-200 response raises `UNEXPECTED_CHARACTER_LIST_RESPONSE`.
+6. **The "no subscription" redirect target isn't one fixed path -- it's instance-specific.**
+   Confirmed live with the same unentitled account against `DRX`/`DRF`: DR's is plain
+   `subscription_needed.asp`, but DRX's (Platinum) is `subscription_to_plat_needed.asp` and DRF's
+   (Fallen) is `subscription_to_fall_needed.asp`. `WebLogin` matches this by pattern
+   (`subscription(?:_to_\w+)?_needed\.asp`) rather than an exact string, so an instance-specific
+   variant not seen yet is still recognized as `NO_SUBSCRIPTION` instead of falling through to the
+   generic `UNEXPECTED_CHARACTER_LIST_RESPONSE`.
 
-All five were invisible in a single browser capture and only surfaced by building a standalone
+All six were invisible in a single browser capture and only surfaced by building a standalone
 client and/or testing more than one account -- worth remembering if this flow needs
 re-verifying after a play.net change: reproduce with a non-browser client against more than one
 account (ideally one with an expired/inactive subscription too), not just by re-watching
@@ -191,14 +200,18 @@ charID={CHAR_CODE}
   - `game=GSF` (GemStone IV Shattered) -> host `storm.gs4.game.play.net`, port `10324` --
     matches EAccess `GSF` (like `DR`/`DRT`/`GST`, unlike the `GS3`->`GS4` Prime mismatch)
 
-  Not yet confirmed live: `DRF` (Fallen), `DRX` (Platinum). Given the confirmed `GS3`->`GS4`
-  mismatch, **do not assume these match their EAccess codes either** -- each must be probed
-  individually before being relied on. `GSX` (GemStone Platinum) is not applicable at all -- the
-  instance itself has been retired (confirmed by the account holder; `LoginHelpers.VALID_GAME_CODES`
-  already excludes it independent of this module). `WebLogin` carries its own explicit
-  `CONFIRMED_INSTANCES` table (seeded from EAccess codes where confirmed identical, overridden
-  where not, and simply absent for anything unconfirmed or retired), not reusing EAccess's codes
-  directly.
+  `DRX` (Platinum) and `DRF` (Fallen) are wired in end-to-end (`game=DRX`/`game=DRF`, assumed
+  identical to their EAccess codes as DR/DRT/GSF's do -- only `GS3`->`GS4` has ever diverged) but
+  **not live-confirmed**: no account with these entitlements has been available to test with, so
+  their `expected_host`/`expected_port` are deliberately left unpinned in `CONFIRMED_INSTANCES`
+  (see that constant's comment for what "unverified" relaxes vs. still enforces). Confirmed live
+  with an unentitled account that both reach the real server correctly and fail cleanly (`NO_SUBSCRIPTION`,
+  via each instance's own named subscription page -- `subscription_to_plat_needed.asp` /
+  `subscription_to_fall_needed.asp`, not the generic `subscription_needed.asp` -- see "Implementation
+  Status"), which at least validates `character_list_path` and the request shape; the actual
+  `GAMEHOST`/`GAMEPORT` a real entitled account gets back is still unconfirmed. `GSX` (GemStone
+  Platinum) is not applicable at all -- the instance itself has been retired (confirmed by the
+  account holder; `LoginHelpers.VALID_GAME_CODES` already excludes it independent of this module).
 - `instanceID=0` in both observed cases -- meaning not yet determined (possibly multi-session
   slot, unrelated to which game instance is selected -- that's `game`).
 - Response: `302` to `/{gameName}/play/playing_web.asp`.
@@ -252,10 +265,14 @@ future fallback needs to tunnel the *game* connection itself over HTTPS too (out
 
 ## Open Questions / Not Yet Probed
 
-- `DRF` (Fallen), `DRX` (Platinum) -- no account with these entitlements available for probing
-  yet. **Given the confirmed `GS3`->`GS4` mismatch on GemStone Prime, do not assume these match
-  their EAccess codes -- verify each one live.** `GSF` (Shattered) is now confirmed (see above);
-  `GSX` (GemStone Platinum) is not applicable -- the instance has been retired.
+- `DRF` (Fallen), `DRX` (Platinum) -- enabled in `CONFIRMED_INSTANCES` as *unverified* entries
+  (`expected_host`/`expected_port` left `nil`, see that constant's comment) so a tester with real
+  entitlement can exercise them without a code change. No such account has been available yet, so
+  the actual `GAMEHOST`/`GAMEPORT` -- and whether `game=DRX`/`game=DRF` truly match their EAccess
+  codes, given the confirmed `GS3`->`GS4` mismatch elsewhere -- remain unconfirmed. Once a real
+  result comes back, hardcode the observed host/port here and remove the `nil`s. `GSF` (Shattered)
+  is fully confirmed (see above); `GSX` (GemStone Platinum) is not applicable at all -- the
+  instance has been retired.
 - Full error-code vocabulary on `login_error.asp` -- "Invalid password" and "Invalid account"
   (nonexistent account name) both confirmed; locked account and other failure modes not yet
   probed. Not currently a gap in practice: `WebLogin.login` already takes the coarser approach

--- a/docs/web-login-protocol-analysis.md
+++ b/docs/web-login-protocol-analysis.md
@@ -97,11 +97,19 @@ return_okay_page=%2Fdr%2Fplay%2Fhome.asp
 - On failure: `302` redirect to `return_error_page` instead. **The redirect target itself is the
   pass/fail signal** -- compare the `Location` header's path against the two page params you
   sent, don't parse body text for control flow.
-  - Confirmed failure case: wrong password -> redirects to
-    `/dr/login_error.asp?error=&returnto=/dr/`, page body has heading `"Invalid password."`.
-    Other failure modes (bad account name, locked account, etc.) not yet probed -- likely land on
-    the same `login_error.asp` page with a different heading, analogous to EAccess's
-    `REJECT`/`NORECORD`/`INVALID`/`PASSWORD` codes but not yet enumerated here.
+  - Confirmed failure cases, both landing on the same `login_error.asp` redirect target with only
+    the body heading differing:
+    - Wrong password on a real account -> `/dr/login_error.asp?error=&returnto=/dr/`, heading
+      `"Invalid password."`.
+    - Nonexistent account name (confirmed with a random fictitious name, e.g. `SDLG3kDSKk38`) ->
+      `/dr/login_error.asp?error=&returnto=/dr/play/home.asp`, heading `"Invalid account."`.
+    `WebLogin.login` classifies both identically as `LOGIN_FAILED` (matching the redirect path
+    only, not the heading -- see "AUTH_FAILED" note below) -- this matters in practice for a
+    stale/mistyped saved account name, which resolves the same way a bad password does: a single
+    fast, fatal failure with no wasted retries or fallback loop, not an indefinite hang or a
+    generic/unclear error. Locked account and other failure modes are still not yet probed --
+    likely land on the same page with yet another heading, and would already be handled the same
+    way (any redirect to `login_error.asp`, regardless of heading, is `LOGIN_FAILED`).
 
 `return_okay_page`/`return_error_page` are attacker-controlled-looking (client supplies them) but
 game-specific (`/dr/...` vs presumably `/gs4/...`) -- set them to the game's own home/error page.
@@ -248,14 +256,17 @@ future fallback needs to tunnel the *game* connection itself over HTTPS too (out
   yet. **Given the confirmed `GS3`->`GS4` mismatch on GemStone Prime, do not assume these match
   their EAccess codes -- verify each one live.** `GSF` (Shattered) is now confirmed (see above);
   `GSX` (GemStone Platinum) is not applicable -- the instance has been retired.
-- Full error-code vocabulary on `login_error.asp` (bad account name, locked account, etc.) --
-  only "Invalid password" confirmed. Needed to build the fatal-vs-transient error classification
-  `Authenticator.with_retry` already does for EAccess (`FATAL_ERROR_CODES`).
-  - Body heading (`h4`) appears to carry the specific reason; a client would need to parse it,
-    or accept a coarser "auth failed" signal instead of granular error codes.
-  - Consider whether error handling should instead treat *any* redirect to `return_error_page` as
-    a single "AUTH_FAILED" class initially, refining later if specific messages need distinct
-    retry semantics (e.g. a transient site error vs bad credentials).
+- Full error-code vocabulary on `login_error.asp` -- "Invalid password" and "Invalid account"
+  (nonexistent account name) both confirmed; locked account and other failure modes not yet
+  probed. Not currently a gap in practice: `WebLogin.login` already takes the coarser approach
+  described below (any redirect to `return_error_page` is `LOGIN_FAILED`, regardless of heading),
+  so an unprobed failure mode still fails correctly today -- just without a distinguishing code.
+  - Body heading (`h4`) carries the specific reason if a more granular code is ever wanted; not
+    currently parsed.
+  - **Resolved: `WebLogin.login` treats any redirect to `return_error_page` as a single
+    `LOGIN_FAILED` class**, matching the redirect path only, not the heading. Confirmed this
+    correctly covers both known failure modes (bad password, bad account name) without needing to
+    parse body text.
 - Character-generator equivalent (EAccess's `charID=0` -> character generator entry) -- not
   probed. `goplay2.asp`'s `NEWCHARSUB=TRUE` flag looks adjacent but unconfirmed.
 - Cookie/session details (name, TTL, whether it's IP-pinned) -- not inspected; treated as opaque,
@@ -272,4 +283,4 @@ future fallback needs to tunnel the *game* connection itself over HTTPS too (out
 | `M`/`F`/`G`/`P`/`C` (enumerate) | *(not needed)* | Web flow skips straight to a specific `game`+`charID`; no equivalent enumeration observed/needed for the fallback |
 | `L\t{charID}\tSTORM` | `POST goplay2.asp` + 2 redirects | Same `charID` format; `game` param mostly matches EAccess game code but not always (confirmed mismatch: GS Prime is `GS4` here vs `GS3` in EAccess) |
 | `L\tOK\t...GAMEHOST=...GAMEPORT=...KEY=...` | Final redirect `?host=...&port=...&key=...` | Same three values, different transport |
-| `AuthenticationError` codes (`REJECT`, `NORECORD`, ...) | Redirect target (`return_error_page`) + body heading | Coarser today; only "Invalid password" confirmed |
+| `AuthenticationError` codes (`REJECT`, `NORECORD`, ...) | Redirect target (`return_error_page`) only, as a single `LOGIN_FAILED` | Coarser by design; confirmed to correctly cover both bad-password and bad-account-name |

--- a/docs/web-login-protocol-analysis.md
+++ b/docs/web-login-protocol-analysis.md
@@ -1,0 +1,221 @@
+# Web Login Protocol Analysis
+
+## Overview
+
+This document captures findings from probing play.net's HTTPS web login flow (`www.play.net`),
+as a candidate fallback authentication path for when `eaccess.play.net:7910` (TLS) is
+unreachable. Captured via a live browser session (Playwright) against `https://www.play.net/dr/play/`
+using a real test account, DragonRealms Prime and DragonRealms Prime Test instances.
+
+Unlike the EAccess protocol (tab-delimited text over a raw TLS socket, see
+[eaccess-protocol-analysis.md](eaccess-protocol-analysis.md)), this flow is a sequence of
+ordinary HTTPS form POSTs / redirects (ASP.NET, `www.play.net`), authenticated by a session
+cookie set after login. It terminates in the same information the EAccess `L` command returns:
+a game server host, port, and one-time connection key.
+
+---
+
+## Implementation Status
+
+A `Lich::Common::Authentication::WebLogin` module implementing this flow has been built
+(`lib/common/authentication/web_login.rb`) and exercised live end-to-end: DR Test, GemStone Prime
+(`GS3`->`GS4` mapping), GemStone Test, and a bad-password failure all confirmed working against
+the real play.net servers, matching the browser-captured hosts/ports exactly. Two things were
+only discovered by building and running a non-browser HTTP client, not by watching the browser:
+
+1. **A browser-like `User-Agent` header is required on every request, including the very first
+   GET.** play.net's front end (CloudFront/WAF) returns a bare `500` for Ruby's default
+   `Net::HTTP` User-Agent (`Ruby/x.y.z`) -- not documented anywhere, not visible from the browser
+   capture since a real browser always sends one. Every request must set this header.
+2. **The login POST requires a pre-existing ASP session cookie from a prior `GET` of the
+   sign-in page** (e.g. `GET /dr/signin_needed.asp`) -- posting `login.asp` cold (no session
+   cookie) also returns a bare `500`. A real browser always visits the sign-in page before
+   submitting the form, so this dependency is invisible in a browser capture alone. The module
+   issues this GET itself and carries its cookie into the login POST.
+
+Both were invisible in the pure browser capture and only surfaced once a standalone Ruby client
+tried the same requests -- worth remembering if this flow needs re-verifying after a play.net
+change: reproduce with a non-browser client, not just by re-watching DevTools.
+
+---
+
+## Request Chain
+
+### 1 -- Login (establishes session cookie)
+
+```
+POST https://www.play.net/includes/common/login/login.asp
+Content-Type: application/x-www-form-urlencoded
+
+return_okay_page=%2Fdr%2Fplay%2Fhome.asp
+&return_error_page=%2Fdr%2Flogin_error.asp
+&remember_account=
+&remember_password=
+&account_name={ACCOUNT}
+&account_password={PASSWORD}
+&submit=Login
+```
+
+- Password is sent **in the clear as an HTTPS form field** -- no client-side hashing/obfuscation
+  (unlike EAccess's XOR scheme). Security rests entirely on TLS.
+- On success: `302` redirect to whatever `return_okay_page` was set to. A session cookie is
+  established (not inspected in detail here -- treat as an opaque authenticated session, sent
+  automatically by any HTTP client that preserves cookies across the chain).
+- On failure: `302` redirect to `return_error_page` instead. **The redirect target itself is the
+  pass/fail signal** -- compare the `Location` header's path against the two page params you
+  sent, don't parse body text for control flow.
+  - Confirmed failure case: wrong password -> redirects to
+    `/dr/login_error.asp?error=&returnto=/dr/`, page body has heading `"Invalid password."`.
+    Other failure modes (bad account name, locked account, etc.) not yet probed -- likely land on
+    the same `login_error.asp` page with a different heading, analogous to EAccess's
+    `REJECT`/`NORECORD`/`INVALID`/`PASSWORD` codes but not yet enumerated here.
+
+`return_okay_page`/`return_error_page` are attacker-controlled-looking (client supplies them) but
+game-specific (`/dr/...` vs presumably `/gs4/...`) -- set them to the game's own home/error page.
+
+---
+
+### 1a -- Resolving `charID` (no EAccess-`C`-equivalent enumeration endpoint)
+
+Unlike EAccess's `C` command, there is no separate API call that lists an account's characters
+for a game family. The character list is server-rendered directly into the game's `home.asp`
+page (the `return_okay_page` from step 1) as radio inputs, confirmed live:
+
+```html
+<input type=radio name="charID" id="W_TESTACCOUNT_000" value="W_TESTACCOUNT_000" checked  >
+<label for="W_TESTACCOUNT_000"><span class="normS1">Raiyen</span></label><br>
+```
+
+So resolving a `char_name` to the `charID` needed for step 2 means: `GET` the family's
+`home.asp` (or equivalent per-instance page, e.g. `playdrt.asp` for DR Test, `play_test.asp` for
+GS Test -- same character list, different subscription-tier framing) with the session cookie
+from step 1, then regex-scrape `id="(W_[^"]+)"` paired with the following
+`<label for="\1"><span[^>]*>([^<]+)</span>` for the display name. Confirmed the session cookie
+from a single `login.asp` call is valid across both game families (DR and GS4) in the same
+browser session -- one login, both games' `home.asp` pages render correctly without re-posting
+credentials.
+
+This HTML-scrape step is inherently more fragile than EAccess's tab-delimited `C` response --
+any markup change on play.net's end breaks it silently (returns no match) rather than erroring
+clearly. Treat it as the most likely maintenance burden of this whole fallback path.
+
+---
+
+### 2 -- Select Character / Game Instance
+
+```
+POST https://www.play.net/includes/common/play/goplay2.asp
+Content-Type: application/x-www-form-urlencoded
+
+charID={CHAR_CODE}
+&NEWCHARSUB=TRUE
+&managesub=0
+&gameName={dr|gs4}
+&instanceID=0
+&game={GAME_CODE}
+&frontend=web
+```
+
+- `charID` -- same character-code format EAccess's `C` command returns (e.g. `W_TESTACCOUNT_000`).
+  Characters are shared across instances of the same game family here too (confirmed: same
+  `charID` worked unchanged for both `game=DR` and `game=DRT`).
+- `gameName` -- the game **family**, lowercase: `dr` for all DragonRealms instances, `gs4` for
+  all GemStone IV instances (confirmed live).
+- `game` -- the specific **instance code**. **Does NOT always match the EAccess game code --
+  confirm each one live, don't assume passthrough.** Confirmed:
+  - `game=DR` (DragonRealms Prime) -> host `storm.dr.game.play.net`, port `11024` -- matches EAccess `DR`
+  - `game=DRT` (DragonRealms Prime Test) -> host `hydra.simutronics.com`, port `11624` -- matches EAccess `DRT`
+  - `game=GS4` (GemStone IV Prime) -> host `storm.gs4.game.play.net`, port `10024` --
+    **differs from EAccess, which uses `GS3` for this instance.** The web layer has its own code
+    table; `GS3` is not accepted here (untested whether it would error or silently fail --
+    `GS4` is the confirmed-working value).
+  - `game=GST` (GemStone IV Prime Test) -> host `chimera.simutronics.com`, port `10624` --
+    matches EAccess `GST`
+
+  Not yet confirmed live: `DRF` (Fallen), `DRX` (Platinum), `GSF` (Shattered), `GSX` (Platinum).
+  Given the confirmed `GS3`->`GS4` mismatch, **do not assume these match their EAccess codes
+  either** -- each must be probed individually before being relied on. A `WebLogin` module should
+  carry its own explicit `game_code` mapping table (seeded from EAccess codes where confirmed
+  identical, overridden where not), not reuse EAccess's codes directly.
+- `instanceID=0` in both observed cases -- meaning not yet determined (possibly multi-session
+  slot, unrelated to which game instance is selected -- that's `game`).
+- Response: `302` to `/{gameName}/play/playing_web.asp`.
+
+---
+
+### 3 -- Redirect Chain to Connection Info
+
+```
+GET /{gameName}/play/playing_web.asp
+  -> 302 -> /includes/common/play/goplay_web.asp
+    -> 302 -> https://www.play.net/play/home.asp?host={GAMEHOST}&port={GAMEPORT}&key={KEY}
+```
+
+The final `Location` header carries the same triple as EAccess's `L\tOK\t...` response
+(`GAMEHOST`/`GAMEPORT`/`KEY` keys in that protocol). This is the payload our fallback module
+actually needs -- everything before this is just how to obtain it over HTTPS instead of TLS:7910.
+
+**This is a one-time key** -- same characteristic as the EAccess session key: presumably expires
+quickly and is single-use, so it must be fetched fresh per connection attempt, not cached.
+
+---
+
+## What Happens After (informational -- not needed for the fallback)
+
+The official web client (loaded at `/play/home.asp?host=...&port=...&key=...`) does **not** open
+a raw TCP socket to `{GAMEHOST}:{GAMEPORT}` -- browsers can't. Instead
+(`style/js/all_web_fe_min.js`, `SimuSocket.tryWebSocket`):
+
+```js
+socket = new WebSocket("wss://" + actualHost + "/shim/" + port, "websocket_shim-protocol");
+socket.onopen = () => {
+  socket.send("<c>" + key + "\r\n");
+  socket.send("<c>/FE:WebFE /VERSION:0.2015.9.29.0 /P:WIN_XP  /XML\r\n");
+  socket.send("\r\n");
+  socket.send("\r\n");
+};
+```
+
+i.e. the game host runs a WebSocket-to-TCP shim at `wss://{host}/shim/{port}` for browser clients,
+which then speaks the same key-then-`/FE:` handshake a native Wrayth/Stormfront client sends over
+a raw TCP connection.
+
+**This shim is not needed for our fallback**, provided the game connection ports themselves
+(11024, 11624, etc.) remain reachable and only `eaccess.play.net:7910` is blocked -- Lich's
+existing raw-socket game connection code should work unchanged once fed `GAMEHOST`/`GAMEPORT`/`KEY`
+obtained via this HTTPS path instead of via EAccess. The WS shim would only become relevant if a
+future fallback needs to tunnel the *game* connection itself over HTTPS too (out of scope here).
+
+---
+
+## Open Questions / Not Yet Probed
+
+- `DRF` (Fallen), `DRX`/`GSX` (Platinum), `GSF` (Shattered) -- account used for probing only
+  holds DR/DRT/GS4(Prime)/GST entitlements, so these instance codes are untested against this
+  account's subscription tier. **Given the confirmed `GS3`->`GS4` mismatch on GemStone Prime,
+  do not assume these match their EAccess codes -- verify each one live.**
+- Full error-code vocabulary on `login_error.asp` (bad account name, locked account, etc.) --
+  only "Invalid password" confirmed. Needed to build the fatal-vs-transient error classification
+  `Authenticator.with_retry` already does for EAccess (`FATAL_ERROR_CODES`).
+  - Body heading (`h4`) appears to carry the specific reason; a client would need to parse it,
+    or accept a coarser "auth failed" signal instead of granular error codes.
+  - Consider whether error handling should instead treat *any* redirect to `return_error_page` as
+    a single "AUTH_FAILED" class initially, refining later if specific messages need distinct
+    retry semantics (e.g. a transient site error vs bad credentials).
+- Character-generator equivalent (EAccess's `charID=0` -> character generator entry) -- not
+  probed. `goplay2.asp`'s `NEWCHARSUB=TRUE` flag looks adjacent but unconfirmed.
+- Cookie/session details (name, TTL, whether it's IP-pinned) -- not inspected; treated as opaque,
+  handled by any client that persists cookies across the 4-request chain.
+- Rate limiting / lockout behavior -- not tested (avoided repeated probing on the live site).
+
+---
+
+## Summary Mapping to EAccess
+
+| EAccess (TLS:7910) | Web (HTTPS) | Notes |
+|---|---|---|
+| `K` + `A` (hash + authenticate) | `POST login.asp` | Password sent in the clear over HTTPS instead of XOR-obfuscated over TLS |
+| `M`/`F`/`G`/`P`/`C` (enumerate) | *(not needed)* | Web flow skips straight to a specific `game`+`charID`; no equivalent enumeration observed/needed for the fallback |
+| `L\t{charID}\tSTORM` | `POST goplay2.asp` + 2 redirects | Same `charID` format; `game` param mostly matches EAccess game code but not always (confirmed mismatch: GS Prime is `GS4` here vs `GS3` in EAccess) |
+| `L\tOK\t...GAMEHOST=...GAMEPORT=...KEY=...` | Final redirect `?host=...&port=...&key=...` | Same three values, different transport |
+| `AuthenticationError` codes (`REJECT`, `NORECORD`, ...) | Redirect target (`return_error_page`) + body heading | Coarser today; only "Invalid password" confirmed |

--- a/docs/web-login-protocol-analysis.md
+++ b/docs/web-login-protocol-analysis.md
@@ -18,10 +18,11 @@ a game server host, port, and one-time connection key.
 ## Implementation Status
 
 A `Lich::Common::Authentication::WebLogin` module implementing this flow has been built
-(`lib/common/authentication/web_login.rb`) and exercised live end-to-end: DR Test, GemStone Prime
-(`GS3`->`GS4` mapping), GemStone Test, and a bad-password failure all confirmed working against
-the real play.net servers, matching the browser-captured hosts/ports exactly. Two things were
-only discovered by building and running a non-browser HTTP client, not by watching the browser:
+(`lib/common/authentication/web_login.rb`) and exercised live end-to-end: DR, DR Test, GemStone
+Prime (`GS3`->`GS4` mapping), GemStone Test, GemStone Shattered, and a bad-password failure all
+confirmed working against the real play.net servers, matching the browser-captured hosts/ports
+exactly. Several things were only discovered by building and running a non-browser HTTP client,
+or by testing a second account, not by watching a single browser session:
 
 1. **A browser-like `User-Agent` header is required on every request, including the very first
    GET.** play.net's front end (CloudFront/WAF) returns a bare `500` for Ruby's default
@@ -32,10 +33,25 @@ only discovered by building and running a non-browser HTTP client, not by watchi
    cookie) also returns a bare `500`. A real browser always visits the sign-in page before
    submitting the form, so this dependency is invisible in a browser capture alone. The module
    issues this GET itself and carries its cookie into the login POST.
+3. **An account that has never set a security question is redirected to
+   `/playdotnet/account/security_qa.asp` instead of `return_okay_page` on an otherwise-successful
+   login.** Confirmed live with a second test account. The session is already fully authenticated
+   at that point (the account name renders in the page banner; the real session cookie is already
+   set) -- manually navigating straight to the game's play page instead of following that redirect
+   works fine, confirming it's not a login failure. `WebLogin.login` treats this path as a second
+   acceptable redirect target alongside `okay_page`, rather than raising.
+4. **A character can exist on one instance of a family without appearing on that family's generic
+   `home.asp` at all.** Confirmed live: a GemStone Shattered-only character does not show up on
+   the GemStone Prime page. `DR`/`DRT`/`GS3`/`GST` all happened to share characters visible via
+   the same generic per-family page in initial testing, which masked this -- resolving a charID
+   must scrape the specific instance page a user would actually pick that game code from (e.g.
+   `/gs4/play/playf.asp` for Shattered), not assume the family's `home.asp` has the full
+   account-wide picture. See `CONFIRMED_INSTANCES`' `character_list_path` per entry.
 
-Both were invisible in the pure browser capture and only surfaced once a standalone Ruby client
-tried the same requests -- worth remembering if this flow needs re-verifying after a play.net
-change: reproduce with a non-browser client, not just by re-watching DevTools.
+All four were invisible in a single browser capture and only surfaced by building a standalone
+client and/or testing a second account -- worth remembering if this flow needs re-verifying after
+a play.net change: reproduce with a non-browser client against more than one account, not just by
+re-watching DevTools on one login.
 
 ---
 
@@ -61,6 +77,10 @@ return_okay_page=%2Fdr%2Fplay%2Fhome.asp
 - On success: `302` redirect to whatever `return_okay_page` was set to. A session cookie is
   established (not inspected in detail here -- treat as an opaque authenticated session, sent
   automatically by any HTTP client that preserves cookies across the chain).
+  - **Alternate success redirect, confirmed live:** an account that has never set a security
+    question is redirected to `/playdotnet/account/security_qa.asp` instead. The session is
+    already fully authenticated at this point -- treat this the same as a redirect to
+    `return_okay_page`, not a failure. See "Implementation Status" above.
 - On failure: `302` redirect to `return_error_page` instead. **The redirect target itself is the
   pass/fail signal** -- compare the `Location` header's path against the two page params you
   sent, don't parse body text for control flow.
@@ -86,14 +106,30 @@ page (the `return_okay_page` from step 1) as radio inputs, confirmed live:
 <label for="W_TESTACCOUNT_000"><span class="normS1">Raiyen</span></label><br>
 ```
 
-So resolving a `char_name` to the `charID` needed for step 2 means: `GET` the family's
-`home.asp` (or equivalent per-instance page, e.g. `playdrt.asp` for DR Test, `play_test.asp` for
-GS Test -- same character list, different subscription-tier framing) with the session cookie
-from step 1, then regex-scrape `id="(W_[^"]+)"` paired with the following
+So resolving a `char_name` to the `charID` needed for step 2 means: `GET` the specific instance's
+character-selection page -- **not necessarily the family's generic `home.asp`** -- with the
+session cookie from step 1, then regex-scrape `id="(W_[^"]+)"` paired with the following
 `<label for="\1"><span[^>]*>([^<]+)</span>` for the display name. Confirmed the session cookie
 from a single `login.asp` call is valid across both game families (DR and GS4) in the same
-browser session -- one login, both games' `home.asp` pages render correctly without re-posting
-credentials.
+browser session -- one login, both games' pages render correctly without re-posting credentials.
+
+**The right page to scrape is instance-specific, confirmed live:**
+
+| Instance | Page |
+|---|---|
+| `DR` (Prime) | `/dr/play/home.asp` |
+| `DRT` (Test) | `/dr/play/playdrt.asp` |
+| `GS3` (Prime) | `/gs4/play/home.asp` |
+| `GST` (Test) | `/gs4/play/play_test.asp` |
+| `GSF` (Shattered) | `/gs4/play/playf.asp` |
+
+For `DR`/`DRT`/`GS3`/`GST`, the same character happened to be visible via any of these pages in
+initial testing (the account's DR/DRT characters and GS3/GST characters were each shared across
+that pair) -- but that is **not a safe general assumption**. Confirmed live with a Shattered-only
+character: it appears on `/gs4/play/playf.asp` but does **not** appear on `/gs4/play/home.asp`
+(GemStone Prime) at all -- that page shows "Create a new character" as the only option, with no
+indication a Shattered character exists. Always scrape the same page a user would actually pick
+that specific game code from.
 
 This HTML-scrape step is inherently more fragile than EAccess's tab-delimited `C` response --
 any markup change on play.net's end breaks it silently (returns no match) rather than erroring
@@ -131,12 +167,17 @@ charID={CHAR_CODE}
     `GS4` is the confirmed-working value).
   - `game=GST` (GemStone IV Prime Test) -> host `chimera.simutronics.com`, port `10624` --
     matches EAccess `GST`
+  - `game=GSF` (GemStone IV Shattered) -> host `storm.gs4.game.play.net`, port `10324` --
+    matches EAccess `GSF` (like `DR`/`DRT`/`GST`, unlike the `GS3`->`GS4` Prime mismatch)
 
-  Not yet confirmed live: `DRF` (Fallen), `DRX` (Platinum), `GSF` (Shattered), `GSX` (Platinum).
-  Given the confirmed `GS3`->`GS4` mismatch, **do not assume these match their EAccess codes
-  either** -- each must be probed individually before being relied on. A `WebLogin` module should
-  carry its own explicit `game_code` mapping table (seeded from EAccess codes where confirmed
-  identical, overridden where not), not reuse EAccess's codes directly.
+  Not yet confirmed live: `DRF` (Fallen), `DRX` (Platinum). Given the confirmed `GS3`->`GS4`
+  mismatch, **do not assume these match their EAccess codes either** -- each must be probed
+  individually before being relied on. `GSX` (GemStone Platinum) is not applicable at all -- the
+  instance itself has been retired (confirmed by the account holder; `LoginHelpers.VALID_GAME_CODES`
+  already excludes it independent of this module). `WebLogin` carries its own explicit
+  `CONFIRMED_INSTANCES` table (seeded from EAccess codes where confirmed identical, overridden
+  where not, and simply absent for anything unconfirmed or retired), not reusing EAccess's codes
+  directly.
 - `instanceID=0` in both observed cases -- meaning not yet determined (possibly multi-session
   slot, unrelated to which game instance is selected -- that's `game`).
 - Response: `302` to `/{gameName}/play/playing_web.asp`.
@@ -190,10 +231,10 @@ future fallback needs to tunnel the *game* connection itself over HTTPS too (out
 
 ## Open Questions / Not Yet Probed
 
-- `DRF` (Fallen), `DRX`/`GSX` (Platinum), `GSF` (Shattered) -- account used for probing only
-  holds DR/DRT/GS4(Prime)/GST entitlements, so these instance codes are untested against this
-  account's subscription tier. **Given the confirmed `GS3`->`GS4` mismatch on GemStone Prime,
-  do not assume these match their EAccess codes -- verify each one live.**
+- `DRF` (Fallen), `DRX` (Platinum) -- no account with these entitlements available for probing
+  yet. **Given the confirmed `GS3`->`GS4` mismatch on GemStone Prime, do not assume these match
+  their EAccess codes -- verify each one live.** `GSF` (Shattered) is now confirmed (see above);
+  `GSX` (GemStone Platinum) is not applicable -- the instance has been retired.
 - Full error-code vocabulary on `login_error.asp` (bad account name, locked account, etc.) --
   only "Invalid password" confirmed. Needed to build the fatal-vs-transient error classification
   `Authenticator.with_retry` already does for EAccess (`FATAL_ERROR_CODES`).

--- a/docs/web-login-protocol-analysis.md
+++ b/docs/web-login-protocol-analysis.md
@@ -47,11 +47,24 @@ or by testing a second account, not by watching a single browser session:
    must scrape the specific instance page a user would actually pick that game code from (e.g.
    `/gs4/play/playf.asp` for Shattered), not assume the family's `home.asp` has the full
    account-wide picture. See `CONFIRMED_INSTANCES`' `character_list_path` per entry.
+5. **An account with no active subscription on the requested instance triggers a SECOND
+   redirect, from `okay_page` itself, that a naive client never sees.** Confirmed live with a
+   third test account: `login.asp`'s own redirect still lands on `okay_page` (e.g.
+   `/dr/play/home.asp`) successfully -- login itself does not fail. But `GET`ting that page (the
+   same request `.resolve_char_code` makes to scrape the character list) returns another `302`,
+   to `/{family}/play/subscription_needed.asp`, which a plain (non-redirect-following) HTTP
+   client -- ours included, deliberately, see class doc -- does not follow. Without an explicit
+   check, this silently falls through to an empty body scrape and a misleading
+   `CHARACTER_NOT_FOUND` instead of the real cause. `WebLogin` now inspects the character-list
+   response's status: a redirect to `subscription_needed.asp` raises a distinct `NO_SUBSCRIPTION`
+   (classified fatal in `Authenticator::FATAL_ERROR_CODES` -- retrying won't help), and any other
+   non-200 response raises `UNEXPECTED_CHARACTER_LIST_RESPONSE`.
 
-All four were invisible in a single browser capture and only surfaced by building a standalone
-client and/or testing a second account -- worth remembering if this flow needs re-verifying after
-a play.net change: reproduce with a non-browser client against more than one account, not just by
-re-watching DevTools on one login.
+All five were invisible in a single browser capture and only surfaced by building a standalone
+client and/or testing more than one account -- worth remembering if this flow needs
+re-verifying after a play.net change: reproduce with a non-browser client against more than one
+account (ideally one with an expired/inactive subscription too), not just by re-watching
+DevTools on one login.
 
 ---
 

--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -25,7 +25,8 @@ module Lich
       # PASSWORD = wrong password, CHARACTER_NOT_FOUND = character not in account
       # GENERATOR_NOT_AVAILABLE = account not entitled to create a character on the instance
       # LOGIN_FAILED = WebLogin's credential-rejection signal (see web_login.rb)
-      FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND GENERATOR_NOT_AVAILABLE LOGIN_FAILED].freeze
+      # NO_SUBSCRIPTION = WebLogin: account has no active subscription on the requested instance
+      FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND GENERATOR_NOT_AVAILABLE LOGIN_FAILED NO_SUBSCRIPTION].freeze
 
       # Connection-level failures where the endpoint itself didn't respond --
       # retrying the same unreachable endpoint 3 times with backoff wastes

--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -27,6 +27,32 @@ module Lich
       # LOGIN_FAILED = WebLogin's credential-rejection signal (see web_login.rb)
       FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND GENERATOR_NOT_AVAILABLE LOGIN_FAILED].freeze
 
+      # Connection-level failures where the endpoint itself didn't respond --
+      # retrying the same unreachable endpoint 3 times with backoff wastes
+      # time (and, when a web fallback is available, delays it) compared to a
+      # protocol-level hiccup on an endpoint that IS reachable, which is
+      # still worth retrying. with_retry stops after the first attempt for
+      # these instead of exhausting MAX_AUTH_RETRIES.
+      UNREACHABLE_ERROR_CLASSES = [
+        SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT,
+        Errno::EHOSTUNREACH, Errno::ENETUNREACH, OpenSSL::SSL::SSLError
+      ].freeze
+
+      # @api private
+      # True for a connection-level failure (see UNREACHABLE_ERROR_CLASSES),
+      # or the "timed out authenticating" RuntimeError EAccess/WebLogin's own
+      # auth_with_timeout watchdogs raise when the endpoint never responds at
+      # all (a black-holed connection times out rather than refusing
+      # immediately, so it never raises one of the Errno classes).
+      #
+      # @param error [StandardError] the error caught by with_retry
+      # @return [Boolean]
+      def self.unreachable_error?(error)
+        return true if UNREACHABLE_ERROR_CLASSES.any? { |klass| error.is_a?(klass) }
+
+        error.is_a?(RuntimeError) && error.message.to_s.start_with?('error: timed out authenticating')
+      end
+
       # Authenticates a user with the game server.
       #
       # By default, authenticates via EAccess (eaccess.play.net:7910). If
@@ -55,6 +81,19 @@ module Lich
       # @return [Hash, Array] Authentication data containing connection information
       # @raise [StandardError] Re-raises the last error after all retries (and fallback, if applicable) exhausted
       def self.authenticate(account:, password:, character: nil, game_code: nil, legacy: false, generator: false, auth_provider: :eaccess)
+        # Provider-neutral: EAccess.auth also sets this internally (before
+        # its own protocol exchange even starts, so it's visible mid-attempt
+        # for the eaccess path), but WebLogin.auth does not, and the forced
+        # auth_provider: :web / fallback-to-web paths would otherwise skip
+        # EAccess entirely and leave this unset -- breaking session-file
+        # creation, setup-file resolution, and active-session lifecycle
+        # naming, which all read Account.character.
+        if defined?(Lich::Common::Account)
+          Lich::Common::Account.name = account
+          Lich::Common::Account.game_code = game_code
+          Lich::Common::Account.character = character
+        end
+
         if auth_provider == :web
           unless web_fallback_supported?(character: character, game_code: game_code, legacy: legacy, generator: generator)
             raise ArgumentError, "auth_provider: :web requires character and game_code, and supports neither legacy nor generator"
@@ -88,6 +127,16 @@ module Lich
         end
       end
 
+      # Dispatches to the appropriate EAccess.auth_with_timeout call shape
+      # based on which of character/game_code/legacy/generator were given.
+      #
+      # @param account [String] account name
+      # @param password [String] account password
+      # @param character [String, nil] character name
+      # @param game_code [String, nil] game instance code
+      # @param legacy [Boolean] use the legacy multi-game enumeration mode
+      # @param generator [Boolean] enter the character generator
+      # @return [Hash, Array] see EAccess.auth
       # @api private
       def self.authenticate_via_eaccess(account:, password:, character:, game_code:, legacy:, generator:)
         with_retry do
@@ -114,12 +163,18 @@ module Lich
         end
       end
 
-      # @api private
       # WebLogin only implements a normal single-character login -- no
       # equivalent yet for legacy multi-game enumeration or character
       # generator entry (see docs/web-login-protocol-analysis.md).
+      #
+      # @param character [String, nil] character name
+      # @param game_code [String, nil] game instance code
+      # @param legacy [Boolean] legacy multi-game enumeration mode requested
+      # @param generator [Boolean] character generator entry requested
+      # @return [Boolean] true if this request shape has a WebLogin equivalent
+      # @api private
       def self.web_fallback_supported?(character:, game_code:, legacy:, generator:)
-        character && game_code && !legacy && !generator
+        !!(character && game_code && !legacy && !generator)
       end
 
       # Executes a block with retry logic for transient errors
@@ -153,9 +208,18 @@ module Lich
               raise FatalAuthError, e.message
             end
 
-            # Transient auth error - allow retry
             last_error = e
 
+            if unreachable_error?(e)
+              # The endpoint itself didn't respond -- retrying it again
+              # immediately isn't going to help, and (when a web fallback is
+              # available) every retry here directly delays it. Stop now
+              # instead of exhausting MAX_AUTH_RETRIES.
+              Lich.log "warn: Authentication endpoint unreachable (#{e.class}: #{e.message}); not retrying the same endpoint"
+              break
+            end
+
+            # Transient (but reachable) auth error - allow retry
             if attempt < MAX_AUTH_RETRIES - 1
               delay = AUTH_RETRY_BASE_DELAY * (2**attempt)
               Lich.log "warn: Authentication attempt #{attempt + 1}/#{MAX_AUTH_RETRIES} failed: " \

--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -28,12 +28,17 @@ module Lich
       # NO_SUBSCRIPTION = WebLogin: account has no active subscription on the requested instance
       FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND GENERATOR_NOT_AVAILABLE LOGIN_FAILED NO_SUBSCRIPTION].freeze
 
-      # Connection-level failures where the endpoint itself didn't respond --
-      # retrying the same unreachable endpoint 3 times with backoff wastes
-      # time (and, when a web fallback is available, delays it) compared to a
-      # protocol-level hiccup on an endpoint that IS reachable, which is
-      # still worth retrying. with_retry stops after the first attempt for
-      # these instead of exhausting MAX_AUTH_RETRIES.
+      # Connection-level failures where the endpoint itself didn't respond.
+      # with_retry can stop after the first attempt for these (see its
+      # fast_fail_unreachable: parameter) when an alternate provider is
+      # actually available to hand off to -- retrying the same unreachable
+      # endpoint 3 times with backoff only wastes time in that case, since
+      # it just delays the handoff. When there is NO alternate provider
+      # (legacy/generator EAccess calls, or a WebLogin call itself, forced
+      # or already-the-fallback), these same error classes get full retries
+      # like any other transient error: an ECONNRESET or "SSL_read:
+      # unexpected eof" mid-exchange is not proof the endpoint is down, and
+      # there is nothing to fail fast *to*.
       UNREACHABLE_ERROR_CLASSES = [
         SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT,
         Errno::EHOSTUNREACH, Errno::ENETUNREACH, OpenSSL::SSL::SSLError
@@ -107,8 +112,13 @@ module Lich
           return result
         end
 
+        fallback_available = web_fallback_supported?(character: character, game_code: game_code, legacy: legacy, generator: generator)
+
         begin
-          result = authenticate_via_eaccess(account: account, password: password, character: character, game_code: game_code, legacy: legacy, generator: generator)
+          result = authenticate_via_eaccess(
+            account: account, password: password, character: character, game_code: game_code,
+            legacy: legacy, generator: generator, fast_fail_unreachable: fallback_available
+          )
           Lich.log "info: authenticated via eaccess"
           result
         rescue FatalAuthError
@@ -117,7 +127,7 @@ module Lich
           # second system for no benefit. Surface the real problem.
           raise
         rescue StandardError => e
-          raise unless web_fallback_supported?(character: character, game_code: game_code, legacy: legacy, generator: generator)
+          raise unless fallback_available
 
           Lich.log "warn: EAccess authentication unavailable (#{e.class}: #{e.message}); falling back to web login"
           result = with_retry {
@@ -137,10 +147,13 @@ module Lich
       # @param game_code [String, nil] game instance code
       # @param legacy [Boolean] use the legacy multi-game enumeration mode
       # @param generator [Boolean] enter the character generator
+      # @param fast_fail_unreachable [Boolean] stop after one attempt on a connection-level
+      #   failure instead of retrying -- only pass true when a WebLogin fallback is actually
+      #   available to hand off to (see Authenticator.authenticate)
       # @return [Hash, Array] see EAccess.auth
       # @api private
-      def self.authenticate_via_eaccess(account:, password:, character:, game_code:, legacy:, generator:)
-        with_retry do
+      def self.authenticate_via_eaccess(account:, password:, character:, game_code:, legacy:, generator:, fast_fail_unreachable: false)
+        with_retry(fast_fail_unreachable: fast_fail_unreachable) do
           if game_code && (character || generator)
             EAccess.auth_with_timeout(
               account: account,
@@ -180,14 +193,23 @@ module Lich
 
       # Executes a block with retry logic for transient errors
       #
+      # @param fast_fail_unreachable [Boolean] if true, a connection-level failure (see
+      #   .unreachable_error?) stops retrying after the first attempt instead of exhausting
+      #   MAX_AUTH_RETRIES. Only pass true when an alternate provider is actually available to
+      #   hand off to (see Authenticator.authenticate) -- otherwise this just gives up early on
+      #   what may be a genuinely transient, reachable-endpoint error (e.g. an ECONNRESET or
+      #   "SSL_read: unexpected eof" mid-exchange) with nothing to fail over to.
       # @yield The block to execute with retry
       # @return [Object] The result of the block
       # @raise [FatalAuthError] For fatal auth failures (bad credentials, etc.)
       # @raise [StandardError] Re-raises the last error after all retries exhausted
-      def self.with_retry
+      def self.with_retry(fast_fail_unreachable: false)
         last_error = nil
+        attempts_made = 0
 
         MAX_AUTH_RETRIES.times do |attempt|
+          attempts_made = attempt + 1
+
           begin
             result = yield
 
@@ -211,16 +233,21 @@ module Lich
 
             last_error = e
 
-            if unreachable_error?(e)
-              # The endpoint itself didn't respond -- retrying it again
-              # immediately isn't going to help, and (when a web fallback is
-              # available) every retry here directly delays it. Stop now
-              # instead of exhausting MAX_AUTH_RETRIES.
-              Lich.log "warn: Authentication endpoint unreachable (#{e.class}: #{e.message}); not retrying the same endpoint"
+            if fast_fail_unreachable && unreachable_error?(e)
+              # The endpoint itself didn't respond, and an alternate
+              # provider is available -- retrying it again immediately
+              # isn't going to help, and every retry here directly delays
+              # the handoff. Stop now instead of exhausting MAX_AUTH_RETRIES.
+              Lich.log "warn: Authentication endpoint unreachable (#{e.class}: #{e.message}); not retrying the same endpoint -- an alternate provider is available"
               break
             end
 
-            # Transient (but reachable) auth error - allow retry
+            # Transient auth error - allow retry (this covers
+            # unreachable_error? classes too when fast_fail_unreachable is
+            # false, e.g. legacy/generator EAccess calls or any WebLogin
+            # call -- there is no alternate provider to fail fast *to* there,
+            # so a reset mid-exchange gets the same retry chance as any
+            # other transient error).
             if attempt < MAX_AUTH_RETRIES - 1
               delay = AUTH_RETRY_BASE_DELAY * (2**attempt)
               Lich.log "warn: Authentication attempt #{attempt + 1}/#{MAX_AUTH_RETRIES} failed: " \
@@ -230,8 +257,11 @@ module Lich
           end
         end
 
-        # All retries exhausted - re-raise the last error
-        Lich.log "error: Authentication failed after #{MAX_AUTH_RETRIES} attempts: #{last_error&.message}"
+        # All retries exhausted (or fast-failed early) - re-raise the last
+        # error, logging how many attempts actually happened rather than
+        # always claiming MAX_AUTH_RETRIES.
+        attempt_word = attempts_made == 1 ? 'attempt' : 'attempts'
+        Lich.log "error: Authentication failed after #{attempts_made} #{attempt_word}: #{last_error&.message}"
         raise last_error
       end
     end

--- a/lib/common/authentication/authenticator.rb
+++ b/lib/common/authentication/authenticator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'eaccess'
+require_relative 'web_login'
 
 module Lich
   module Common
@@ -16,14 +17,32 @@ module Lich
       MAX_AUTH_RETRIES = 3
       AUTH_RETRY_BASE_DELAY = 5 # seconds, doubles each retry: 5s, 10s, 20s
 
-      # Known fatal error codes that should not be retried
+      # Known fatal error codes that should not be retried. Shared across
+      # every provider's AuthenticationError (EAccess, WebLogin) -- with_retry
+      # classifies by error_code alone, not by exception class, so this list
+      # applies uniformly regardless of which provider raised it.
       # REJECT = bad credentials, NORECORD = account not found, INVALID = invalid request
       # PASSWORD = wrong password, CHARACTER_NOT_FOUND = character not in account
       # GENERATOR_NOT_AVAILABLE = account not entitled to create a character on the instance
-      FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND GENERATOR_NOT_AVAILABLE].freeze
+      # LOGIN_FAILED = WebLogin's credential-rejection signal (see web_login.rb)
+      FATAL_ERROR_CODES = %w[REJECT NORECORD INVALID PASSWORD CHARACTER_NOT_FOUND GENERATOR_NOT_AVAILABLE LOGIN_FAILED].freeze
 
-      # Authenticates a user with the game server
-      # Includes automatic retry with exponential backoff for transient errors
+      # Authenticates a user with the game server.
+      #
+      # By default, authenticates via EAccess (eaccess.play.net:7910). If
+      # EAccess fails for any reason OTHER than rejected credentials (a
+      # FatalAuthError -- REJECT/PASSWORD/NORECORD/etc), automatically falls
+      # back to the HTTPS WebLogin path once EAccess's own retries are
+      # exhausted. This distinction matters: EAccess being unreachable is a
+      # reason to try a different transport; EAccess correctly rejecting a
+      # bad password is not -- falling back in that case would just resubmit
+      # the same bad credentials to a second system for no benefit. See
+      # docs/web-login-protocol-analysis.md.
+      #
+      # Fallback only applies to a normal single-character login (character
+      # AND game_code present, not legacy, not generator) -- WebLogin has no
+      # equivalent yet for the legacy multi-game enumeration mode or
+      # character-generator entry.
       #
       # @param account [String] User account name
       # @param password [String] User password
@@ -31,9 +50,46 @@ module Lich
       # @param game_code [String, nil] Game code (optional)
       # @param legacy [Boolean] Whether to use legacy authentication
       # @param generator [Boolean] Whether to enter the character generator instead of selecting a character
+      # @param auth_provider [Symbol] :eaccess (default, with automatic web fallback) or :web to force
+      #   the HTTPS WebLogin path directly, skipping EAccess entirely
       # @return [Hash, Array] Authentication data containing connection information
-      # @raise [StandardError] Re-raises the last error after all retries exhausted
-      def self.authenticate(account:, password:, character: nil, game_code: nil, legacy: false, generator: false)
+      # @raise [StandardError] Re-raises the last error after all retries (and fallback, if applicable) exhausted
+      def self.authenticate(account:, password:, character: nil, game_code: nil, legacy: false, generator: false, auth_provider: :eaccess)
+        if auth_provider == :web
+          unless web_fallback_supported?(character: character, game_code: game_code, legacy: legacy, generator: generator)
+            raise ArgumentError, "auth_provider: :web requires character and game_code, and supports neither legacy nor generator"
+          end
+
+          result = with_retry {
+            WebLogin.auth_with_timeout(account: account, password: password, character: character, game_code: game_code)
+          }
+          Lich.log "info: authenticated via web login (forced by auth_provider: :web)"
+          return result
+        end
+
+        begin
+          result = authenticate_via_eaccess(account: account, password: password, character: character, game_code: game_code, legacy: legacy, generator: generator)
+          Lich.log "info: authenticated via eaccess"
+          result
+        rescue FatalAuthError
+          # Credentials were rejected -- WebLogin would reject the same
+          # credentials too, so falling back would just resubmit them to a
+          # second system for no benefit. Surface the real problem.
+          raise
+        rescue StandardError => e
+          raise unless web_fallback_supported?(character: character, game_code: game_code, legacy: legacy, generator: generator)
+
+          Lich.log "warn: EAccess authentication unavailable (#{e.class}: #{e.message}); falling back to web login"
+          result = with_retry {
+            WebLogin.auth_with_timeout(account: account, password: password, character: character, game_code: game_code)
+          }
+          Lich.log "info: authenticated via web login (fallback from eaccess)"
+          result
+        end
+      end
+
+      # @api private
+      def self.authenticate_via_eaccess(account:, password:, character:, game_code:, legacy:, generator:)
         with_retry do
           if game_code && (character || generator)
             EAccess.auth_with_timeout(
@@ -58,6 +114,14 @@ module Lich
         end
       end
 
+      # @api private
+      # WebLogin only implements a normal single-character login -- no
+      # equivalent yet for legacy multi-game enumeration or character
+      # generator entry (see docs/web-login-protocol-analysis.md).
+      def self.web_fallback_supported?(character:, game_code:, legacy:, generator:)
+        character && game_code && !legacy && !generator
+      end
+
       # Executes a block with retry logic for transient errors
       #
       # @yield The block to execute with retry
@@ -77,26 +141,19 @@ module Lich
             end
 
             return result
-          rescue EAccess::AuthenticationError => e
-            # Check if this is a fatal auth failure
-            if FATAL_ERROR_CODES.any? { |code| e.error_code&.include?(code) }
+          rescue FatalAuthError
+            # Don't retry fatal auth failures - re-raise immediately
+            raise
+          rescue StandardError => e
+            # Classified by error_code alone, not exception class, so this
+            # applies uniformly to any provider's AuthenticationError
+            # (EAccess, WebLogin) -- both expose the same error_code shape.
+            if e.respond_to?(:error_code) && FATAL_ERROR_CODES.any? { |code| e.error_code&.include?(code) }
               Lich.log "error: Authentication fatally failed: #{e.message}"
               raise FatalAuthError, e.message
             end
 
             # Transient auth error - allow retry
-            last_error = e
-
-            if attempt < MAX_AUTH_RETRIES - 1
-              delay = AUTH_RETRY_BASE_DELAY * (2**attempt)
-              Lich.log "warn: Authentication attempt #{attempt + 1}/#{MAX_AUTH_RETRIES} failed: " \
-                       "#{e.message}, retrying in #{delay}s..."
-              sleep(delay)
-            end
-          rescue FatalAuthError
-            # Don't retry fatal auth failures - re-raise immediately
-            raise
-          rescue StandardError => e
             last_error = e
 
             if attempt < MAX_AUTH_RETRIES - 1

--- a/lib/common/authentication/cli.rb
+++ b/lib/common/authentication/cli.rb
@@ -21,12 +21,14 @@ module Lich
         # @param frontend [String, nil] Frontend type (stormfront, avalon, wizard)
         # @param custom_launch [String, nil] Custom launch filter (if provided, frontend is ignored for matching)
         # @param data_dir [String] Directory containing saved login entries
+        # @param auth_provider [Symbol] :eaccess (default, with automatic web fallback) or :web to force
+        #   the HTTPS WebLogin path directly -- see Authenticator.authenticate
         # @return [Array<String>, nil] Launch data strings if successful, nil if login fails
         #
         # @example
         #   launch_data = CLI.execute('MyCharacter', game_code: 'GS3', frontend: 'stormfront', data_dir: '/path/to/data')
         #   # => ["GAME=GS3", "GAMEHOST=eaccess.play.net", ...]
-        def self.execute(character_name, game_code: nil, frontend: nil, custom_launch: nil, data_dir: nil)
+        def self.execute(character_name, game_code: nil, frontend: nil, custom_launch: nil, data_dir: nil, auth_provider: :eaccess)
           data_dir ||= DATA_DIR
 
           unless character_name && !character_name.empty?
@@ -47,7 +49,7 @@ module Lich
           return nil unless char_entry
 
           # Decrypt password and authenticate
-          decrypt_and_authenticate(char_entry, entry_data)
+          decrypt_and_authenticate(char_entry, entry_data, auth_provider: auth_provider)
         end
 
         # Resolves a saved character without decrypting its password or
@@ -119,7 +121,7 @@ module Lich
         #
         # @example
         #   launch_data = CLI.execute_new_character('MYACCOUNT', game_code: 'DR', data_dir: '/path/to/data')
-        def self.execute_new_character(account_name, game_code: nil, frontend: nil, custom_launch: nil, custom_launch_dir: nil, data_dir: nil)
+        def self.execute_new_character(account_name, game_code: nil, frontend: nil, custom_launch: nil, custom_launch_dir: nil, data_dir: nil, auth_provider: :eaccess)
           data_dir ||= DATA_DIR
 
           unless account_name && !account_name.empty?
@@ -149,7 +151,7 @@ module Lich
             generator: true,
           }
 
-          decrypt_and_authenticate(char_entry, entry_data)
+          decrypt_and_authenticate(char_entry, entry_data, auth_provider: auth_provider)
         end
 
         # Treats nil and the :__unset CLI sentinel as "value not provided".
@@ -285,8 +287,10 @@ module Lich
         # @param char_entry [Hash] character entry with :username, :password, :char_name, :game_code, :frontend keys
         #   and an optional :generator flag for character-generator entry
         # @param entry_data [Hash] full entry data (needed for encryption mode)
+        # @param auth_provider [Symbol] :eaccess (default, with automatic web fallback) or :web to force
+        #   the HTTPS WebLogin path directly -- see Authenticator.authenticate
         # @return [Array<String>, nil] launch data strings if successful, nil on failure
-        def self.decrypt_and_authenticate(char_entry, entry_data)
+        def self.decrypt_and_authenticate(char_entry, entry_data, auth_provider: :eaccess)
           # Get encryption mode from YAML
           encryption_mode = (entry_data[:encryption_mode] || 'plaintext').to_sym
 
@@ -314,7 +318,8 @@ module Lich
               password: plaintext_password,
               character: char_entry[:char_name],
               game_code: char_entry[:game_code],
-              generator: char_entry[:generator] || false
+              generator: char_entry[:generator] || false,
+              auth_provider: auth_provider
             )
 
             # Format and return launch data

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -26,6 +26,15 @@ module Lich
         # When sent via the L command, the game server starts the character creation flow.
         NEW_CHARACTER_CODE = "0"
 
+        # Bounds the TCP connect to eaccess.play.net:7910 so a silently-dropped
+        # SYN (firewalled/blocked, no RST) fails in seconds instead of hanging
+        # on the OS connect timeout (commonly ~75s on Linux, driven by
+        # tcp_syn_retries) -- observed live when the port is unreachable but
+        # not actively refused. This only bounds the TCP handshake itself; it
+        # is not a substitute for auth_with_timeout's overall watchdog, which
+        # also covers the TLS handshake and the K/A/M/F/G/P/C/L exchange.
+        CONNECT_TIMEOUT = 5
+
         # @api private
         def self.pem
           @pem ||= File.join(DATA_DIR, "simu.pem")
@@ -40,8 +49,9 @@ module Lich
         def self.download_pem(hostname = "eaccess.play.net", port = 7910)
           # Create an OpenSSL context
           ctx = OpenSSL::SSL::SSLContext.new
-          # Get remote TCP socket
-          sock = TCPSocket.new(hostname, port)
+          # Get remote TCP socket, bounded so an unreachable port fails fast
+          # instead of hanging on the OS connect timeout -- see CONNECT_TIMEOUT.
+          sock = Socket.tcp(hostname, port, connect_timeout: CONNECT_TIMEOUT)
           # pass that socket to OpenSSL
           ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
           # establish connection, if possible
@@ -65,7 +75,8 @@ module Lich
         # @api private
         def self.socket(hostname = "eaccess.play.net", port = 7910)
           download_pem unless pem_exist?
-          socket = TCPSocket.open(hostname, port)
+          # Bounded connect -- see CONNECT_TIMEOUT.
+          socket = Socket.tcp(hostname, port, connect_timeout: CONNECT_TIMEOUT)
           cert_store              = OpenSSL::X509::Store.new
           ssl_context             = OpenSSL::SSL::SSLContext.new
           ssl_context.cert_store  = cert_store

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -110,6 +110,12 @@ module Lich
           # establish connection, if possible
           stage("tls_handshake:pem_bootstrap", probable_cause: "TLS termination misconfiguration (not probable on its own)") do
             ssl.connect
+          rescue StandardError
+            # sync_close only closes the underlying TCP socket when the
+            # SSLSocket itself is explicitly closed -- a failed connect never
+            # reaches that point, and would otherwise leak this descriptor.
+            sock.close rescue nil
+            raise
           end
           # write the .pem to disk
           File.write(pem, ssl.peer_cert)
@@ -151,6 +157,13 @@ module Lich
           ssl_socket.sync_close = true
           connected = stage("tls_handshake:main", probable_cause: "TLS termination misconfiguration (not probable on its own)") do
             ssl_socket.connect
+          rescue StandardError
+            # sync_close only closes the underlying TCP socket when the
+            # SSLSocket itself is explicitly closed -- a failed connect never
+            # reaches that point, and would otherwise leak this descriptor
+            # across retries/fallback.
+            socket.close rescue nil
+            raise
           end
           # Not wrapped in the tls_handshake stage above: a cert mismatch is
           # its own distinct stage (cert_pin_mismatch, logged inside

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -2,6 +2,7 @@
 
 require "openssl"
 require "socket"
+require_relative "launch_result"
 
 module Lich
   module Common
@@ -172,6 +173,7 @@ module Lich
                                      k, v = kv.split("=")
                                      [k.downcase, v]
                                    }.to_h
+              login_info = LaunchResult.normalize(login_info)
             else
               login_info = Array.new
               for game in response.sub(/^M\t/, '').scan(/[^\t]+\t[^\t\n]+/)

--- a/lib/common/authentication/eaccess.rb
+++ b/lib/common/authentication/eaccess.rb
@@ -35,6 +35,57 @@ module Lich
         # also covers the TLS handshake and the K/A/M/F/G/P/C/L exchange.
         CONNECT_TIMEOUT = 5
 
+        # Simutronics-recognized rejection tokens the `A` command can return.
+        # Distinguishes a normal, expected credential rejection from an
+        # unrecognized/empty/malformed response, which points at a different
+        # class of problem (relay or backend divergence) -- see
+        # docs/eaccess-failure-diagnostics.md.
+        KNOWN_REJECTION_TOKENS = %w[REJECT NORECORD INVALID PASSWORD].freeze
+
+        # @param error [StandardError] the error raised by the a_response stage
+        # @return [String] a probable-cause hint distinguishing a normal credential
+        #   rejection from an unrecognized response
+        # @api private
+        def self.classify_a_response_failure(error)
+          code = error.respond_to?(:error_code) ? error.error_code : nil
+          if code && KNOWN_REJECTION_TOKENS.any? { |token| code.include?(token) }
+            "recognized credential rejection (#{code}) -- normal, not a backend issue"
+          else
+            "unrecognized/malformed response -- possible application/backend divergence"
+          end
+        end
+
+        # Wraps a step of the connect/handshake/protocol exchange so a
+        # failure is logged with which stage it happened in, how long that
+        # stage ran before failing, and a probable-cause hint -- see
+        # docs/eaccess-failure-diagnostics.md for the full taxonomy. Never
+        # logs raw protocol response bodies, the account password, or the
+        # session key: only the stage name, exception class/message, and the
+        # derived probable-cause classification.
+        #
+        # Also records the stage name on the current thread so
+        # auth_with_timeout can report which stage was in flight if the
+        # overall watchdog has to kill a hung attempt.
+        #
+        # @param name [String] stage identifier (see docs/eaccess-failure-diagnostics.md)
+        # @param probable_cause [String, Proc] a fixed hint, or a callable receiving the raised
+        #   error and returning a hint -- used when the classification depends on what failed
+        #   (e.g. a_response's recognized-rejection-vs-divergence split)
+        # @yield the stage's work
+        # @return the block's return value
+        # @raise [StandardError] re-raises whatever the block raised, after logging
+        # @api private
+        def self.stage(name, probable_cause:)
+          Thread.current[:eaccess_stage] = name
+          started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          yield
+        rescue StandardError => e
+          duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).round(3)
+          cause = probable_cause.respond_to?(:call) ? probable_cause.call(e) : probable_cause
+          Lich.log "warn: EAccess stage '#{name}' failed after #{duration}s (#{e.class}: #{e.message}) -- likely cause: #{cause}"
+          raise
+        end
+
         # @api private
         def self.pem
           @pem ||= File.join(DATA_DIR, "simu.pem")
@@ -51,11 +102,15 @@ module Lich
           ctx = OpenSSL::SSL::SSLContext.new
           # Get remote TCP socket, bounded so an unreachable port fails fast
           # instead of hanging on the OS connect timeout -- see CONNECT_TIMEOUT.
-          sock = Socket.tcp(hostname, port, connect_timeout: CONNECT_TIMEOUT)
+          sock = stage("tcp_connect:pem_bootstrap", probable_cause: "firewall/routing/load-balancer silently dropping packets (probable), or the host actively refusing (distinct cause)") do
+            Socket.tcp(hostname, port, connect_timeout: CONNECT_TIMEOUT)
+          end
           # pass that socket to OpenSSL
           ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
           # establish connection, if possible
-          ssl.connect
+          stage("tls_handshake:pem_bootstrap", probable_cause: "TLS termination misconfiguration (not probable on its own)") do
+            ssl.connect
+          end
           # write the .pem to disk
           File.write(pem, ssl.peer_cert)
         end
@@ -64,19 +119,29 @@ module Lich
         def self.verify_pem(conn)
           # return if conn.peer_cert.to_s = File.read(pem)
           if !(conn.peer_cert.to_s == File.read(pem))
-            Lich.log "Exception, \nssl peer certificate did not match #{pem}\nwas:\n#{conn.peer_cert}"
+            # Ambiguous by design: a legitimate Simutronics cert rotation and
+            # a MITM presenting a different certificate look identical here.
+            # Flagged as its own stage (cert_pin_mismatch) rather than folded
+            # into a generic warning -- see docs/eaccess-failure-diagnostics.md.
+            # The certificate itself is public data, not a secret, so it's
+            # safe to log in full for diagnosis.
+            Lich.log "warn: EAccess stage 'cert_pin_mismatch' -- peer certificate differs from the " \
+                     "pinned #{pem}; re-pinning automatically. Expected on a legitimate cert " \
+                     "rotation, but indistinguishable here from a MITM presenting a different " \
+                     "certificate. was:\n#{conn.peer_cert}"
             download_pem
           else
             return true
           end
-          #     fail Exception, "\nssl peer certificate did not match #{pem}\nwas:\n#{conn.peer_cert}"
         end
 
         # @api private
         def self.socket(hostname = "eaccess.play.net", port = 7910)
           download_pem unless pem_exist?
           # Bounded connect -- see CONNECT_TIMEOUT.
-          socket = Socket.tcp(hostname, port, connect_timeout: CONNECT_TIMEOUT)
+          socket = stage("tcp_connect:main", probable_cause: "firewall/routing/load-balancer silently dropping packets (probable), or the host actively refusing (distinct cause)") do
+            Socket.tcp(hostname, port, connect_timeout: CONNECT_TIMEOUT)
+          end
           cert_store              = OpenSSL::X509::Store.new
           ssl_context             = OpenSSL::SSL::SSLContext.new
           ssl_context.cert_store  = cert_store
@@ -84,7 +149,14 @@ module Lich
           cert_store.add_file(pem) if pem_exist?
           ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
           ssl_socket.sync_close = true
-          EAccess.verify_pem(ssl_socket.connect)
+          connected = stage("tls_handshake:main", probable_cause: "TLS termination misconfiguration (not probable on its own)") do
+            ssl_socket.connect
+          end
+          # Not wrapped in the tls_handshake stage above: a cert mismatch is
+          # its own distinct stage (cert_pin_mismatch, logged inside
+          # verify_pem), not a handshake failure -- the handshake itself
+          # already succeeded by this point.
+          EAccess.verify_pem(connected)
           return ssl_socket
         end
 
@@ -115,76 +187,99 @@ module Lich
             # it is vitally important to verify self-signed certs
             # because there is no chain-of-trust for them
             EAccess.verify_pem(conn)
-            conn.puts "K\n"
-            hashkey = EAccess.read(conn)
+
+            hashkey = stage("k_response", probable_cause: "a relay or the EAccess target behind 7910 (possible)") do
+              conn.puts "K\n"
+              key = EAccess.read(conn)
+              # A malformed/empty K response would otherwise silently produce
+              # garbage password bytes below, surfacing two steps later as an
+              # unrelated-looking a_response failure instead of being
+              # attributed to this stage.
+              raise AuthenticationError, "MALFORMED_K_RESPONSE" if key.to_s.strip.empty?
+
+              key
+            end
             # pp "hash=%s" % hashkey
             password = password.split('').map { |c| c.getbyte(0) }
             hashkey = hashkey.split('').map { |c| c.getbyte(0) }
             password.each_index { |i| password[i] = ((password[i] - 32) ^ hashkey[i]) + 32 }
             password = password.map { |c| c.chr }.join
-            conn.puts "A\t#{account}\t#{password}\n"
-            response = EAccess.read(conn)
-            unless /KEY\t(?<key>.*)\t/.match(response)
-              error_code = response.split(/\s+/).last
-              raise AuthenticationError, error_code
+
+            stage("a_response", probable_cause: ->(e) { classify_a_response_failure(e) }) do
+              conn.puts "A\t#{account}\t#{password}\n"
+              response = EAccess.read(conn)
+              unless /KEY\t(?<key>.*)\t/.match(response)
+                error_code = response.split(/\s+/).last
+                raise AuthenticationError, error_code
+              end
             end
             # pp "A:response=%s" % response
-            conn.puts "M\n"
-            response = EAccess.read(conn)
-            raise StandardError, response unless response =~ /^M\t/
+            response = stage("m_response", probable_cause: "session accepted but the immediate follow-up command failed -- possible session-affinity issue on a load-balanced backend") do
+              conn.puts "M\n"
+              m_response = EAccess.read(conn)
+              raise StandardError, m_response unless m_response =~ /^M\t/
+
+              m_response
+            end
             # pp "M:response=%s" % response
 
             unless legacy
-              conn.puts "F\t#{game_code}\n"
-              response = EAccess.read(conn)
-              # F reports the account's tier for this instance. NEW_TO_GAME is the
-              # normal response for any instance the account is not subscribed to --
-              # not an error. The generator path tolerates it because character
-              # creation is exactly the flow that targets instances the account does
-              # not already hold; whether creation is permitted is decided later by
-              # the L response, not here.
-              unless response =~ /NORMAL|PREMIUM|TRIAL|INTERNAL|FREE/ || (generator && response =~ /NEW_TO_GAME/)
-                raise StandardError, response
+              stage("entitlement_response", probable_cause: "a backend/DB dependency specific to entitlements, not the auth path itself") do
+                conn.puts "F\t#{game_code}\n"
+                response = EAccess.read(conn)
+                # F reports the account's tier for this instance. NEW_TO_GAME is the
+                # normal response for any instance the account is not subscribed to --
+                # not an error. The generator path tolerates it because character
+                # creation is exactly the flow that targets instances the account does
+                # not already hold; whether creation is permitted is decided later by
+                # the L response, not here.
+                unless response =~ /NORMAL|PREMIUM|TRIAL|INTERNAL|FREE/ || (generator && response =~ /NEW_TO_GAME/)
+                  raise StandardError, response
+                end
+                if defined?(Lich::Common::Account)
+                  Lich::Common::Account.subscription = response
+                end
+                # pp "F:response=%s" % response
+                conn.puts "G\t#{game_code}\n"
+                EAccess.read(conn)
+                # pp "G:response=%s" % response
+                conn.puts "P\t#{game_code}\n"
+                EAccess.read(conn)
+                # pp "P:response=%s" % response
+                conn.puts "C\n"
+                response = EAccess.read(conn)
+                # pp "C:response=%s" % response
+                if defined?(Lich::Common::Account)
+                  Lich::Common::Account.members = response
+                end
               end
-              if defined?(Lich::Common::Account)
-                Lich::Common::Account.subscription = response
-              end
-              # pp "F:response=%s" % response
-              conn.puts "G\t#{game_code}\n"
-              EAccess.read(conn)
-              # pp "G:response=%s" % response
-              conn.puts "P\t#{game_code}\n"
-              EAccess.read(conn)
-              # pp "P:response=%s" % response
-              conn.puts "C\n"
-              response = EAccess.read(conn)
-              # pp "C:response=%s" % response
-              if defined?(Lich::Common::Account)
-                Lich::Common::Account.members = response
-              end
+
               char_code = generator ? NEW_CHARACTER_CODE : resolve_char_code(response, character)
-              conn.puts "L\t#{char_code}\tSTORM\n"
-              response = EAccess.read(conn)
-              # Both success and failure are prefixed with "L\t" (e.g. the server
-              # returns "L\tPROBLEM\t1" when the account is not entitled to create on
-              # this instance), so require the explicit OK before parsing the launch
-              # payload -- otherwise a PROBLEM line is parsed into a garbage hash.
-              unless response =~ /^L\tOK\t/
-                # On the generator path a PROBLEM here means the account has no
-                # entitlement to create a character on this instance (e.g. an
-                # unsubscribed Fallen/Shattered). Fail fast with a clear code rather
-                # than crash or launch broken data.
-                raise AuthenticationError, "GENERATOR_NOT_AVAILABLE" if generator
-                raise StandardError, response
-              end
-              # pp "L:response=%s" % response
-              login_info = response.sub(/^L\tOK\t/, '')
+
+              login_info = stage("l_response", probable_cause: "protocol/backend divergence at the final step") do
+                conn.puts "L\t#{char_code}\tSTORM\n"
+                l_response = EAccess.read(conn)
+                # Both success and failure are prefixed with "L\t" (e.g. the server
+                # returns "L\tPROBLEM\t1" when the account is not entitled to create on
+                # this instance), so require the explicit OK before parsing the launch
+                # payload -- otherwise a PROBLEM line is parsed into a garbage hash.
+                unless l_response =~ /^L\tOK\t/
+                  # On the generator path a PROBLEM here means the account has no
+                  # entitlement to create a character on this instance (e.g. an
+                  # unsubscribed Fallen/Shattered). Fail fast with a clear code rather
+                  # than crash or launch broken data.
+                  raise AuthenticationError, "GENERATOR_NOT_AVAILABLE" if generator
+                  raise StandardError, l_response
+                end
+                # pp "L:response=%s" % l_response
+                parsed = l_response.sub(/^L\tOK\t/, '')
                                    .split("\t")
                                    .map { |kv|
                                      k, v = kv.split("=")
                                      [k.downcase, v]
                                    }.to_h
-              login_info = LaunchResult.normalize(login_info)
+                LaunchResult.normalize(parsed)
+              end
             else
               login_info = Array.new
               for game in response.sub(/^M\t/, '').scan(/[^\t]+\t[^\t\n]+/)
@@ -269,7 +364,15 @@ module Lich
             auth(**kwargs)
           }
           if auth_thread.join(timeout).nil?
+            # The stage marker set by `stage` lives on the thread object
+            # itself, readable from here even after kill -- the one case
+            # where the exchange hangs with no exception at all (a stalled
+            # connect or a read that never returns) otherwise leaves zero
+            # indication of which step it was stuck in. See
+            # docs/eaccess-failure-diagnostics.md.
+            stalled_stage = auth_thread[:eaccess_stage] || "connect (pre-stage)"
             auth_thread.kill rescue nil
+            Lich.log "warn: EAccess timed out after #{timeout}s while in stage '#{stalled_stage}'"
             raise "error: timed out authenticating with EAccess after #{timeout}s"
           end
           auth_thread.value

--- a/lib/common/authentication/launch_result.rb
+++ b/lib/common/authentication/launch_result.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Lich
+  module Common
+    module Authentication
+      # Normalizes the launch-result hash returned by a single-character
+      # authentication (EAccess's non-legacy .auth, WebLogin's .auth) to one
+      # shared shape, so Authenticator and downstream consumers (LaunchData,
+      # session_launcher) don't need to know which provider produced it.
+      #
+      # Deliberately a plain Hash, not a Struct/value class -- callers
+      # (LaunchData.prepare) already consume it duck-typed as
+      # `auth_data.map { |k, v| ... }`, and EAccess's legacy multi-game
+      # enumeration mode returns a wholly different shape (an Array of
+      # per-character hashes) that this module does not apply to.
+      module LaunchResult
+        # KEY is the one field both providers always have: EAccess gets it
+        # from every successful L response (even the generator path, which
+        # can omit GAMEHOST/GAMEPORT -- see eaccess_spec.rb's generator
+        # tests), and WebLogin gets it from the final redirect's query
+        # string. GAMEHOST/GAMEPORT are correspondingly NOT required here.
+        REQUIRED_KEYS = %w[key].freeze
+
+        # Raised when a provider's launch data is missing a field every
+        # consumer of this shared shape depends on.
+        class MissingLaunchDataError < StandardError
+          def initialize(missing_keys)
+            super("launch result missing required key(s): #{missing_keys.join(', ')}")
+          end
+        end
+
+        # @param raw [Hash] provider-specific launch data (string or symbol keys)
+        # @return [Hash] the same data with lowercase string keys, frozen
+        # @raise [MissingLaunchDataError] if a required key is absent or blank
+        def self.normalize(raw)
+          normalized = raw.each_with_object({}) { |(k, v), h| h[k.to_s.downcase] = v }
+
+          missing = REQUIRED_KEYS.select { |key| normalized[key].to_s.empty? }
+          raise MissingLaunchDataError, missing unless missing.empty?
+
+          normalized.freeze
+        end
+      end
+    end
+  end
+end

--- a/lib/common/authentication/web_login.rb
+++ b/lib/common/authentication/web_login.rb
@@ -78,6 +78,8 @@ module Lich
             self
           end
 
+          # Builds the Cookie header value for the next request.
+          #
           # @return [String, nil] Cookie header value for the next request, or nil if empty
           def header
             return nil if @pairs.empty?
@@ -195,18 +197,6 @@ module Lich
           auth_thread.value
         end
 
-        # Step 0 + 1: GET the family's sign-in page first to establish an ASP
-        # session cookie, then POST credentials against that session --
-        # confirmed live as required: posting login.asp cold (no prior GET,
-        # no session cookie) gets a bare 500 from the server, matching how a
-        # real browser always visits signin_needed.asp before submitting the
-        # form. Failure is detected by comparing the redirect target's PATH
-        # against the two page paths we supplied -- not a prefix match
-        # against the raw Location string, which would also match an
-        # unrelated same-prefix page (e.g. "login_error.aspX") and would miss
-        # an absolute-URL redirect entirely -- and NOT by parsing response
-        # body text.
-        #
         # An account that has never set a security question is redirected
         # here instead of okay_page on an otherwise-successful login --
         # confirmed live. The session is already fully authenticated at this
@@ -219,6 +209,19 @@ module Lich
         # CHARACTER_NOT_FOUND rather than proceeding on bad data.
         SECURITY_QA_PATH = "/playdotnet/account/security_qa.asp"
 
+        # GETs the family's sign-in page first to establish an ASP session
+        # cookie, then POSTs credentials against that session -- confirmed
+        # live as required: posting login.asp cold (no prior GET, no session
+        # cookie) gets a bare 500 from the server, matching how a real
+        # browser always visits signin_needed.asp before submitting the
+        # form. Failure is detected by comparing the redirect target's PATH
+        # against the two page paths we supplied -- not a prefix match
+        # against the raw Location string, which would also match an
+        # unrelated same-prefix page (e.g. "login_error.aspX") and would
+        # miss an absolute-URL redirect entirely -- and NOT by parsing
+        # response body text. See SECURITY_QA_PATH for the one other
+        # accepted redirect target.
+        #
         # @param http [Net::HTTP] open connection to BASE_HOST
         # @param jar [CookieJar] session cookie jar, mutated in place
         # @param account [String] account name
@@ -268,13 +271,15 @@ module Lich
         # @param character [String] character name to match (case-insensitive)
         # @return [String] the matched charID (e.g. "W_ACCOUNT_000")
         # @raise [AuthenticationError] "NO_SUBSCRIPTION" if the account has no active subscription
-        #   on this instance, "CHARACTER_NOT_FOUND" if no radio input matches, or
-        #   "UNEXPECTED_CHARACTER_LIST_RESPONSE" for any other non-200 response
+        #   on this instance, "CHARACTER_NOT_FOUND" if no radio input matches a 200 response, or
+        #   "UNEXPECTED_CHARACTER_LIST_RESPONSE" for any other non-200 response (a 3xx to anywhere
+        #   but subscription_needed.asp, or a 4xx/5xx)
         # @api private
         def self.resolve_char_code(http, jar, instance:, character:)
           response = get(http, jar, instance[:character_list_path])
+          code = response.code.to_i
 
-          if (300..399).cover?(response.code.to_i)
+          if (300..399).cover?(code)
             # Confirmed live: an account with no active subscription on this
             # instance gets a *second* redirect here (the first, from
             # login.asp, already landed on okay_page successfully) --
@@ -286,6 +291,15 @@ module Lich
 
             raise AuthenticationError, "UNEXPECTED_CHARACTER_LIST_RESPONSE"
           end
+
+          # A non-3xx error response (4xx/5xx -- e.g. a transient 503) must
+          # not fall through to the scraper either: an empty/error body
+          # scrapes to no match, which would otherwise raise the same
+          # CHARACTER_NOT_FOUND a real "no such character" case raises --
+          # and Authenticator treats CHARACTER_NOT_FOUND as fatal (no
+          # retry), silently discarding what may well have been a transient,
+          # retryable server error.
+          raise AuthenticationError, "UNEXPECTED_CHARACTER_LIST_RESPONSE" unless code == 200
 
           body = response.body.to_s
           body.scan(/id="(W_[A-Za-z0-9_]+)"[^>]*>\s*<label for="\1"><span[^>]*>([^<]+)<\/span>/).each do |char_code, name|
@@ -391,9 +405,12 @@ module Lich
           location = response["location"]
           raise AuthenticationError, "UNEXPECTED_NON_REDIRECT_RESPONSE" unless (300..399).cover?(code) && location && !location.empty?
 
-          return location if full_url
-
-          URI.parse(location).path
+          # Always parse -- even when returning the raw string for chaining
+          # (full_url) -- so a malformed Location raises malformed_code here
+          # rather than being handed unvalidated to `get` as if it were a
+          # well-formed relative path.
+          parsed = URI.parse(location)
+          full_url ? location : parsed.path
         rescue URI::InvalidURIError
           raise AuthenticationError, malformed_code
         end
@@ -454,6 +471,9 @@ module Lich
           raise AuthenticationError, "MALFORMED_LAUNCH_URL"
         end
 
+        # Issues a GET with the common headers set, absorbing any cookies
+        # from the response into the jar before returning it.
+        #
         # @param http [Net::HTTP] open connection to BASE_HOST
         # @param jar [CookieJar] session cookie jar, mutated in place
         # @param path [String] request path

--- a/lib/common/authentication/web_login.rb
+++ b/lib/common/authentication/web_login.rb
@@ -267,12 +267,27 @@ module Lich
         # @param instance [Hash] a CONFIRMED_INSTANCES entry
         # @param character [String] character name to match (case-insensitive)
         # @return [String] the matched charID (e.g. "W_ACCOUNT_000")
-        # @raise [AuthenticationError] "CHARACTER_NOT_FOUND" if no radio input matches
+        # @raise [AuthenticationError] "NO_SUBSCRIPTION" if the account has no active subscription
+        #   on this instance, "CHARACTER_NOT_FOUND" if no radio input matches, or
+        #   "UNEXPECTED_CHARACTER_LIST_RESPONSE" for any other non-200 response
         # @api private
         def self.resolve_char_code(http, jar, instance:, character:)
           response = get(http, jar, instance[:character_list_path])
-          body = response.body.to_s
 
+          if (300..399).cover?(response.code.to_i)
+            # Confirmed live: an account with no active subscription on this
+            # instance gets a *second* redirect here (the first, from
+            # login.asp, already landed on okay_page successfully) --
+            # `get` doesn't follow it, so this would otherwise silently fall
+            # through to an empty body scrape and a misleading
+            # CHARACTER_NOT_FOUND instead of the real cause.
+            subscription_needed_path = "/#{instance[:family]}/play/subscription_needed.asp"
+            raise AuthenticationError, "NO_SUBSCRIPTION" if response["location"] == subscription_needed_path
+
+            raise AuthenticationError, "UNEXPECTED_CHARACTER_LIST_RESPONSE"
+          end
+
+          body = response.body.to_s
           body.scan(/id="(W_[A-Za-z0-9_]+)"[^>]*>\s*<label for="\1"><span[^>]*>([^<]+)<\/span>/).each do |char_code, name|
             return char_code if name.strip.casecmp?(character)
           end

--- a/lib/common/authentication/web_login.rb
+++ b/lib/common/authentication/web_login.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require_relative "launch_result"
+
+module Lich
+  module Common
+    module Authentication
+      # HTTPS-based fallback authentication against play.net's web login flow
+      # (www.play.net), for use when the TLS EAccess protocol
+      # (eaccess.play.net:7910) is unreachable.
+      #
+      # Mirrors EAccess's public interface (.auth / .auth_with_timeout) and
+      # returns the same login_info hash shape (lowercase GAMEHOST/GAMEPORT/KEY
+      # keys, etc.) so Authenticator can select a backend without callers
+      # changing. See docs/web-login-protocol-analysis.md for how this
+      # contract was reverse-engineered from a live browser capture, and for
+      # what remains unconfirmed (GS4/DR Fallen/Platinum/Shattered instance
+      # codes, full error vocabulary, HTML-scrape fragility).
+      #
+      # Unlike EAccess, there is no enumeration endpoint for an account's
+      # characters -- the character list is server-rendered into the game's
+      # home.asp page as radio inputs, so resolving a character name to its
+      # charID means scraping that HTML (see .resolve_char_code). This is the
+      # most fragile part of this module: a play.net markup change breaks it
+      # silently rather than with a clear protocol error.
+      module WebLogin
+        # Raised on login failure or when a character/game code can't be resolved.
+        # error_code is a best-effort label, not a stable server-provided code
+        # like EAccess's REJECT/NORECORD/etc -- see docs/web-login-protocol-analysis.md
+        # "Open Questions" for what remains unconfirmed.
+        class AuthenticationError < StandardError
+          attr_reader :error_code
+
+          def initialize(error_code)
+            @error_code = error_code
+            super("Error(#{error_code})")
+          end
+        end
+
+        BASE_HOST = "www.play.net"
+
+        # Minimal in-memory cookie jar, private to a single .auth call (a
+        # fresh instance per call -- never shared across accounts/sessions).
+        # Only tracks name=value pairs; attributes (Path/HttpOnly/Secure/
+        # Expires/etc) are dropped since we're just replaying whatever the
+        # server issued back to the same host, not implementing full RFC 6265
+        # scoping.
+        # @api private
+        class CookieJar
+          def initialize
+            @pairs = {}
+          end
+
+          # Reads Set-Cookie headers from a response and merges them in,
+          # keyed by cookie name, so a response that only rotates one cookie
+          # doesn't drop others still needed from an earlier response.
+          def absorb(response)
+            response.get_fields("set-cookie").to_a.each do |raw|
+              name, value = raw.split(";", 2).first.to_s.split("=", 2)
+              @pairs[name] = value if name && !name.empty?
+            end
+            self
+          end
+
+          # Cookie header value for the next request, or nil if empty.
+          def header
+            return nil if @pairs.empty?
+
+            @pairs.map { |name, value| "#{name}=#{value}" }.join("; ")
+          end
+        end
+
+        # play.net's front end (CloudFront/WAF) returns a bare 500 for any
+        # request without a browser-like User-Agent -- confirmed live, not
+        # documented anywhere. Ruby's Net::HTTP default UA ("Ruby/x.y.z") is
+        # rejected outright, including on the very first GET. Every request
+        # this module makes must carry this header.
+        USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+        # Game family per instance code, used to build the correct /{family}/... paths.
+        GAME_FAMILY = {
+          "DR" => "dr", "DRT" => "dr", "DRF" => "dr", "DRX" => "dr",
+          "GS3" => "gs4", "GST" => "gs4", "GSF" => "gs4", "GSX" => "gs4"
+        }.freeze
+
+        # The web login flow's own `game` form value, which is NOT always the
+        # same as the EAccess game_code -- confirmed live mismatch: GemStone
+        # Prime is "GS4" here vs "GS3" over EAccess. Only DR, DRT, GS3(->GS4),
+        # and GST are confirmed live; DRF/DRX/GSF/GSX are unconfirmed and
+        # assumed unchanged from the EAccess code pending verification (see
+        # docs/web-login-protocol-analysis.md).
+        WEB_GAME_CODE = {
+          "GS3" => "GS4"
+        }.freeze
+
+        # @api private
+        def self.web_game_code(game_code)
+          WEB_GAME_CODE.fetch(game_code, game_code)
+        end
+
+        # @api private
+        def self.game_family(game_code)
+          GAME_FAMILY.fetch(game_code) { raise AuthenticationError, "UNKNOWN_GAME_CODE" }
+        end
+
+        # Authenticates against play.net's web login flow and resolves a
+        # character launch. Does not support EAccess's `legacy` multi-game
+        # enumeration mode or the `generator` (character-0) flow -- neither
+        # has a confirmed web-flow equivalent yet (see protocol doc).
+        #
+        # @param password [String] account password (sent as an HTTPS form field, not obfuscated client-side)
+        # @param account [String] account name
+        # @param character [String] character name to select (resolved to a charID by scraping home.asp)
+        # @param game_code [String] EAccess-style game instance code (e.g. "DR", "GS3", "GST")
+        # @return [Hash] login info hash: gamehost, gameport, key (confirmed from the server),
+        #   plus game/gamecode/fullgamename/gamefile (NOT server-provided by this flow --
+        #   synthesized locally to match EAccess's STORM/Wrayth defaults so downstream
+        #   LaunchData formatting keeps working; verify these are still correct before
+        #   trusting them for a frontend other than Stormfront/Wrayth)
+        # @raise [AuthenticationError] on login failure or unresolved character/game code
+        def self.auth(password:, account:, character:, game_code:)
+          family = game_family(game_code)
+          http = Net::HTTP.new(BASE_HOST, 443)
+          http.use_ssl = true
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          jar = CookieJar.new
+
+          login(http, jar, account: account, password: password, family: family)
+          char_code = resolve_char_code(http, jar, family: family, character: character)
+          host, port, key = select_character(http, jar, char_code: char_code, family: family, game_code: game_code)
+
+          LaunchResult.normalize(
+            "gamehost"     => host,
+            "gameport"     => port,
+            "key"          => key,
+            # Not returned by this flow -- synthesized to match EAccess's
+            # STORM/Wrayth defaults (see class doc). LaunchData.prepare
+            # already overrides GAME/GAMEFILE/FULLGAMENAME per-frontend for
+            # wizard/avalon/saga/suks, so this only needs to be a correct
+            # default for the Stormfront/Wrayth case.
+            "game"         => "STORM",
+            "gamecode"     => game_code,
+            "fullgamename" => "Wrayth",
+            "gamefile"     => "WRAYTH.EXE",
+          )
+        end
+
+        # @param timeout [Integer, Float] seconds to wait for the full exchange
+        # @param kwargs [Hash] forwarded to {.auth}
+        # @return [Hash] see {.auth}
+        # @raise [RuntimeError] if the exchange does not complete within +timeout+
+        # @raise [StandardError] re-raises whatever {.auth} raises
+        # @see .auth
+        def self.auth_with_timeout(timeout: 30, **kwargs)
+          auth_thread = Thread.new {
+            Thread.current.report_on_exception = false
+            auth(**kwargs)
+          }
+          if auth_thread.join(timeout).nil?
+            auth_thread.kill rescue nil
+            raise "error: timed out authenticating with web login after #{timeout}s"
+          end
+          auth_thread.value
+        end
+
+        # @api private
+        # Step 0 + 1: GET the family's sign-in page first to establish an ASP
+        # session cookie, then POST credentials against that session --
+        # confirmed live as required: posting login.asp cold (no prior GET,
+        # no session cookie) gets a bare 500 from the server, matching how a
+        # real browser always visits signin_needed.asp before submitting the
+        # form. Failure is detected by comparing the redirect target against
+        # the error page we supplied -- NOT by parsing response body text.
+        def self.login(http, jar, account:, password:, family:)
+          okay_page = "/#{family}/play/home.asp"
+          error_page = "/#{family}/login_error.asp"
+
+          get(http, jar, "/#{family}/signin_needed.asp")
+
+          request = Net::HTTP::Post.new("/includes/common/login/login.asp")
+          set_common_headers(request, jar)
+          request["Content-Type"] = "application/x-www-form-urlencoded"
+          request.body = URI.encode_www_form(
+            return_okay_page: okay_page,
+            return_error_page: error_page,
+            remember_account: "",
+            remember_password: "",
+            account_name: account,
+            account_password: password,
+            submit: "Login"
+          )
+          response = http.request(request)
+          jar.absorb(response)
+
+          location = response["location"].to_s
+          if location.start_with?(error_page)
+            raise AuthenticationError, "LOGIN_FAILED"
+          end
+          unless location.start_with?(okay_page)
+            raise AuthenticationError, "UNEXPECTED_LOGIN_RESPONSE"
+          end
+        end
+
+        # @api private
+        # Step 1a: scrape the family's home.asp for the charID matching
+        # `character`. See docs/web-login-protocol-analysis.md for the exact
+        # markup this depends on and why it's the most fragile part of this
+        # module.
+        def self.resolve_char_code(http, jar, family:, character:)
+          response = get(http, jar, "/#{family}/play/home.asp")
+          body = response.body.to_s
+
+          body.scan(/id="(W_[A-Za-z0-9_]+)"[^>]*>\s*<label for="\1"><span[^>]*>([^<]+)<\/span>/).each do |char_code, name|
+            return char_code if name.strip.casecmp?(character)
+          end
+
+          raise AuthenticationError, "CHARACTER_NOT_FOUND"
+        end
+
+        # @api private
+        # Steps 2-4: submit the character/instance selection and follow the
+        # two redirects to the final host/port/key triple, without ever
+        # fetching the web client page itself.
+        def self.select_character(http, jar, char_code:, family:, game_code:)
+          request = Net::HTTP::Post.new("/includes/common/play/goplay2.asp")
+          set_common_headers(request, jar)
+          request["Content-Type"] = "application/x-www-form-urlencoded"
+          request.body = URI.encode_www_form(
+            charID: char_code,
+            managesub: 0,
+            gameName: family,
+            instanceID: 0,
+            game: web_game_code(game_code),
+            frontend: "web"
+          )
+          response = http.request(request)
+          jar.absorb(response)
+          location = follow_redirects(http, jar, response)
+
+          uri = URI.parse(location)
+          params = URI.decode_www_form(uri.query.to_s).to_h
+          host, port, key = params["host"], params["port"], params["key"]
+          raise AuthenticationError, "NO_CONNECTION_INFO" unless host && port && key
+
+          [host, port, key]
+        end
+
+        # @api private
+        # Follows relative Location redirects via GET until an absolute
+        # Location is reached, validates its origin, and returns that URL
+        # string without fetching it -- the final hop carries the connection
+        # info in its query string; fetching it would load the web client
+        # page itself, which we don't want (see class doc).
+        #
+        # A relative Location can never escape www.play.net on its own,
+        # since every GET here reuses the same `http` connection, which is
+        # bound to BASE_HOST regardless of what path string it's given. The
+        # one point that guarantee doesn't hold is an absolute Location, so
+        # any absolute URL -- https or otherwise -- is validated immediately
+        # rather than ever being handed to `get` as if it were a path: an
+        # off-host or downgraded-to-http redirect (compromised/MITM'd
+        # response, unexpected play.net change) must not be trusted, and
+        # must not be silently misinterpreted as a relative path either.
+        def self.follow_redirects(http, jar, response)
+          loop do
+            location = response["location"].to_s
+            if location =~ %r{\Ahttps?://}i
+              uri = URI.parse(location)
+              raise AuthenticationError, "UNTRUSTED_REDIRECT_HOST" unless uri.scheme == "https" && uri.host == BASE_HOST
+
+              return location
+            end
+
+            response = get(http, jar, location)
+          end
+        end
+
+        # @api private
+        def self.get(http, jar, path)
+          request = Net::HTTP::Get.new(path)
+          set_common_headers(request, jar)
+          response = http.request(request)
+          jar.absorb(response)
+          response
+        end
+
+        # @api private
+        # User-Agent is required on every request -- see USER_AGENT.
+        def self.set_common_headers(request, jar)
+          request["User-Agent"] = USER_AGENT
+          cookie = jar.header
+          request["Cookie"] = cookie if cookie
+        end
+      end
+    end
+  end
+end

--- a/lib/common/authentication/web_login.rb
+++ b/lib/common/authentication/web_login.rb
@@ -16,8 +16,13 @@ module Lich
       # keys, etc.) so Authenticator can select a backend without callers
       # changing. See docs/web-login-protocol-analysis.md for how this
       # contract was reverse-engineered from a live browser capture, and for
-      # what remains unconfirmed (GS4/DR Fallen/Platinum/Shattered instance
-      # codes, full error vocabulary, HTML-scrape fragility).
+      # what remains unconfirmed.
+      #
+      # Only game codes confirmed live against the real servers are enabled
+      # (see CONFIRMED_INSTANCES) -- fail closed rather than assume an
+      # untested instance code behaves like a confirmed one; the web layer's
+      # own game codes are not always identical to EAccess's (confirmed
+      # mismatch: GemStone Prime is "GS4" here vs "GS3" over EAccess).
       #
       # Unlike EAccess, there is no enumeration endpoint for an account's
       # characters -- the character list is server-rendered into the game's
@@ -41,6 +46,12 @@ module Lich
 
         BASE_HOST = "www.play.net"
 
+        # Redirect hops .follow_redirects will chase before giving up. The
+        # confirmed live chain is 2 hops (goplay2.asp -> playing_web.asp ->
+        # goplay_web.asp -> final https:// Location); this leaves headroom
+        # without allowing an unbounded loop on an unexpected response.
+        MAX_REDIRECTS = 5
+
         # Minimal in-memory cookie jar, private to a single .auth call (a
         # fresh instance per call -- never shared across accounts/sessions).
         # Only tracks name=value pairs; attributes (Path/HttpOnly/Secure/
@@ -56,6 +67,9 @@ module Lich
           # Reads Set-Cookie headers from a response and merges them in,
           # keyed by cookie name, so a response that only rotates one cookie
           # doesn't drop others still needed from an earlier response.
+          #
+          # @param response [Net::HTTPResponse] response to read Set-Cookie from
+          # @return [CookieJar] self
           def absorb(response)
             response.get_fields("set-cookie").to_a.each do |raw|
               name, value = raw.split(";", 2).first.to_s.split("=", 2)
@@ -64,7 +78,7 @@ module Lich
             self
           end
 
-          # Cookie header value for the next request, or nil if empty.
+          # @return [String, nil] Cookie header value for the next request, or nil if empty
           def header
             return nil if @pairs.empty?
 
@@ -79,30 +93,31 @@ module Lich
         # this module makes must carry this header.
         USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
-        # Game family per instance code, used to build the correct /{family}/... paths.
-        GAME_FAMILY = {
-          "DR" => "dr", "DRT" => "dr", "DRF" => "dr", "DRX" => "dr",
-          "GS3" => "gs4", "GST" => "gs4", "GSF" => "gs4", "GSX" => "gs4"
+        # Every game code this module will accept, each confirmed live
+        # against the real play.net servers -- see
+        # docs/web-login-protocol-analysis.md. Fail closed: a game_code not
+        # in this table raises rather than guessing its family/web-code/host
+        # from the EAccess table, since GS3->GS4 already proved that
+        # assumption wrong once. `expected_host`/`expected_port` are also
+        # used to validate the server's own response (.extract_connection_info)
+        # rather than trusting whatever host/port comes back unchecked.
+        #
+        # DRF/DRX/GSF/GSX are deliberately absent -- add an entry only after
+        # a live probe confirms both the `game` form value this flow expects
+        # and the resulting host/port, the same way these four were.
+        CONFIRMED_INSTANCES = {
+          "DR"  => { family: "dr",  web_game_code: "DR",  expected_host: "storm.dr.game.play.net",  expected_port: "11024" },
+          "DRT" => { family: "dr",  web_game_code: "DRT", expected_host: "hydra.simutronics.com",   expected_port: "11624" },
+          "GS3" => { family: "gs4", web_game_code: "GS4", expected_host: "storm.gs4.game.play.net", expected_port: "10024" },
+          "GST" => { family: "gs4", web_game_code: "GST", expected_host: "chimera.simutronics.com", expected_port: "10624" },
         }.freeze
 
-        # The web login flow's own `game` form value, which is NOT always the
-        # same as the EAccess game_code -- confirmed live mismatch: GemStone
-        # Prime is "GS4" here vs "GS3" over EAccess. Only DR, DRT, GS3(->GS4),
-        # and GST are confirmed live; DRF/DRX/GSF/GSX are unconfirmed and
-        # assumed unchanged from the EAccess code pending verification (see
-        # docs/web-login-protocol-analysis.md).
-        WEB_GAME_CODE = {
-          "GS3" => "GS4"
-        }.freeze
-
+        # @param game_code [String] EAccess-style game instance code
+        # @return [Hash] the CONFIRMED_INSTANCES entry for game_code
+        # @raise [AuthenticationError] "UNSUPPORTED_GAME_CODE" if game_code is not confirmed live
         # @api private
-        def self.web_game_code(game_code)
-          WEB_GAME_CODE.fetch(game_code, game_code)
-        end
-
-        # @api private
-        def self.game_family(game_code)
-          GAME_FAMILY.fetch(game_code) { raise AuthenticationError, "UNKNOWN_GAME_CODE" }
+        def self.instance_for(game_code)
+          CONFIRMED_INSTANCES.fetch(game_code) { raise AuthenticationError, "UNSUPPORTED_GAME_CODE" }
         end
 
         # Authenticates against play.net's web login flow and resolves a
@@ -113,23 +128,24 @@ module Lich
         # @param password [String] account password (sent as an HTTPS form field, not obfuscated client-side)
         # @param account [String] account name
         # @param character [String] character name to select (resolved to a charID by scraping home.asp)
-        # @param game_code [String] EAccess-style game instance code (e.g. "DR", "GS3", "GST")
+        # @param game_code [String] EAccess-style game instance code -- must be a key of CONFIRMED_INSTANCES
         # @return [Hash] login info hash: gamehost, gameport, key (confirmed from the server),
         #   plus game/gamecode/fullgamename/gamefile (NOT server-provided by this flow --
         #   synthesized locally to match EAccess's STORM/Wrayth defaults so downstream
         #   LaunchData formatting keeps working; verify these are still correct before
         #   trusting them for a frontend other than Stormfront/Wrayth)
-        # @raise [AuthenticationError] on login failure or unresolved character/game code
+        # @raise [AuthenticationError] on login failure, an unsupported/unresolved game code or
+        #   character, or a server response that doesn't match the confirmed protocol shape
         def self.auth(password:, account:, character:, game_code:)
-          family = game_family(game_code)
+          instance = instance_for(game_code)
           http = Net::HTTP.new(BASE_HOST, 443)
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
           jar = CookieJar.new
 
-          login(http, jar, account: account, password: password, family: family)
-          char_code = resolve_char_code(http, jar, family: family, character: character)
-          host, port, key = select_character(http, jar, char_code: char_code, family: family, game_code: game_code)
+          login(http, jar, account: account, password: password, family: instance[:family])
+          char_code = resolve_char_code(http, jar, family: instance[:family], character: character)
+          host, port, key = select_character(http, jar, char_code: char_code, instance: instance)
 
           LaunchResult.normalize(
             "gamehost"     => host,
@@ -165,14 +181,28 @@ module Lich
           auth_thread.value
         end
 
-        # @api private
         # Step 0 + 1: GET the family's sign-in page first to establish an ASP
         # session cookie, then POST credentials against that session --
         # confirmed live as required: posting login.asp cold (no prior GET,
         # no session cookie) gets a bare 500 from the server, matching how a
         # real browser always visits signin_needed.asp before submitting the
-        # form. Failure is detected by comparing the redirect target against
-        # the error page we supplied -- NOT by parsing response body text.
+        # form. Failure is detected by comparing the redirect target's PATH
+        # against the two page paths we supplied -- not a prefix match
+        # against the raw Location string, which would also match an
+        # unrelated same-prefix page (e.g. "login_error.aspX") and would miss
+        # an absolute-URL redirect entirely -- and NOT by parsing response
+        # body text.
+        #
+        # @param http [Net::HTTP] open connection to BASE_HOST
+        # @param jar [CookieJar] session cookie jar, mutated in place
+        # @param account [String] account name
+        # @param password [String] account password
+        # @param family [String] game family path segment ("dr" or "gs4")
+        # @return [void]
+        # @raise [AuthenticationError] "LOGIN_FAILED" on rejected credentials, "UNEXPECTED_LOGIN_RESPONSE"
+        #   on any other redirect target, or "UNEXPECTED_NON_REDIRECT_RESPONSE"/"MALFORMED_LOGIN_REDIRECT"
+        #   if the response isn't a well-formed redirect at all
+        # @api private
         def self.login(http, jar, account:, password:, family:)
           okay_page = "/#{family}/play/home.asp"
           error_page = "/#{family}/login_error.asp"
@@ -194,20 +224,23 @@ module Lich
           response = http.request(request)
           jar.absorb(response)
 
-          location = response["location"].to_s
-          if location.start_with?(error_page)
-            raise AuthenticationError, "LOGIN_FAILED"
-          end
-          unless location.start_with?(okay_page)
-            raise AuthenticationError, "UNEXPECTED_LOGIN_RESPONSE"
-          end
+          path = redirect_path(response, malformed_code: "MALFORMED_LOGIN_REDIRECT")
+          raise AuthenticationError, "LOGIN_FAILED" if path == error_page
+          raise AuthenticationError, "UNEXPECTED_LOGIN_RESPONSE" unless path == okay_page
         end
 
-        # @api private
         # Step 1a: scrape the family's home.asp for the charID matching
         # `character`. See docs/web-login-protocol-analysis.md for the exact
         # markup this depends on and why it's the most fragile part of this
         # module.
+        #
+        # @param http [Net::HTTP] open connection to BASE_HOST
+        # @param jar [CookieJar] session cookie jar
+        # @param family [String] game family path segment ("dr" or "gs4")
+        # @param character [String] character name to match (case-insensitive)
+        # @return [String] the matched charID (e.g. "W_ACCOUNT_000")
+        # @raise [AuthenticationError] "CHARACTER_NOT_FOUND" if no radio input matches
+        # @api private
         def self.resolve_char_code(http, jar, family:, character:)
           response = get(http, jar, "/#{family}/play/home.asp")
           body = response.body.to_s
@@ -219,35 +252,40 @@ module Lich
           raise AuthenticationError, "CHARACTER_NOT_FOUND"
         end
 
-        # @api private
         # Steps 2-4: submit the character/instance selection and follow the
-        # two redirects to the final host/port/key triple, without ever
-        # fetching the web client page itself.
-        def self.select_character(http, jar, char_code:, family:, game_code:)
+        # redirects to the final host/port/key triple, without ever fetching
+        # the web client page itself.
+        #
+        # @param http [Net::HTTP] open connection to BASE_HOST
+        # @param jar [CookieJar] session cookie jar
+        # @param char_code [String] charID from .resolve_char_code
+        # @param instance [Hash] a CONFIRMED_INSTANCES entry
+        # @return [Array(String, String, String)] [host, port, key]
+        # @api private
+        def self.select_character(http, jar, char_code:, instance:)
           request = Net::HTTP::Post.new("/includes/common/play/goplay2.asp")
           set_common_headers(request, jar)
           request["Content-Type"] = "application/x-www-form-urlencoded"
           request.body = URI.encode_www_form(
             charID: char_code,
+            # Present in every confirmed live capture except GemStone Test's
+            # (see docs/web-login-protocol-analysis.md) -- sent unconditionally
+            # since an extra form field the server doesn't need for that one
+            # case is far cheaper than silently omitting one it does need.
+            NEWCHARSUB: "TRUE",
             managesub: 0,
-            gameName: family,
+            gameName: instance[:family],
             instanceID: 0,
-            game: web_game_code(game_code),
+            game: instance[:web_game_code],
             frontend: "web"
           )
           response = http.request(request)
           jar.absorb(response)
           location = follow_redirects(http, jar, response)
 
-          uri = URI.parse(location)
-          params = URI.decode_www_form(uri.query.to_s).to_h
-          host, port, key = params["host"], params["port"], params["key"]
-          raise AuthenticationError, "NO_CONNECTION_INFO" unless host && port && key
-
-          [host, port, key]
+          extract_connection_info(location, instance: instance)
         end
 
-        # @api private
         # Follows relative Location redirects via GET until an absolute
         # Location is reached, validates its origin, and returns that URL
         # string without fetching it -- the final hop carries the connection
@@ -259,24 +297,124 @@ module Lich
         # bound to BASE_HOST regardless of what path string it's given. The
         # one point that guarantee doesn't hold is an absolute Location, so
         # any absolute URL -- https or otherwise -- is validated immediately
-        # rather than ever being handed to `get` as if it were a path: an
-        # off-host or downgraded-to-http redirect (compromised/MITM'd
-        # response, unexpected play.net change) must not be trusted, and
-        # must not be silently misinterpreted as a relative path either.
+        # (.validate_final_url!) rather than ever being handed to `get` as if
+        # it were a path.
+        #
+        # @param http [Net::HTTP] open connection to BASE_HOST
+        # @param jar [CookieJar] session cookie jar
+        # @param response [Net::HTTPResponse] the response to start following redirects from
+        # @return [String] the validated final absolute URL (not fetched)
+        # @raise [AuthenticationError] "TOO_MANY_REDIRECTS" past MAX_REDIRECTS hops, or anything
+        #   .redirect_path / .validate_final_url! raises
+        # @api private
         def self.follow_redirects(http, jar, response)
-          loop do
-            location = response["location"].to_s
+          MAX_REDIRECTS.times do
+            location = redirect_path(response, malformed_code: "MALFORMED_REDIRECT_URL", full_url: true)
+            # Any absolute URL -- not just https:// -- must be validated
+            # immediately rather than ever reaching `get` as if it were a
+            # relative path: a plain http:// Location would otherwise be
+            # requested literally as a path string on the existing HTTPS
+            # connection instead of being recognized (and rejected) as the
+            # downgrade attempt it is.
             if location =~ %r{\Ahttps?://}i
-              uri = URI.parse(location)
-              raise AuthenticationError, "UNTRUSTED_REDIRECT_HOST" unless uri.scheme == "https" && uri.host == BASE_HOST
-
+              validate_final_url!(location)
               return location
             end
 
             response = get(http, jar, location)
           end
+
+          raise AuthenticationError, "TOO_MANY_REDIRECTS"
         end
 
+        # Extracts a redirect's target from a response, rejecting anything
+        # that isn't an actual well-formed redirect. Used for both the login
+        # POST's single redirect (where the target only needs to be a path,
+        # to compare against okay_page/error_page) and each hop of
+        # .follow_redirects (where the raw Location -- absolute or relative
+        # -- is needed to continue the chain).
+        #
+        # @param response [Net::HTTPResponse] response to read the redirect from
+        # @param malformed_code [String] AuthenticationError code to raise if Location doesn't parse
+        # @param full_url [Boolean] if true, return the raw Location string (for chaining, since it
+        #   may be relative); if false (default), return just the parsed path (for a same-request
+        #   pass/fail comparison against a known path, robust to an absolute-URL redirect too)
+        # @return [String] the redirect's path, or the raw Location if full_url is true
+        # @raise [AuthenticationError] "UNEXPECTED_NON_REDIRECT_RESPONSE" if the response isn't a 3xx
+        #   with a non-blank Location, or malformed_code if Location doesn't parse as a URI
+        # @api private
+        def self.redirect_path(response, malformed_code:, full_url: false)
+          code = response.code.to_i
+          location = response["location"]
+          raise AuthenticationError, "UNEXPECTED_NON_REDIRECT_RESPONSE" unless (300..399).cover?(code) && location && !location.empty?
+
+          return location if full_url
+
+          URI.parse(location).path
+        rescue URI::InvalidURIError
+          raise AuthenticationError, malformed_code
+        end
+
+        # Strict origin/shape check on the final redirect target: exactly
+        # `https://www.play.net/play/home.asp`, default port, no userinfo.
+        # An off-host target, a downgraded-to-http target, or an unexpected
+        # path/port (compromised/MITM'd response, unexpected play.net
+        # change) must not be trusted, and must not be silently
+        # misinterpreted as something else either.
+        #
+        # @param location [String] absolute URL to validate
+        # @return [void]
+        # @raise [AuthenticationError] "UNTRUSTED_REDIRECT_HOST" if any check fails
+        # @api private
+        def self.validate_final_url!(location)
+          uri = URI.parse(location)
+          valid = uri.is_a?(URI::HTTPS) && uri.host == BASE_HOST && uri.port == 443 &&
+                  uri.userinfo.nil? && uri.path == "/play/home.asp"
+          raise AuthenticationError, "UNTRUSTED_REDIRECT_HOST" unless valid
+        rescue URI::InvalidURIError
+          raise AuthenticationError, "UNTRUSTED_REDIRECT_HOST"
+        end
+
+        # Parses the final redirect's query string into the host/port/key
+        # triple, validated against the requested instance's expected
+        # values rather than trusted as-is. Rejects a duplicate query key
+        # (last-value-wins would otherwise let a repeated `key` param
+        # silently override the real one) and any blank value.
+        #
+        # @param location [String] the validated final URL from .follow_redirects
+        # @param instance [Hash] a CONFIRMED_INSTANCES entry
+        # @return [Array(String, String, String)] [host, port, key]
+        # @raise [AuthenticationError] "MALFORMED_LAUNCH_URL" if the query string doesn't parse,
+        #   "DUPLICATE_QUERY_PARAM" if host/port/key appears more than once, "NO_CONNECTION_INFO"
+        #   if any of host/port/key is missing or blank, or "UNEXPECTED_CONNECTION_INFO" if the
+        #   returned host/port don't match the requested instance's expected values
+        # @api private
+        def self.extract_connection_info(location, instance:)
+          uri = URI.parse(location)
+          grouped = URI.decode_www_form(uri.query.to_s).group_by(&:first)
+
+          %w[host port key].each do |name|
+            raise AuthenticationError, "DUPLICATE_QUERY_PARAM" if grouped[name] && grouped[name].size > 1
+          end
+
+          host = grouped["host"]&.first&.last
+          port = grouped["port"]&.first&.last
+          key = grouped["key"]&.first&.last
+          raise AuthenticationError, "NO_CONNECTION_INFO" if [host, port, key].any? { |v| v.to_s.empty? }
+
+          unless host == instance[:expected_host] && port == instance[:expected_port]
+            raise AuthenticationError, "UNEXPECTED_CONNECTION_INFO"
+          end
+
+          [host, port, key]
+        rescue URI::InvalidURIError, ArgumentError
+          raise AuthenticationError, "MALFORMED_LAUNCH_URL"
+        end
+
+        # @param http [Net::HTTP] open connection to BASE_HOST
+        # @param jar [CookieJar] session cookie jar, mutated in place
+        # @param path [String] request path
+        # @return [Net::HTTPResponse]
         # @api private
         def self.get(http, jar, path)
           request = Net::HTTP::Get.new(path)
@@ -286,8 +424,12 @@ module Lich
           response
         end
 
-        # @api private
         # User-Agent is required on every request -- see USER_AGENT.
+        #
+        # @param request [Net::HTTPRequest] request to set headers on, mutated in place
+        # @param jar [CookieJar] session cookie jar
+        # @return [void]
+        # @api private
         def self.set_common_headers(request, jar)
           request["User-Agent"] = USER_AGENT
           cookie = jar.header

--- a/lib/common/authentication/web_login.rb
+++ b/lib/common/authentication/web_login.rb
@@ -52,6 +52,13 @@ module Lich
         # without allowing an unbounded loop on an unexpected response.
         MAX_REDIRECTS = 5
 
+        # Bounds each individual HTTP request's connect and read phases (see
+        # .auth) so a single black-holed request fails in seconds instead of
+        # relying entirely on auth_with_timeout's 30s overall watchdog --
+        # mirrors EAccess::CONNECT_TIMEOUT's rationale.
+        OPEN_TIMEOUT = 5
+        READ_TIMEOUT = 10
+
         # Minimal in-memory cookie jar, private to a single .auth call (a
         # fresh instance per call -- never shared across accounts/sessions).
         # Only tracks name=value pairs; attributes (Path/HttpOnly/Secure/
@@ -183,29 +190,38 @@ module Lich
         #   character, or a server response that doesn't match the confirmed protocol shape
         def self.auth(password:, account:, character:, game_code:)
           instance = instance_for(game_code)
-          http = Net::HTTP.new(BASE_HOST, 443)
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
           jar = CookieJar.new
 
-          login(http, jar, account: account, password: password, family: instance[:family])
-          char_code = resolve_char_code(http, jar, instance: instance, character: character)
-          host, port, key = select_character(http, jar, char_code: char_code, instance: instance)
+          # Block form: Net::HTTP.start finishes (closes) the connection in
+          # an ensure regardless of how the block exits, on every path --
+          # previously a bare Net::HTTP.new was never explicitly closed on
+          # success or failure, leaving the socket open until GC finalized
+          # it. open_timeout/read_timeout also bound each individual
+          # request's connect/read phases, so a single black-holed request
+          # fails in seconds instead of relying entirely on
+          # auth_with_timeout's 30s overall watchdog to unstick it --
+          # mirrors EAccess::CONNECT_TIMEOUT's rationale.
+          Net::HTTP.start(BASE_HOST, 443, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                           open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
+            login(http, jar, account: account, password: password, family: instance[:family])
+            char_code = resolve_char_code(http, jar, instance: instance, character: character)
+            host, port, key = select_character(http, jar, char_code: char_code, instance: instance)
 
-          LaunchResult.normalize(
-            "gamehost"     => host,
-            "gameport"     => port,
-            "key"          => key,
-            # Not returned by this flow -- synthesized to match EAccess's
-            # STORM/Wrayth defaults (see class doc). LaunchData.prepare
-            # already overrides GAME/GAMEFILE/FULLGAMENAME per-frontend for
-            # wizard/avalon/saga/suks, so this only needs to be a correct
-            # default for the Stormfront/Wrayth case.
-            "game"         => "STORM",
-            "gamecode"     => game_code,
-            "fullgamename" => "Wrayth",
-            "gamefile"     => "WRAYTH.EXE",
-          )
+            LaunchResult.normalize(
+              "gamehost"     => host,
+              "gameport"     => port,
+              "key"          => key,
+              # Not returned by this flow -- synthesized to match EAccess's
+              # STORM/Wrayth defaults (see class doc). LaunchData.prepare
+              # already overrides GAME/GAMEFILE/FULLGAMENAME per-frontend for
+              # wizard/avalon/saga/suks, so this only needs to be a correct
+              # default for the Stormfront/Wrayth case.
+              "game"         => "STORM",
+              "gamecode"     => game_code,
+              "fullgamename" => "Wrayth",
+              "gamefile"     => "WRAYTH.EXE",
+            )
+          end
         end
 
         # @param timeout [Integer, Float] seconds to wait for the full exchange

--- a/lib/common/authentication/web_login.rb
+++ b/lib/common/authentication/web_login.rb
@@ -95,14 +95,34 @@ module Lich
         # this module makes must carry this header.
         USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
-        # Every game code this module will accept, each confirmed live
-        # against the real play.net servers -- see
-        # docs/web-login-protocol-analysis.md. Fail closed: a game_code not
-        # in this table raises rather than guessing its family/web-code/host
-        # from the EAccess table, since GS3->GS4 already proved that
-        # assumption wrong once. `expected_host`/`expected_port` are also
-        # used to validate the server's own response (.extract_connection_info)
-        # rather than trusting whatever host/port comes back unchecked.
+        # Every game code this module will accept, each with a
+        # `character_list_path` (the actual page a user would pick that game
+        # code from -- see below) and a `web_game_code` (the `game` form
+        # value; not always identical to the EAccess code -- confirmed
+        # mismatch: GemStone Prime is "GS4" here vs "GS3" over EAccess).
+        # Fail closed: a game_code not in this table raises rather than
+        # guessing at any of this from the EAccess table.
+        #
+        # `expected_host`/`expected_port`, when present, pin
+        # .extract_connection_info to the exact live-confirmed values rather
+        # than trusting whatever the server's response says. DR, DRT, GS3,
+        # GST, and GSF are all confirmed this way.
+        #
+        # DRX (Platinum) and DRF (Fallen) are enabled with `expected_host`/
+        # `expected_port` deliberately left nil: nobody has an account with
+        # these entitlements to confirm live yet, but they're wired in
+        # end-to-end (character_list_path, family, and a best-guess
+        # web_game_code assuming it matches the EAccess code, as it does for
+        # DR/DRT/GSF -- only GS3->GS4 has ever diverged) so a tester who does
+        # have access can exercise this without a code change. See
+        # .extract_connection_info for what "unverified" relaxes and what it
+        # still enforces, and docs/web-login-protocol-analysis.md for what to
+        # do once a real result comes back: hardcode the observed host/port
+        # here and this comment no longer applies.
+        #
+        # GSX (GemStone Platinum) is absent because the instance itself has
+        # been retired -- LoginHelpers.VALID_GAME_CODES already excludes it
+        # for the same reason, independent of this module.
         #
         # `character_list_path` matters: confirmed live that a character can
         # exist on ONE instance of a family but not appear on that family's
@@ -113,24 +133,33 @@ module Lich
         # has the full account-wide picture (true for DR/DRT/GS3/GST, where
         # the same character happens to be shared, but not a safe general
         # assumption).
-        #
-        # DRF/DRX are deliberately absent -- add an entry only after a live
-        # probe confirms both the `game` form value this flow expects and
-        # the resulting host/port, the same way these five were. GSX
-        # (GemStone Platinum) is absent because the instance itself has been
-        # retired -- LoginHelpers.VALID_GAME_CODES already excludes it for
-        # the same reason, independent of this module.
         CONFIRMED_INSTANCES = {
           "DR"  => { family: "dr",  web_game_code: "DR",  character_list_path: "/dr/play/home.asp",       expected_host: "storm.dr.game.play.net",  expected_port: "11024" },
           "DRT" => { family: "dr",  web_game_code: "DRT", character_list_path: "/dr/play/playdrt.asp",    expected_host: "hydra.simutronics.com",   expected_port: "11624" },
+          "DRX" => { family: "dr",  web_game_code: "DRX", character_list_path: "/dr/play/playx.asp",      expected_host: nil, expected_port: nil }, # unverified -- see comment above
+          "DRF" => { family: "dr",  web_game_code: "DRF", character_list_path: "/dr/play/playf.asp",      expected_host: nil, expected_port: nil }, # unverified -- see comment above
           "GS3" => { family: "gs4", web_game_code: "GS4", character_list_path: "/gs4/play/home.asp",      expected_host: "storm.gs4.game.play.net", expected_port: "10024" },
           "GST" => { family: "gs4", web_game_code: "GST", character_list_path: "/gs4/play/play_test.asp", expected_host: "chimera.simutronics.com", expected_port: "10624" },
           "GSF" => { family: "gs4", web_game_code: "GSF", character_list_path: "/gs4/play/playf.asp",     expected_host: "storm.gs4.game.play.net", expected_port: "10324" },
         }.freeze
 
+        # The fallback guard for an unverified instance's connection info
+        # (.extract_connection_info), since there's no exact expected_host to
+        # match yet -- the returned host must at least end in one of these.
+        # A confirmed instance's exact-match check already implies this, so
+        # this only comes into play for the unverified case.
+        TRUSTED_GAME_HOST_SUFFIXES = [".simutronics.com", ".simutronics.net", ".game.play.net"].freeze
+
+        # @param host [String] hostname to check
+        # @return [Boolean] true if host ends in a known Simutronics game-server domain
+        # @api private
+        def self.trusted_game_host?(host)
+          TRUSTED_GAME_HOST_SUFFIXES.any? { |suffix| host.to_s.end_with?(suffix) }
+        end
+
         # @param game_code [String] EAccess-style game instance code
         # @return [Hash] the CONFIRMED_INSTANCES entry for game_code
-        # @raise [AuthenticationError] "UNSUPPORTED_GAME_CODE" if game_code is not confirmed live
+        # @raise [AuthenticationError] "UNSUPPORTED_GAME_CODE" if game_code is not in CONFIRMED_INSTANCES at all
         # @api private
         def self.instance_for(game_code)
           CONFIRMED_INSTANCES.fetch(game_code) { raise AuthenticationError, "UNSUPPORTED_GAME_CODE" }
@@ -286,8 +315,17 @@ module Lich
             # `get` doesn't follow it, so this would otherwise silently fall
             # through to an empty body scrape and a misleading
             # CHARACTER_NOT_FOUND instead of the real cause.
-            subscription_needed_path = "/#{instance[:family]}/play/subscription_needed.asp"
-            raise AuthenticationError, "NO_SUBSCRIPTION" if response["location"] == subscription_needed_path
+            #
+            # Not one fixed path: confirmed live that this varies per
+            # instance -- DR's is plain "subscription_needed.asp", but
+            # DRX's/DRF's are "subscription_to_plat_needed.asp" /
+            # "subscription_to_fall_needed.asp". Matched by pattern rather
+            # than an exact string so an instance-specific variant we
+            # haven't seen yet (e.g. if GST/GSF ever needs one) is still
+            # recognized instead of falling through to the generic
+            # UNEXPECTED_CHARACTER_LIST_RESPONSE below.
+            subscription_needed_pattern = %r{\A/#{Regexp.escape(instance[:family])}/play/subscription(?:_to_\w+)?_needed\.asp\z}
+            raise AuthenticationError, "NO_SUBSCRIPTION" if response["location"].to_s.match?(subscription_needed_pattern)
 
             raise AuthenticationError, "UNEXPECTED_CHARACTER_LIST_RESPONSE"
           end
@@ -436,18 +474,28 @@ module Lich
         end
 
         # Parses the final redirect's query string into the host/port/key
-        # triple, validated against the requested instance's expected
-        # values rather than trusted as-is. Rejects a duplicate query key
-        # (last-value-wins would otherwise let a repeated `key` param
-        # silently override the real one) and any blank value.
+        # triple. Rejects a duplicate query key (last-value-wins would
+        # otherwise let a repeated `key` param silently override the real
+        # one) and any blank value.
+        #
+        # For a confirmed instance (expected_host/expected_port both
+        # present), the returned host/port must match exactly rather than
+        # being trusted as-is. For an unverified instance (see
+        # CONFIRMED_INSTANCES), there's nothing yet to match exactly, so the
+        # host is instead checked against TRUSTED_GAME_HOST_SUFFIXES -- a
+        # looser but still real guard, and the observed host/port are logged
+        # so they can be promoted into CONFIRMED_INSTANCES once a live
+        # result confirms them.
         #
         # @param location [String] the validated final URL from .follow_redirects
         # @param instance [Hash] a CONFIRMED_INSTANCES entry
         # @return [Array(String, String, String)] [host, port, key]
         # @raise [AuthenticationError] "MALFORMED_LAUNCH_URL" if the query string doesn't parse,
         #   "DUPLICATE_QUERY_PARAM" if host/port/key appears more than once, "NO_CONNECTION_INFO"
-        #   if any of host/port/key is missing or blank, or "UNEXPECTED_CONNECTION_INFO" if the
-        #   returned host/port don't match the requested instance's expected values
+        #   if any of host/port/key is missing or blank, "UNEXPECTED_CONNECTION_INFO" if a
+        #   confirmed instance's returned host/port don't match its expected values, or
+        #   "UNTRUSTED_CONNECTION_HOST" if an unverified instance's returned host isn't a
+        #   recognized Simutronics game-server domain
         # @api private
         def self.extract_connection_info(location, instance:)
           uri = URI.parse(location)
@@ -462,8 +510,16 @@ module Lich
           key = grouped["key"]&.first&.last
           raise AuthenticationError, "NO_CONNECTION_INFO" if [host, port, key].any? { |v| v.to_s.empty? }
 
-          unless host == instance[:expected_host] && port == instance[:expected_port]
-            raise AuthenticationError, "UNEXPECTED_CONNECTION_INFO"
+          if instance[:expected_host] && instance[:expected_port]
+            unless host == instance[:expected_host] && port == instance[:expected_port]
+              raise AuthenticationError, "UNEXPECTED_CONNECTION_INFO"
+            end
+          else
+            raise AuthenticationError, "UNTRUSTED_CONNECTION_HOST" unless trusted_game_host?(host)
+
+            Lich.log "warn: WebLogin -- #{instance[:web_game_code]} has no pinned host/port yet " \
+                     "(unverified instance); observed host=#{host} port=#{port}. If this login " \
+                     "succeeded, hardcode these into CONFIRMED_INSTANCES."
           end
 
           [host, port, key]

--- a/lib/common/authentication/web_login.rb
+++ b/lib/common/authentication/web_login.rb
@@ -102,14 +102,28 @@ module Lich
         # used to validate the server's own response (.extract_connection_info)
         # rather than trusting whatever host/port comes back unchecked.
         #
-        # DRF/DRX/GSF/GSX are deliberately absent -- add an entry only after
-        # a live probe confirms both the `game` form value this flow expects
-        # and the resulting host/port, the same way these four were.
+        # `character_list_path` matters: confirmed live that a character can
+        # exist on ONE instance of a family but not appear on that family's
+        # generic /home.asp at all (a GemStone Shattered-only character does
+        # not show up on the GemStone Prime page) -- so .resolve_char_code
+        # must scrape the same instance-specific page a user would actually
+        # pick this game code from, not assume the family's home.asp always
+        # has the full account-wide picture (true for DR/DRT/GS3/GST, where
+        # the same character happens to be shared, but not a safe general
+        # assumption).
+        #
+        # DRF/DRX are deliberately absent -- add an entry only after a live
+        # probe confirms both the `game` form value this flow expects and
+        # the resulting host/port, the same way these five were. GSX
+        # (GemStone Platinum) is absent because the instance itself has been
+        # retired -- LoginHelpers.VALID_GAME_CODES already excludes it for
+        # the same reason, independent of this module.
         CONFIRMED_INSTANCES = {
-          "DR"  => { family: "dr",  web_game_code: "DR",  expected_host: "storm.dr.game.play.net",  expected_port: "11024" },
-          "DRT" => { family: "dr",  web_game_code: "DRT", expected_host: "hydra.simutronics.com",   expected_port: "11624" },
-          "GS3" => { family: "gs4", web_game_code: "GS4", expected_host: "storm.gs4.game.play.net", expected_port: "10024" },
-          "GST" => { family: "gs4", web_game_code: "GST", expected_host: "chimera.simutronics.com", expected_port: "10624" },
+          "DR"  => { family: "dr",  web_game_code: "DR",  character_list_path: "/dr/play/home.asp",       expected_host: "storm.dr.game.play.net",  expected_port: "11024" },
+          "DRT" => { family: "dr",  web_game_code: "DRT", character_list_path: "/dr/play/playdrt.asp",    expected_host: "hydra.simutronics.com",   expected_port: "11624" },
+          "GS3" => { family: "gs4", web_game_code: "GS4", character_list_path: "/gs4/play/home.asp",      expected_host: "storm.gs4.game.play.net", expected_port: "10024" },
+          "GST" => { family: "gs4", web_game_code: "GST", character_list_path: "/gs4/play/play_test.asp", expected_host: "chimera.simutronics.com", expected_port: "10624" },
+          "GSF" => { family: "gs4", web_game_code: "GSF", character_list_path: "/gs4/play/playf.asp",     expected_host: "storm.gs4.game.play.net", expected_port: "10324" },
         }.freeze
 
         # @param game_code [String] EAccess-style game instance code
@@ -144,7 +158,7 @@ module Lich
           jar = CookieJar.new
 
           login(http, jar, account: account, password: password, family: instance[:family])
-          char_code = resolve_char_code(http, jar, family: instance[:family], character: character)
+          char_code = resolve_char_code(http, jar, instance: instance, character: character)
           host, port, key = select_character(http, jar, char_code: char_code, instance: instance)
 
           LaunchResult.normalize(
@@ -193,6 +207,18 @@ module Lich
         # an absolute-URL redirect entirely -- and NOT by parsing response
         # body text.
         #
+        # An account that has never set a security question is redirected
+        # here instead of okay_page on an otherwise-successful login --
+        # confirmed live. The session is already fully authenticated at this
+        # point (the account name renders in the page banner; Set-Cookie
+        # already carries the real session), so this is not a login failure
+        # -- .resolve_char_code's own subsequent GET of okay_page picks up
+        # the same authenticated session, matching what manually navigating
+        # straight to the game's play page does in a browser. If that
+        # assumption were ever wrong, resolve_char_code fails safely with
+        # CHARACTER_NOT_FOUND rather than proceeding on bad data.
+        SECURITY_QA_PATH = "/playdotnet/account/security_qa.asp"
+
         # @param http [Net::HTTP] open connection to BASE_HOST
         # @param jar [CookieJar] session cookie jar, mutated in place
         # @param account [String] account name
@@ -226,23 +252,25 @@ module Lich
 
           path = redirect_path(response, malformed_code: "MALFORMED_LOGIN_REDIRECT")
           raise AuthenticationError, "LOGIN_FAILED" if path == error_page
-          raise AuthenticationError, "UNEXPECTED_LOGIN_RESPONSE" unless path == okay_page
+          return if path == okay_page || path == SECURITY_QA_PATH
+
+          raise AuthenticationError, "UNEXPECTED_LOGIN_RESPONSE"
         end
 
-        # Step 1a: scrape the family's home.asp for the charID matching
-        # `character`. See docs/web-login-protocol-analysis.md for the exact
-        # markup this depends on and why it's the most fragile part of this
-        # module.
+        # Step 1a: scrape the requested instance's character-selection page
+        # for the charID matching `character`. See
+        # docs/web-login-protocol-analysis.md for the exact markup this
+        # depends on and why it's the most fragile part of this module.
         #
         # @param http [Net::HTTP] open connection to BASE_HOST
         # @param jar [CookieJar] session cookie jar
-        # @param family [String] game family path segment ("dr" or "gs4")
+        # @param instance [Hash] a CONFIRMED_INSTANCES entry
         # @param character [String] character name to match (case-insensitive)
         # @return [String] the matched charID (e.g. "W_ACCOUNT_000")
         # @raise [AuthenticationError] "CHARACTER_NOT_FOUND" if no radio input matches
         # @api private
-        def self.resolve_char_code(http, jar, family:, character:)
-          response = get(http, jar, "/#{family}/play/home.asp")
+        def self.resolve_char_code(http, jar, instance:, character:)
+          response = get(http, jar, instance[:character_list_path])
           body = response.body.to_s
 
           body.scan(/id="(W_[A-Za-z0-9_]+)"[^>]*>\s*<label for="\1"><span[^>]*>([^<]+)<\/span>/).each do |char_code, name|

--- a/lib/common/cli/cli_orchestration.rb
+++ b/lib/common/cli/cli_orchestration.rb
@@ -288,6 +288,8 @@ module Lich
         # of the real login path (Authenticator.authenticate), which also
         # uses WebLogin, either forced via --auth-provider=web or
         # automatically as a fallback when EAccess is unreachable.
+        #
+        # @return [void] exits the process; never returns normally
         def self.handle_web_login_test
           idx = ARGV.index('--web-login-test')
           account = ARGV[idx + 1]

--- a/lib/common/cli/cli_orchestration.rb
+++ b/lib/common/cli/cli_orchestration.rb
@@ -283,10 +283,11 @@ module Lich
         end
 
         # Standalone probe of the HTTPS web-login fallback path (see
-        # docs/web-login-protocol-analysis.md). Deliberately NOT wired into
-        # Authenticator/EAccess -- this exercises Web.auth_with_timeout in
-        # isolation so the fallback can be validated against play.net before
-        # any real login path depends on it.
+        # docs/web-login-protocol-analysis.md). Exercises
+        # WebLogin.auth_with_timeout directly against play.net -- independent
+        # of the real login path (Authenticator.authenticate), which also
+        # uses WebLogin, either forced via --auth-provider=web or
+        # automatically as a fallback when EAccess is unreachable.
         def self.handle_web_login_test
           idx = ARGV.index('--web-login-test')
           account = ARGV[idx + 1]
@@ -329,7 +330,11 @@ module Lich
               game_code: game_code
             )
             $stdout.puts 'Success:'
-            login_info.each { |k, v| $stdout.puts "  #{k.upcase}=#{v}" }
+            # KEY is a live, usable one-time game-server credential -- printing
+            # it would leave a real secret in terminal scrollback/log capture
+            # for a probe that never consumes it. Only non-secret connection
+            # metadata is shown.
+            login_info.each { |k, v| $stdout.puts "  #{k.upcase}=#{k == 'key' ? '[scrubbed]' : v}" }
             exit 0
           rescue Lich::Common::Authentication::WebLogin::AuthenticationError => e
             $stdout.puts "error: web login failed: #{e.error_code}"

--- a/lib/common/cli/cli_orchestration.rb
+++ b/lib/common/cli/cli_orchestration.rb
@@ -7,6 +7,7 @@ require_relative 'cli_conversion'
 require_relative 'cli_encryption_mode_change'
 require_relative '../authentication/cli'
 require_relative '../authentication/login_helpers'
+require_relative '../authentication/web_login'
 require_relative '../gui/game_selection'
 require_relative 'cli_option_validator'
 
@@ -41,6 +42,8 @@ module Lich
               handle_convert_entries
             when /^--change-encryption-mode$/, /^-cem$/
               handle_change_encryption_mode
+            when /^--web-login-test$/
+              handle_web_login_test
             end
           end
 
@@ -277,6 +280,64 @@ module Lich
           master_password = ARGV[mp_index + 1] if mp_index
 
           exit Lich::Common::CLI::EncryptionModeChange.change_mode(new_mode, master_password)
+        end
+
+        # Standalone probe of the HTTPS web-login fallback path (see
+        # docs/web-login-protocol-analysis.md). Deliberately NOT wired into
+        # Authenticator/EAccess -- this exercises Web.auth_with_timeout in
+        # isolation so the fallback can be validated against play.net before
+        # any real login path depends on it.
+        def self.handle_web_login_test
+          idx = ARGV.index('--web-login-test')
+          account = ARGV[idx + 1]
+          char_name = ARGV[idx + 2]
+
+          lich_script = File.join(LICH_DIR, 'lich.rbw')
+          usage = "Usage: ruby #{lich_script} --web-login-test ACCOUNT CHAR_NAME --game-code CODE\n" \
+                  "Reads the account's password from data/entry.yaml (ACCOUNT must already be saved there).\n" \
+                  'This is a standalone probe of the HTTPS web-login fallback path -- it does NOT ' \
+                  'touch the normal EAccess login flow.'
+
+          account = CliOptionValidator.require_positional(account, name: 'ACCOUNT', usage: usage)
+          char_name = CliOptionValidator.require_positional(char_name, name: 'CHAR_NAME', usage: usage)
+
+          game_code = CliOptionValidator.extract_flag_value(
+            '--game-code',
+            usage: usage,
+            valid_values: Lich::Common::Authentication::LoginHelpers::VALID_GAME_CODES
+          )
+          if game_code.nil?
+            $stdout.puts 'error: --game-code is required'
+            $stdout.puts usage
+            exit 1
+          end
+
+          entries = Lich::Common::Authentication::EntryStore.load_saved_entries(DATA_DIR, false)
+          entry = entries.find { |e| e[:user_id].to_s.casecmp?(account) }
+          if entry.nil?
+            $stdout.puts "error: Account '#{account}' not found in #{Lich::Common::Authentication::EntryStore.yaml_file_path(DATA_DIR)}"
+            exit 1
+          end
+
+          $stdout.puts "Probing web login fallback for #{account} / #{char_name} (#{game_code})..."
+
+          begin
+            login_info = Lich::Common::Authentication::WebLogin.auth_with_timeout(
+              account: account,
+              password: entry[:password],
+              character: char_name,
+              game_code: game_code
+            )
+            $stdout.puts 'Success:'
+            login_info.each { |k, v| $stdout.puts "  #{k.upcase}=#{v}" }
+            exit 0
+          rescue Lich::Common::Authentication::WebLogin::AuthenticationError => e
+            $stdout.puts "error: web login failed: #{e.error_code}"
+            exit 1
+          rescue StandardError => e
+            $stdout.puts "error: #{e.class}: #{e.message}"
+            exit 1
+          end
         end
       end
     end

--- a/lib/main/argv_options.rb
+++ b/lib/main/argv_options.rb
@@ -82,6 +82,8 @@ module Lich
               @argv_options[:gui] = true
             when /^--game=(.+)$/i
               @argv_options[:game] = $1
+            when /^--auth-provider=(eaccess|web)$/i
+              @argv_options[:auth_provider] = $1.downcase.to_sym
             when /^--account=(.+)$/i
               @argv_options[:account] = $1
             when /^--password=(.+)$/i

--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -168,7 +168,8 @@ reconnect_if_wanted = proc {
                             game_code: requested_instance,
                             frontend: requested_fe,
                             custom_launch: requested_custom_launch,
-                            data_dir: DATA_DIR
+                            data_dir: DATA_DIR,
+                            auth_provider: @argv_options[:auth_provider] || :eaccess
                           )
                         else
                           Lich::Common::Authentication::CLI.execute(
@@ -176,7 +177,8 @@ reconnect_if_wanted = proc {
                             game_code: requested_instance,
                             frontend: lookup_frontend,
                             custom_launch: requested_custom_launch,
-                            data_dir: DATA_DIR
+                            data_dir: DATA_DIR,
+                            auth_provider: @argv_options[:auth_provider] || :eaccess
                           )
                         end
 

--- a/spec/lib/common/authentication/authenticator_spec.rb
+++ b/spec/lib/common/authentication/authenticator_spec.rb
@@ -132,6 +132,89 @@ RSpec.describe Lich::Common::Authentication do
     end
   end
 
+  describe '.authenticate web fallback' do
+    let(:auth_result) { { 'key' => 'abc123', 'gamehost' => 'h', 'gameport' => 'p' } }
+
+    before do
+      allow(Lich).to receive(:log)
+      allow(described_class).to receive(:sleep) # no real backoff delay in tests
+    end
+
+    it 'forces WebLogin directly when auth_provider: :web, without touching EAccess' do
+      expect(Lich::Common::Authentication::EAccess).not_to receive(:auth)
+      expect(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).with(
+        account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3'
+      ).and_return(auth_result)
+
+      result = described_class.authenticate(
+        account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3', auth_provider: :web
+      )
+      expect(result).to eq(auth_result)
+      expect(Lich).to have_received(:log).with(/authenticated via web login \(forced by auth_provider: :web\)/)
+    end
+
+    it 'logs which provider succeeded on a plain EAccess login' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_return(auth_result)
+
+      described_class.authenticate(account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3')
+
+      expect(Lich).to have_received(:log).with('info: authenticated via eaccess')
+    end
+
+    it 'falls back to WebLogin when EAccess raises a non-fatal (transport) error' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'getaddrinfo failed')
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_return(auth_result)
+
+      result = described_class.authenticate(
+        account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3'
+      )
+      expect(result).to eq(auth_result)
+      expect(Lich::Common::Authentication::WebLogin).to have_received(:auth_with_timeout).with(
+        account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3'
+      )
+      expect(Lich).to have_received(:log).with(/authenticated via web login \(fallback from eaccess\)/)
+    end
+
+    it 'does NOT fall back to WebLogin when EAccess rejects credentials (fatal)' do
+      error = Lich::Common::Authentication::EAccess::AuthenticationError.new('PASSWORD')
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(error)
+      expect(Lich::Common::Authentication::WebLogin).not_to receive(:auth_with_timeout)
+
+      expect {
+        described_class.authenticate(account: 'testuser', password: 'wrong', character: 'TestChar', game_code: 'GS3')
+      }.to raise_error(Lich::Common::Authentication::FatalAuthError, /PASSWORD/)
+    end
+
+    it 'does not fall back for legacy (no WebLogin equivalent)' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'unreachable')
+      expect(Lich::Common::Authentication::WebLogin).not_to receive(:auth_with_timeout)
+
+      expect {
+        described_class.authenticate(account: 'testuser', password: 'testpass', legacy: true)
+      }.to raise_error(SocketError)
+    end
+
+    it 'does not fall back for generator entry (no WebLogin equivalent)' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'unreachable')
+      expect(Lich::Common::Authentication::WebLogin).not_to receive(:auth_with_timeout)
+
+      expect {
+        described_class.authenticate(account: 'testuser', password: 'testpass', game_code: 'GS3', generator: true)
+      }.to raise_error(SocketError)
+    end
+
+    it 'treats a WebLogin credential rejection as fatal too (LOGIN_FAILED), without exhausting retries first' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'unreachable')
+      web_error = Lich::Common::Authentication::WebLogin::AuthenticationError.new('LOGIN_FAILED')
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_raise(web_error)
+
+      expect {
+        described_class.authenticate(account: 'testuser', password: 'wrong', character: 'TestChar', game_code: 'GS3')
+      }.to raise_error(Lich::Common::Authentication::FatalAuthError, /LOGIN_FAILED/)
+      expect(Lich::Common::Authentication::WebLogin).to have_received(:auth_with_timeout).once # not retried
+    end
+  end
+
   describe '.with_retry' do
     before do
       allow(Lich).to receive(:log)

--- a/spec/lib/common/authentication/authenticator_spec.rb
+++ b/spec/lib/common/authentication/authenticator_spec.rb
@@ -228,6 +228,17 @@ RSpec.describe Lich::Common::Authentication do
       expect(Lich::Common::Authentication::WebLogin).to have_received(:auth_with_timeout).once # not retried
     end
 
+    it 'treats WebLogin NO_SUBSCRIPTION as fatal too, without exhausting retries first' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'unreachable')
+      web_error = Lich::Common::Authentication::WebLogin::AuthenticationError.new('NO_SUBSCRIPTION')
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_raise(web_error)
+
+      expect {
+        described_class.authenticate(account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'DR')
+      }.to raise_error(Lich::Common::Authentication::FatalAuthError, /NO_SUBSCRIPTION/)
+      expect(Lich::Common::Authentication::WebLogin).to have_received(:auth_with_timeout).once # not retried
+    end
+
     it 'sets Account.name/game_code/character for auth_provider: :web (WebLogin.auth does not set it itself)' do
       allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_return(auth_result)
 

--- a/spec/lib/common/authentication/authenticator_spec.rb
+++ b/spec/lib/common/authentication/authenticator_spec.rb
@@ -38,6 +38,20 @@ module Lich
   end
 end unless defined?(Lich::Common::Authentication::EAccess)
 
+# Account state -- same accessor shape EAccess.auth sets internally (see
+# eaccess.rb); Authenticator.authenticate now sets the same state at a
+# provider-neutral boundary so WebLogin gets it too (see "Account state"
+# specs below).
+module Lich
+  module Common
+    module Account
+      class << self
+        attr_accessor :name, :game_code, :character, :subscription, :members
+      end
+    end
+  end
+end unless defined?(Lich::Common::Account)
+
 # Require the actual authenticator code
 require_relative '../../../../lib/common/authentication/authenticator'
 
@@ -212,6 +226,61 @@ RSpec.describe Lich::Common::Authentication do
         described_class.authenticate(account: 'testuser', password: 'wrong', character: 'TestChar', game_code: 'GS3')
       }.to raise_error(Lich::Common::Authentication::FatalAuthError, /LOGIN_FAILED/)
       expect(Lich::Common::Authentication::WebLogin).to have_received(:auth_with_timeout).once # not retried
+    end
+
+    it 'sets Account.name/game_code/character for auth_provider: :web (WebLogin.auth does not set it itself)' do
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_return(auth_result)
+
+      described_class.authenticate(
+        account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3', auth_provider: :web
+      )
+
+      expect(Lich::Common::Account.name).to eq('testuser')
+      expect(Lich::Common::Account.game_code).to eq('GS3')
+      expect(Lich::Common::Account.character).to eq('TestChar')
+    end
+
+    it 'sets Account.name/game_code/character on fallback to WebLogin too' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'unreachable')
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_return(auth_result)
+
+      described_class.authenticate(account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3')
+
+      expect(Lich::Common::Account.character).to eq('TestChar')
+    end
+
+    it 'does not retry a SocketError 3 times before falling back -- fails fast on an unreachable endpoint' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'getaddrinfo failed')
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_return(auth_result)
+
+      described_class.authenticate(account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3')
+
+      expect(Lich::Common::Authentication::EAccess).to have_received(:auth).once
+      expect(described_class).not_to have_received(:sleep)
+    end
+  end
+
+  describe '.unreachable_error?' do
+    it 'is true for connection-level errors' do
+      [
+        SocketError.new, Errno::ECONNREFUSED.new, Errno::ECONNRESET.new, Errno::ETIMEDOUT.new,
+        Errno::EHOSTUNREACH.new, Errno::ENETUNREACH.new, OpenSSL::SSL::SSLError.new
+      ].each do |error|
+        expect(described_class.unreachable_error?(error)).to be(true), "expected #{error.class} to be unreachable"
+      end
+    end
+
+    it 'is true for the auth_with_timeout watchdog timeout (a black-holed connection times out rather than refusing)' do
+      error = RuntimeError.new('error: timed out authenticating with EAccess after 30s')
+      expect(described_class.unreachable_error?(error)).to be true
+    end
+
+    it 'is false for a protocol-level error on a reachable endpoint' do
+      expect(described_class.unreachable_error?(StandardError.new('weird response'))).to be false
+    end
+
+    it 'is false for an unrelated RuntimeError that is not the timeout watchdog' do
+      expect(described_class.unreachable_error?(RuntimeError.new('some other runtime error'))).to be false
     end
   end
 

--- a/spec/lib/common/authentication/authenticator_spec.rb
+++ b/spec/lib/common/authentication/authenticator_spec.rb
@@ -269,6 +269,92 @@ RSpec.describe Lich::Common::Authentication do
       expect(Lich::Common::Authentication::EAccess).to have_received(:auth).once
       expect(described_class).not_to have_received(:sleep)
     end
+
+    it 'logs the actual number of attempts made, not always MAX_AUTH_RETRIES, when fast-failing early' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'getaddrinfo failed')
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_return(auth_result)
+
+      described_class.authenticate(account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3')
+
+      expect(Lich).to have_received(:log).with(/Authentication failed after 1 attempt:/)
+    end
+
+    it 'still retries a transient reachable-endpoint error (not fast-failed) 3 times when no fallback is available' do
+      # legacy: true has no WebLogin fallback (web_fallback_supported? is
+      # false), so this also confirms the retry loop doesn't reach for a
+      # fallback that isn't there -- EAccess.auth is the only thing stubbed.
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(StandardError, 'weird protocol response')
+
+      expect {
+        described_class.authenticate(account: 'testuser', password: 'testpass', legacy: true)
+      }.to raise_error(StandardError, /weird protocol response/)
+      expect(Lich::Common::Authentication::EAccess).to have_received(:auth).exactly(3).times
+      expect(Lich).to have_received(:log).with(/Authentication failed after 3 attempts:/)
+    end
+
+    it 'does NOT fast-fail an unreachable-classified error on a legacy call -- there is no alternate provider to hand off to' do
+      expect(Lich::Common::Authentication::WebLogin).not_to receive(:auth_with_timeout)
+      attempts = 0
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth) do
+        attempts += 1
+        raise Errno::ECONNRESET if attempts == 1
+
+        []
+      end
+
+      result = described_class.authenticate(account: 'testuser', password: 'testpass', legacy: true)
+
+      expect(result).to eq([])
+      expect(attempts).to eq(2) # retried, not fast-failed, and recovered on the 2nd attempt
+    end
+
+    it 'does NOT fast-fail an unreachable-classified error on generator entry -- there is no alternate provider to hand off to' do
+      attempts = 0
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth) do
+        attempts += 1
+        raise Errno::ECONNRESET if attempts == 1
+
+        auth_result
+      end
+
+      result = described_class.authenticate(account: 'testuser', password: 'testpass', game_code: 'GS3', generator: true)
+
+      expect(result).to eq(auth_result)
+      expect(attempts).to eq(2)
+    end
+
+    it 'does NOT fast-fail an unreachable-classified error on a forced-web call -- there is no alternate provider to hand off to' do
+      attempts = 0
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout) do
+        attempts += 1
+        raise Errno::ECONNRESET if attempts == 1
+
+        auth_result
+      end
+
+      result = described_class.authenticate(
+        account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3', auth_provider: :web
+      )
+
+      expect(result).to eq(auth_result)
+      expect(attempts).to eq(2)
+    end
+
+    it 'does NOT fast-fail an unreachable-classified error on the fallback-to-web attempt itself -- no third provider' do
+      allow(Lich::Common::Authentication::EAccess).to receive(:auth).and_raise(SocketError, 'unreachable')
+      attempts = 0
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout) do
+        attempts += 1
+        raise Errno::ECONNRESET if attempts == 1
+
+        auth_result
+      end
+
+      result = described_class.authenticate(account: 'testuser', password: 'testpass', character: 'TestChar', game_code: 'GS3')
+
+      expect(result).to eq(auth_result)
+      expect(attempts).to eq(2)
+    end
   end
 
   describe '.unreachable_error?' do

--- a/spec/lib/common/authentication/authenticator_spec.rb
+++ b/spec/lib/common/authentication/authenticator_spec.rb
@@ -152,6 +152,14 @@ RSpec.describe Lich::Common::Authentication do
     before do
       allow(Lich).to receive(:log)
       allow(described_class).to receive(:sleep) # no real backoff delay in tests
+      # Account uses persistent class-level attributes (not reset between
+      # examples by default) -- without this, a real regression in
+      # Authenticator's Account-state-setting could go undetected, since a
+      # later example's assertion could pass on a value a prior example
+      # already left behind rather than one this example's call actually set.
+      Lich::Common::Account.name = nil
+      Lich::Common::Account.game_code = nil
+      Lich::Common::Account.character = nil
     end
 
     it 'forces WebLogin directly when auth_provider: :web, without touching EAccess' do

--- a/spec/lib/common/authentication/cli_spec.rb
+++ b/spec/lib/common/authentication/cli_spec.rb
@@ -254,7 +254,8 @@ RSpec.describe Lich::Common::Authentication::CLI do
           password: 'testpass',
           character: 'NEW',
           game_code: 'DR',
-          generator: true
+          generator: true,
+          auth_provider: :eaccess
         ).and_return({ 'key' => 'abc' })
 
         result = described_class.execute_new_character('testuser', game_code: 'DR', data_dir: data_dir)
@@ -271,7 +272,8 @@ RSpec.describe Lich::Common::Authentication::CLI do
           password: 'testpass',
           character: 'NEW',
           game_code: 'DR',
-          generator: true
+          generator: true,
+          auth_provider: :eaccess
         ).and_return({ 'key' => 'abc' })
 
         described_class.execute_new_character('TESTUSER', game_code: 'DR', data_dir: data_dir)

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -96,6 +96,61 @@ RSpec.describe Lich::Common::Authentication::EAccess do
     end
   end
 
+  describe '.stage' do
+    before { allow(Lich).to receive(:log) }
+
+    it 'returns the block value on success without logging' do
+      result = described_class.stage('test_stage', probable_cause: 'n/a') { 42 }
+      expect(result).to eq(42)
+      expect(Lich).not_to have_received(:log)
+    end
+
+    it 'records the stage name on the current thread while the block runs' do
+      recorded = nil
+      described_class.stage('test_stage', probable_cause: 'n/a') do
+        recorded = Thread.current[:eaccess_stage]
+      end
+      expect(recorded).to eq('test_stage')
+    end
+
+    it 'logs the stage name, duration, exception, and a fixed probable-cause hint, then re-raises' do
+      expect {
+        described_class.stage('test_stage', probable_cause: 'a fixed hint') { raise StandardError, 'boom' }
+      }.to raise_error(StandardError, 'boom')
+
+      expect(Lich).to have_received(:log)
+        .with(/EAccess stage 'test_stage' failed after [\d.]+s \(StandardError: boom\) -- likely cause: a fixed hint/)
+    end
+
+    it 'derives the probable-cause hint from a callable, passing it the raised error' do
+      classify = ->(e) { "classified: #{e.message}" }
+
+      expect {
+        described_class.stage('test_stage', probable_cause: classify) { raise StandardError, 'boom' }
+      }.to raise_error(StandardError)
+
+      expect(Lich).to have_received(:log).with(/likely cause: classified: boom/)
+    end
+  end
+
+  describe '.classify_a_response_failure' do
+    it 'classifies a known Simutronics rejection token as a normal, expected rejection' do
+      %w[REJECT NORECORD INVALID PASSWORD].each do |token|
+        error = described_class::AuthenticationError.new(token)
+        expect(described_class.classify_a_response_failure(error)).to match(/recognized credential rejection \(#{token}\)/)
+      end
+    end
+
+    it 'classifies an unrecognized error_code as a possible backend divergence' do
+      error = described_class::AuthenticationError.new('')
+      expect(described_class.classify_a_response_failure(error)).to match(/unrecognized\/malformed response/)
+    end
+
+    it 'classifies an error with no error_code at all as a possible backend divergence' do
+      expect(described_class.classify_a_response_failure(StandardError.new('boom'))).to match(/unrecognized\/malformed response/)
+    end
+  end
+
   describe '.socket' do
     # A dropped SYN on 7910 (firewalled, no RST) previously hung on the OS
     # connect timeout (~75s) before TCPSocket.open ever raised. Socket.tcp's
@@ -276,6 +331,18 @@ RSpec.describe Lich::Common::Authentication::EAccess do
       end
     end
 
+    context 'when the K response is empty' do
+      it 'raises MALFORMED_K_RESPONSE at the k_response stage instead of silently hashing garbage password bytes' do
+        allow(Lich).to receive(:log)
+        allow(described_class).to receive(:read).and_return('')
+
+        expect {
+          described_class.auth(account: 'ACCT', password: 'pass', character: 'X', game_code: 'DR')
+        }.to raise_error(described_class::AuthenticationError, /MALFORMED_K_RESPONSE/)
+        expect(Lich).to have_received(:log).with(/EAccess stage 'k_response' failed/)
+      end
+    end
+
     context 'when the server refuses generator entry with L PROBLEM' do
       # Unsubscribed Fallen/Shattered: F is NEW_TO_GAME and the server returns
       # "L\tPROBLEM\t1" because the account is not entitled to create there.
@@ -327,6 +394,31 @@ RSpec.describe Lich::Common::Authentication::EAccess do
       expect {
         described_class.auth_with_timeout(timeout: 1, account: 'ACCT', password: 'pass')
       }.to raise_error(described_class::AuthenticationError, /REJECT/)
+    end
+
+    it 'logs which stage was in flight when the watchdog kills a hung attempt' do
+      allow(Lich).to receive(:log)
+      allow(described_class).to receive(:auth) do
+        Thread.current[:eaccess_stage] = 'k_response'
+        sleep 0.2
+      end
+
+      expect {
+        described_class.auth_with_timeout(timeout: 0.01, account: 'A', password: 'p')
+      }.to raise_error(/timed out authenticating with EAccess/)
+
+      expect(Lich).to have_received(:log).with(/timed out after 0.01s while in stage 'k_response'/)
+    end
+
+    it "reports 'connect (pre-stage)' when the watchdog fires before any stage was entered" do
+      allow(Lich).to receive(:log)
+      allow(described_class).to receive(:auth) { sleep 0.2 }
+
+      expect {
+        described_class.auth_with_timeout(timeout: 0.01, account: 'A', password: 'p')
+      }.to raise_error(/timed out authenticating with EAccess/)
+
+      expect(Lich).to have_received(:log).with(/timed out after 0.01s while in stage 'connect \(pre-stage\)'/)
     end
   end
 end

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -397,6 +397,15 @@ RSpec.describe Lich::Common::Authentication::EAccess do
     end
 
     it 'logs which stage was in flight when the watchdog kills a hung attempt' do
+      # timeout: 0.01 was flaky -- the spawned auth_thread isn't guaranteed to
+      # get scheduled and execute the stage-marker assignment within a 10ms
+      # window under CI load, which would make this observe "connect
+      # (pre-stage)" instead of "k_response". 0.05s against a 0.2s stub sleep
+      # gives real margin without meaningfully slowing the suite. (A
+      # Queue-based rendezvous was considered instead, but risks a genuine
+      # test hang if the watchdog's Thread#kill lands between the
+      # stage-marker assignment and the queue push -- a timing margin has no
+      # such failure mode.)
       allow(Lich).to receive(:log)
       allow(described_class).to receive(:auth) do
         Thread.current[:eaccess_stage] = 'k_response'
@@ -404,10 +413,10 @@ RSpec.describe Lich::Common::Authentication::EAccess do
       end
 
       expect {
-        described_class.auth_with_timeout(timeout: 0.01, account: 'A', password: 'p')
+        described_class.auth_with_timeout(timeout: 0.05, account: 'A', password: 'p')
       }.to raise_error(/timed out authenticating with EAccess/)
 
-      expect(Lich).to have_received(:log).with(/timed out after 0.01s while in stage 'k_response'/)
+      expect(Lich).to have_received(:log).with(/timed out after 0.05s while in stage 'k_response'/)
     end
 
     it "reports 'connect (pre-stage)' when the watchdog fires before any stage was entered" do

--- a/spec/lib/common/authentication/eaccess_spec.rb
+++ b/spec/lib/common/authentication/eaccess_spec.rb
@@ -90,6 +90,39 @@ RSpec.describe Lich::Common::Authentication::EAccess do
     end
   end
 
+  describe 'CONNECT_TIMEOUT' do
+    it 'is 5 seconds' do
+      expect(described_class::CONNECT_TIMEOUT).to eq(5)
+    end
+  end
+
+  describe '.socket' do
+    # A dropped SYN on 7910 (firewalled, no RST) previously hung on the OS
+    # connect timeout (~75s) before TCPSocket.open ever raised. Socket.tcp's
+    # connect_timeout: bounds just the TCP handshake to CONNECT_TIMEOUT --
+    # verified here by making the connect itself fail immediately and
+    # asserting the timeout kwarg was passed and the error propagates
+    # normally (no cleartext fallback, no swallowing).
+    it 'bounds the TCP connect with CONNECT_TIMEOUT instead of an unbounded TCPSocket.open' do
+      allow(described_class).to receive(:pem_exist?).and_return(true)
+      expect(Socket).to receive(:tcp)
+        .with('eaccess.play.net', 7910, connect_timeout: described_class::CONNECT_TIMEOUT)
+        .and_raise(Errno::ETIMEDOUT)
+
+      expect { described_class.socket }.to raise_error(Errno::ETIMEDOUT)
+    end
+  end
+
+  describe '.download_pem' do
+    it 'bounds the TCP connect with CONNECT_TIMEOUT instead of an unbounded TCPSocket.new' do
+      expect(Socket).to receive(:tcp)
+        .with('eaccess.play.net', 7910, connect_timeout: described_class::CONNECT_TIMEOUT)
+        .and_raise(Errno::ETIMEDOUT)
+
+      expect { described_class.download_pem }.to raise_error(Errno::ETIMEDOUT)
+    end
+  end
+
   describe '.auth' do
     # Note: The auth method involves complex network operations (SSL sockets, protocol exchange)
     # and is better tested via integration tests. Unit testing it requires extensive mocking

--- a/spec/lib/common/authentication/launch_result_spec.rb
+++ b/spec/lib/common/authentication/launch_result_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require_relative '../../../../lib/common/authentication/launch_result'
+
+RSpec.describe Lich::Common::Authentication::LaunchResult do
+  describe '.normalize' do
+    it 'downcases keys and freezes the result' do
+      result = described_class.normalize('GAMEHOST' => 'h', 'KEY' => 'k')
+      expect(result).to eq('gamehost' => 'h', 'key' => 'k')
+      expect(result).to be_frozen
+    end
+
+    it 'passes through keys that are already lowercase strings' do
+      result = described_class.normalize('gamehost' => 'h', 'key' => 'k')
+      expect(result).to eq('gamehost' => 'h', 'key' => 'k')
+    end
+
+    it 'accepts symbol keys' do
+      result = described_class.normalize(gamehost: 'h', key: 'k')
+      expect(result).to eq('gamehost' => 'h', 'key' => 'k')
+    end
+
+    it 'does not require gamehost/gameport (the EAccess generator path can omit them)' do
+      expect { described_class.normalize('key' => 'abc') }.not_to raise_error
+    end
+
+    it 'raises when key is missing' do
+      expect {
+        described_class.normalize('gamehost' => 'h', 'gameport' => 'p')
+      }.to raise_error(described_class::MissingLaunchDataError, /key/)
+    end
+
+    it 'raises when key is present but blank' do
+      expect {
+        described_class.normalize('key' => '')
+      }.to raise_error(described_class::MissingLaunchDataError)
+    end
+  end
+end

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -161,6 +161,32 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       end
     end
 
+    context 'when the account has no active subscription on the requested instance' do
+      # Confirmed live: login.asp's own redirect still lands on okay_page
+      # successfully (login() does not raise), but okay_page ITSELF then
+      # redirects a second time to subscription_needed.asp -- `get` doesn't
+      # follow that second redirect, so without this check it would
+      # silently fall through to an empty body scrape and a misleading
+      # CHARACTER_NOT_FOUND instead of the real cause.
+      let(:home_page_response) { response_double(location: '/dr/play/subscription_needed.asp') }
+
+      it 'raises NO_SUBSCRIPTION rather than a misleading CHARACTER_NOT_FOUND' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /NO_SUBSCRIPTION/)
+      end
+    end
+
+    context 'when the character-list page redirects somewhere other than subscription_needed.asp' do
+      let(:home_page_response) { response_double(location: '/dr/some_other_redirect.asp') }
+
+      it 'raises UNEXPECTED_CHARACTER_LIST_RESPONSE' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_CHARACTER_LIST_RESPONSE/)
+      end
+    end
+
     context 'when login redirects to the error page' do
       let(:login_okay_response) { response_double(location: '/dr/login_error.asp?error=&returnto=/dr/') }
 

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
     it 'returns the confirmed instance data for a supported game code' do
       instance = described_class.instance_for('DRT')
       expect(instance).to eq(
-        family: 'dr', web_game_code: 'DRT',
+        family: 'dr', web_game_code: 'DRT', character_list_path: '/dr/play/playdrt.asp',
         expected_host: 'hydra.simutronics.com', expected_port: '11624'
       )
     end
@@ -44,8 +44,20 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       expect(described_class.instance_for('GS3')[:web_game_code]).to eq('GS4')
     end
 
+    it 'confirms GSF matches the EAccess code directly (unlike GS3->GS4)' do
+      expect(described_class.instance_for('GSF')[:web_game_code]).to eq('GSF')
+    end
+
+    it 'gives each instance its own character-selection page (a character can exist on one ' \
+       'instance of a family without appearing on that family\'s generic home.asp -- confirmed ' \
+       'live: a GemStone Shattered-only character does not show up on the GemStone Prime page)' do
+      expect(described_class.instance_for('GS3')[:character_list_path]).to eq('/gs4/play/home.asp')
+      expect(described_class.instance_for('GST')[:character_list_path]).to eq('/gs4/play/play_test.asp')
+      expect(described_class.instance_for('GSF')[:character_list_path]).to eq('/gs4/play/playf.asp')
+    end
+
     it 'raises UNSUPPORTED_GAME_CODE for an unconfirmed instance (fail closed)' do
-      %w[DRF DRX GSF GSX ZZ].each do |code|
+      %w[DRF DRX GSX ZZ].each do |code|
         expect { described_class.instance_for(code) }
           .to raise_error(described_class::AuthenticationError, /UNSUPPORTED_GAME_CODE/), "expected #{code} to be rejected"
       end
@@ -58,7 +70,8 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
 
     let(:preflight_response) { response_double(code: '200', set_cookie: ['ASPSESSIONID=abc123; secure; path=/; HttpOnly']) }
     let(:login_okay_response) { response_double(location: '/dr/play/home.asp', set_cookie: ['AWSALB=xyz; Path=/']) }
-    # Real markup captured live from /dr/play/home.asp -- see protocol doc "1a".
+    # Real markup captured live from /dr/play/playdrt.asp (DRT's
+    # character_list_path) -- see protocol doc "1a".
     let(:home_page_body) do
       <<~HTML
         <input type=radio name="charID" id="W_TESTACCOUNT_000" value="W_TESTACCOUNT_000" checked  >
@@ -79,7 +92,7 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
         when '/includes/common/login/login.asp'
           login_requests << req
           login_okay_response
-        when '/dr/play/home.asp' then home_page_response
+        when '/dr/play/playdrt.asp' then home_page_response # DRT's character_list_path, not the family's generic home.asp
         when '/includes/common/play/goplay2.asp'
           goplay2_requests << req
           goplay2_response
@@ -124,6 +137,20 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
         described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRF')
       }.to raise_error(described_class::AuthenticationError, /UNSUPPORTED_GAME_CODE/)
       expect(http).not_to have_received(:request)
+    end
+
+    context 'when login redirects to the account security-question setup gate instead of okay_page' do
+      # Confirmed live: an account that has never set a security question is
+      # redirected to /playdotnet/account/security_qa.asp on an otherwise-
+      # successful login. The session is already authenticated at that point
+      # (Set-Cookie already carries the real session) -- this must not be
+      # treated as a login failure.
+      let(:login_okay_response) { response_double(location: '/playdotnet/account/security_qa.asp') }
+
+      it 'does not raise, and resolve_char_code proceeds using the already-authenticated session' do
+        result = described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        expect(result['gamehost']).to eq('hydra.simutronics.com')
+      end
     end
 
     context 'when the requested character is not on the scraped page' do

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -21,43 +21,42 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
     allow(http).to receive(:verify_mode=)
   end
 
-  def response_double(location: nil, set_cookie: [], body: nil)
+  def response_double(code: '302', location: nil, set_cookie: [], body: nil)
     instance_double(
       Net::HTTPResponse,
+      code: code,
       :[] => location,
       get_fields: set_cookie,
       body: body
     )
   end
 
-  describe '.web_game_code' do
-    it 'maps GS3 to GS4 (confirmed live mismatch from EAccess)' do
-      expect(described_class.web_game_code('GS3')).to eq('GS4')
+  describe '.instance_for' do
+    it 'returns the confirmed instance data for a supported game code' do
+      instance = described_class.instance_for('DRT')
+      expect(instance).to eq(
+        family: 'dr', web_game_code: 'DRT',
+        expected_host: 'hydra.simutronics.com', expected_port: '11624'
+      )
     end
 
-    it 'passes through codes confirmed identical to EAccess' do
-      expect(described_class.web_game_code('DR')).to eq('DR')
-      expect(described_class.web_game_code('DRT')).to eq('DRT')
-      expect(described_class.web_game_code('GST')).to eq('GST')
-    end
-  end
-
-  describe '.game_family' do
-    it 'maps DR-family codes to "dr"' do
-      %w[DR DRT DRF DRX].each { |code| expect(described_class.game_family(code)).to eq('dr') }
+    it 'maps GS3 to the web layer\'s own GS4 code (confirmed live mismatch from EAccess)' do
+      expect(described_class.instance_for('GS3')[:web_game_code]).to eq('GS4')
     end
 
-    it 'maps GS-family codes to "gs4"' do
-      %w[GS3 GST GSF GSX].each { |code| expect(described_class.game_family(code)).to eq('gs4') }
-    end
-
-    it 'raises for an unknown game code' do
-      expect { described_class.game_family('ZZ') }.to raise_error(described_class::AuthenticationError, /UNKNOWN_GAME_CODE/)
+    it 'raises UNSUPPORTED_GAME_CODE for an unconfirmed instance (fail closed)' do
+      %w[DRF DRX GSF GSX ZZ].each do |code|
+        expect { described_class.instance_for(code) }
+          .to raise_error(described_class::AuthenticationError, /UNSUPPORTED_GAME_CODE/), "expected #{code} to be rejected"
+      end
     end
   end
 
   describe '.auth' do
-    let(:preflight_response) { response_double(set_cookie: ['ASPSESSIONID=abc123; secure; path=/; HttpOnly']) }
+    let(:login_requests) { [] }
+    let(:goplay2_requests) { [] }
+
+    let(:preflight_response) { response_double(code: '200', set_cookie: ['ASPSESSIONID=abc123; secure; path=/; HttpOnly']) }
     let(:login_okay_response) { response_double(location: '/dr/play/home.asp', set_cookie: ['AWSALB=xyz; Path=/']) }
     # Real markup captured live from /dr/play/home.asp -- see protocol doc "1a".
     let(:home_page_body) do
@@ -66,7 +65,7 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
         <label for="W_TESTACCOUNT_000"><span class="normS1">Raiyen</span></label><br>
       HTML
     end
-    let(:home_page_response) { response_double(body: home_page_body) }
+    let(:home_page_response) { response_double(code: '200', body: home_page_body) }
     let(:goplay2_response) { response_double(location: '/dr/play/playing_web.asp') }
     let(:redirect1_response) { response_double(location: '/includes/common/play/goplay_web.asp') }
     let(:redirect2_response) do
@@ -74,10 +73,21 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
     end
 
     before do
-      allow(http).to receive(:request).and_return(
-        preflight_response, login_okay_response, home_page_response,
-        goplay2_response, redirect1_response, redirect2_response
-      )
+      allow(http).to receive(:request) do |req|
+        case req.path
+        when '/dr/signin_needed.asp' then preflight_response
+        when '/includes/common/login/login.asp'
+          login_requests << req
+          login_okay_response
+        when '/dr/play/home.asp' then home_page_response
+        when '/includes/common/play/goplay2.asp'
+          goplay2_requests << req
+          goplay2_response
+        when '/dr/play/playing_web.asp' then redirect1_response
+        when '/includes/common/play/goplay_web.asp' then redirect2_response
+        else raise "unstubbed request to #{req.path}"
+        end
+      end
     end
 
     it 'returns the confirmed host/port/key plus synthesized STORM/Wrayth launch fields' do
@@ -99,6 +109,23 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       expect(result['gamehost']).to eq('hydra.simutronics.com')
     end
 
+    it 'GETs the sign-in page before POSTing credentials (login.asp cold gets a bare 500 -- see protocol doc)' do
+      described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+      expect(http).to have_received(:request).with(an_object_having_attributes(path: '/dr/signin_needed.asp')).ordered
+    end
+
+    it 'includes NEWCHARSUB=TRUE on the goplay2.asp POST (present in every confirmed capture but GS Test\'s)' do
+      described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+      expect(goplay2_requests.first.body).to include('NEWCHARSUB=TRUE')
+    end
+
+    it 'raises for an unsupported game code without making any request' do
+      expect {
+        described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRF')
+      }.to raise_error(described_class::AuthenticationError, /UNSUPPORTED_GAME_CODE/)
+      expect(http).not_to have_received(:request)
+    end
+
     context 'when the requested character is not on the scraped page' do
       it 'raises CHARACTER_NOT_FOUND' do
         expect {
@@ -118,6 +145,26 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       end
     end
 
+    context 'when login redirects to an absolute URL on the error page path (not just a relative one)' do
+      let(:login_okay_response) { response_double(location: 'https://www.play.net/dr/login_error.asp?error=1') }
+
+      it 'still classifies it as LOGIN_FAILED by comparing the parsed path, not a raw prefix match' do
+        expect {
+          described_class.auth(password: 'wrong', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /LOGIN_FAILED/)
+      end
+    end
+
+    context 'when login redirects to an unrelated page that merely shares the error page as a string prefix' do
+      let(:login_okay_response) { response_double(location: '/dr/login_error.aspSOMETHINGELSE') }
+
+      it 'does NOT misclassify it as LOGIN_FAILED (path comparison, not prefix match)' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_LOGIN_RESPONSE/)
+      end
+    end
+
     context 'when login redirects somewhere unexpected' do
       let(:login_okay_response) { response_double(location: '/dr/some_other_page.asp') }
 
@@ -125,6 +172,16 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
         expect {
           described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
         }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_LOGIN_RESPONSE/)
+      end
+    end
+
+    context 'when the login response is not a redirect at all (no Location, or non-3xx)' do
+      let(:login_okay_response) { response_double(code: '200', location: nil) }
+
+      it 'raises UNEXPECTED_NON_REDIRECT_RESPONSE rather than treating a blank location as a path' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_NON_REDIRECT_RESPONSE/)
       end
     end
 
@@ -148,7 +205,65 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       it 'raises rather than following a non-https redirect' do
         expect {
           described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
-        }.to raise_error(described_class::AuthenticationError)
+        }.to raise_error(described_class::AuthenticationError, /UNTRUSTED_REDIRECT_HOST/)
+      end
+    end
+
+    context 'when the final redirect carries userinfo, a non-default port, and the wrong path' do
+      let(:redirect2_response) do
+        response_double(location: 'https://user@www.play.net:444/not-the-launch-page?host=&port=&key=')
+      end
+
+      it 'raises UNTRUSTED_REDIRECT_HOST' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNTRUSTED_REDIRECT_HOST/)
+      end
+    end
+
+    context 'when the final redirect has a duplicate query key' do
+      let(:redirect2_response) do
+        response_double(location: 'https://www.play.net/play/home.asp?host=hydra.simutronics.com&port=11624&key=abc123&key=evil')
+      end
+
+      it 'raises DUPLICATE_QUERY_PARAM rather than silently taking one of the two key values' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /DUPLICATE_QUERY_PARAM/)
+      end
+    end
+
+    context 'when the final redirect has a blank connection value' do
+      let(:redirect2_response) do
+        response_double(location: 'https://www.play.net/play/home.asp?host=hydra.simutronics.com&port=&key=abc123')
+      end
+
+      it 'raises NO_CONNECTION_INFO' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /NO_CONNECTION_INFO/)
+      end
+    end
+
+    context 'when the returned host/port do not match the requested instance\'s confirmed values' do
+      let(:redirect2_response) do
+        response_double(location: 'https://www.play.net/play/home.asp?host=unexpected.example&port=1&key=abc123')
+      end
+
+      it 'raises UNEXPECTED_CONNECTION_INFO rather than trusting arbitrary connection data' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_CONNECTION_INFO/)
+      end
+    end
+
+    context 'when a redirect never resolves to an absolute URL' do
+      let(:redirect2_response) { response_double(location: '/includes/common/play/goplay_web.asp') } # loops back on itself
+
+      it 'raises TOO_MANY_REDIRECTS rather than looping forever' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /TOO_MANY_REDIRECTS/)
       end
     end
   end
@@ -180,9 +295,9 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
     end
 
     it 'returns the result of .auth on success' do
-      allow(described_class).to receive(:auth).and_return({ 'gamehost' => 'h' })
+      allow(described_class).to receive(:auth).and_return('key' => 'k')
       result = described_class.auth_with_timeout(password: 'pw', account: 'A', character: 'C', game_code: 'DRT')
-      expect(result).to eq({ 'gamehost' => 'h' })
+      expect(result).to eq('key' => 'k')
     end
   end
 end

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -187,12 +187,29 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       end
     end
 
-    context 'when login redirects to the error page' do
+    context 'when login redirects to the error page (bad password on a real account)' do
       let(:login_okay_response) { response_double(location: '/dr/login_error.asp?error=&returnto=/dr/') }
 
       it 'raises LOGIN_FAILED without attempting character resolution' do
         expect {
           described_class.auth(password: 'wrong', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /LOGIN_FAILED/)
+        expect(http).to have_received(:request).twice # preflight + login POST only
+      end
+    end
+
+    context 'when login redirects to the error page (nonexistent account name)' do
+      # Confirmed live with a random fictitious account name (e.g.
+      # "SDLG3kDSKk38"): distinct body heading ("Invalid account." vs
+      # "Invalid password.") but the same login_error.asp redirect target --
+      # classified identically as LOGIN_FAILED. Matters in practice for a
+      # stale/mistyped saved account name: fails fast and fatally, same as a
+      # bad password, rather than hanging or producing an unclear error.
+      let(:login_okay_response) { response_double(location: '/dr/login_error.asp?error=&returnto=/dr/play/home.asp') }
+
+      it 'raises LOGIN_FAILED, identically to a bad password' do
+        expect {
+          described_class.auth(password: 'RandomFakePassword123!', account: 'SDLG3kDSKk38', character: 'Whoever', game_code: 'DRT')
         }.to raise_error(described_class::AuthenticationError, /LOGIN_FAILED/)
         expect(http).to have_received(:request).twice # preflight + login POST only
       end

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -56,10 +56,19 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       expect(described_class.instance_for('GSF')[:character_list_path]).to eq('/gs4/play/playf.asp')
     end
 
-    it 'raises UNSUPPORTED_GAME_CODE for an unconfirmed instance (fail closed)' do
-      %w[DRF DRX GSX ZZ].each do |code|
+    it 'raises UNSUPPORTED_GAME_CODE for a game code not in the table at all (fail closed)' do
+      %w[GSX ZZ].each do |code|
         expect { described_class.instance_for(code) }
           .to raise_error(described_class::AuthenticationError, /UNSUPPORTED_GAME_CODE/), "expected #{code} to be rejected"
+      end
+    end
+
+    it 'accepts DRX/DRF (unverified -- no live account entitlement to confirm host/port yet) with nil expected_host/expected_port' do
+      %w[DRX DRF].each do |code|
+        instance = described_class.instance_for(code)
+        expect(instance[:expected_host]).to be_nil
+        expect(instance[:expected_port]).to be_nil
+        expect(instance[:family]).to eq('dr')
       end
     end
   end
@@ -93,6 +102,8 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
           login_requests << req
           login_okay_response
         when '/dr/play/playdrt.asp' then home_page_response # DRT's character_list_path, not the family's generic home.asp
+        when '/dr/play/playx.asp' then home_page_response # DRX's character_list_path (unverified instance)
+        when '/dr/play/playf.asp' then home_page_response # DRF's character_list_path (unverified instance)
         when '/includes/common/play/goplay2.asp'
           goplay2_requests << req
           goplay2_response
@@ -134,7 +145,7 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
 
     it 'raises for an unsupported game code without making any request' do
       expect {
-        described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRF')
+        described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'GSX')
       }.to raise_error(described_class::AuthenticationError, /UNSUPPORTED_GAME_CODE/)
       expect(http).not_to have_received(:request)
     end
@@ -173,6 +184,20 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       it 'raises NO_SUBSCRIPTION rather than a misleading CHARACTER_NOT_FOUND' do
         expect {
           described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /NO_SUBSCRIPTION/)
+      end
+    end
+
+    context 'when the account has no subscription on an instance with its own named subscription page' do
+      # Confirmed live: DR's is plain "subscription_needed.asp", but DRX's
+      # (Platinum) is "subscription_to_plat_needed.asp" and DRF's (Fallen) is
+      # "subscription_to_fall_needed.asp" -- matched by pattern, not an exact
+      # string, so these instance-specific variants are still recognized.
+      let(:home_page_response) { response_double(location: '/dr/play/subscription_to_plat_needed.asp') }
+
+      it 'raises NO_SUBSCRIPTION for the Platinum-specific redirect too' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRX')
         }.to raise_error(described_class::AuthenticationError, /NO_SUBSCRIPTION/)
       end
     end
@@ -340,6 +365,36 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
         expect {
           described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
         }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_CONNECTION_INFO/)
+      end
+    end
+
+    context 'for an unverified instance (DRX/DRF -- no live account entitlement to confirm host/port yet)' do
+      context 'when the returned host is a recognized Simutronics game-server domain' do
+        let(:redirect2_response) do
+          response_double(location: 'https://www.play.net/play/home.asp?host=storm.dr.game.play.net&port=11324&key=abc123')
+        end
+
+        it 'accepts it and logs the observed host/port for later promotion into CONFIRMED_INSTANCES' do
+          allow(Lich).to receive(:log)
+
+          result = described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRX')
+
+          expect(result['gamehost']).to eq('storm.dr.game.play.net')
+          expect(result['gameport']).to eq('11324')
+          expect(Lich).to have_received(:log).with(/DRX has no pinned host\/port yet.*observed host=storm\.dr\.game\.play\.net port=11324/)
+        end
+      end
+
+      context 'when the returned host is NOT a recognized Simutronics game-server domain' do
+        let(:redirect2_response) do
+          response_double(location: 'https://www.play.net/play/home.asp?host=attacker.example&port=1&key=abc123')
+        end
+
+        it 'raises UNTRUSTED_CONNECTION_HOST rather than trusting an unverified instance\'s connection data blindly' do
+          expect {
+            described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRF')
+          }.to raise_error(described_class::AuthenticationError, /UNTRUSTED_CONNECTION_HOST/)
+        end
       end
     end
 

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -187,6 +187,22 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
       end
     end
 
+    context 'when the character-list page returns a non-3xx HTTP error (e.g. a transient 503)' do
+      # A 4xx/5xx must NOT fall through to the body scraper: an empty/error
+      # body scrapes to no match, which would otherwise raise the same
+      # CHARACTER_NOT_FOUND a real "no such character" case raises --
+      # and Authenticator treats CHARACTER_NOT_FOUND as fatal (no retry),
+      # silently discarding what may well have been a transient, retryable
+      # server error.
+      let(:home_page_response) { response_double(code: '503', location: nil, body: 'Temporarily unavailable') }
+
+      it 'raises UNEXPECTED_CHARACTER_LIST_RESPONSE rather than a fatal CHARACTER_NOT_FOUND' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_CHARACTER_LIST_RESPONSE/)
+      end
+    end
+
     context 'when login redirects to the error page (bad password on a real account)' do
       let(:login_okay_response) { response_double(location: '/dr/login_error.asp?error=&returnto=/dr/') }
 
@@ -334,6 +350,21 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
         expect {
           described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
         }.to raise_error(described_class::AuthenticationError, /TOO_MANY_REDIRECTS/)
+      end
+    end
+
+    context 'when a mid-chain relative redirect Location is malformed' do
+      # redirect_path(..., full_url: true) used to return the raw Location
+      # before ever calling URI.parse, so a malformed relative Location was
+      # handed to `get` unvalidated instead of raising MALFORMED_REDIRECT_URL
+      # here. A literal space is invalid in a URI (confirmed:
+      # URI.parse("/invalid path") raises URI::InvalidURIError).
+      let(:goplay2_response) { response_double(location: '/invalid path') }
+
+      it 'raises MALFORMED_REDIRECT_URL rather than requesting the malformed path unvalidated' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /MALFORMED_REDIRECT_URL/)
       end
     end
   end

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+# NOTE: This spec intentionally does NOT require spec_helper. It tests the
+# Web login fallback in isolation, stubbing Net::HTTP so no real network
+# calls are made. The request/response fixtures below (paths, form bodies,
+# HTML markup, redirect chains) are taken verbatim from a live capture
+# against play.net -- see docs/web-login-protocol-analysis.md. The module
+# itself has also been exercised live end-to-end (DR/DRT/GS3->GS4/GST, plus
+# a bad-password failure) as part of building it; these specs are regression
+# coverage for that already-verified behavior, not a substitute for it.
+
+require 'rspec'
+require_relative '../../../../lib/common/authentication/web_login'
+
+RSpec.describe Lich::Common::Authentication::WebLogin do
+  let(:http) { instance_double(Net::HTTP) }
+
+  before do
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:use_ssl=)
+    allow(http).to receive(:verify_mode=)
+  end
+
+  def response_double(location: nil, set_cookie: [], body: nil)
+    instance_double(
+      Net::HTTPResponse,
+      :[] => location,
+      get_fields: set_cookie,
+      body: body
+    )
+  end
+
+  describe '.web_game_code' do
+    it 'maps GS3 to GS4 (confirmed live mismatch from EAccess)' do
+      expect(described_class.web_game_code('GS3')).to eq('GS4')
+    end
+
+    it 'passes through codes confirmed identical to EAccess' do
+      expect(described_class.web_game_code('DR')).to eq('DR')
+      expect(described_class.web_game_code('DRT')).to eq('DRT')
+      expect(described_class.web_game_code('GST')).to eq('GST')
+    end
+  end
+
+  describe '.game_family' do
+    it 'maps DR-family codes to "dr"' do
+      %w[DR DRT DRF DRX].each { |code| expect(described_class.game_family(code)).to eq('dr') }
+    end
+
+    it 'maps GS-family codes to "gs4"' do
+      %w[GS3 GST GSF GSX].each { |code| expect(described_class.game_family(code)).to eq('gs4') }
+    end
+
+    it 'raises for an unknown game code' do
+      expect { described_class.game_family('ZZ') }.to raise_error(described_class::AuthenticationError, /UNKNOWN_GAME_CODE/)
+    end
+  end
+
+  describe '.auth' do
+    let(:preflight_response) { response_double(set_cookie: ['ASPSESSIONID=abc123; secure; path=/; HttpOnly']) }
+    let(:login_okay_response) { response_double(location: '/dr/play/home.asp', set_cookie: ['AWSALB=xyz; Path=/']) }
+    # Real markup captured live from /dr/play/home.asp -- see protocol doc "1a".
+    let(:home_page_body) do
+      <<~HTML
+        <input type=radio name="charID" id="W_TESTACCOUNT_000" value="W_TESTACCOUNT_000" checked  >
+        <label for="W_TESTACCOUNT_000"><span class="normS1">Raiyen</span></label><br>
+      HTML
+    end
+    let(:home_page_response) { response_double(body: home_page_body) }
+    let(:goplay2_response) { response_double(location: '/dr/play/playing_web.asp') }
+    let(:redirect1_response) { response_double(location: '/includes/common/play/goplay_web.asp') }
+    let(:redirect2_response) do
+      response_double(location: 'https://www.play.net/play/home.asp?host=hydra.simutronics.com&port=11624&key=abc123')
+    end
+
+    before do
+      allow(http).to receive(:request).and_return(
+        preflight_response, login_okay_response, home_page_response,
+        goplay2_response, redirect1_response, redirect2_response
+      )
+    end
+
+    it 'returns the confirmed host/port/key plus synthesized STORM/Wrayth launch fields' do
+      result = described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+
+      expect(result).to eq(
+        'gamehost'     => 'hydra.simutronics.com',
+        'gameport'     => '11624',
+        'key'          => 'abc123',
+        'game'         => 'STORM',
+        'gamecode'     => 'DRT',
+        'fullgamename' => 'Wrayth',
+        'gamefile'     => 'WRAYTH.EXE'
+      )
+    end
+
+    it 'matches the character by display name case-insensitively' do
+      result = described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'raiyen', game_code: 'DRT')
+      expect(result['gamehost']).to eq('hydra.simutronics.com')
+    end
+
+    context 'when the requested character is not on the scraped page' do
+      it 'raises CHARACTER_NOT_FOUND' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'NoSuchChar', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /CHARACTER_NOT_FOUND/)
+      end
+    end
+
+    context 'when login redirects to the error page' do
+      let(:login_okay_response) { response_double(location: '/dr/login_error.asp?error=&returnto=/dr/') }
+
+      it 'raises LOGIN_FAILED without attempting character resolution' do
+        expect {
+          described_class.auth(password: 'wrong', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /LOGIN_FAILED/)
+        expect(http).to have_received(:request).twice # preflight + login POST only
+      end
+    end
+
+    context 'when login redirects somewhere unexpected' do
+      let(:login_okay_response) { response_double(location: '/dr/some_other_page.asp') }
+
+      it 'raises UNEXPECTED_LOGIN_RESPONSE' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNEXPECTED_LOGIN_RESPONSE/)
+      end
+    end
+
+    context 'when the final redirect points off www.play.net' do
+      let(:redirect2_response) do
+        response_double(location: 'https://attacker.example/play/home.asp?host=evil.example&port=1&key=x')
+      end
+
+      it 'raises UNTRUSTED_REDIRECT_HOST rather than trusting the connection info' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError, /UNTRUSTED_REDIRECT_HOST/)
+      end
+    end
+
+    context 'when the final redirect downgrades to plain http' do
+      let(:redirect2_response) do
+        response_double(location: 'http://www.play.net/play/home.asp?host=h&port=1&key=x')
+      end
+
+      it 'raises rather than following a non-https redirect' do
+        expect {
+          described_class.auth(password: 'pw', account: 'TESTACCOUNT', character: 'Raiyen', game_code: 'DRT')
+        }.to raise_error(described_class::AuthenticationError)
+      end
+    end
+  end
+
+  describe described_class::CookieJar do
+    it 'returns nil when nothing has been absorbed yet' do
+      expect(subject.header).to be_nil
+    end
+
+    it 'keeps the newer value for a cookie absorbed twice, but keeps other cookies' do
+      subject.absorb(response_double(set_cookie: ['A=1; Path=/', 'B=2; Path=/']))
+      subject.absorb(response_double(set_cookie: ['B=3; Path=/']))
+      expect(subject.header).to eq('A=1; B=3')
+    end
+
+    it 'ignores a response with no Set-Cookie headers' do
+      subject.absorb(response_double(set_cookie: ['A=1']))
+      subject.absorb(response_double(set_cookie: []))
+      expect(subject.header).to eq('A=1')
+    end
+  end
+
+  describe '.auth_with_timeout' do
+    it 'raises when the exchange exceeds the timeout' do
+      allow(described_class).to receive(:auth) { sleep 0.2 }
+      expect {
+        described_class.auth_with_timeout(timeout: 0.01, password: 'pw', account: 'A', character: 'C', game_code: 'DRT')
+      }.to raise_error(/timed out authenticating with web login/)
+    end
+
+    it 'returns the result of .auth on success' do
+      allow(described_class).to receive(:auth).and_return({ 'gamehost' => 'h' })
+      result = described_class.auth_with_timeout(password: 'pw', account: 'A', character: 'C', game_code: 'DRT')
+      expect(result).to eq({ 'gamehost' => 'h' })
+    end
+  end
+end

--- a/spec/lib/common/authentication/web_login_spec.rb
+++ b/spec/lib/common/authentication/web_login_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe Lich::Common::Authentication::WebLogin do
   let(:http) { instance_double(Net::HTTP) }
 
   before do
-    allow(Net::HTTP).to receive(:new).and_return(http)
-    allow(http).to receive(:use_ssl=)
-    allow(http).to receive(:verify_mode=)
+    allow(Net::HTTP).to receive(:start).and_yield(http)
   end
 
   def response_double(code: '302', location: nil, set_cookie: [], body: nil)

--- a/spec/lib/common/cli/cli_orchestration_spec.rb
+++ b/spec/lib/common/cli/cli_orchestration_spec.rb
@@ -162,6 +162,17 @@ RSpec.describe Lich::Common::CLI::CLIOrchestration do
         .with(account: 'DOUG', password: 'secret', character: 'Raiyen', game_code: 'DRT')
     end
 
+    it 'never prints the live one-time KEY (a real usable credential) to stdout' do
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout)
+        .and_return('gamehost' => 'h', 'gameport' => 'p', 'key' => 'super-secret-key-value')
+      stub_const('ARGV', ['--web-login-test', 'DOUG', 'Raiyen', '--game-code', 'DRT'])
+
+      expect { described_class.handle_web_login_test }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+      expect($stdout.string).not_to include('super-secret-key-value')
+      expect($stdout.string).to include('KEY=[scrubbed]')
+      expect($stdout.string).to include('GAMEHOST=h') # non-secret fields still shown
+    end
+
     it 'exits 1 and reports the error code on authentication failure' do
       error = Lich::Common::Authentication::WebLogin::AuthenticationError.new('LOGIN_FAILED')
       allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_raise(error)

--- a/spec/lib/common/cli/cli_orchestration_spec.rb
+++ b/spec/lib/common/cli/cli_orchestration_spec.rb
@@ -143,4 +143,56 @@ RSpec.describe Lich::Common::CLI::CLIOrchestration do
       expect(Lich::Common::Authentication::CLIPassword).not_to have_received(:add_character)
     end
   end
+
+  describe '.handle_web_login_test' do
+    let(:saved_entries) do
+      [{ user_id: 'DOUG', password: 'secret', char_name: 'Raiyen', game_code: 'DRT' }]
+    end
+
+    before do
+      allow(Lich::Common::Authentication::EntryStore).to receive(:load_saved_entries).and_return(saved_entries)
+    end
+
+    it 'authenticates via Web using the password from the saved entry, not ARGV' do
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_return('gamehost' => 'h', 'gameport' => 'p', 'key' => 'k')
+      stub_const('ARGV', ['--web-login-test', 'DOUG', 'Raiyen', '--game-code', 'DRT'])
+
+      expect { described_class.handle_web_login_test }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+      expect(Lich::Common::Authentication::WebLogin).to have_received(:auth_with_timeout)
+        .with(account: 'DOUG', password: 'secret', character: 'Raiyen', game_code: 'DRT')
+    end
+
+    it 'exits 1 and reports the error code on authentication failure' do
+      error = Lich::Common::Authentication::WebLogin::AuthenticationError.new('LOGIN_FAILED')
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout).and_raise(error)
+      stub_const('ARGV', ['--web-login-test', 'DOUG', 'Raiyen', '--game-code', 'DRT'])
+
+      expect { described_class.handle_web_login_test }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      expect($stdout.string).to include('LOGIN_FAILED')
+    end
+
+    it 'exits 1 without authenticating when the account is not in the saved entries' do
+      stub_const('ARGV', ['--web-login-test', 'NOBODY', 'Raiyen', '--game-code', 'DRT'])
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout)
+
+      expect { described_class.handle_web_login_test }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      expect(Lich::Common::Authentication::WebLogin).not_to have_received(:auth_with_timeout)
+    end
+
+    it 'exits 1 without authenticating when --game-code is missing' do
+      stub_const('ARGV', ['--web-login-test', 'DOUG', 'Raiyen'])
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout)
+
+      expect { described_class.handle_web_login_test }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      expect(Lich::Common::Authentication::WebLogin).not_to have_received(:auth_with_timeout)
+    end
+
+    it 'exits 1 without authenticating when --game-code is not a recognized code' do
+      stub_const('ARGV', ['--web-login-test', 'DOUG', 'Raiyen', '--game-code', 'ZZ'])
+      allow(Lich::Common::Authentication::WebLogin).to receive(:auth_with_timeout)
+
+      expect { described_class.handle_web_login_test }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+      expect(Lich::Common::Authentication::WebLogin).not_to have_received(:auth_with_timeout)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds an HTTPS-based authentication fallback for when `eaccess.play.net:7910` (TLS) is unreachable, mirroring play.net's own web login flow instead of the EAccess protocol. Also instruments EAccess itself with per-stage failure diagnostics, added during review to help distinguish *why* 7910 is unreachable (network vs. TLS vs. backend) the next time this comes up.

- **`Lich::Common::Authentication::WebLogin`** — provider implementing the reverse-engineered web login chain (`login.asp` → `goplay2.asp` → redirect chain → `GAMEHOST`/`GAMEPORT`/`KEY`). Full protocol writeup in `docs/web-login-protocol-analysis.md`. Fail-closed `CONFIRMED_INSTANCES` table (only game codes verified live, or explicitly marked "unverified" with a relaxed but real check, are accepted), a private in-memory cookie jar, strict origin/scheme/path validation on the final redirect with the returned host/port cross-checked against the requested instance's expected values, bounded redirect count, and a browser-matching `User-Agent` (play.net's WAF 500s without one).
- **`Lich::Common::Authentication::LaunchResult`** — shared normalizer so `EAccess.auth` and `WebLogin.auth` return the same hash shape.
- **`Authenticator.authenticate`** — `auth_provider:` kwarg (`:eaccess` default, `:web` to force). Automatic fallback to `WebLogin` when EAccess fails for any reason *other than* rejected credentials, with the fast-fail-on-unreachable-endpoint behavior scoped specifically to the case where a fallback is actually available (legacy/generator EAccess calls and WebLogin itself keep full retry semantics, since there's nothing to fail over to). Logs which provider actually authenticated.
- **`--auth-provider=web`** CLI flag, and **`--web-login-test`** standalone probe (reads the password from `entry.yaml`, never ARGV).
- **`EAccess` failure diagnostics** — an 11-stage taxonomy (`docs/eaccess-failure-diagnostics.md`) logging which stage of the TCP/TLS/K-A-M-F-G-P-C-L exchange failed, how long it ran, and a probable-cause hint, without ever logging the password, session key, or character list. Also bounds the TLS TCP connect itself to 5s instead of the OS's ~75s default, so a dropped SYN fails fast.

## Verification

Live-verified end-to-end against the real play.net servers (not mocked) for **all five confirmed instances**: `DR`, `DRT`, `GS3` (maps to the web layer's own `GS4` code — confirmed mismatch, documented), `GST`, and `GS4 Shattered (GSF)`. Also verified: a bad-password failure, a nonexistent-account-name failure, an account with no active subscription (`NO_SUBSCRIPTION`, including instance-specific variants of that redirect), and an account requiring one-time security-question setup (handled transparently). Verified through the real `lich.rbw --login --auth-provider=web` entrypoint multiple times across these scenarios.

`DRX` (Platinum) and `DRF` (Fallen) are wired in end-to-end as **unverified** entries — `character_list_path` and a best-guess `web_game_code` are set, but `expected_host`/`expected_port` are deliberately left unpinned pending an account with real entitlement. Checked as much as possible without one: both correctly reach the real server and fail cleanly (`NO_SUBSCRIPTION`) with the existing unentitled test account, rather than crashing. `GSX` (GemStone Platinum) is excluded outright rather than listed as pending: confirmed with the account holder that the instance has been retired.

## Test plan

- [x] Full spec suite passes (7110 examples, 0 failures)
- [x] `rubocop` clean on all touched/added files
- [x] Live end-to-end against play.net: DR, DRT, GS3→GS4, GST, GSF, bad password, bad account name, no-subscription account (including DRX/DRF's instance-specific variant), security-question gate
- [x] Live end-to-end through the real `lich.rbw --login --auth-provider=web` / `--web-login-test` entrypoints, including the default EAccess-only path
- [ ] `DRX`/`DRF` — wired in and reachable, but the actual `GAMEHOST`/`GAMEPORT` needs an account with real entitlement to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added HTTPS WebLogin authentication, with optional forced use and automatic fallback when supported.
  - Added `--auth-provider` selection for EAccess or WebLogin.
  - Added `--web-login-test` to verify WebLogin connectivity and display non-sensitive connection details.
  - Added clearer authentication failure diagnostics, stage timing, and timeout reporting.

- **Bug Fixes**
  - Added connection time limits and validation for malformed authentication responses.
  - Standardized launch data handling across authentication methods.

- **Documentation**
  - Documented authentication failure diagnostics and the WebLogin protocol flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->