### PR TITLE
feat(gs): Lich::Gemstone::Mana.pulse, the MANA PULSE verb once

### DIFF
--- a/lib/common/gameloader.rb
+++ b/lib/common/gameloader.rb
@@ -30,6 +30,7 @@ module Lich
         require File.join(LIB_DIR, 'gemstone', 'fog.rb')
         require File.join(LIB_DIR, 'gemstone', 'infomon', 'status.rb')
         require File.join(LIB_DIR, 'gemstone', 'stance.rb')
+        require File.join(LIB_DIR, 'gemstone', 'mana.rb')
         require File.join(LIB_DIR, 'gemstone', 'experience.rb')
         require File.join(LIB_DIR, 'attributes', 'spellsong.rb')
         require File.join(LIB_DIR, 'gemstone', 'infomon', 'activespell.rb')

--- a/lib/gemstone/mana.rb
+++ b/lib/gemstone/mana.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Mana: the MANA PULSE verb (Mana Control), sent and confirmed once.
+#
+# bigshot, ebounty and eherbs each carry a copy of the same "pulse if I can't
+# afford this spell" sequence with the same four result lines. This is that
+# sequence.
+#
+#   Mana.pulse            # pulse now, return the game's answer
+#   Mana.pulse(130)       # pulse only if 130 is known and not currently affordable
+#   Mana.pulse(Spell[130])
+module Lich
+  module Gemstone
+    module Mana
+      PULSE_RESULT = Regexp.union(
+        /^An invigorating rush of mana pulses through you/i,
+        /^You are too mentally fatigued to attempt this ability/i,
+        /^You're already at full mana\./i,
+        /^Your mana control skills are not yet advanced/i,
+      ).freeze
+
+      PULSED = /^An invigorating rush of mana pulses through you/i.freeze
+
+      # Send MANA PULSE, optionally only when it would help cast a given spell.
+      #
+      # @param spell [Integer, Spell, nil] when given, pulse only if the spell is
+      #   known and not affordable right now
+      # @param timeout [Numeric]
+      # @return [Boolean] true when mana was gained, false when the game refused,
+      #   nothing confirmed, or the spell did not need it
+      def self.pulse(spell = nil, timeout: 2)
+        unless spell.nil?
+          spell = Spell[spell] unless spell.is_a?(Spell)
+          return false if spell.nil? || !spell.known? || spell.affordable?
+        end
+        waitrt?
+        result = dothistimeout('mana pulse', timeout, PULSE_RESULT)
+        sleep 0.2
+        result.to_s =~ PULSED ? true : false
+      end
+    end
+  end
+end

--- a/spec/lib/gemstone/mana_spec.rb
+++ b/spec/lib/gemstone/mana_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require 'gemstone/mana'
+
+module Kernel
+  def dothistimeout(_action, _timeout, _success_line); end unless method_defined?(:dothistimeout)
+end
+
+# Spell stand-in: Mana only asks known? and affordable?.
+class FakeSpell
+  attr_accessor :known, :affordable
+
+  def initialize(known: true, affordable: true)
+    @known = known
+    @affordable = affordable
+  end
+
+  def known? = known
+  def affordable? = affordable
+
+  class << self
+    attr_accessor :table
+
+    def [](num) = (table || {})[num]
+  end
+end
+
+RSpec.describe Lich::Gemstone::Mana do
+  before do
+    stub_const('Spell', FakeSpell)
+    allow(described_class).to receive(:waitrt?)
+    allow(described_class).to receive(:sleep)
+    allow(described_class).to receive(:dothistimeout).and_return('An invigorating rush of mana pulses through you.')
+    Spell.table = { 130 => Spell.new(known: true, affordable: false), 9825 => Spell.new(known: false) }
+  end
+
+  it 'pulses and reports mana gained' do
+    expect(described_class).to receive(:dothistimeout).with('mana pulse', 2, described_class::PULSE_RESULT)
+                                                      .and_return('An invigorating rush of mana pulses through you.')
+    expect(described_class.pulse).to be true
+  end
+
+  it 'reports false when the game refuses' do
+    allow(described_class).to receive(:dothistimeout).and_return("You're already at full mana.")
+    expect(described_class.pulse).to be false
+  end
+
+  it 'reports false when nothing confirms' do
+    allow(described_class).to receive(:dothistimeout).and_return(nil)
+    expect(described_class.pulse).to be false
+  end
+
+  it 'waits out roundtime before sending' do
+    expect(described_class).to receive(:waitrt?).ordered
+    expect(described_class).to receive(:dothistimeout).ordered.and_return('An invigorating rush of mana pulses through you.')
+    described_class.pulse
+  end
+
+  context 'given a spell' do
+    it 'pulses when the spell is known and not affordable' do
+      expect(described_class).to receive(:dothistimeout)
+      expect(described_class.pulse(130)).to be true
+    end
+
+    it 'accepts a Spell object' do
+      expect(described_class).to receive(:dothistimeout)
+      described_class.pulse(Spell[130])
+    end
+
+    it 'does nothing when the spell is affordable' do
+      Spell.table[130].affordable = true
+      expect(described_class).not_to receive(:dothistimeout)
+      expect(described_class.pulse(130)).to be false
+    end
+
+    it 'does nothing when the spell is unknown' do
+      expect(described_class).not_to receive(:dothistimeout)
+      expect(described_class.pulse(9825)).to be false
+    end
+
+    it 'does nothing for a spell number that does not exist' do
+      expect(described_class).not_to receive(:dothistimeout)
+      expect(described_class.pulse(1)).to be false
+    end
+  end
+
+  it 'PULSE_RESULT matches every reply the game uses' do
+    [
+      'An invigorating rush of mana pulses through you.',
+      'You are too mentally fatigued to attempt this ability.',
+      "You're already at full mana.",
+      'Your mana control skills are not yet advanced enough.',
+    ].each { |line| expect(line).to match(described_class::PULSE_RESULT) }
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Lich::Gemstone::Mana.pulse(spell = nil, timeout: 2)`, one home for the MANA PULSE verb that several EO scripts each carry a copy of.

- With no argument it sends `mana pulse` and returns true only when mana was gained.
- With a spell number it pulses only when the spell is known and not currently affordable, so a caller can write `Mana.pulse(1010); cast` without its own bookkeeping.
- Waits out roundtime first; returns false on the "already pulsed" and "nothing to pulse" replies.
- Loaded from the gemstone game loader after `status.rb`.

## Test plan

- [x] `spec/lib/gemstone/mana_spec.rb`, 10 examples
- [x] rubocop clean on touched files
- [x] Exercised in game

🤖 Generated with [Claude Code](https://claude.com/claude-code)
