### PR TITLE
feat(all): add static-only map route selection

### DIFF
--- a/docs/static-map-routing.md
+++ b/docs/static-map-routing.md
@@ -1,0 +1,19 @@
+# Optional static map routing
+
+`Map.dijkstra(source, destination, static_only: true)` and
+`room.dijkstra(destination, static_only: true)` reuse the existing pathfinder but
+skip edges unless `wayto` is a plain String and `timeto` is a finite, nonnegative
+real Numeric. StringProc weights are skipped before evaluation. The existing
+`dijkstra_hashes` aliases accept the same keyword.
+
+Omitting the keyword, or passing `false`, preserves normal route selection and
+dynamic weight evaluation. Existing positional instance overrides remain
+compatible with default class dispatch. No preference weights or map entries
+are changed. Return values remain the existing predecessor/distance hashes.
+
+Static routing can find a longer ordinary route or leave the destination
+unreachable when dynamic edges are necessary. It does not execute movement,
+validate the meaning of a String command, prove a destination safe, or guarantee
+that mutable map data remains unchanged after planning. Callers must validate
+commands and current room transitions and enforce their own execution budget.
+This restriction is not a sandbox for arbitrary Ruby objects or map extensions.

--- a/docs/static-map-routing.md
+++ b/docs/static-map-routing.md
@@ -7,9 +7,14 @@ real Numeric. StringProc weights are skipped before evaluation. The existing
 `dijkstra_hashes` aliases accept the same keyword.
 
 Omitting the keyword, or passing `false`, preserves normal route selection and
-dynamic weight evaluation. Existing positional instance overrides remain
-compatible with default class dispatch. No preference weights or map entries
-are changed. Return values remain the existing predecessor/distance hashes.
+dynamic weight evaluation. In both cases, class dispatch passes only the
+positional destination, so existing positional-only `Room#dijkstra` overrides
+remain compatible. Explicitly passing `static_only: true` forwards that keyword
+to the instance method. Custom overrides must accept and honor the keyword to
+support static routing; an override accepting only the positional destination
+raises `ArgumentError` when called with this opt-in. No preference weights or
+map entries are changed. Return values remain the existing predecessor/distance
+hashes.
 
 Static routing can find a longer ordinary route or leave the destination
 unreachable when dynamic edges are necessary. It does not execute movement,

--- a/lib/common/map/map_base.rb
+++ b/lib/common/map/map_base.rb
@@ -523,12 +523,13 @@ module Lich
         # Class-level dijkstra dispatcher
         # @param source [Integer, String, Object] room, room id or lookup string
         # @param destination [Integer, Array, nil] Target room(s) or nil for full graph
+        # @param static_only [Boolean] skip executable/dynamic edges without evaluating them
         # @return [Array<Hash>, nil] see Room#dijkstra
-        def dijkstra(source, destination = nil)
+        def dijkstra(source, destination = nil, static_only: false)
           if source.is_a?(self)
-            source.dijkstra(destination)
+            static_only ? source.dijkstra(destination, static_only: true) : source.dijkstra(destination)
           elsif (room = self[source])
-            room.dijkstra(destination)
+            static_only ? room.dijkstra(destination, static_only: true) : room.dijkstra(destination)
           else
             echo 'Map.dijkstra: error: invalid source room'
             nil
@@ -769,9 +770,12 @@ module Lich
         # rooms actually reached rather than the highest id plus one, and
         # iteration yields pairs rather than slots.
         # @param destination [Integer, Array, nil] Target room(s) or nil for full graph
+        # @param static_only [Boolean] use only plain String wayto edges with
+        #   finite, nonnegative real Numeric weights; never evaluate StringProc
+        #   weights in this mode. This is route selection, not command validation.
         # @return [Array<Hash>, nil] [previous, distances] keyed by room id, or
         #   nil when the search failed
-        def dijkstra(destination = nil)
+        def dijkstra(destination = nil, static_only: false)
           self.class.load unless self.class.loaded?
           source = @id
           visited = {}
@@ -811,7 +815,13 @@ module Lich
               adj_room_i = adj_room.to_i
               next if visited[adj_room_i]
 
