### PR TITLE
feat(gs): Lich::Stash.wield and Stash.hands put named items into hands

### DIFF
--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -453,6 +453,15 @@ module Lich
       wanted = { right: right, left: left }
       resolved = wanted.transform_values { |want| want == :keep || want.nil? ? want : find_item(want) }
 
+      # A wanted item sitting in the hand the caller asked to keep can only be
+      # moved by a swap, which would change that hand. Refuse before touching anything.
+      HANDS.each do |hand|
+        other = hand == :right ? :left : :right
+        item = resolved[hand]
+        next unless item.is_a?(GameObj) && wanted[other] == :keep && hand_holding(item) == other
+        raise ArgumentError, "hands: #{item.name} is in the #{other} hand, which was asked to be kept"
+      end
+
       # Both wanted items are present but in each other's hands: one swap.
       if resolved[:right].is_a?(GameObj) && resolved[:left].is_a?(GameObj) &&
          hand_holding(resolved[:right]) == :left && hand_holding(resolved[:left]) == :right

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -493,17 +493,22 @@ module Lich
 
       # Empty first, so a wanted item can land in a freed hand. A hand asked to
       # be emptied that is holding the item wanted in the OTHER hand needs a
-      # swap, not a stash: stashing would drag the item into a container only
-      # for the wield below to fetch it straight back out.
+      # swap, not a stash: stashing would drag the wanted item into a container
+      # only for the wield below to fetch it straight back out. If the other
+      # hand is occupied by something unwanted, stash THAT and then swap, so
+      # the item the caller asked for never goes into a container.
       HANDS.each do |hand|
         next unless resolved[hand].nil? && wanted.key?(hand) && !(wanted[hand] == :keep)
         next if empty_hand?(hand)
         other = hand == :right ? :left : :right
         other_item = resolved[other]
-        if other_item.is_a?(GameObj) && hand_holding(other_item) == hand && empty_hand?(other)
-          waitrt?
-          dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
-          next if empty_hand?(hand)
+        if other_item.is_a?(GameObj) && hand_holding(other_item) == hand
+          free_hand(other) unless empty_hand?(other)
+          if empty_hand?(other)
+            waitrt?
+            dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
+            next if empty_hand?(hand)
+          end
         end
         free_hand(hand)
       end

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -281,10 +281,9 @@ module Lich
     #   ready-list slot (:weapon, :shield, ...); or a name matched the way
     #   find_container matches, case-insensitive and with words allowed to be
     #   non-adjacent ("vultite broadsword" matches "vultite hand-forged broadsword")
-    # @param loud_fail [Boolean] raise when not found or ambiguous
-    # @return [GameObj, nil]
-    # @raise [RuntimeError] when loud_fail and the item is missing, or a name
-    #   matches more than one item (that is a profile bug the user should see)
+    # @param loud_fail [Boolean] raise when nothing matches
+    # @return [GameObj, nil] the best candidate from find_items for a name
+    # @raise [RuntimeError] when loud_fail and the item is missing
     def self.find_item(param, loud_fail: true)
       return param if param.is_a?(GameObj)
 
@@ -292,17 +291,28 @@ module Lich
               when Integer then GameObj[param.to_s]
               when Symbol then find_ready_item(param)
               when String
-                if param =~ /\A\d+\z/
-                  GameObj[param]
-                else
-                  matches = known_items.select { |obj| name_matches?(obj, param) }.uniq(&:id)
-                  matches = inventory_matches(param) if matches.empty?
-                  fail "Item[name: #{param}] matches #{matches.size} items: #{matches.map(&:name).join(', ')}" if matches.size > 1 && loud_fail
-                  matches.first
-                end
+                param =~ /\A\d+\z/ ? GameObj[param] : find_items(param).first
               end
       fail "could not find Item[#{param.inspect}]" if found.nil? && loud_fail
       found
+    end
+
+    # Every distinct item a name could mean, best first, without sending
+    # anything. Ordered by how specific the match is (whole name, then part
+    # of the name, then noun only) and then by where the item is (hands,
+    # ready list, worn, containers), which is the order the game itself
+    # resolves a bare noun in. Items with identical names are interchangeable
+    # and collapse to the first.
+    #
+    # @param name [String]
+    # @return [Array<GameObj>] empty when nothing matches
+    def self.find_items(name)
+      ranked = known_items_ranked.select { |obj, _loc| name_matches?(obj, name) }
+      ranked = inventory_matches(name).map { |obj| [obj, 4] } if ranked.empty?
+      ranked.sort_by.with_index { |(obj, loc), i| [match_specificity(obj, name), loc, i] }
+                    .map(&:first)
+            .uniq(&:id)
+            .uniq(&:name)
     end
 
     # The full inventory tree, refreshed on request through the game's
@@ -380,7 +390,14 @@ module Lich
     # @raise [RuntimeError] when the item cannot be found or never arrives
     def self.wield(param, hand: nil)
       fail "wield: hand must be :right, :left or nil, got #{hand.inspect}" unless hand.nil? || HANDS.include?(hand)
-      item = find_item(param)
+      if param.is_a?(String) && param !~ /\A\d+\z/
+        candidates = find_items(param)
+        fail "could not find Item[#{param.inspect}]" if candidates.empty?
+        item = candidates.first
+        echo "wield: #{param} -> #{item.name} (of #{candidates.size} kinds: #{candidates.map(&:name).join(', ')})" if candidates.size > 1
+      else
+        item = find_item(param)
+      end
 
       holding = hand_holding(item)
       if holding
@@ -503,6 +520,28 @@ module Lich
       ReadyList.ready_list[slot]
     end
 
+    # known_items with a location rank: 0 hands, 1 ready list, 2 worn, 3 in a container.
+    #
+    # @return [Array<Array(GameObj, Integer)>]
+    def self.known_items_ranked
+      hands = [GameObj.right_hand, GameObj.left_hand].compact.reject { |obj| obj.id.nil? }
+      ready = ReadyList.checked? ? ReadyList.ready_list.values.compact : []
+      hands.map { |obj| [obj, 0] } +
+        ready.map { |obj| [obj, 1] } +
+        GameObj.inv.to_a.map { |obj| [obj, 2] } +
+        GameObj.containers.values.flatten.map { |obj| [obj, 3] }
+    end
+
+    # 0 when the name is the whole item name, 1 when it is a run of whole
+    # words inside it, 2 when only the noun (or a loose match) hit.
+    def self.match_specificity(obj, name)
+      wanted = name.strip.downcase
+      actual = obj.name.to_s.downcase
+      return 0 if actual == wanted
+      return 1 if actual =~ /(?:\A|\s)#{Regexp.escape(wanted)}(?:\s|\z)/ && wanted.include?(' ')
+      2
+    end
+
     # Every item Lich currently knows the character has: hands, worn, and the
     # contents of containers that have been looked in.
     #
