### PR TITLE
fix(dr): unpause the exact scripts safe_pause_list paused, by object

### DIFF
--- a/lib/dragonrealms/commons/common.rb
+++ b/lib/dragonrealms/commons/common.rb
@@ -983,23 +983,35 @@ module Lich
         @safe_pause_prev_ignore_pause = @safe_pause_holder&.ignore_pause
         @safe_pause_holder&.ignore_pause = true
 
-        paused_script_list = []
+        # Capture the exact Script objects we pause -- not their names. The
+        # matching safe_unpause_list restores from this list directly instead of
+        # re-scanning Script.running by name. A name + live-rescan restore
+        # silently drops any script that has left Script.running between pause
+        # and unpause (gone hidden, or mid start/teardown) or whose pause flags
+        # changed, stranding it paused forever while the log still claims it was
+        # unpaused. Holding the objects makes the restore undo exactly what the
+        # pause did.
+        paused_scripts = []
         Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != Script.self.name }.each do |s|
           s.pause
-          paused_script_list << s.name
+          paused_scripts << s
         end
-        Lich::Messaging.msg("plain", "DRC: Pausing #{paused_script_list} to run #{Script.self.name}")
-        return paused_script_list
+        Lich::Messaging.msg("plain", "DRC: Pausing #{paused_scripts.map(&:name)} to run #{Script.self.name}")
+        return paused_scripts
       end
 
-      def safe_unpause_list(scripts_to_unpause)
+      def safe_unpause_list(paused_scripts)
         return false unless $safe_pause_lock.owned?
 
-        if scripts_to_unpause.empty?
+        if paused_scripts.empty?
           Lich::Messaging.msg("plain", "DRC: #{Script.self.name} has finished.")
         else
-          Lich::Messaging.msg("plain", "DRC: Unpausing #{scripts_to_unpause}, #{Script.self.name} has finished.")
-          Script.running.find_all { |s| s.paused? && !s.no_pause_all && scripts_to_unpause.include?(s.name) }.each(&:unpause)
+          Lich::Messaging.msg("plain", "DRC: Unpausing #{paused_scripts.map(&:name)}, #{Script.self.name} has finished.")
+          # Unpause exactly the objects we paused, regardless of their current
+          # Script.running visibility or flags. Skip any a peer already unpaused
+          # so we neither emit spurious "is not paused" noise nor fight another
+          # coordinator that has since taken ownership of the pause.
+          paused_scripts.each { |s| s.unpause if s.paused? }
         end
         # Restore the holder's pre-lock pause immunity before releasing the lock,
         # so we never leave a script permanently unpausable.

--- a/spec/lib/dragonrealms/commons/common_spec.rb
+++ b/spec/lib/dragonrealms/commons/common_spec.rb
@@ -1042,9 +1042,9 @@ RSpec.describe Lich::DragonRealms::DRC do
         expect(described_class.safe_pause_list).to be false
       end
 
-      it 'pauses scripts and returns their names' do
+      it 'pauses scripts and returns the paused Script objects' do
         result = described_class.safe_pause_list
-        expect(result).to eq(['other'])
+        expect(result).to eq([mock_script])
       end
     end
 
@@ -1054,11 +1054,29 @@ RSpec.describe Lich::DragonRealms::DRC do
       end
 
       it 'unpauses scripts and releases lock' do
-        described_class.safe_pause_list
+        paused = described_class.safe_pause_list
         mock_script.paused = true
-        described_class.safe_unpause_list(['other'])
+        described_class.safe_unpause_list(paused)
         expect(mock_script).to have_received(:unpause)
         expect($safe_pause_lock.owned?).to be false
+      end
+
+      # Regression: safe_pause_list used to hand back script *names* and
+      # safe_unpause_list re-derived the unpause set from a fresh
+      # Script.running scan, matching by name. Any script that left
+      # Script.running between pause and unpause (gone hidden, or mid
+      # start/teardown) was silently dropped and stranded paused forever,
+      # while the log still claimed it was unpaused. Capturing and restoring
+      # the exact objects fixes this.
+      it 'unpauses a paused script even after it leaves Script.running' do
+        paused = described_class.safe_pause_list
+        expect(paused).to eq([mock_script])
+        mock_script.paused = true
+        # The script goes hidden / deregisters: no longer visible to a live
+        # Script.running rescan.
+        allow(Script).to receive(:running).and_return([])
+        described_class.safe_unpause_list(paused)
+        expect(mock_script).to have_received(:unpause)
       end
 
       context 'when list is empty' do
@@ -1093,8 +1111,8 @@ RSpec.describe Lich::DragonRealms::DRC do
       end
 
       it 'restores the holder pause setting when the lock is released' do
-        described_class.safe_pause_list
-        described_class.safe_unpause_list(['other'])
+        paused = described_class.safe_pause_list
+        described_class.safe_unpause_list(paused)
         expect(holder.ignore_pause).to be false
       end
 


### PR DESCRIPTION
## Problem

`DRC.safe_pause_list` returned a list of script *names*, and `DRC.safe_unpause_list` restored by re-scanning live `Script.running` and matching those names:

```ruby
Script.running.find_all { |s| s.paused? && !s.no_pause_all && names.include?(s.name) }.each(&:unpause)
```

The unpause set is re-derived from live state at unpause time, not from what was actually paused. Any script that leaves `Script.running` between pause and unpause — gone hidden, or mid start/teardown — or whose `no_pause_all` flag flips, silently drops out of the rescan and is **stranded paused forever**. Because pausing is cooperative, that script parks at its next checkpoint and never wakes. The log also actively misleads: the `Unpausing [...]` message prints the captured names, so it claims to unpause a script the code never touches.

**Real incident:** `almanac`'s `safe_pause_list` paused `t2` while `t2` was mid-`wait_for_script_to_complete` launching a child (`autopick`). By unpause time `t2` was no longer in the rescanned set, so `safe_unpause_list` skipped it even though the message listed it. `t2` stayed paused for the rest of the session (no further output for ~21 min).

## Fix

`safe_pause_list` captures and returns the exact **Script objects** it paused. `safe_unpause_list` unpauses those objects directly (`unpause if paused?`), regardless of their current `Script.running` visibility or flags — undoing exactly the pause it issued. The `Pausing`/`Unpausing` log messages map the same objects to names, so message and action can no longer diverge.

No caller inspects the returned list's contents (all ~15 dr-scripts callers use it only as a truthiness gate and pass it back), so the names→objects contract swap is safe.

## Scope / non-goals

Targeted follow-up to #1525. Like that hotfix, it does **not** remove the fragile pausing-as-coordination model or the multiple non-interoperating pause mechanisms — the lease-based command broker remains the structural fix. This removes one silent-strand failure mode now.

## Testing

- New regression spec in `spec/lib/dragonrealms/commons/common_spec.rb`: a paused script that leaves `Script.running` is still unpaused. Verified **red on the old code** (unpause called 0 times) and **green on the new**.
- Updated the existing safe_pause/unpause specs to the object contract.
- Full suite green (7147 examples, 0 failures) and `rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)