-              edge_weight = if room.timeto[adj_room].is_a?(StringProc)
+              edge_weight = if static_only
+                              weight = room.timeto[adj_room]
+                              next unless room.wayto[adj_room].instance_of?(String) && weight.is_a?(Numeric) &&
+                                          weight.real? && weight.finite? && weight >= 0
+
+                              weight
+                            elsif room.timeto[adj_room].is_a?(StringProc)
                               room.timeto[adj_room].call
                             else
                               room.timeto[adj_room]

--- a/lib/common/map/map_base.rb
+++ b/lib/common/map/map_base.rb
@@ -526,9 +526,8 @@ module Lich
         # @param static_only [Boolean] skip executable/dynamic edges without evaluating them
         # @return [Array<Hash>, nil] see Room#dijkstra
         def dijkstra(source, destination = nil, static_only: false)
-          if source.is_a?(self)
-            static_only ? source.dijkstra(destination, static_only: true) : source.dijkstra(destination)
-          elsif (room = self[source])
+          room = source.is_a?(self) ? source : self[source]
+          if room
             static_only ? room.dijkstra(destination, static_only: true) : room.dijkstra(destination)
           else
             echo 'Map.dijkstra: error: invalid source room'

--- a/spec/lib/common/map/game_map_shared_examples.rb
+++ b/spec/lib/common/map/game_map_shared_examples.rb
@@ -406,6 +406,66 @@ RSpec.shared_examples 'a game Map class' do |game|
       expect(previous[2]).to eq(1)
     end
 
+    it 'skips executable weights before calling them in static routing only' do
+      dynamic = StringProc.new('0.1')
+      calls = 0
+      allow(dynamic).to receive(:call) { calls += 1; 0.1 }
+      map_class[1].timeto['2'] = dynamic
+
+      expect(map_class.dijkstra(1, 2, static_only: true).last[2]).to be_nil
+      expect(map_class.dijkstra_hashes(map_class[1], 2, static_only: true).last[2]).to be_nil
+      expect(map_class[1].dijkstra_hashes(2, static_only: true).last[2]).to be_nil
+      expect(calls).to eq(0)
+      expect(map_class.dijkstra(1, 2).last[2]).to eq(0.1)
+      expect(map_class.dijkstra(1, 2, static_only: false).last[2]).to eq(0.1)
+      expect(calls).to eq(2)
+    end
+
+    it 'finds an existing static alternative without changing default route preference' do
+      shared_room(3, title: '[Three]', description: 'third')
+      map_class[1].wayto['3'] = 'east'
+      map_class[1].timeto['3'] = 1
+      map_class[3].wayto['2'] = 'north'
+      map_class[3].timeto['2'] = 1
+      map_class[1].wayto['2'] = StringProc.new('raise "must not execute movement during planning"')
+
+      expect(map_class.dijkstra(1, 2).first[2]).to eq(1)
+      previous, distances = map_class.dijkstra(1, 2, static_only: true)
+      expect(previous[2]).to eq(3)
+      expect(previous[3]).to eq(1)
+      expect(distances[2]).to eq(2)
+    end
+
+    it 'uses the captured static weight without rereading an executable replacement' do
+      dynamic = StringProc.new('raise "must not evaluate replacement"')
+      weights = map_class[1].timeto
+      allow(weights).to receive(:[]).with('2').and_return(0.5, dynamic)
+      expect(dynamic).not_to receive(:call)
+      expect(map_class[1].dijkstra(2, static_only: true).last[2]).to eq(0.5)
+      expect(weights).to have_received(:[]).with('2').once
+    end
+
+    it 'rejects nonplain string edges and invalid static weights without coercion' do
+      [nil, :north, proc { raise 'not a string' }, Class.new(String).new('north')].each do |way|
+        map_class[1].wayto['2'] = way
+        expect(map_class[1].dijkstra(2, static_only: true).last[2]).to be_nil
+      end
+      map_class[1].wayto['2'] = 'north'
+      [nil, true, '0.5', -1, Float::INFINITY, -Float::INFINITY, Float::NAN, Complex(1, 1)].each do |weight|
+        map_class[1].timeto['2'] = weight
+        expect(map_class[1].dijkstra(2, static_only: true).last[2]).to be_nil
+      end
+      map_class[1].timeto['2'] = 0
+      expect(map_class[1].dijkstra(2, static_only: true).last[2]).to eq(0)
+    end
+
+    it 'keeps legacy positional instance overrides compatible in default class dispatch' do
+      room = map_class[1]
+      room.define_singleton_method(:dijkstra) { |destination| destination }
+      expect(map_class.dijkstra(room, 2)).to eq(2)
+      expect(map_class.dijkstra(1, 2, static_only: false)).to eq(2)
+    end
+
     it 'yields nil for a room it never reached' do
       _, distances = map_class[1].dijkstra
 