@@ -518,7 +557,7 @@ module Lich
       obj.name =~ %r[#{param.strip}]i || obj.name =~ %r[#{param.sub(' ', ' .*')}]i
     end
 
-    private_class_method :find_ready_item, :known_items, :name_matches?, :inventory_matches
+    private_class_method :find_ready_item, :known_items, :known_items_ranked, :match_specificity, :name_matches?, :inventory_matches
 
     def self.equip_hands(left: false, right: false, both: false)
       if both

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -452,6 +452,9 @@ module Lich
     def self.hands(right: :keep, left: :keep)
       wanted = { right: right, left: left }
       resolved = wanted.transform_values { |want| want == :keep || want.nil? ? want : find_item(want) }
+      if resolved[:right].is_a?(GameObj) && resolved[:left].is_a?(GameObj) && resolved[:right].id == resolved[:left].id
+        raise ArgumentError, "hands: #{resolved[:right].name} was asked for in both hands"
+      end
 
       # A wanted item sitting in the hand the caller asked to keep can only be
       # moved by a swap, which would change that hand. Refuse before touching anything.

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -296,12 +296,61 @@ module Lich
                   GameObj[param]
                 else
                   matches = known_items.select { |obj| name_matches?(obj, param) }.uniq(&:id)
+                  matches = inventory_matches(param) if matches.empty?
                   fail "Item[name: #{param}] matches #{matches.size} items: #{matches.map(&:name).join(', ')}" if matches.size > 1 && loud_fail
                   matches.first
                 end
               end
       fail "could not find Item[#{param.inspect}]" if found.nil? && loud_fail
       found
+    end
+
+    # The full inventory tree, refreshed on request through the game's
+    # inventory manager. This is what knows about items in containers Lich
+    # has never looked in, and whether each container is closed right now.
+    #
+    # @param refresh [Boolean] ask the game for a fresh tree (one command)
+    # @return [Lich::Common::Inventory::Snapshot, nil]
+    def self.inventory(refresh: true)
+      return nil unless defined?(Lich::Common::Inventory)
+      refresh ? Lich::Common::Inventory.refresh : Lich::Common::Inventory.current
+    rescue StandardError
+      nil
+    end
+
+    # Open every closed container between the item and the player, outermost
+    # first, confirming each. Locked containers are left alone.
+    #
+    # @param item [GameObj]
+    # @return [Boolean] false when a container on the way is locked or would not open
+    def self.open_path_to(item)
+      snapshot = inventory(refresh: false) || inventory
+      entry = snapshot && snapshot[item.id]
+      return true if entry.nil? # Inventory does not know it; nothing to open
+
+      chain = []
+      parent = entry.parent_item
+      while parent
+        chain.unshift(parent)
+        parent = parent.parent_item
+      end
+      chain.each do |container|
+        next unless container.closed?
+        return false if container.locked?
+        return false unless open_container(container.id)
+      end
+      true
+    end
+
+    OPEN_CONFIRM = /^You open|^That is already open|^It is already open|^You can't|^You don't seem|^You need|is locked/.freeze
+
+    # @param id [String] container id
+    # @return [Boolean] whether the container is open afterwards
+    def self.open_container(id)
+      waitrt?
+      result = dothistimeout("open ##{id}", 3, OPEN_CONFIRM)
+      return true if result =~ /^You open|already open/
+      false
     end
 
     # @return [Symbol, nil] :right or :left when the item is in that hand
@@ -349,15 +398,20 @@ module Lich
         stash_hands(right: true)
       end
 
-      container = container_holding(item)
-      self.container(container) if container # opens it when it is closed
+      fail "wield: a container holding #{item.name} is locked or would not open" unless open_path_to(item)
 
-      if worn?(item)
-        fput "remove ##{item.id}"
-      else
-        fput "get ##{item.id}"
-      end
+      fetch = worn?(item) ? "remove ##{item.id}" : "get ##{item.id}"
+      fput fetch
       ITEM_CONFIRM_TRIES.times { break if in_hand?(item); sleep ITEM_CONFIRM_SLEEP }
+
+      # Did not arrive: the usual cause is a container closed since Lich last
+      # saw inside it. Ask the game for the current tree, open, try once more.
+      unless in_hand?(item)
+        inventory
+        fail "wield: a container holding #{item.name} is locked or would not open" unless open_path_to(item)
+        fput fetch
+        ITEM_CONFIRM_TRIES.times { break if in_hand?(item); sleep ITEM_CONFIRM_SLEEP }
+      end
       fail "wield: #{item.name} did not arrive in hand" unless in_hand?(item)
 
       if hand && hand_holding(item) != hand
@@ -417,11 +471,29 @@ module Lich
       GameObj.inv.to_a.any? { |obj| obj.id == item.id }
     end
 
-    # @return [GameObj, nil] the container Lich knows the item to be inside
+    # @return [GameObj, nil] the container Lich knows the item to be inside,
+    #   from the looked-in registries or the inventory tree
     def self.container_holding(item)
       entry = GameObj.containers.find { |_id, items| items.to_a.any? { |obj| obj.id == item.id } }
-      return nil if entry.nil?
-      GameObj.inv.to_a.find { |obj| obj.id == entry.first } || GameObj[entry.first]
+      return GameObj.inv.to_a.find { |obj| obj.id == entry.first } || GameObj[entry.first] if entry
+
+      snapshot = inventory(refresh: false)
+      parent = snapshot && snapshot[item.id]&.parent_item
+      parent && GameObj[parent.id]
+    end
+
+    # Items from the inventory tree whose name matches, as GameObjs. Inventory
+    # registers a GameObj for every item it sees, so the id lookup succeeds
+    # even for items in containers nobody has looked in.
+    #
+    # @return [Array<GameObj>]
+    def self.inventory_matches(param)
+      snapshot = inventory
+      return [] if snapshot.nil?
+      snapshot.all.select { |item| name_matches?(item, param) }
+                  .reject { |item| item.in_room? || item.at_feet? }
+                  .map { |item| GameObj[item.id] }
+                  .compact
     end
 
     # @return [GameObj, nil] the item in a ready-list slot, checking the list once if needed
@@ -446,7 +518,7 @@ module Lich
       obj.name =~ %r[#{param.strip}]i || obj.name =~ %r[#{param.sub(' ', ' .*')}]i
     end
 
-    private_class_method :find_ready_item, :known_items, :name_matches?
+    private_class_method :find_ready_item, :known_items, :name_matches?, :inventory_matches
 
     def self.equip_hands(left: false, right: false, both: false)
       if both

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -377,6 +377,25 @@ module Lich
       !hand_holding(item).nil?
     end
 
+    # Free a hand for an item we are about to put there.
+    #
+    # stash_hands is the public empty_hand/empty_right_hand API: it pushes a
+    # "put this back" action onto the process-wide $fill_*_hand_actions stacks
+    # that equip_hands / fill_hand pop. wield and hands displace an item on
+    # purpose and never restore it, so leaving an entry behind would corrupt
+    # the stack another script is using. Stash, then drop the entry we just
+    # added, leaving any pre-existing entries untouched.
+    #
+    # @param hand [Symbol] :right or :left
+    # @return [void]
+    def self.free_hand(hand)
+      return if empty_hand?(hand)
+      stack = hand == :right ? ($fill_right_hand_actions ||= []) : ($fill_left_hand_actions ||= [])
+      depth = stack.length
+      stash_hands(**{ hand => true })
+      stack.pop while stack.length > depth
+    end
+
     # Get a named item into a hand.
     #
     # Worn items are removed, items in containers are fetched (opening the
@@ -410,9 +429,9 @@ module Lich
 
       waitrt?
       if hand
-        stash_hands(**{ hand => true }) unless empty_hand?(hand)
+        free_hand(hand)
       elsif !empty_hand?(:right) && !empty_hand?(:left)
-        stash_hands(right: true)
+        free_hand(:right)
       end
 
       fail "wield: a container holding #{item.name} is locked or would not open" unless open_path_to(item)
@@ -472,10 +491,21 @@ module Lich
         dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
       end
 
-      # Empty first, so a wanted item can land in a freed hand.
+      # Empty first, so a wanted item can land in a freed hand. A hand asked to
+      # be emptied that is holding the item wanted in the OTHER hand needs a
+      # swap, not a stash: stashing would drag the item into a container only
+      # for the wield below to fetch it straight back out.
       HANDS.each do |hand|
         next unless resolved[hand].nil? && wanted.key?(hand) && !(wanted[hand] == :keep)
-        stash_hands(**{ hand => true }) unless empty_hand?(hand)
+        next if empty_hand?(hand)
+        other = hand == :right ? :left : :right
+        other_item = resolved[other]
+        if other_item.is_a?(GameObj) && hand_holding(other_item) == hand && empty_hand?(other)
+          waitrt?
+          dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
+          next if empty_hand?(hand)
+        end
+        free_hand(hand)
       end
 
       HANDS.each do |hand|
@@ -563,10 +593,17 @@ module Lich
       hands + GameObj.inv.to_a + GameObj.containers.values.flatten
     end
 
-    # Same matching find_container uses, so a profile string means the same
-    # thing whether it names a bag or a weapon.
+    # Same matching find_container uses (substring, and words that may be
+    # non-adjacent), so a profile string means the same thing whether it names
+    # a bag or a weapon. Unlike find_container the pattern is escaped, so an
+    # item name or profile string carrying regex metacharacters cannot raise.
     def self.name_matches?(obj, param)
-      obj.name =~ %r[#{param.strip}]i || obj.name =~ %r[#{param.sub(' ', ' .*')}]i
+      wanted = param.to_s.strip
+      return false if wanted.empty?
+      name = obj.name.to_s
+      return true if name =~ /#{Regexp.escape(wanted)}/i
+      loose = wanted.split(/ /, 2).map { |part| Regexp.escape(part) }.join(' .*')
+      name =~ /#{loose}/i ? true : false
     end
 
     private_class_method :find_ready_item, :known_items, :known_items_ranked, :match_specificity, :name_matches?, :inventory_matches

--- a/lib/stash.rb
+++ b/lib/stash.rb
@@ -261,6 +261,193 @@ module Lich
       $fill_right_hand_actions.push(actions) if right
     end
 
+    # -------------------------------------------------------------------------
+    # Named items: find, wield, and reconcile both hands to a wanted state.
+    #
+    # stash_hands / equip_hands remember and restore whatever was held. The
+    # methods below are the other half: "put THIS item in my hand", where the
+    # item is named by a profile string, an id, a GameObj, or a ready-list slot.
+    # Every command is sent by id, so an ambiguous noun never reaches the game.
+    # -------------------------------------------------------------------------
+
+    HANDS = %i[right left].freeze
+
+    ITEM_CONFIRM_TRIES = 20
+    ITEM_CONFIRM_SLEEP = 0.1
+
+    # Resolve an item reference to a GameObj without sending anything.
+    #
+    # @param param [GameObj, Integer, String, Symbol] a GameObj; an id; a
+    #   ready-list slot (:weapon, :shield, ...); or a name matched the way
+    #   find_container matches, case-insensitive and with words allowed to be
+    #   non-adjacent ("vultite broadsword" matches "vultite hand-forged broadsword")
+    # @param loud_fail [Boolean] raise when not found or ambiguous
+    # @return [GameObj, nil]
+    # @raise [RuntimeError] when loud_fail and the item is missing, or a name
+    #   matches more than one item (that is a profile bug the user should see)
+    def self.find_item(param, loud_fail: true)
+      return param if param.is_a?(GameObj)
+
+      found = case param
+              when Integer then GameObj[param.to_s]
+              when Symbol then find_ready_item(param)
+              when String
+                if param =~ /\A\d+\z/
+                  GameObj[param]
+                else
+                  matches = known_items.select { |obj| name_matches?(obj, param) }.uniq(&:id)
+                  fail "Item[name: #{param}] matches #{matches.size} items: #{matches.map(&:name).join(', ')}" if matches.size > 1 && loud_fail
+                  matches.first
+                end
+              end
+      fail "could not find Item[#{param.inspect}]" if found.nil? && loud_fail
+      found
+    end
+
+    # @return [Symbol, nil] :right or :left when the item is in that hand
+    def self.hand_holding(item)
+      id = item.is_a?(GameObj) ? item.id : item.to_s
+      return nil if id.nil?
+      return :right if GameObj.right_hand&.id == id
+      return :left if GameObj.left_hand&.id == id
+      nil
+    end
+
+    # @return [Boolean]
+    def self.in_hand?(item)
+      !hand_holding(item).nil?
+    end
+
+    # Get a named item into a hand.
+    #
+    # Worn items are removed, items in containers are fetched (opening the
+    # container first when Lich knows it is closed), and the target hand is
+    # emptied through stash_hands beforehand so nothing is dropped. When no
+    # hand is given the item goes wherever the game puts it.
+    #
+    # @param param [GameObj, Integer, String, Symbol] see find_item
+    # @param hand [Symbol, nil] :right, :left, or nil for either
+    # @return [GameObj] the item now in hand
+    # @raise [RuntimeError] when the item cannot be found or never arrives
+    def self.wield(param, hand: nil)
+      fail "wield: hand must be :right, :left or nil, got #{hand.inspect}" unless hand.nil? || HANDS.include?(hand)
+      item = find_item(param)
+
+      holding = hand_holding(item)
+      if holding
+        return item if hand.nil? || holding == hand
+        waitrt?
+        dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
+        return item if hand_holding(item) == hand
+        fail "wield: could not move #{item.name} to the #{hand} hand"
+      end
+
+      waitrt?
+      if hand
+        stash_hands(**{ hand => true }) unless empty_hand?(hand)
+      elsif !empty_hand?(:right) && !empty_hand?(:left)
+        stash_hands(right: true)
+      end
+
+      container = container_holding(item)
+      self.container(container) if container # opens it when it is closed
+
+      if worn?(item)
+        fput "remove ##{item.id}"
+      else
+        fput "get ##{item.id}"
+      end
+      ITEM_CONFIRM_TRIES.times { break if in_hand?(item); sleep ITEM_CONFIRM_SLEEP }
+      fail "wield: #{item.name} did not arrive in hand" unless in_hand?(item)
+
+      if hand && hand_holding(item) != hand
+        dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
+        fail "wield: could not move #{item.name} to the #{hand} hand" unless hand_holding(item) == hand
+      end
+      item
+    end
+
+    # Reconcile both hands to a wanted state without dropping anything.
+    #
+    #   Stash.hands(right: 'broadsword', left: :shield)   # wield both
+    #   Stash.hands(right: nil)                           # empty the right hand, leave left alone
+    #   Stash.hands(left: :keep, right: 'runestaff')
+    #
+    # Each hand takes :keep (leave it, the default), nil (empty it), or any item
+    # reference find_item accepts. An item already in the other hand is swapped
+    # across rather than stashed and fetched.
+    #
+    # @return [Hash{Symbol => GameObj, nil}] what each hand holds afterwards
+    def self.hands(right: :keep, left: :keep)
+      wanted = { right: right, left: left }
+      resolved = wanted.transform_values { |want| want == :keep || want.nil? ? want : find_item(want) }
+
+      # Both wanted items are present but in each other's hands: one swap.
+      if resolved[:right].is_a?(GameObj) && resolved[:left].is_a?(GameObj) &&
+         hand_holding(resolved[:right]) == :left && hand_holding(resolved[:left]) == :right
+        waitrt?
+        dothistimeout 'swap', 3, /^You don't have anything to swap!|^You swap/
+      end
+
+      # Empty first, so a wanted item can land in a freed hand.
+      HANDS.each do |hand|
+        next unless resolved[hand].nil? && wanted.key?(hand) && !(wanted[hand] == :keep)
+        stash_hands(**{ hand => true }) unless empty_hand?(hand)
+      end
+
+      HANDS.each do |hand|
+        item = resolved[hand]
+        next unless item.is_a?(GameObj)
+        wield(item, hand: hand)
+      end
+
+      { right: GameObj.right_hand&.id ? GameObj.right_hand : nil,
+        left: GameObj.left_hand&.id ? GameObj.left_hand : nil }
+    end
+
+    # @param hand [Symbol] :right or :left
+    # @return [Boolean]
+    def self.empty_hand?(hand)
+      obj = hand == :right ? GameObj.right_hand : GameObj.left_hand
+      obj.nil? || obj.id.nil?
+    end
+
+    # @return [Boolean] whether the item is in worn inventory (needs REMOVE, not GET)
+    def self.worn?(item)
+      GameObj.inv.to_a.any? { |obj| obj.id == item.id }
+    end
+
+    # @return [GameObj, nil] the container Lich knows the item to be inside
+    def self.container_holding(item)
+      entry = GameObj.containers.find { |_id, items| items.to_a.any? { |obj| obj.id == item.id } }
+      return nil if entry.nil?
+      GameObj.inv.to_a.find { |obj| obj.id == entry.first } || GameObj[entry.first]
+    end
+
+    # @return [GameObj, nil] the item in a ready-list slot, checking the list once if needed
+    def self.find_ready_item(slot)
+      fail "unknown ready-list slot #{slot.inspect}" unless ReadyList.ready_list.key?(slot)
+      ReadyList.check(silent: true, quiet: true) unless ReadyList.valid?
+      ReadyList.ready_list[slot]
+    end
+
+    # Every item Lich currently knows the character has: hands, worn, and the
+    # contents of containers that have been looked in.
+    #
+    # @return [Array<GameObj>]
+    def self.known_items
+      hands = [GameObj.right_hand, GameObj.left_hand].compact.reject { |obj| obj.id.nil? }
+      hands + GameObj.inv.to_a + GameObj.containers.values.flatten
+    end
+
+    # Same matching find_container uses, so a profile string means the same
+    # thing whether it names a bag or a weapon.
+    def self.name_matches?(obj, param)
+      obj.name =~ %r[#{param.strip}]i || obj.name =~ %r[#{param.sub(' ', ' .*')}]i
+    end
+
+    private_class_method :find_ready_item, :known_items, :name_matches?
+
     def self.equip_hands(left: false, right: false, both: false)
       if both
         for action in $fill_hands_actions.pop

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -377,5 +377,74 @@ RSpec.describe Lich::Stash, 'named items' do
       expect(described_class).not_to receive(:stash_hands)
       expect { described_class.hands(right: nil, left: 'halberd') }.to raise_error(RuntimeError, /could not find/)
     end
+
+    it 'swaps instead of stashing when the hand being emptied holds the other wanted item' do
+      hold(:left, sword)
+      expect(described_class).to receive(:dothistimeout).with('swap', 3, anything).once do
+        hold(:right, sword)
+        hold(:left, empty)
+      end
+      expect(described_class).not_to receive(:stash_hands)
+      expect(described_class).not_to receive(:fput)
+      result = described_class.hands(right: sword, left: nil)
+      expect(result[:right].id).to eq('101')
+      expect(result[:left]).to be_nil
+    end
+
+    it 'still stashes when the hand being emptied holds something unwanted' do
+      hold(:left, dagger)
+      hold(:right, shield)
+      expect(described_class).to receive(:stash_hands).with(left: true) { hold(:left, empty) }
+      described_class.hands(left: nil)
+    end
+  end
+
+  describe 'hand-restore stacks' do
+    before do
+      $fill_right_hand_actions = []
+      $fill_left_hand_actions = []
+      # The real stash_hands pushes a restore action; imitate that here.
+      allow(described_class).to receive(:stash_hands) do |right: false, left: false, **|
+        $fill_right_hand_actions.push([-> {}]) if right
+        $fill_left_hand_actions.push([-> {}]) if left
+        hold(:right, empty) if right
+        hold(:left, empty) if left
+      end
+    end
+
+    it 'leaves no leftover restore action when wield frees a hand' do
+      hold(:right, dagger)
+      on_fput('get #101', sword, :right)
+      described_class.wield(sword, hand: :right)
+      expect($fill_right_hand_actions).to be_empty
+    end
+
+    it 'leaves no leftover restore action when hands empties a hand' do
+      hold(:left, dagger)
+      described_class.hands(left: nil)
+      expect($fill_left_hand_actions).to be_empty
+    end
+
+    it 'does not disturb a restore action another script already pushed' do
+      mine = [-> {}]
+      $fill_right_hand_actions.push(mine)
+      hold(:right, dagger)
+      on_fput('get #101', sword, :right)
+      described_class.wield(sword, hand: :right)
+      expect($fill_right_hand_actions).to eq([mine])
+    end
+  end
+
+  describe '.find_items regex safety' do
+    it 'does not raise on a name carrying regex metacharacters' do
+      weird = StashItem.new(id: '901', noun: 'rod', name: 'a rod (unbalanced', type: 'weapon')
+      GameObj.containers['99'] = [weird]
+      expect { described_class.find_items('a rod (unbalanced') }.not_to raise_error
+      expect(described_class.find_items('a rod (unbalanced').map(&:id)).to include('901')
+    end
+
+    it 'does not raise when the search string is a bare metacharacter' do
+      expect { described_class.find_items('+') }.not_to raise_error
+    end
   end
 end

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -358,6 +358,15 @@ RSpec.describe Lich::Stash, 'named items' do
       described_class.hands(right: sword, left: shield)
     end
 
+    it 'refuses to swap an item out of a hand asked to be kept' do
+      hold(:right, shield)
+      hold(:left, sword)
+      expect(described_class).not_to receive(:dothistimeout)
+      expect(described_class).not_to receive(:fput)
+      expect { described_class.hands(right: sword) }.to raise_error(ArgumentError, /left hand, which was asked to be kept/)
+      expect(GameObj.left_hand.id).to eq('101')
+    end
+
     it 'resolves names before touching anything, so an unknown name changes nothing' do
       hold(:right, dagger)
       expect(described_class).not_to receive(:stash_hands)

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -358,6 +358,11 @@ RSpec.describe Lich::Stash, 'named items' do
       described_class.hands(right: sword, left: shield)
     end
 
+    it 'refuses the same item in both hands' do
+      expect(described_class).not_to receive(:fput)
+      expect { described_class.hands(right: sword, left: 'broadsword') }.to raise_error(ArgumentError, /both hands/)
+    end
+
     it 'refuses to swap an item out of a hand asked to be kept' do
       hold(:right, shield)
       hold(:left, sword)

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Lich::Stash, 'named items' do
         attr_accessor :ready_list, :valid
 
         def valid?(*) = valid
+        def checked? = true
         def check(*); end
       end
     end)
@@ -121,13 +122,54 @@ RSpec.describe Lich::Stash, 'named items' do
       expect { described_class.find_item(:hat) }.to raise_error(RuntimeError, /unknown ready-list slot/)
     end
 
-    it 'raises when a name matches more than one item' do
-      expect { described_class.find_item('steel') }.to raise_error(RuntimeError, /matches 2 items/)
+    it 'takes the best candidate when a name matches more than one item' do
+      GameObj.set_left_hand(dagger)
+      expect(described_class.find_item('steel').id).to eq('102')
     end
 
     it 'raises when nothing matches, or returns nil when asked not to' do
       expect { described_class.find_item('halberd') }.to raise_error(RuntimeError, /could not find/)
       expect(described_class.find_item('halberd', loud_fail: false)).to be_nil
+    end
+  end
+
+  describe '.find_items' do
+    let(:rod_worn)   { StashItem.new(id: '301', noun: 'rod', name: 'iridian-woven rod', type: 'wand') }
+    let(:rod_sack1)  { StashItem.new(id: '302', noun: 'rod', name: 'slender wooden rod', type: 'wand') }
+    let(:rod_sack2)  { StashItem.new(id: '303', noun: 'rod', name: 'slender wooden rod', type: 'wand') }
+    let(:rod_tree)   { StashItem.new(id: '304', noun: 'rod', name: 'prickle-clad sandbox tree rod', type: 'wand') }
+
+    before do
+      allow(GameObj).to receive(:inv).and_return([cloak, sack, rod_worn])
+      allow(GameObj).to receive(:containers).and_return({ '105' => [rod_sack1, rod_sack2, rod_tree] })
+    end
+
+    it 'orders by location for a noun-only match and collapses identical names' do
+      expect(described_class.find_items('rod').map(&:id)).to eq(%w[301 302 304])
+    end
+
+    it 'puts a hand item first' do
+      GameObj.set_right_hand(rod_tree)
+      expect(described_class.find_items('rod').first.id).to eq('304')
+    end
+
+    it 'puts a ready-list item ahead of worn' do
+      ready_list[:wand] = rod_sack2
+      expect(described_class.find_items('rod').map(&:id)).to eq(%w[303 301 304])
+    end
+
+    it 'prefers a whole-name match over a partial one' do
+      expect(described_class.find_items('slender wooden rod').first.id).to eq('302')
+      expect(described_class.find_items('sandbox tree rod').first.id).to eq('304')
+    end
+
+    it 'prefers whole words inside the name over a noun-only hit' do
+      GameObj.set_right_hand(rod_worn)
+      expect(described_class.find_items('wooden rod').first.id).to eq('302')
+    end
+
+    it 'is empty when nothing matches' do
+      expect(described_class.find_items('halberd')).to eq([])
     end
   end
 
@@ -260,6 +302,12 @@ RSpec.describe Lich::Stash, 'named items' do
       expect(inventory.refreshes).to eq(1)
     end
 
+    it 'says which item it picked when the name meant more than one kind' do
+      expect(described_class).to receive(:echo).with(/wield: steel -> steel shield \(of 2 kinds/)
+      on_fput('remove #103', shield, :right)
+      described_class.wield('steel')
+    end
+
     it 'rejects a bad hand' do
       expect { described_class.wield(sword, hand: :both) }.to raise_error(RuntimeError, /hand must be/)
     end
@@ -300,10 +348,10 @@ RSpec.describe Lich::Stash, 'named items' do
       described_class.hands(right: sword, left: shield)
     end
 
-    it 'resolves names before touching anything, so an ambiguous name changes nothing' do
+    it 'resolves names before touching anything, so an unknown name changes nothing' do
       GameObj.set_right_hand(dagger)
       expect(described_class).not_to receive(:stash_hands)
-      expect { described_class.hands(right: nil, left: 'steel') }.to raise_error(RuntimeError, /matches 2 items/)
+      expect { described_class.hands(right: nil, left: 'halberd') }.to raise_error(RuntimeError, /could not find/)
     end
   end
 end

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -18,6 +18,29 @@ class StashItem < Lich::Common::GameObj
   end
 end
 
+# The inventory tree as Stash sees it: a snapshot answering [] and all, holding
+# items that know their parent and their closed / locked flags.
+InvItem = Struct.new(:id, :noun, :name, :parent_item, :flags, :relation, keyword_init: true) do
+  def closed? = flags.include?('closed')
+  def locked? = flags.include?('locked')
+  def in_room? = relation == 'room'
+  def at_feet? = relation == 'atfeet'
+end
+
+class FakeInventory
+  attr_accessor :items, :refreshes
+
+  def initialize(items = [])
+    @items = items
+    @refreshes = 0
+  end
+
+  def refresh(*) = (@refreshes += 1; self)
+  def current = self
+  def [](id) = @items.find { |i| i.id == id.to_s }
+  def all = @items
+end
+
 RSpec.describe Lich::Stash, 'named items' do
   let(:sword)  { StashItem.new(id: '101', noun: 'broadsword', name: 'vultite hand-forged broadsword', type: 'weapon') }
   let(:dagger) { StashItem.new(id: '102', noun: 'dagger', name: 'steel dagger', type: 'weapon') }
@@ -49,9 +72,11 @@ RSpec.describe Lich::Stash, 'named items' do
     allow(described_class).to receive(:waitrt?)
     allow(described_class).to receive(:dothistimeout)
     allow(described_class).to receive(:stash_hands)
-    allow(described_class).to receive(:container)
     allow(described_class).to receive(:sleep)
+    stub_const('Lich::Common::Inventory', inventory)
   end
+
+  let(:inventory) { FakeInventory.new }
 
   # Make the next fput of `command` land `item` in `hand`, the way the game would.
   def on_fput(command, item, hand)
@@ -132,11 +157,71 @@ RSpec.describe Lich::Stash, 'named items' do
       expect(described_class.wield('broadsword', hand: :right).id).to eq('101')
     end
 
-    it 'fetches from a container by id, opening the container first' do
-      expect(described_class).to receive(:container).with(sack)
+    it 'fetches from a container by id without opening when it is open' do
+      inventory.items = [InvItem.new(id: '105', noun: 'sack', name: 'leather sack', flags: []),
+                         InvItem.new(id: '101', noun: 'broadsword', name: 'vultite hand-forged broadsword', flags: [])]
+      inventory.items[1].parent_item = inventory.items[0]
+      expect(described_class).not_to receive(:dothistimeout)
       on_fput('get #101', sword, :right)
       expect(described_class.wield('broadsword').id).to eq('101')
       expect(GameObj.right_hand.id).to eq('101')
+    end
+
+    context 'with closed containers' do
+      let(:chest) { InvItem.new(id: '200', noun: 'chest', name: 'oak chest', flags: ['closed']) }
+      let(:pouch) { InvItem.new(id: '201', noun: 'pouch', name: 'silk pouch', flags: ['closed'], parent_item: nil) }
+      let(:gem)   { StashItem.new(id: '202', noun: 'ruby', name: 'blood-red ruby', type: 'gem') }
+
+      before do
+        pouch.parent_item = chest
+        inventory.items = [chest, pouch, InvItem.new(id: '202', noun: 'ruby', name: 'blood-red ruby', flags: [], parent_item: pouch)]
+        allow(GameObj).to receive(:[]) { |id| ([sword, dagger, shield, cloak, sack, gem]).find { |o| o.id == id.to_s } }
+      end
+
+      it 'opens each closed container on the way, outermost first, then gets' do
+        expect(described_class).to receive(:dothistimeout).with('open #200', 3, described_class::OPEN_CONFIRM).ordered.and_return('You open an oak chest.')
+        expect(described_class).to receive(:dothistimeout).with('open #201', 3, described_class::OPEN_CONFIRM).ordered.and_return('You open a silk pouch.')
+        on_fput('get #202', gem, :right)
+        expect(described_class.wield(gem).id).to eq('202')
+      end
+
+      it 'treats "already open" as open' do
+        chest.flags.clear
+        allow(described_class).to receive(:dothistimeout).with('open #201', anything, anything).and_return('That is already open.')
+        on_fput('get #202', gem, :right)
+        expect(described_class.wield(gem).id).to eq('202')
+      end
+
+      it 'raises without sending get when a container is locked' do
+        chest.flags << 'locked'
+        expect(described_class).not_to receive(:fput)
+        expect { described_class.wield(gem) }.to raise_error(RuntimeError, /locked or would not open/)
+      end
+
+      it 'raises when the open is refused' do
+        allow(described_class).to receive(:dothistimeout).with('open #200', anything, anything).and_return("You can't open that.")
+        expect { described_class.wield(gem) }.to raise_error(RuntimeError, /locked or would not open/)
+      end
+
+      it 'finds an item by name that only the inventory tree knows about' do
+        expect(described_class.find_item('blood-red ruby').id).to eq('202')
+        expect(inventory.refreshes).to eq(1)
+      end
+    end
+
+    it 'refreshes, opens, and retries once when the item does not arrive' do
+      sack_entry = InvItem.new(id: '105', noun: 'sack', name: 'leather sack', flags: [])
+      inventory.items = [sack_entry, InvItem.new(id: '101', noun: 'broadsword', name: 'vultite hand-forged broadsword', flags: [], parent_item: sack_entry)]
+      calls = 0
+      allow(described_class).to receive(:fput).with('get #101') do
+        calls += 1
+        GameObj.set_right_hand(sword) if calls == 2
+      end
+      # The refresh after the first miss is what reveals the sack was closed meanwhile.
+      allow(inventory).to receive(:refresh) { sack_entry.flags = ['closed']; inventory }
+      expect(described_class).to receive(:dothistimeout).with('open #105', anything, anything).and_return('You open a leather sack.')
+      expect(described_class.wield(sword).id).to eq('101')
+      expect(calls).to eq(2)
     end
 
     it 'removes a worn item instead of getting it' do
@@ -169,9 +254,10 @@ RSpec.describe Lich::Stash, 'named items' do
       expect(described_class.wield(sword, hand: :left).id).to eq('101')
     end
 
-    it 'raises when the item never arrives' do
+    it 'raises when the item never arrives, after one refresh and retry' do
       allow(described_class).to receive(:fput)
       expect { described_class.wield(sword) }.to raise_error(RuntimeError, /did not arrive/)
+      expect(inventory.refreshes).to eq(1)
     end
 
     it 'rejects a bad hand' do

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -391,6 +391,23 @@ RSpec.describe Lich::Stash, 'named items' do
       expect(result[:left]).to be_nil
     end
 
+    it 'stashes the unwanted item and swaps, never stashing the wanted one' do
+      hold(:left, sword)   # wanted in the right hand
+      hold(:right, dagger) # unwanted
+      expect(described_class).to receive(:stash_hands).with(right: true).once do
+        hold(:right, empty)
+      end
+      expect(described_class).not_to receive(:stash_hands).with(left: true)
+      expect(described_class).to receive(:dothistimeout).with('swap', 3, anything).once do
+        hold(:right, sword)
+        hold(:left, empty)
+      end
+      expect(described_class).not_to receive(:fput)
+      result = described_class.hands(right: sword, left: nil)
+      expect(result[:right].id).to eq('101')
+      expect(result[:left]).to be_nil
+    end
+
     it 'still stashes when the hand being emptied holds something unwanted' do
       hold(:left, dagger)
       hold(:right, shield)

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -51,8 +51,18 @@ RSpec.describe Lich::Stash, 'named items' do
 
   let(:ready_list) { { weapon: nil, shield: nil, sheath: nil } }
 
+  # Hands are stubbed rather than set through the spec_helper mock: in a full
+  # run the production GameObj is loaded by other specs and reads its hands
+  # from class variables the mock setters never touch.
+  let(:hands) { { right: nil, left: nil } }
+
+  def hold(hand, item)
+    hands[hand] = item
+  end
+
   before do
-    GameObj.clear_hands
+    allow(GameObj).to receive(:right_hand) { hands[:right] }
+    allow(GameObj).to receive(:left_hand) { hands[:left] }
     allow(GameObj).to receive(:inv).and_return([cloak, sack, shield])
     allow(GameObj).to receive(:containers).and_return({ '105' => [sword, dagger] })
     allow(GameObj).to receive(:[]) { |id| [sword, dagger, shield, cloak, sack].find { |o| o.id == id.to_s } }
@@ -82,7 +92,7 @@ RSpec.describe Lich::Stash, 'named items' do
   # Make the next fput of `command` land `item` in `hand`, the way the game would.
   def on_fput(command, item, hand)
     allow(described_class).to receive(:fput).with(command) do
-      hand == :right ? GameObj.set_right_hand(item) : GameObj.set_left_hand(item)
+      hold(hand, item)
     end
   end
 
@@ -101,7 +111,7 @@ RSpec.describe Lich::Stash, 'named items' do
     end
 
     it 'searches hands, worn items, and known container contents' do
-      GameObj.set_right_hand(dagger)
+      hold(:right, dagger)
       expect(described_class.find_item('dagger').id).to eq('102')
       expect(described_class.find_item('cloak')).to be(cloak)
       expect(described_class.find_item('broadsword')).to be(sword)
@@ -123,7 +133,7 @@ RSpec.describe Lich::Stash, 'named items' do
     end
 
     it 'takes the best candidate when a name matches more than one item' do
-      GameObj.set_left_hand(dagger)
+      hold(:left, dagger)
       expect(described_class.find_item('steel').id).to eq('102')
     end
 
@@ -149,7 +159,7 @@ RSpec.describe Lich::Stash, 'named items' do
     end
 
     it 'puts a hand item first' do
-      GameObj.set_right_hand(rod_tree)
+      hold(:right, rod_tree)
       expect(described_class.find_items('rod').first.id).to eq('304')
     end
 
@@ -164,7 +174,7 @@ RSpec.describe Lich::Stash, 'named items' do
     end
 
     it 'prefers whole words inside the name over a noun-only hit' do
-      GameObj.set_right_hand(rod_worn)
+      hold(:right, rod_worn)
       expect(described_class.find_items('wooden rod').first.id).to eq('302')
     end
 
@@ -175,7 +185,7 @@ RSpec.describe Lich::Stash, 'named items' do
 
   describe '.hand_holding / .in_hand?' do
     it 'reports which hand holds the item' do
-      GameObj.set_left_hand(shield)
+      hold(:left, shield)
       expect(described_class.hand_holding(shield)).to eq(:left)
       expect(described_class.hand_holding(sword)).to be_nil
       expect(described_class.in_hand?(shield)).to be true
@@ -185,16 +195,16 @@ RSpec.describe Lich::Stash, 'named items' do
 
   describe '.wield' do
     it 'is a no-op when the item is already in a hand and no hand was asked for' do
-      GameObj.set_left_hand(sword)
+      hold(:left, sword)
       expect(described_class).not_to receive(:fput)
       expect(described_class.wield('broadsword').id).to eq('101')
     end
 
     it 'swaps when the item is in the other hand' do
-      GameObj.set_left_hand(sword)
+      hold(:left, sword)
       expect(described_class).to receive(:dothistimeout).with('swap', 3, anything) do
-        GameObj.set_right_hand(sword)
-        GameObj.set_left_hand(empty)
+        hold(:right, sword)
+        hold(:left, empty)
       end
       expect(described_class.wield('broadsword', hand: :right).id).to eq('101')
     end
@@ -257,7 +267,7 @@ RSpec.describe Lich::Stash, 'named items' do
       calls = 0
       allow(described_class).to receive(:fput).with('get #101') do
         calls += 1
-        GameObj.set_right_hand(sword) if calls == 2
+        hold(:right, sword) if calls == 2
       end
       # The refresh after the first miss is what reveals the sack was closed meanwhile.
       allow(inventory).to receive(:refresh) { sack_entry.flags = ['closed']; inventory }
@@ -273,16 +283,16 @@ RSpec.describe Lich::Stash, 'named items' do
     end
 
     it 'empties the target hand first when it is occupied' do
-      GameObj.set_right_hand(dagger)
-      expect(described_class).to receive(:stash_hands).with(right: true) { GameObj.set_right_hand(empty) }
+      hold(:right, dagger)
+      expect(described_class).to receive(:stash_hands).with(right: true) { hold(:right, empty) }
       on_fput('get #101', sword, :right)
       described_class.wield(sword, hand: :right)
     end
 
     it 'frees the right hand when both are full and no hand was asked for' do
-      GameObj.set_right_hand(dagger)
-      GameObj.set_left_hand(shield)
-      expect(described_class).to receive(:stash_hands).with(right: true) { GameObj.set_right_hand(empty) }
+      hold(:right, dagger)
+      hold(:left, shield)
+      expect(described_class).to receive(:stash_hands).with(right: true) { hold(:right, empty) }
       on_fput('get #101', sword, :right)
       described_class.wield(sword)
     end
@@ -290,8 +300,8 @@ RSpec.describe Lich::Stash, 'named items' do
     it 'swaps after fetching when the game put it in the wrong hand' do
       on_fput('get #101', sword, :right)
       expect(described_class).to receive(:dothistimeout).with('swap', 3, anything) do
-        GameObj.set_left_hand(sword)
-        GameObj.set_right_hand(empty)
+        hold(:left, sword)
+        hold(:right, empty)
       end
       expect(described_class.wield(sword, hand: :left).id).to eq('101')
     end
@@ -315,7 +325,7 @@ RSpec.describe Lich::Stash, 'named items' do
 
   describe '.hands' do
     it 'leaves both hands alone by default' do
-      GameObj.set_right_hand(dagger)
+      hold(:right, dagger)
       expect(described_class).not_to receive(:fput)
       expect(described_class).not_to receive(:stash_hands)
       result = described_class.hands
@@ -324,8 +334,8 @@ RSpec.describe Lich::Stash, 'named items' do
     end
 
     it 'empties a hand given nil' do
-      GameObj.set_right_hand(dagger)
-      expect(described_class).to receive(:stash_hands).with(right: true) { GameObj.set_right_hand(empty) }
+      hold(:right, dagger)
+      expect(described_class).to receive(:stash_hands).with(right: true) { hold(:right, empty) }
       expect(described_class.hands(right: nil)[:right]).to be_nil
     end
 
@@ -338,18 +348,18 @@ RSpec.describe Lich::Stash, 'named items' do
     end
 
     it 'swaps once when the two wanted items are in each other\'s hands' do
-      GameObj.set_right_hand(shield)
-      GameObj.set_left_hand(sword)
+      hold(:right, shield)
+      hold(:left, sword)
       expect(described_class).to receive(:dothistimeout).with('swap', 3, anything).once do
-        GameObj.set_right_hand(sword)
-        GameObj.set_left_hand(shield)
+        hold(:right, sword)
+        hold(:left, shield)
       end
       expect(described_class).not_to receive(:fput)
       described_class.hands(right: sword, left: shield)
     end
 
     it 'resolves names before touching anything, so an unknown name changes nothing' do
-      GameObj.set_right_hand(dagger)
+      hold(:right, dagger)
       expect(described_class).not_to receive(:stash_hands)
       expect { described_class.hands(right: nil, left: 'halberd') }.to raise_error(RuntimeError, /could not find/)
     end

--- a/spec/lib/stash_wield_spec.rb
+++ b/spec/lib/stash_wield_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'stash'
+
+module Kernel
+  def dothistimeout(_action, _timeout, _success_line); end unless method_defined?(:dothistimeout)
+end
+
+# A GameObj the production code recognises as one (is_a? GameObj), with the
+# readers Stash touches. spec_helper's MockGameObj is not a GameObj subclass.
+class StashItem < Lich::Common::GameObj
+  attr_accessor :id, :noun, :name, :type
+
+  def initialize(id: nil, noun: nil, name: 'Empty', type: nil)
+    super(id, noun, name)
+    @type = type
+  end
+end
+
+RSpec.describe Lich::Stash, 'named items' do
+  let(:sword)  { StashItem.new(id: '101', noun: 'broadsword', name: 'vultite hand-forged broadsword', type: 'weapon') }
+  let(:dagger) { StashItem.new(id: '102', noun: 'dagger', name: 'steel dagger', type: 'weapon') }
+  let(:shield) { StashItem.new(id: '103', noun: 'shield', name: 'steel shield', type: 'shield') }
+  let(:cloak)  { StashItem.new(id: '104', noun: 'cloak', name: 'black cloak', type: 'clothing') }
+  let(:sack)   { StashItem.new(id: '105', noun: 'sack', name: 'leather sack', type: 'container') }
+  let(:empty)  { StashItem.new }
+
+  let(:ready_list) { { weapon: nil, shield: nil, sheath: nil } }
+
+  before do
+    GameObj.clear_hands
+    allow(GameObj).to receive(:inv).and_return([cloak, sack, shield])
+    allow(GameObj).to receive(:containers).and_return({ '105' => [sword, dagger] })
+    allow(GameObj).to receive(:[]) { |id| [sword, dagger, shield, cloak, sack].find { |o| o.id == id.to_s } }
+
+    stub_const('Lich::Gemstone::ReadyList', Class.new do
+      class << self
+        attr_accessor :ready_list, :valid
+
+        def valid?(*) = valid
+        def check(*); end
+      end
+    end)
+    Lich::Gemstone::ReadyList.ready_list = ready_list
+    Lich::Gemstone::ReadyList.valid = true
+    stub_const('ReadyList', Lich::Gemstone::ReadyList)
+
+    allow(described_class).to receive(:waitrt?)
+    allow(described_class).to receive(:dothistimeout)
+    allow(described_class).to receive(:stash_hands)
+    allow(described_class).to receive(:container)
+    allow(described_class).to receive(:sleep)
+  end
+
+  # Make the next fput of `command` land `item` in `hand`, the way the game would.
+  def on_fput(command, item, hand)
+    allow(described_class).to receive(:fput).with(command) do
+      hand == :right ? GameObj.set_right_hand(item) : GameObj.set_left_hand(item)
+    end
+  end
+
+  describe '.find_item' do
+    it 'returns a GameObj untouched' do
+      expect(described_class.find_item(sword)).to be(sword)
+    end
+
+    it 'looks an id up as a string or integer' do
+      expect(described_class.find_item('102')).to be(dagger)
+      expect(described_class.find_item(102)).to be(dagger)
+    end
+
+    it 'matches a name case-insensitively with non-adjacent words' do
+      expect(described_class.find_item('Vultite Broadsword')).to be(sword)
+    end
+
+    it 'searches hands, worn items, and known container contents' do
+      GameObj.set_right_hand(dagger)
+      expect(described_class.find_item('dagger').id).to eq('102')
+      expect(described_class.find_item('cloak')).to be(cloak)
+      expect(described_class.find_item('broadsword')).to be(sword)
+    end
+
+    it 'resolves a ready-list slot' do
+      ready_list[:weapon] = sword
+      expect(described_class.find_item(:weapon)).to be(sword)
+    end
+
+    it 'checks the ready list first when it is stale' do
+      Lich::Gemstone::ReadyList.valid = false
+      expect(Lich::Gemstone::ReadyList).to receive(:check).with(silent: true, quiet: true)
+      described_class.find_item(:weapon, loud_fail: false)
+    end
+
+    it 'raises on an unknown slot' do
+      expect { described_class.find_item(:hat) }.to raise_error(RuntimeError, /unknown ready-list slot/)
+    end
+
+    it 'raises when a name matches more than one item' do
+      expect { described_class.find_item('steel') }.to raise_error(RuntimeError, /matches 2 items/)
+    end
+
+    it 'raises when nothing matches, or returns nil when asked not to' do
+      expect { described_class.find_item('halberd') }.to raise_error(RuntimeError, /could not find/)
+      expect(described_class.find_item('halberd', loud_fail: false)).to be_nil
+    end
+  end
+
+  describe '.hand_holding / .in_hand?' do
+    it 'reports which hand holds the item' do
+      GameObj.set_left_hand(shield)
+      expect(described_class.hand_holding(shield)).to eq(:left)
+      expect(described_class.hand_holding(sword)).to be_nil
+      expect(described_class.in_hand?(shield)).to be true
+      expect(described_class.in_hand?('103')).to be true
+    end
+  end
+
+  describe '.wield' do
+    it 'is a no-op when the item is already in a hand and no hand was asked for' do
+      GameObj.set_left_hand(sword)
+      expect(described_class).not_to receive(:fput)
+      expect(described_class.wield('broadsword').id).to eq('101')
+    end
+
+    it 'swaps when the item is in the other hand' do
+      GameObj.set_left_hand(sword)
+      expect(described_class).to receive(:dothistimeout).with('swap', 3, anything) do
+        GameObj.set_right_hand(sword)
+        GameObj.set_left_hand(empty)
+      end
+      expect(described_class.wield('broadsword', hand: :right).id).to eq('101')
+    end
+
+    it 'fetches from a container by id, opening the container first' do
+      expect(described_class).to receive(:container).with(sack)
+      on_fput('get #101', sword, :right)
+      expect(described_class.wield('broadsword').id).to eq('101')
+      expect(GameObj.right_hand.id).to eq('101')
+    end
+
+    it 'removes a worn item instead of getting it' do
+      ready_list[:shield] = shield
+      on_fput('remove #103', shield, :left)
+      expect(described_class.wield(:shield, hand: :left).id).to eq('103')
+    end
+
+    it 'empties the target hand first when it is occupied' do
+      GameObj.set_right_hand(dagger)
+      expect(described_class).to receive(:stash_hands).with(right: true) { GameObj.set_right_hand(empty) }
+      on_fput('get #101', sword, :right)
+      described_class.wield(sword, hand: :right)
+    end
+
+    it 'frees the right hand when both are full and no hand was asked for' do
+      GameObj.set_right_hand(dagger)
+      GameObj.set_left_hand(shield)
+      expect(described_class).to receive(:stash_hands).with(right: true) { GameObj.set_right_hand(empty) }
+      on_fput('get #101', sword, :right)
+      described_class.wield(sword)
+    end
+
+    it 'swaps after fetching when the game put it in the wrong hand' do
+      on_fput('get #101', sword, :right)
+      expect(described_class).to receive(:dothistimeout).with('swap', 3, anything) do
+        GameObj.set_left_hand(sword)
+        GameObj.set_right_hand(empty)
+      end
+      expect(described_class.wield(sword, hand: :left).id).to eq('101')
+    end
+
+    it 'raises when the item never arrives' do
+      allow(described_class).to receive(:fput)
+      expect { described_class.wield(sword) }.to raise_error(RuntimeError, /did not arrive/)
+    end
+
+    it 'rejects a bad hand' do
+      expect { described_class.wield(sword, hand: :both) }.to raise_error(RuntimeError, /hand must be/)
+    end
+  end
+
+  describe '.hands' do
+    it 'leaves both hands alone by default' do
+      GameObj.set_right_hand(dagger)
+      expect(described_class).not_to receive(:fput)
+      expect(described_class).not_to receive(:stash_hands)
+      result = described_class.hands
+      expect(result[:right]).to have_attributes(id: '102')
+      expect(result[:left]).to be_nil
+    end
+
+    it 'empties a hand given nil' do
+      GameObj.set_right_hand(dagger)
+      expect(described_class).to receive(:stash_hands).with(right: true) { GameObj.set_right_hand(empty) }
+      expect(described_class.hands(right: nil)[:right]).to be_nil
+    end
+
+    it 'wields into each hand' do
+      on_fput('get #101', sword, :right)
+      on_fput('remove #103', shield, :left)
+      result = described_class.hands(right: 'broadsword', left: 'steel shield')
+      expect(result[:right].id).to eq('101')
+      expect(result[:left].id).to eq('103')
+    end
+
+    it 'swaps once when the two wanted items are in each other\'s hands' do
+      GameObj.set_right_hand(shield)
+      GameObj.set_left_hand(sword)
+      expect(described_class).to receive(:dothistimeout).with('swap', 3, anything).once do
+        GameObj.set_right_hand(sword)
+        GameObj.set_left_hand(shield)
+      end
+      expect(described_class).not_to receive(:fput)
+      described_class.hands(right: sword, left: shield)
+    end
+
+    it 'resolves names before touching anything, so an ambiguous name changes nothing' do
+      GameObj.set_right_hand(dagger)
+      expect(described_class).not_to receive(:stash_hands)
+      expect { described_class.hands(right: nil, left: 'steel') }.to raise_error(RuntimeError, /matches 2 items/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`stash_hands` / `equip_hands` remember and restore whatever was held. This is the other half: get a specific item into a hand, named by a profile string, an id, a GameObj, or a ready-list slot, and reconcile both hands to a wanted state without dropping anything. Every command is sent by `#id`, so an ambiguous noun never reaches the game.

## What it does

```ruby
Lich::Stash.find_items('rod')                 # every distinct candidate, best first, nothing sent
Lich::Stash.find_item('vultite broadsword')  # the best one, raises only if nothing matches
Lich::Stash.wield('broadsword')              # into whichever hand the game picks
Lich::Stash.wield(:weapon, hand: :left)      # ready-list slot, specific hand (swaps if needed)
Lich::Stash.hands(right: 'broadsword', left: :shield)
Lich::Stash.hands(right: nil)                # empty the right hand, leave left alone (:keep is the default)
```

- **Resolution.** `find_items` matches the way `find_container` does (case-insensitive, words may be non-adjacent) and ranks by specificity (whole name, whole words inside the name, noun only) then location (hands, ready list, worn, containers), which is the order the game resolves a bare noun. Identical names collapse to one. When the GameObj registries miss, it refreshes `Lich::Common::Inventory` and matches the full tree, so an item in a sack nobody has looked in still resolves. `wield` echoes one line naming what it picked when the name meant more than one kind.
- **Containers.** Before the `get`, `wield` walks the item's parent chain in the inventory snapshot and opens each container whose current flag says closed, outermost first, each confirmed. Locked stops it before any `get`. If the item doesn't arrive (usually a container closed since Lich last looked), it refreshes once, reopens, and retries the `get` once before raising.
- **Hands.** The target hand is emptied through `stash_hands` first, worn items are `remove`d and the rest `get`, arrival is confirmed by id, and a `swap` follows if the game put it in the other hand. `hands` resolves every name before touching anything and does one `swap` when the two wanted items are in each other's hands.

The existing `Stash.container` look-and-open path is untouched; `add_to_bag` still uses it.

## Files

- `lib/stash.rb`: `find_item`, `find_items`, `wield`, `hands`, `open_path_to`, `open_container`, and the small readers they're built from (`hand_holding`, `in_hand?`, `empty_hand?`, `worn?`, `container_holding`)
- `spec/lib/stash_wield_spec.rb`: 37 examples with fakes for ReadyList and the Inventory snapshot

## Testing

- `bundle exec rspec spec/lib/stash_wield_spec.rb` green, rubocop clean on both files.
- In game: wield by name, id, and ready slot; from an open sack (no `open` sent), a closed sack (`open` then `get`), a sack never looked in (one `_inventory manager` then `get`), and a sack closed after Lich saw inside it (`get` misses, refresh, `open`, `get`); `hands` reconciles and empties; a name matching several kinds echoes the pick.

## Why now

Second of two small lib additions that let the e-scripts drop their private copies of common helpers (bigshot `cmd_wield`, eherbs and eloot hand helpers). Independent of the Stance PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