--- a/spec/lib/common/map/game_map_shared_examples.rb
+++ b/spec/lib/common/map/game_map_shared_examples.rb
@@ -463,7 +463,37 @@ RSpec.shared_examples 'a game Map class' do |game|
       room = map_class[1]
       room.define_singleton_method(:dijkstra) { |destination| destination }
       expect(map_class.dijkstra(room, 2)).to eq(2)
+      expect(map_class.dijkstra(1, 2)).to eq(2)
+      expect(map_class.dijkstra(room, 2, static_only: false)).to eq(2)
       expect(map_class.dijkstra(1, 2, static_only: false)).to eq(2)
+    end
+
+    it 'requires legacy positional instance overrides to accept the static routing keyword before opting in' do
+      room = map_class[1]
+      room.define_singleton_method(:dijkstra) { |destination| destination }
+
+      expect { map_class.dijkstra(room, 2, static_only: true) }.to raise_error(ArgumentError)
+      expect { map_class.dijkstra(1, 2, static_only: true) }.to raise_error(ArgumentError)
+    end
+
+    it 'forwards the static routing opt-in to keyword-aware instance overrides' do
+      room = map_class[1]
+      room.define_singleton_method(:dijkstra) { |destination, static_only: false| [destination, static_only] }
+
+      expect(map_class.dijkstra(room, 2, static_only: true)).to eq([2, true])
+      expect(map_class.dijkstra(1, 2, static_only: true)).to eq([2, true])
+    end
+
+    it 'echoes an error and returns nil for an invalid source room' do
+      expect(map_class).to receive(:echo).with('Map.dijkstra: error: invalid source room')
+
+      expect(map_class.dijkstra(999_999)).to be_nil
+    end
+
+    it 'echoes the same error and returns nil for an invalid source room with static routing' do
+      expect(map_class).to receive(:echo).with('Map.dijkstra: error: invalid source room')
+
+      expect(map_class.dijkstra(999_999, static_only: true)).to be_nil
     end
 
     it 'yields nil for a room it never reached' do


### PR DESCRIPTION
## Summary

- add an opt-in `static_only:` keyword to class- and room-level map Dijkstra routing
- skip executable/dynamic edges without evaluating them when static routing is requested
- accept only plain String `wayto` values and finite, nonnegative real Numeric weights in that mode
- preserve existing routing and dynamic weight evaluation when the keyword is omitted or false

## Motivation

Some callers need to inspect whether an ordinary static route exists before granting movement authority. The existing pathfinder may evaluate `StringProc` weights while selecting a route. `static_only: true` provides a side-effect-free selection subset without changing map data, route preferences, or the default behavior used by existing callers.

This is route selection only. It does not execute movement, validate command text, prove a destination safe, or sandbox arbitrary map extensions. A route that requires a dynamic edge is deliberately reported as unreachable in static mode even when normal routing could traverse it.

## Compatibility

- `Map.dijkstra(source, destination)` and `room.dijkstra(destination)` retain their current behavior
- `static_only: false` is equivalent to omitting the keyword
- existing positional instance overrides remain compatible with default class dispatch
- return values remain the existing predecessor/distance hashes

## Verification

Shared GS/DR map examples cover:

- skipping executable weights before invocation
- selecting a longer static alternative without changing default preference
- reading a selected static weight once
- rejecting nonplain commands and invalid/nonfinite weights
- preserving legacy positional instance overrides

Hosted Ruby tests, RuboCop, syntax checks, and PR-title validation are green.
