### PR TITLE
feat(gs): Lich::Gemstone::Bank, Currency refresh, and WEALTH parser lines

### DIFF
--- a/lib/common/gameloader.rb
+++ b/lib/common/gameloader.rb
@@ -34,6 +34,7 @@ module Lich
         require File.join(LIB_DIR, 'gemstone', 'psms.rb')
         require File.join(LIB_DIR, 'attributes', 'char.rb')
         require File.join(LIB_DIR, 'gemstone', 'currency.rb')
+        require File.join(LIB_DIR, 'gemstone', 'bank.rb')
         # require File.join(LIB_DIR, 'gemstone', 'character', 'disk.rb') # dup
         require File.join(LIB_DIR, 'gemstone', 'group.rb')
         require File.join(LIB_DIR, 'gemstone', 'critranks')

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -278,22 +278,31 @@ module Lich
         taken = 0
         want = amount
         refused = false
-        notes_in(stow).each do
-          if bal.positive?
-            got = withdraw_silver(bal)
-            if got.nil?
-              refused = true
-              break
-            end
+
+        # Drain what the account already holds before touching any notes: that
+        # has to happen even when the stow container is empty.
+        if bal.positive?
+          got = withdraw_silver(bal)
+          if got.nil?
+            refused = true
+          else
             taken += got
             want -= got
-            bal = 0
           end
+        end
+
+        until refused || want <= 0
           note = notes_in(stow).first
-          break if note.nil?
+          if note.nil?
+            refused = true
+            break
+          end
           fput "get ##{note.id}"
           value = deposit_note(note)
-          break if value.nil?
+          if value.nil?
+            refused = true
+            break
+          end
           got = withdraw_silver([value, want].min)
           if got.nil?
             refused = true
@@ -301,8 +310,8 @@ module Lich
           end
           taken += got
           want -= got
-          break if want <= 0
         end
+
         Currency.refresh
         refused && taken.zero? ? nil : taken
       end

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -211,26 +211,38 @@ module Lich
       # @param amount [Integer, :all]
       # @param stow [GameObj, nil] where notes go; the STOW default container
       # @return [Integer, nil] silver put away in total, nil when the bank refused
+      #   before anything was deposited
       def self.deposit_f2p(amount = :all, stow: StowList.default)
         total = 0
+        refused = false
+        remaining = amount == :all ? nil : amount
         loop do
           info = account
-          return nil if info.nil?
+          if info.nil?
+            refused = true
+            break
+          end
           carried = Currency.silver(refresh: true).to_i
-          carried = [carried, amount].min unless amount == :all
+          carried = [carried, remaining].min if remaining
           break unless carried.positive?
 
           max = info[:max]
           if max.nil? || info[:balance] + carried < max
-            dothistimeout("deposit #{carried}", 3, Pattern::DEPOSIT)
-            total += carried
+            got = deposited(dothistimeout("deposit #{carried}", 3, Pattern::DEPOSIT))
+            refused = got.nil?
+            total += got.to_i
             break
           end
 
           room = max - info[:balance]
           if room.positive?
-            dothistimeout("deposit #{room}", 3, Pattern::DEPOSIT)
-            total += room
+            got = deposited(dothistimeout("deposit #{room}", 3, Pattern::DEPOSIT))
+            if got.nil?
+              refused = true
+              break
+            end
+            total += got
+            remaining -= got if remaining
           end
           carried = Currency.silver(refresh: true).to_i
           note_size = carried >= F2P_NOTE_BUFFER ? max : max - (F2P_NOTE_BUFFER - carried)
@@ -240,7 +252,7 @@ module Lich
           Lich::Stash.add_to_bag(stow, note)
         end
         Currency.refresh
-        total
+        refused && total.zero? ? nil : total
       end
 
       # Free-to-play withdrawal: the balance may be short of +amount+ while notes
@@ -254,18 +266,23 @@ module Lich
         return nil if info.nil?
         bal = info[:balance]
         if bal >= amount
-          dothistimeout("withdraw #{amount} silver", 3, Pattern::WITHDRAW)
+          got = withdraw_silver(amount)
           Currency.refresh
-          return amount
+          return got
         end
 
         taken = 0
         want = amount
+        refused = false
         notes_in(stow).each do
           if bal.positive?
-            dothistimeout("withdraw #{bal} silver", 3, Pattern::WITHDRAW)
-            taken += bal
-            want -= bal
+            got = withdraw_silver(bal)
+            if got.nil?
+              refused = true
+              break
+            end
+            taken += got
+            want -= got
             bal = 0
           end
           note = notes_in(stow).first
@@ -273,14 +290,17 @@ module Lich
           fput "get ##{note.id}"
           value = deposit_note(note)
           break if value.nil?
-          take = [value, want].min
-          dothistimeout("withdraw #{take} silver", 3, Pattern::WITHDRAW)
-          taken += take
-          want -= take
+          got = withdraw_silver([value, want].min)
+          if got.nil?
+            refused = true
+            break
+          end
+          taken += got
+          want -= got
           break if want <= 0
         end
         Currency.refresh
-        taken
+        refused && taken.zero? ? nil : taken
       end
 
       # The Pinefar banker wanders; give him a moment to be at the counter.
@@ -295,6 +315,17 @@ module Lich
         end
         true
       end
+
+      # WITHDRAW N SILVER, confirmed.
+      #
+      # @api private
+      # @return [Integer, nil] silver handed over, nil when refused or unanswered
+      def self.withdraw_silver(amount)
+        result = dothistimeout("withdraw #{amount} silver", 3, Pattern::WITHDRAW)
+        return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
+        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : amount
+      end
+      private_class_method :withdraw_silver
 
       # @api private
       def self.deposited(result)

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -45,9 +45,12 @@ module Lich
         # Replies that mean the withdrawal did not happen.
         WITHDRAW_REFUSED = /seem to have that much|looks at you suspiciously|chuckles at you|taps her quill|purses her lips/.freeze
 
-        ACCOUNT_START   = /You currently have an account|you don't have access/i.freeze
+        ACCOUNT_START   = /You currently have the following amounts on deposit|You currently have an account|you don't have access/i.freeze
+        ACCOUNT_LINE    = /^\s+(?<bank>.+?) Bank: (?<silver>[\d,]+)$/.freeze
+        ACCOUNT_TOTAL   = /^\s+Total: (?<silver>[\d,]+)$/.freeze
         ACCOUNT_BALANCE = /in the amount of (?<silver>[\d,]+) silver/.freeze
         ACCOUNT_MAX     = /a maximum of (?<silver>[\d,]+) silvers/.freeze
+        ACCOUNT_END     = /urchin bank runner uses remaining|a maximum of|you don't have access|<prompt/i.freeze
         NO_ACCESS       = /you don't have access/i.freeze
         NOTE_VALUE      = /has a value of (?<silver>[\d,]+) silver and reads/.freeze
         NOTE_READ       = /Hold in right hand to use|has a value of/.freeze
@@ -75,21 +78,50 @@ module Lich
         Lich::Common::Account.type.to_s == 'FREE'
       end
 
-      # BANK ACCOUNT, parsed.
+      # BANK ACCOUNT, parsed. The listing covers every town's account, so
+      # +balance+ is the one for the town the character is standing in, picked
+      # by matching the bank's name against the room's location.
       #
-      # @return [Hash{Symbol => Integer, nil}, nil] +{ balance:, max: }+ (+max+ nil
-      #   when the account has no cap), or nil when this town's bank refuses access
+      # @return [Hash, nil] +{ balance:, max:, banks:, total: }+ where +banks+ maps
+      #   town name to silver, +max+ is the f2p cap (nil without one), or nil
+      #   when this town's bank refuses access
       def self.account
-        lines = Lich::Util.issue_command('bank account', Pattern::ACCOUNT_START, silent: true, quiet: true)
+        lines = Lich::Util.issue_command('bank account', Pattern::ACCOUNT_START, Pattern::ACCOUNT_END, silent: true, quiet: true)
         return nil if lines.any? { |l| l =~ Pattern::NO_ACCESS }
-        balance = lines.find { |l| l =~ Pattern::ACCOUNT_BALANCE } ? Regexp.last_match[:silver].delete(',').to_i : 0
-        max = lines.find { |l| l =~ Pattern::ACCOUNT_MAX } ? Regexp.last_match[:silver].delete(',').to_i : nil
-        { balance: balance, max: max }
+        banks = {}
+        total = nil
+        max = nil
+        balance = nil
+        lines.each do |line|
+          if line =~ Pattern::ACCOUNT_LINE
+            banks[Regexp.last_match[:bank]] = Regexp.last_match[:silver].delete(',').to_i
+          elsif line =~ Pattern::ACCOUNT_TOTAL
+            total = Regexp.last_match[:silver].delete(',').to_i
+          elsif line =~ Pattern::ACCOUNT_BALANCE
+            balance = Regexp.last_match[:silver].delete(',').to_i
+          elsif line =~ Pattern::ACCOUNT_MAX
+            max = Regexp.last_match[:silver].delete(',').to_i
+          end
+        end
+        balance ||= banks[local_bank(banks.keys)] || 0
+        { balance: balance, max: max, banks: banks, total: total || banks.values.sum }
       end
 
-      # @return [Integer, nil] account balance, nil without access
+      # @return [Integer, nil] balance at this town's bank, nil without access
       def self.balance
         account&.fetch(:balance)
+      end
+
+      # The bank named for the town the character is in ("Four Winds" for a room
+      # located on Four Winds Isle), or the only bank listed.
+      #
+      # @param names [Array<String>] bank names from BANK ACCOUNT
+      # @return [String, nil]
+      def self.local_bank(names)
+        return names.first if names.size == 1
+        location = Room.current&.location.to_s
+        return nil if location.empty?
+        names.find { |n| location.start_with?(n) } || names.find { |n| location.include?(n) || n.include?(location) }
       end
 
       # @return [GameObj, nil] a bank note in either hand

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -29,21 +29,27 @@ module Lich
           /^You hand your notes to the teller/,
         ).freeze
 
-        WITHDRAW = Regexp.union(
+        # The teller's answer to a withdrawal, without the debt notice: that
+        # comes first and the real answer follows it.
+        WITHDRAW_RESULT = Regexp.union(
           /^Very well, a withdrawal of (?<silver>[\d,]+) silver/,
           /teller scribbles the transaction into a book and hands you (?<silver>[\d,]+) silver/,
           /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silver/,
           /^The banker nods and says, "Alright, here ye go/,
           /^The teller (?:carefully|hands you|makes|taps her quill|purses her lips)/,
-          /I have a bill of (?<debt>[\d,]+) silvers?/,
           /seem to have that much/,
           /debt collector/,
           /looks at you suspiciously/,
           /chuckles at you/,
         ).freeze
 
+        DEBT     = /I have a bill of (?<debt>[\d,]+) silvers?/.freeze
+        WITHDRAW = Regexp.union(WITHDRAW_RESULT, DEBT).freeze
+
         # Replies that mean the withdrawal did not happen.
         WITHDRAW_REFUSED = /seem to have that much|looks at you suspiciously|chuckles at you|taps her quill|purses her lips/.freeze
+        NOTE_HANDED      = /hands you a (?:bank )?note/.freeze
+        PINEFAR_HANDED   = /Alright, here ye go/.freeze
 
         ACCOUNT_START   = /You currently have the following amounts on deposit|You currently have an account|you don't have access/i.freeze
         ACCOUNT_LINE    = /^\s+(?<bank>.+?) Bank: (?<silver>[\d,]+)$/.freeze
@@ -189,19 +195,17 @@ module Lich
         waitrt?
         result = if pinefar?
                    wait_for_banker
-                   dothistimeout("ask banker for #{amount} silvers", 3, Pattern::WITHDRAW)
+                   withdraw_reply("ask banker for #{amount} silvers", 3)
                  elsif note
-                   dothistimeout("withdraw #{amount} note", 5, Pattern::WITHDRAW)
+                   withdraw_reply("withdraw #{amount} note", 5)
                  else
-                   dothistimeout("withdraw #{amount} silvers", 3, Pattern::WITHDRAW)
+                   withdraw_reply("withdraw #{amount} silvers", 3)
                  end
         Currency.refresh unless note
         return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
-        if result =~ /(?<debt>[\d,]+) silvers? (?:presented by your creditors|that I suggest you pay)/
-          Lich::Messaging.msg('warn', "Bank: a debt of #{Regexp.last_match[:debt]} silver was collected first")
-        end
-        return amount if note
-        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : amount
+        return (result =~ Pattern::NOTE_HANDED ? amount : nil) if note
+        return amount if result =~ Pattern::PINEFAR_HANDED
+        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : nil
       end
 
       # Free-to-play deposit: fill the account to its cap, convert the overflow to
@@ -316,14 +320,28 @@ module Lich
         true
       end
 
+      # Send a withdrawal and return the teller's answer to it. A debt notice
+      # is not an answer: warn about it and keep waiting for the line that is.
+      #
+      # @api private
+      # @return [String, nil]
+      def self.withdraw_reply(command, timeout)
+        result = dothistimeout(command, timeout, Pattern::WITHDRAW)
+        return result unless result =~ Pattern::DEBT
+        Lich::Messaging.msg('warn', "Bank: a debt of #{Regexp.last_match[:debt]} silver was collected first")
+        matchtimeout(timeout, Pattern::WITHDRAW_RESULT) || nil
+      end
+      private_class_method :withdraw_reply
+
       # WITHDRAW N SILVER, confirmed.
       #
       # @api private
-      # @return [Integer, nil] silver handed over, nil when refused or unanswered
+      # @return [Integer, nil] silver the teller said was handed over, nil when
+      #   refused or unanswered
       def self.withdraw_silver(amount)
-        result = dothistimeout("withdraw #{amount} silver", 3, Pattern::WITHDRAW)
+        result = withdraw_reply("withdraw #{amount} silver", 3)
         return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
-        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : amount
+        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : nil
       end
       private_class_method :withdraw_silver
 

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -137,7 +137,10 @@ module Lich
       # @param names [Array<String>] bank names from BANK ACCOUNT
       # @return [String, nil]
       def self.local_bank(names)
-        location = Room.current&.location.to_s
+        # Map#location can be false for a room that has not been surveyed, and
+        # false.to_s is "false" -- a non-empty string that matches no bank.
+        location = Room.current&.location
+        return nil unless location.is_a?(String)
         return nil if location.empty?
         names.find { |n| location.start_with?(n) } || names.find { |n| location.include?(n) || n.include?(location) }
       end
@@ -166,7 +169,9 @@ module Lich
       #
       # @param amount [Integer, :all]
       # @return [Integer, nil] silver deposited as the bank reported it, 0 when
-      #   there was nothing to deposit, nil when the bank refused
+      #   there was nothing to deposit, nil when the bank refused. The Pinefar
+      #   banker confirms without echoing a figure, so a successful deposit
+      #   there reports 0; do not sum these to track silver banked.
       def self.deposit(amount = :all)
         return deposit_f2p(amount) if f2p? && !pinefar?
 

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+# Bank: the GemStone bank verbs, sent and confirmed once.
+#
+# eloot, eherbs and ebounty each carry the same deposit / withdraw / note
+# sequences with the same reply lines, plus the Pinefar depository's different
+# wording and the free-to-play balance cap. This is that set, in one place.
+# Getting to the bank is a script's job (see libeo's EO.go2); these assume the
+# character is already standing at one.
+#
+#   Bank.here?                 # standing at a bank
+#   Bank.account               # { balance: 12345, max: nil } from BANK ACCOUNT, nil without access
+#   Bank.deposit               # everything carried; f2p accounts respect the cap and take notes
+#   Bank.deposit(5000)
+#   Bank.deposit_note          # the note in hand
+#   Bank.withdraw(8000)        # silver; the f2p path drains notes from the stow container first
+#   Bank.withdraw(8000, note: true)
+module Lich
+  module Gemstone
+    module Bank
+      module Pattern
+        DEPOSIT = Regexp.union(
+          /^You deposit (?<silver>[\d,]+) silvers? into your account/,
+          /^That's a total of (?<silver>[\d,]+) silver/,
+          /^You deposit your note worth (?<silver>[\d,]+) into your account/,
+          /They add up to (?<silver>[\d,]+) (?:silver|silvers)/,
+          /^You have no coins to deposit/,
+          /takes your silvers?/,
+          /^You hand your notes to the teller/,
+        ).freeze
+
+        WITHDRAW = Regexp.union(
+          /^Very well, a withdrawal of (?<silver>[\d,]+) silver/,
+          /teller scribbles the transaction into a book and hands you (?<silver>[\d,]+) silver/,
+          /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silver/,
+          /^The banker nods and says, "Alright, here ye go/,
+          /^The teller (?:carefully|hands you|makes|taps her quill|purses her lips)/,
+          /I have a bill of (?<debt>[\d,]+) silvers?/,
+          /seem to have that much/,
+          /debt collector/,
+          /looks at you suspiciously/,
+          /chuckles at you/,
+        ).freeze
+
+        # Replies that mean the withdrawal did not happen.
+        WITHDRAW_REFUSED = /seem to have that much|looks at you suspiciously|chuckles at you|taps her quill|purses her lips/.freeze
+
+        ACCOUNT_START   = /You currently have an account|you don't have access/i.freeze
+        ACCOUNT_BALANCE = /in the amount of (?<silver>[\d,]+) silver/.freeze
+        ACCOUNT_MAX     = /a maximum of (?<silver>[\d,]+) silvers/.freeze
+        NO_ACCESS       = /you don't have access/i.freeze
+        NOTE_VALUE      = /has a value of (?<silver>[\d,]+) silver and reads/.freeze
+        NOTE_READ       = /Hold in right hand to use|has a value of/.freeze
+      end
+
+      PINEFAR_TITLE = '[Pinefar, Depository]'
+      NOTE_NOUN = /^(?:note|scrip|chit)$/.freeze
+
+      # Silver kept on hand when the f2p deposit loop sizes a note, so the next
+      # pass can still deposit something. eloot's number.
+      F2P_NOTE_BUFFER = 10_000
+
+      # @return [Boolean] standing at a bank (a tagged room or the Pinefar depository)
+      def self.here?
+        pinefar? || Room.current&.tags.to_a.include?('bank') ? true : false
+      end
+
+      # @return [Boolean] the Pinefar depository, which has a banker NPC and its own verbs
+      def self.pinefar?
+        XMLData.room_title == PINEFAR_TITLE
+      end
+
+      # @return [Boolean] free-to-play account: capped balance, notes for the overflow
+      def self.f2p?
+        Lich::Common::Account.type.to_s == 'FREE'
+      end
+
+      # BANK ACCOUNT, parsed.
+      #
+      # @return [Hash{Symbol => Integer, nil}, nil] +{ balance:, max: }+ (+max+ nil
+      #   when the account has no cap), or nil when this town's bank refuses access
+      def self.account
+        lines = Lich::Util.issue_command('bank account', Pattern::ACCOUNT_START, silent: true, quiet: true)
+        return nil if lines.any? { |l| l =~ Pattern::NO_ACCESS }
+        balance = lines.find { |l| l =~ Pattern::ACCOUNT_BALANCE } ? Regexp.last_match[:silver].delete(',').to_i : 0
+        max = lines.find { |l| l =~ Pattern::ACCOUNT_MAX } ? Regexp.last_match[:silver].delete(',').to_i : nil
+        { balance: balance, max: max }
+      end
+
+      # @return [Integer, nil] account balance, nil without access
+      def self.balance
+        account&.fetch(:balance)
+      end
+
+      # @return [GameObj, nil] a bank note in either hand
+      def self.note_in_hand
+        [GameObj.right_hand, GameObj.left_hand].compact.find { |i| i.noun =~ NOTE_NOUN }
+      end
+
+      # @param container [GameObj, nil] defaults to the STOW default container
+      # @return [Array<GameObj>] bank notes Lich knows to be in that container
+      def self.notes_in(container = StowList.default)
+        container&.contents.to_a.select { |obj| obj.noun =~ NOTE_NOUN }
+      end
+
+      # @param note [GameObj] a note in hand
+      # @return [Integer] its value, 0 when unreadable
+      def self.note_value(note = note_in_hand)
+        return 0 if note.nil?
+        waitrt?
+        line = dothistimeout("read ##{note.id}", 3, Pattern::NOTE_READ)
+        line.to_s =~ Pattern::NOTE_VALUE ? Regexp.last_match[:silver].delete(',').to_i : 0
+      end
+
+      # Deposit silver.
+      #
+      # @param amount [Integer, :all]
+      # @return [Integer, nil] silver deposited as the bank reported it, 0 when
+      #   there was nothing to deposit, nil when the bank refused
+      def self.deposit(amount = :all)
+        return deposit_f2p(amount) if f2p? && !pinefar?
+
+        waitrt?
+        result = if pinefar?
+                   silver = amount == :all ? Currency.silver(refresh: true) : amount
+                   return 0 unless silver.to_i.positive?
+                   wait_for_banker
+                   dothistimeout("give banker #{silver} silver", 3, Pattern::DEPOSIT)
+                 else
+                   dothistimeout("deposit #{amount == :all ? 'all' : amount}", 3, Regexp.union(Pattern::DEPOSIT, Pattern::NO_ACCESS))
+                 end
+        Currency.refresh
+        deposited(result)
+      end
+
+      # Deposit the note in hand. Pinefar cannot take notes.
+      #
+      # @param note [GameObj, nil]
+      # @return [Integer, nil] the note's value as the bank reported it, nil when
+      #   there is no note or the bank cannot take it
+      def self.deposit_note(note = note_in_hand)
+        return nil if note.nil? || pinefar?
+        waitrt?
+        result = dothistimeout("deposit ##{note.id}", 3, Pattern::DEPOSIT)
+        20.times { break if note_in_hand.nil?; sleep 0.1 }
+        deposited(result)
+      end
+
+      # Withdraw silver, or a note for that amount.
+      #
+      # @param amount [Integer]
+      # @param note [Boolean] take a note rather than coins
+      # @return [Integer, nil] silver withdrawn (the note's face value for a note),
+      #   nil when the bank refused
+      def self.withdraw(amount, note: false)
+        return withdraw_f2p(amount) if f2p? && !note && !pinefar?
+
+        waitrt?
+        result = if pinefar?
+                   wait_for_banker
+                   dothistimeout("ask banker for #{amount} silvers", 3, Pattern::WITHDRAW)
+                 elsif note
+                   dothistimeout("withdraw #{amount} note", 5, Pattern::WITHDRAW)
+                 else
+                   dothistimeout("withdraw #{amount} silvers", 3, Pattern::WITHDRAW)
+                 end
+        Currency.refresh unless note
+        return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
+        if result =~ /(?<debt>[\d,]+) silvers? (?:presented by your creditors|that I suggest you pay)/
+          Lich::Messaging.msg('warn', "Bank: a debt of #{Regexp.last_match[:debt]} silver was collected first")
+        end
+        return amount if note
+        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : amount
+      end
+
+      # Free-to-play deposit: fill the account to its cap, convert the overflow to
+      # a note and stow it, repeat until everything carried is put away.
+      #
+      # @param amount [Integer, :all]
+      # @param stow [GameObj, nil] where notes go; the STOW default container
+      # @return [Integer, nil] silver put away in total, nil when the bank refused
+      def self.deposit_f2p(amount = :all, stow: StowList.default)
+        total = 0
+        loop do
+          info = account
+          return nil if info.nil?
+          carried = Currency.silver(refresh: true).to_i
+          carried = [carried, amount].min unless amount == :all
+          break unless carried.positive?
+
+          max = info[:max]
+          if max.nil? || info[:balance] + carried < max
+            dothistimeout("deposit #{carried}", 3, Pattern::DEPOSIT)
+            total += carried
+            break
+          end
+
+          room = max - info[:balance]
+          if room.positive?
+            dothistimeout("deposit #{room}", 3, Pattern::DEPOSIT)
+            total += room
+          end
+          carried = Currency.silver(refresh: true).to_i
+          note_size = carried >= F2P_NOTE_BUFFER ? max : max - (F2P_NOTE_BUFFER - carried)
+          break if withdraw(note_size, note: true).nil?
+          note = note_in_hand
+          break if note.nil? || stow.nil?
+          Lich::Stash.add_to_bag(stow, note)
+        end
+        Currency.refresh
+        total
+      end
+
+      # Free-to-play withdrawal: the balance may be short of +amount+ while notes
+      # in the stow container hold the rest, so deposit notes until it covers.
+      #
+      # @param amount [Integer]
+      # @param stow [GameObj, nil]
+      # @return [Integer, nil] silver withdrawn, nil when the bank refused
+      def self.withdraw_f2p(amount, stow: StowList.default)
+        info = account
+        return nil if info.nil?
+        bal = info[:balance]
+        if bal >= amount
+          dothistimeout("withdraw #{amount} silver", 3, Pattern::WITHDRAW)
+          Currency.refresh
+          return amount
+        end
+
+        taken = 0
+        want = amount
+        notes_in(stow).each do
+          if bal.positive?
+            dothistimeout("withdraw #{bal} silver", 3, Pattern::WITHDRAW)
+            taken += bal
+            want -= bal
+            bal = 0
+          end
+          note = notes_in(stow).first
+          break if note.nil?
+          fput "get ##{note.id}"
+          value = deposit_note(note)
+          break if value.nil?
+          take = [value, want].min
+          dothistimeout("withdraw #{take} silver", 3, Pattern::WITHDRAW)
+          taken += take
+          want -= take
+          break if want <= 0
+        end
+        Currency.refresh
+        taken
+      end
+
+      # The Pinefar banker wanders; give him a moment to be at the counter.
+      #
+      # @param timeout [Numeric]
+      # @return [Boolean]
+      def self.wait_for_banker(timeout: 30)
+        deadline = Time.now + timeout
+        until GameObj.npcs.to_a.any? { |npc| npc.noun == 'banker' }
+          return false if Time.now > deadline
+          sleep 1
+        end
+        true
+      end
+
+      # @api private
+      def self.deposited(result)
+        return nil if result.nil? || result =~ Pattern::NO_ACCESS
+        return 0 if result =~ /no coins to deposit/
+        result =~ /(?<silver>[\d,]+)/ ? Regexp.last_match[:silver].delete(',').to_i : 0
+      end
+      private_class_method :deposited
+    end
+  end
+end

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -21,9 +21,9 @@ module Lich
       module Pattern
         DEPOSIT = Regexp.union(
           /^You deposit (?<silver>[\d,]+) silvers? into your account/,
-          /^That's a total of (?<silver>[\d,]+) silver/,
+          /^That's a total of (?<silver>[\d,]+) silvers?/,
           /^You deposit your note worth (?<silver>[\d,]+) into your account/,
-          /They add up to (?<silver>[\d,]+) (?:silver|silvers)/,
+          /They add up to (?<silver>[\d,]+) silvers?/,
           /^You have no coins to deposit/,
           /takes your silvers?/,
           /^You hand your notes to the teller/,
@@ -32,9 +32,9 @@ module Lich
         # The teller's answer to a withdrawal, without the debt notice: that
         # comes first and the real answer follows it.
         WITHDRAW_RESULT = Regexp.union(
-          /^Very well, a withdrawal of (?<silver>[\d,]+) silver/,
-          /teller scribbles the transaction into a book and hands you (?<silver>[\d,]+) silver/,
-          /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silver/,
+          /^Very well, a withdrawal of (?<silver>[\d,]+) silvers?/,
+          /teller scribbles the transaction into a book and hands you (?<silver>[\d,]+) silvers?/,
+          /teller carefully records the transaction, (?:and then )?hands you (?<silver>[\d,]+) silvers?/,
           /^The banker nods and says, "Alright, here ye go/,
           /^The teller (?:carefully|hands you|makes|taps her quill|purses her lips)/,
           /seem to have that much/,
@@ -68,10 +68,10 @@ module Lich
         ACCOUNT_START   = /You currently have the following amounts on deposit|You currently have an account|you don't have access/i.freeze
         ACCOUNT_LINE    = /^\s+(?<bank>.+?) Bank: (?<silver>[\d,]+)$/.freeze
         ACCOUNT_TOTAL   = /^\s+Total: (?<silver>[\d,]+)$/.freeze
-        ACCOUNT_BALANCE = /in the amount of (?<silver>[\d,]+) silver/.freeze
-        ACCOUNT_MAX     = /a maximum of (?<silver>[\d,]+) silvers/.freeze
+        ACCOUNT_BALANCE = /in the amount of (?<silver>[\d,]+) silvers?/.freeze
+        ACCOUNT_MAX     = /a maximum of (?<silver>[\d,]+) silvers?/.freeze
         ACCOUNT_END     = /urchin bank runner uses remaining|a maximum of|you don't have access|<prompt/i.freeze
-        NOTE_VALUE      = /has a value of (?<silver>[\d,]+) silver and reads/.freeze
+        NOTE_VALUE      = /has a value of (?<silver>[\d,]+) silvers? and reads/.freeze
         NOTE_READ       = /Hold in right hand to use|has a value of/.freeze
       end
 
@@ -211,19 +211,24 @@ module Lich
         return withdraw_f2p(amount) if f2p? && !note && !pinefar?
 
         waitrt?
-        result = if pinefar?
-                   wait_for_banker
-                   withdraw_reply("ask banker for #{amount} silvers", 3)
-                 elsif note
-                   withdraw_reply("withdraw #{amount} note", 5)
-                 else
-                   withdraw_reply("withdraw #{amount} silvers", 3)
-                 end
-        Currency.refresh unless note
-        return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
-        return (result =~ Pattern::NOTE_HANDED ? amount : nil) if note
-        return amount if result =~ Pattern::PINEFAR_HANDED
-        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : nil
+        if note
+          result = withdraw_reply("withdraw #{amount} note", 5)
+          return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
+          return result =~ Pattern::NOTE_HANDED ? amount : nil
+        end
+
+        if pinefar?
+          wait_for_banker
+          result = withdraw_reply("ask banker for #{amount} silvers", 3)
+          Currency.refresh
+          return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
+          # The banker confirms without echoing a figure.
+          return result =~ Pattern::PINEFAR_HANDED ? amount : nil
+        end
+
+        got = withdraw_silver(amount)
+        Currency.refresh
+        got
       end
 
       # Free-to-play deposit: fill the account to its cap, convert the overflow to
@@ -368,7 +373,7 @@ module Lich
       def self.withdraw_silver(amount)
         result = withdraw_reply("withdraw #{amount} silver", 3)
         return nil if result.nil? || result =~ Pattern::WITHDRAW_REFUSED
-        result =~ /(?<silver>[\d,]+) silver/ ? Regexp.last_match[:silver].delete(',').to_i : nil
+        result =~ /(?<silver>[\d,]+) silvers?/ ? Regexp.last_match[:silver].delete(',').to_i : nil
       end
       private_class_method :withdraw_silver
 

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -113,12 +113,11 @@ module Lich
       end
 
       # The bank named for the town the character is in ("Four Winds" for a room
-      # located on Four Winds Isle), or the only bank listed.
+      # located on Four Winds Isle).
       #
       # @param names [Array<String>] bank names from BANK ACCOUNT
       # @return [String, nil]
       def self.local_bank(names)
-        return names.first if names.size == 1
         location = Room.current&.location.to_s
         return nil if location.empty?
         names.find { |n| location.start_with?(n) } || names.find { |n| location.include?(n) || n.include?(location) }
@@ -245,6 +244,7 @@ module Lich
             remaining -= got if remaining
           end
           carried = Currency.silver(refresh: true).to_i
+          break if (remaining && remaining <= 0) || !carried.positive?
           note_size = carried >= F2P_NOTE_BUFFER ? max : max - (F2P_NOTE_BUFFER - carried)
           break if withdraw(note_size, note: true).nil?
           note = note_in_hand

--- a/lib/gemstone/bank.rb
+++ b/lib/gemstone/bank.rb
@@ -43,11 +43,25 @@ module Lich
           /chuckles at you/,
         ).freeze
 
-        DEBT     = /I have a bill of (?<debt>[\d,]+) silvers?/.freeze
-        WITHDRAW = Regexp.union(WITHDRAW_RESULT, DEBT).freeze
+        DEBT      = /I have a bill of (?<debt>[\d,]+) silvers?/.freeze
+        NO_ACCESS = /you don't have access/i.freeze
 
-        # Replies that mean the withdrawal did not happen.
-        WITHDRAW_REFUSED = /seem to have that much|looks at you suspiciously|chuckles at you|taps her quill|purses her lips/.freeze
+        # A bank the character has no account at answers a WITHDRAW with the
+        # no-access line, so it has to end the wait like any other answer.
+        WITHDRAW = Regexp.union(WITHDRAW_RESULT, DEBT, NO_ACCESS).freeze
+
+        # Replies that mean the withdrawal did not happen. The teller's
+        # non-committal lines ("makes a note", "taps her quill") carry no silver
+        # figure, so anything that is not an explicit handover counts as refused.
+        WITHDRAW_REFUSED = Regexp.union(
+          /seem to have that much/,
+          /looks at you suspiciously/,
+          /chuckles at you/,
+          /taps her quill/,
+          /purses her lips/,
+          /^The teller makes/,
+          NO_ACCESS,
+        ).freeze
         NOTE_HANDED      = /hands you a (?:bank )?note/.freeze
         PINEFAR_HANDED   = /Alright, here ye go/.freeze
 
@@ -57,7 +71,6 @@ module Lich
         ACCOUNT_BALANCE = /in the amount of (?<silver>[\d,]+) silver/.freeze
         ACCOUNT_MAX     = /a maximum of (?<silver>[\d,]+) silvers/.freeze
         ACCOUNT_END     = /urchin bank runner uses remaining|a maximum of|you don't have access|<prompt/i.freeze
-        NO_ACCESS       = /you don't have access/i.freeze
         NOTE_VALUE      = /has a value of (?<silver>[\d,]+) silver and reads/.freeze
         NOTE_READ       = /Hold in right hand to use|has a value of/.freeze
       end

--- a/lib/gemstone/currency.rb
+++ b/lib/gemstone/currency.rb
@@ -1,7 +1,24 @@
 module Lich
   module Gemstone
     module Currency
-      def self.silver
+      # Silver carried, as Infomon last saw it. Infomon updates it whenever a
+      # WEALTH or INFO response goes by, so the value is only as fresh as the
+      # last of those; pass +refresh: true+ to send WEALTH QUIET first.
+      #
+      # @param refresh [Boolean]
+      # @return [Integer, nil]
+      def self.silver(refresh: false)
+        self.refresh if refresh
+        Lich::Gemstone::Infomon.get('currency.silver')
+      end
+
+      # Send WEALTH QUIET so Infomon re-reads the silver carried. The response
+      # is parsed on the game thread before hooks run, so hiding it from the
+      # front end does not hide it from Infomon.
+      #
+      # @return [Integer, nil] the refreshed silver
+      def self.refresh
+        Lich::Util.issue_command('wealth quiet', Lich::Gemstone::Infomon::Parser::Pattern::WealthSilver, silent: true, quiet: true)
         Lich::Gemstone::Infomon.get('currency.silver')
       end
 

--- a/lib/gemstone/currency.rb
+++ b/lib/gemstone/currency.rb
@@ -12,18 +12,50 @@ module Lich
         Lich::Gemstone::Infomon.get('currency.silver')
       end
 
-      # Send WEALTH QUIET so Infomon re-reads the silver carried. The response
-      # is parsed on the game thread before hooks run, so hiding it from the
-      # front end does not hide it from Infomon.
+      # Send WEALTH so Infomon re-reads the silver carried (WEALTH is quiet by
+      # default; LOUD is the option that echoes to the room). The response is
+      # parsed on the game thread before hooks run, so hiding it from the front
+      # end does not hide it from Infomon.
       #
+      # @param all [Boolean] WEALTH ALL, which also refreshes gigas fragments,
+      #   redsteel marks and gemstone dust
       # @return [Integer, nil] the refreshed silver
-      def self.refresh
-        Lich::Util.issue_command('wealth quiet', Lich::Gemstone::Infomon::Parser::Pattern::WealthSilver, silent: true, quiet: true)
+      def self.refresh(all: false)
+        Lich::Util.issue_command(all ? 'wealth all' : 'wealth', Lich::Gemstone::Infomon::Parser::Pattern::WealthSilver, silent: true, quiet: true)
         Lich::Gemstone::Infomon.get('currency.silver')
       end
 
+      # Silver stored in worn containers, as WEALTH last reported it.
+      #
+      # @return [Integer, nil]
       def self.silver_container
         Lich::Gemstone::Infomon.get('currency.silver_container')
+      end
+
+      # Carried plus container silver, the "carrying a total of" line.
+      #
+      # @param refresh [Boolean]
+      # @return [Integer, nil]
+      def self.silver_total(refresh: false)
+        self.refresh if refresh
+        Lich::Gemstone::Infomon.get('currency.silver_total')
+      end
+
+      # Total value of accessible bank notes, from WEALTH NOTES.
+      #
+      # @param refresh [Boolean]
+      # @return [Integer, nil]
+      def self.notes(refresh: false)
+        refresh_notes if refresh
+        Lich::Gemstone::Infomon.get('currency.notes')
+      end
+
+      # Send WEALTH NOTES so Infomon re-reads the note total.
+      #
+      # @return [Integer, nil]
+      def self.refresh_notes
+        Lich::Util.issue_command('wealth notes', /^Listing accessible bank notes/, /^Total note value:/, silent: true, quiet: true)
+        Lich::Gemstone::Infomon.get('currency.notes')
       end
 
       def self.redsteel_marks

--- a/lib/gemstone/infomon/parser.rb
+++ b/lib/gemstone/infomon/parser.rb
@@ -73,6 +73,8 @@ module Lich
           TicketGold = /^\s*Gold - (?<gold>[\d,]+) gold\.$/.freeze
           WealthSilver = /^You have (?<silver>no|[,\d]+|but one) silver with you\./.freeze
           WealthSilverContainer = /^You are carrying (?<silver>[\d,]+) silver stored within your /.freeze
+          WealthSilverTotal = /^You are carrying a total of (?<silver>[\d,]+) silver\.$/.freeze
+          WealthNotes = /^Total note value: (?<silver>[\d,]+)$/.freeze
           AccountName = /^Account Name:     (?<name>[\w\d\-\_]+)$/.freeze
           AccountSubscription = /^Account Type:     (?<subscription>F2P|Standard|Premium|Platinum)(?: with Shattered)?(?: \(\w+\))?$/.freeze
           ProfileStart = /^PERSONAL INFORMATION$/.freeze
@@ -134,7 +136,7 @@ module Lich
                       SocietyResign, LearnPSM, UnlearnPSM, LostTechnique, LearnTechnique, UnlearnTechnique,
                       Resource, Suffused, VolnFavor, GigasArtifactFragments, RedsteelMarks, TicketGeneral, TicketGold,
                       TicketBlackscrip, TicketBloodscrip, TicketEtherealScrip, TicketSoulShards, TicketRaikhen, TicketAevit,
-                      WealthSilver, WealthSilverContainer, GoalsDetected, GoalsEnded, InnCheckedOut, SpellsongRenewed,
+                      WealthSilver, WealthSilverContainer, WealthSilverTotal, WealthNotes, GoalsDetected, GoalsEnded, InnCheckedOut, SpellsongRenewed,
                       ThornPoisonStart, ThornPoisonProgression, ThornPoisonDeprogression, ThornPoisonEnd, CovertArtsCharges,
                       AccountName, AccountSubscription, ProfileStart, ProfileName, ProfileHouseCHE, ResignCHE, ResignConfirmCHE,
                       ShadowEssence, ShadowEssenceGain, ShadowEssenceCap, SacrificeMana, SacrificeChannel, SacrificeInfest,
@@ -550,6 +552,14 @@ module Lich
             when Pattern::WealthSilverContainer
               match = Regexp.last_match
               Infomon.set('currency.silver_container', match[:silver].delete(',').to_i)
+              :ok
+            when Pattern::WealthSilverTotal
+              match = Regexp.last_match
+              Infomon.set('currency.silver_total', match[:silver].delete(',').to_i)
+              :ok
+            when Pattern::WealthNotes
+              match = Regexp.last_match
+              Infomon.set('currency.notes', match[:silver].delete(',').to_i)
               :ok
             when Pattern::AccountName
               if Lich::Common::Account.name.nil?

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require 'gemstone/bank'
+
+module Kernel
+  def dothistimeout(_action, _timeout, _success_line); end unless method_defined?(:dothistimeout)
+end
+
+RSpec.describe Lich::Gemstone::Bank do
+  let(:note) { MockGameObj.new(id: '500', noun: 'note', name: 'bank note') }
+  let(:sack) { MockGameObj.new(id: '105', noun: 'sack', name: 'leather sack') }
+  let(:hands) { { right: nil, left: nil } }
+  let(:room) { double('Room', tags: ['bank']) }
+  let(:sent) { [] }
+
+  # A scripted game: each dothistimeout call returns the next reply in order.
+  # +before+ runs with the command first, to change hands the way the game would.
+  def replies(*lines, before: nil)
+    allow(described_class).to receive(:dothistimeout) do |cmd, _t, _rx|
+      sent << cmd
+      before&.call(cmd)
+      lines.shift
+    end
+  end
+
+  before do
+    stub_const('Room', Class.new { def self.current; end })
+    allow(Room).to receive(:current).and_return(room)
+    stub_const('Lich::Gemstone::Currency', Module.new do
+      def self.silver(*) = @silver
+
+      def self.silver=(v)
+        @silver = v
+      end
+
+      def self.refresh = @silver
+    end)
+    Lich::Gemstone::Currency.silver = 0
+    stub_const('Lich::Common::Account', Module.new { def self.type = 'NORMAL' })
+    stub_const('Lich::Gemstone::StowList', Class.new { def self.default; end })
+    stub_const('StowList', Lich::Gemstone::StowList)
+    allow(StowList).to receive(:default).and_return(sack)
+    allow(sack).to receive(:contents).and_return([])
+    stub_const('Lich::Stash', Module.new { def self.add_to_bag(_bag, _item); end })
+    allow(GameObj).to receive(:right_hand) { hands[:right] }
+    allow(GameObj).to receive(:left_hand) { hands[:left] }
+    allow(GameObj).to receive(:npcs).and_return([])
+    allow(Lich::Util).to receive(:issue_command).and_return([])
+    allow(described_class).to receive(:waitrt?)
+    allow(described_class).to receive(:sleep)
+    allow(described_class).to receive(:fput)
+    XMLData.singleton_class.class_eval { attr_accessor :room_title }
+    XMLData.room_title = '[Town Bank]'
+  end
+
+  describe '.here? / .pinefar?' do
+    it 'is at a bank by tag' do
+      expect(described_class.here?).to be true
+    end
+
+    it 'is at a bank at the Pinefar depository without the tag' do
+      allow(room).to receive(:tags).and_return([])
+      XMLData.room_title = '[Pinefar, Depository]'
+      expect(described_class.here?).to be true
+      expect(described_class.pinefar?).to be true
+    end
+
+    it 'is not at a bank elsewhere' do
+      allow(room).to receive(:tags).and_return(['town'])
+      expect(described_class.here?).to be false
+    end
+  end
+
+  describe '.account' do
+    it 'parses balance and cap' do
+      allow(Lich::Util).to receive(:issue_command).and_return(
+        ['You currently have an account in the amount of 45,000 silver.',
+         'Your account may hold a maximum of 100,000 silvers.']
+      )
+      expect(described_class.account).to eq(balance: 45_000, max: 100_000)
+    end
+
+    it 'has no cap for a normal account' do
+      allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 45,000 silver.'])
+      expect(described_class.account).to eq(balance: 45_000, max: nil)
+    end
+
+    it 'is nil without access' do
+      allow(Lich::Util).to receive(:issue_command).and_return(["The teller says, \"I'm sorry, you don't have access to an account here.\""])
+      expect(described_class.account).to be_nil
+      expect(described_class.balance).to be_nil
+    end
+  end
+
+  describe '.deposit' do
+    it 'deposits all and reports the amount' do
+      replies('You deposit 1,234 silvers into your account.')
+      expect(described_class.deposit).to eq(1234)
+      expect(sent).to eq(['deposit all'])
+    end
+
+    it 'deposits a specific amount' do
+      replies("That's a total of 500 silver.")
+      expect(described_class.deposit(500)).to eq(500)
+      expect(sent).to eq(['deposit 500'])
+    end
+
+    it 'reports 0 with nothing to deposit' do
+      replies('You have no coins to deposit.')
+      expect(described_class.deposit).to eq(0)
+    end
+
+    it 'is nil when the bank refuses' do
+      replies("I'm sorry, you don't have access to an account here.")
+      expect(described_class.deposit).to be_nil
+    end
+
+    it 'gives the banker at Pinefar after he is at the counter' do
+      XMLData.room_title = '[Pinefar, Depository]'
+      Lich::Gemstone::Currency.silver = 800
+      allow(GameObj).to receive(:npcs).and_return([MockGameObj.new(id: '1', noun: 'banker', name: 'banker')])
+      replies('Smiling greedily, Hurshal takes your silvers and says, "Heh, I\'ll put dese in ye \'Mule bank account right quick."')
+      expect(described_class.deposit).to eq(0)
+      expect(sent).to eq(['give banker 800 silver'])
+    end
+
+    it 'sends nothing at Pinefar with no silver' do
+      XMLData.room_title = '[Pinefar, Depository]'
+      Lich::Gemstone::Currency.silver = 0
+      expect(described_class).not_to receive(:dothistimeout)
+      expect(described_class.deposit).to eq(0)
+    end
+
+    context 'free to play' do
+      before do
+        allow(Lich::Common::Account).to receive(:type).and_return('FREE')
+      end
+
+      it 'deposits everything when it fits under the cap' do
+        allow(Lich::Util).to receive(:issue_command).and_return(
+          ['You currently have an account in the amount of 10,000 silver.',
+           'Your account may hold a maximum of 100,000 silvers.']
+        )
+        Lich::Gemstone::Currency.silver = 5_000
+        replies('You deposit 5,000 silvers into your account.')
+        expect(described_class.deposit).to eq(5_000)
+        expect(sent).to eq(['deposit 5000'])
+      end
+
+      it 'fills to the cap, takes a note, stows it, then deposits the rest' do
+        balances = [
+          ['You currently have an account in the amount of 95,000 silver.', 'Your account may hold a maximum of 100,000 silvers.'],
+          ['You currently have an account in the amount of 0 silver.', 'Your account may hold a maximum of 100,000 silvers.'],
+        ]
+        allow(Lich::Util).to receive(:issue_command) { balances.shift }
+        carried = [20_000, 15_000, 15_000]
+        allow(Lich::Gemstone::Currency).to receive(:silver) { carried.shift }
+        replies('You deposit 5,000 silvers into your account.',
+                'The teller carefully records the transaction, and then hands you a note.',
+                'You deposit 15,000 silvers into your account.',
+                before: ->(cmd) { hands[:right] = note if cmd =~ /note/ })
+        expect(Lich::Stash).to receive(:add_to_bag).with(sack, note)
+        expect(described_class.deposit).to eq(20_000)
+        expect(sent).to eq(['deposit 5000', 'withdraw 100000 note', 'deposit 15000'])
+      end
+
+      it 'is nil without access' do
+        allow(Lich::Util).to receive(:issue_command).and_return(["you don't have access to an account here."])
+        expect(described_class.deposit).to be_nil
+      end
+    end
+  end
+
+  describe '.deposit_note' do
+    it 'deposits the note in hand and reports its value' do
+      hands[:right] = note
+      replies('You deposit your note worth 100,000 into your account.', before: ->(_cmd) { hands[:right] = nil })
+      expect(described_class.deposit_note).to eq(100_000)
+      expect(sent).to eq(['deposit #500'])
+    end
+
+    it 'is nil with no note or at Pinefar' do
+      expect(described_class.deposit_note).to be_nil
+      hands[:right] = note
+      XMLData.room_title = '[Pinefar, Depository]'
+      expect(described_class.deposit_note).to be_nil
+    end
+  end
+
+  describe '.withdraw' do
+    it 'withdraws silver and reports the amount' do
+      replies('The teller carefully records the transaction, and then hands you 8,000 silver.')
+      expect(described_class.withdraw(8000)).to eq(8000)
+      expect(sent).to eq(['withdraw 8000 silvers'])
+    end
+
+    it 'withdraws a note' do
+      replies('The teller carefully records the transaction, and then hands you a note.')
+      expect(described_class.withdraw(50_000, note: true)).to eq(50_000)
+      expect(sent).to eq(['withdraw 50000 note'])
+    end
+
+    it 'is nil when refused' do
+      replies("The teller says, \"You don't seem to have that much in your account.\"")
+      expect(described_class.withdraw(8000)).to be_nil
+    end
+
+    it 'asks the banker at Pinefar' do
+      XMLData.room_title = '[Pinefar, Depository]'
+      allow(GameObj).to receive(:npcs).and_return([MockGameObj.new(id: '1', noun: 'banker', name: 'banker')])
+      replies('The banker nods and says, "Alright, here ye go.  Ye understand I be takin\' a little more than that from ye account in the \'Mule.  I don\'t works for free!"')
+      expect(described_class.withdraw(200)).to eq(200)
+      expect(sent).to eq(['ask banker for 200 silvers'])
+    end
+
+    it 'is nil when the Pinefar banker refuses' do
+      XMLData.room_title = '[Pinefar, Depository]'
+      allow(GameObj).to receive(:npcs).and_return([MockGameObj.new(id: '1', noun: 'banker', name: 'banker')])
+      replies('The banker looks at you suspiciously and says, "Hmm, I don\'t think ye be havin\' enough."')
+      expect(described_class.withdraw(200)).to be_nil
+    end
+
+    context 'free to play' do
+      before { allow(Lich::Common::Account).to receive(:type).and_return('FREE') }
+
+      it 'withdraws directly when the balance covers it' do
+        allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 9,000 silver.'])
+        replies('The teller carefully records the transaction, and then hands you 8,000 silver.')
+        expect(described_class.withdraw(8000)).to eq(8000)
+        expect(sent).to eq(['withdraw 8000 silver'])
+      end
+
+      it 'drains the balance, deposits a stowed note, and withdraws the rest' do
+        allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 3,000 silver.'])
+        allow(sack).to receive(:contents).and_return([note])
+        replies('The teller hands you 3,000 silver.',
+                'You deposit your note worth 100,000 into your account.',
+                'The teller hands you 5,000 silver.')
+        expect(described_class.withdraw(8000)).to eq(8000)
+        expect(sent).to eq(['withdraw 3000 silver', 'deposit #500', 'withdraw 5000 silver'])
+      end
+    end
+  end
+
+  describe '.note_value' do
+    it 'reads the note in hand' do
+      hands[:left] = note
+      replies('This note has a value of 12,500 silver and reads: Bank of Wehnimer\'s Landing.  Hold in right hand to use.')
+      expect(described_class.note_value).to eq(12_500)
+      expect(sent).to eq(['read #500'])
+    end
+
+    it 'is 0 with no note' do
+      expect(described_class.note_value).to eq(0)
+    end
+  end
+
+  describe '.wait_for_banker' do
+    it 'returns once the banker is present' do
+      allow(GameObj).to receive(:npcs).and_return([], [MockGameObj.new(id: '1', noun: 'banker', name: 'banker')])
+      expect(described_class.wait_for_banker).to be true
+    end
+
+    it 'gives up after the timeout' do
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now, now, now + 60)
+      expect(described_class.wait_for_banker(timeout: 30)).to be false
+    end
+  end
+end

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe Lich::Gemstone::Bank do
       expect(described_class.balance).to eq(616_853_785)
     end
 
+    it 'does not take a lone account elsewhere for the local one' do
+      allow(room).to receive(:location).and_return("Wehnimer's Landing")
+      allow(Lich::Util).to receive(:issue_command).and_return(
+        ['You currently have the following amounts on deposit:', '', '             Icemule Trace Bank: 52,138', '                          Total: 52,138']
+      )
+      expect(described_class.balance).to eq(0)
+    end
+
     it 'is 0 with no account in this town' do
       allow(room).to receive(:location).and_return("Wehnimer's Landing")
       allow(Lich::Util).to receive(:issue_command).and_return(listing)
@@ -207,6 +215,16 @@ RSpec.describe Lich::Gemstone::Bank do
                 before: ->(cmd) { hands[:right] = note if cmd =~ /note/ })
         expect(described_class.deposit(10_000)).to eq(10_000)
         expect(sent).to eq(['deposit 5000', 'withdraw 100000 note', 'deposit 5000'])
+      end
+
+      it 'stops once the requested amount is in, without converting savings to a note' do
+        allow(Lich::Util).to receive(:issue_command).and_return(
+          ['You currently have an account in the amount of 95,000 silver.', 'Your account may hold a maximum of 100,000 silvers.']
+        )
+        Lich::Gemstone::Currency.silver = 20_000
+        replies('You deposit 5,000 silvers into your account.')
+        expect(described_class.deposit(5_000)).to eq(5_000)
+        expect(sent).to eq(['deposit 5000'])
       end
 
       it 'counts only what the bank confirmed' do

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe Lich::Gemstone::Bank do
      'You currently have 10 urchin bank runner uses remaining.']
   end
   let(:sent) { [] }
+  let(:no_account_line) do
+    "[Because your account is free, you don't have access to bank accounts in multiple towns.]"
+  end
 
   # A scripted game: each dothistimeout call returns the next reply in order.
   # +before+ runs with the command first, to change hands the way the game would.
@@ -362,6 +365,31 @@ RSpec.describe Lich::Gemstone::Bank do
         expect(described_class.withdraw(8000)).to be_nil
         expect(sent).to be_empty
       end
+    end
+
+    it 'is nil, and does not wait out the timeout, without an account here' do
+      replies(no_account_line)
+      expect(described_class.withdraw(10_000)).to be_nil
+    end
+  end
+
+  # The replies helper stubs dothistimeout and ignores the regex it is handed,
+  # so which lines actually end the wait can only be checked on the patterns.
+  describe 'Pattern::WITHDRAW' do
+    it 'ends the wait on a no-access refusal rather than timing out' do
+      expect(no_account_line).to match(described_class::Pattern::WITHDRAW)
+    end
+
+    it 'counts a no-access refusal as refused' do
+      expect(no_account_line).to match(described_class::Pattern::WITHDRAW_REFUSED)
+    end
+
+    it 'still ends the wait on a handover' do
+      expect('The teller hands you 3,000 silver.').to match(described_class::Pattern::WITHDRAW)
+    end
+
+    it 'does not count a handover as refused' do
+      expect('The teller hands you 3,000 silver.').not_to match(described_class::Pattern::WITHDRAW_REFUSED)
     end
   end
 

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Lich::Gemstone::Bank do
     it 'withdraws silver and reports the amount' do
       replies('The teller carefully records the transaction, and then hands you 8,000 silver.')
       expect(described_class.withdraw(8000)).to eq(8000)
-      expect(sent).to eq(['withdraw 8000 silvers'])
+      expect(sent).to eq(['withdraw 8000 silver'])
     end
 
     it 'withdraws a note' do

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -5,6 +5,7 @@ require 'gemstone/bank'
 
 module Kernel
   def dothistimeout(_action, _timeout, _success_line); end unless method_defined?(:dothistimeout)
+  def matchtimeout(_secs, *_strings); end unless method_defined?(:matchtimeout)
 end
 
 RSpec.describe Lich::Gemstone::Bank do
@@ -276,6 +277,27 @@ RSpec.describe Lich::Gemstone::Bank do
     it 'is nil when refused' do
       replies("The teller says, \"You don't seem to have that much in your account.\"")
       expect(described_class.withdraw(8000)).to be_nil
+    end
+
+    it 'is nil when a note was asked for and none was handed over' do
+      replies("The teller says, \"You don't seem to have that much in your account.\"")
+      expect(described_class.withdraw(8000, note: true)).to be_nil
+    end
+
+    it 'warns about a debt notice and waits for the real answer' do
+      replies("The teller says, \"I have a bill of 1,500 silvers presented by your creditors that I suggest you pay.\"")
+      allow(described_class).to receive(:matchtimeout).with(3, anything)
+                                                      .and_return('The teller carefully records the transaction, and then hands you 6,500 silver.')
+      expect(Lich::Messaging).to receive(:msg).with('warn', /debt of 1,500 silver/)
+      expect(described_class.withdraw(8000)).to eq(6500)
+    end
+
+    it 'is nil when nothing follows the debt notice' do
+      replies("The teller says, \"I have a bill of 1,500 silvers presented by your creditors that I suggest you pay.\"")
+      allow(described_class).to receive(:matchtimeout).and_return(false)
+      allow(Lich::Messaging).to receive(:msg)
+      expect(described_class.withdraw(8000)).to be_nil
+      expect(described_class.withdraw(8000, note: true)).to be_nil
     end
 
     it 'asks the banker at Pinefar' do

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -11,7 +11,18 @@ RSpec.describe Lich::Gemstone::Bank do
   let(:note) { MockGameObj.new(id: '500', noun: 'note', name: 'bank note') }
   let(:sack) { MockGameObj.new(id: '105', noun: 'sack', name: 'leather sack') }
   let(:hands) { { right: nil, left: nil } }
-  let(:room) { double('Room', tags: ['bank']) }
+  let(:room) { double('Room', tags: ['bank'], location: 'Icemule Trace') }
+  let(:listing) do
+    ['You currently have the following amounts on deposit:',
+     '',
+     '             Icemule Trace Bank: 52,138',
+     '                Four Winds Bank: 616,853,785',
+     '                          Total: 616,905,923',
+     '',
+     'You currently have 0 inter-town bank transfer options available.',
+     '',
+     'You currently have 10 urchin bank runner uses remaining.']
+  end
   let(:sent) { [] }
 
   # A scripted game: each dothistimeout call returns the next reply in order.
@@ -73,17 +84,34 @@ RSpec.describe Lich::Gemstone::Bank do
   end
 
   describe '.account' do
-    it 'parses balance and cap' do
+    it 'parses the per-town listing and picks the local bank' do
+      allow(Lich::Util).to receive(:issue_command).and_return(listing)
+      info = described_class.account
+      expect(info[:banks]).to eq('Icemule Trace' => 52_138, 'Four Winds' => 616_853_785)
+      expect(info[:total]).to eq(616_905_923)
+      expect(info[:balance]).to eq(52_138)
+      expect(info[:max]).to be_nil
+      expect(described_class.balance).to eq(52_138)
+    end
+
+    it 'matches the bank by location prefix' do
+      allow(room).to receive(:location).and_return('Four Winds Isle')
+      allow(Lich::Util).to receive(:issue_command).and_return(listing)
+      expect(described_class.balance).to eq(616_853_785)
+    end
+
+    it 'is 0 with no account in this town' do
+      allow(room).to receive(:location).and_return("Wehnimer's Landing")
+      allow(Lich::Util).to receive(:issue_command).and_return(listing)
+      expect(described_class.balance).to eq(0)
+    end
+
+    it 'parses the single-account wording with a cap' do
       allow(Lich::Util).to receive(:issue_command).and_return(
         ['You currently have an account in the amount of 45,000 silver.',
          'Your account may hold a maximum of 100,000 silvers.']
       )
-      expect(described_class.account).to eq(balance: 45_000, max: 100_000)
-    end
-
-    it 'has no cap for a normal account' do
-      allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 45,000 silver.'])
-      expect(described_class.account).to eq(balance: 45_000, max: nil)
+      expect(described_class.account).to include(balance: 45_000, max: 100_000)
     end
 
     it 'is nil without access' do

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -118,6 +118,12 @@ RSpec.describe Lich::Gemstone::Bank do
       expect(described_class.balance).to eq(0)
     end
 
+    it 'is 0, not a match on "false", for an unsurveyed room' do
+      allow(room).to receive(:location).and_return(false)
+      allow(Lich::Util).to receive(:issue_command).and_return(listing)
+      expect(described_class.balance).to eq(0)
+    end
+
     it 'parses the single-account wording with a cap' do
       allow(Lich::Util).to receive(:issue_command).and_return(
         ['You currently have an account in the amount of 45,000 silver.',

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -347,6 +347,21 @@ RSpec.describe Lich::Gemstone::Bank do
         expect(described_class.withdraw(8000)).to eq(8000)
         expect(sent).to eq(['withdraw 3000 silver', 'deposit #500', 'withdraw 5000 silver'])
       end
+
+      it 'still drains the balance when the stow container holds no notes' do
+        allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 2,000 silver.'])
+        allow(sack).to receive(:contents).and_return([])
+        replies('The teller hands you 2,000 silver.')
+        expect(described_class.withdraw(8000)).to eq(2000)
+        expect(sent).to eq(['withdraw 2000 silver'])
+      end
+
+      it 'is nil with no balance and no notes, rather than reporting 0' do
+        allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 0 silver.'])
+        allow(sack).to receive(:contents).and_return([])
+        expect(described_class.withdraw(8000)).to be_nil
+        expect(sent).to be_empty
+      end
     end
   end
 

--- a/spec/lib/gemstone/bank_spec.rb
+++ b/spec/lib/gemstone/bank_spec.rb
@@ -193,6 +193,32 @@ RSpec.describe Lich::Gemstone::Bank do
         expect(sent).to eq(['deposit 5000', 'withdraw 100000 note', 'deposit 15000'])
       end
 
+      it 'never deposits more than the requested amount across passes' do
+        balances = [
+          ['You currently have an account in the amount of 95,000 silver.', 'Your account may hold a maximum of 100,000 silvers.'],
+          ['You currently have an account in the amount of 0 silver.', 'Your account may hold a maximum of 100,000 silvers.'],
+        ]
+        allow(Lich::Util).to receive(:issue_command) { balances.shift }
+        carried = [20_000, 15_000, 15_000]
+        allow(Lich::Gemstone::Currency).to receive(:silver) { carried.shift }
+        replies('You deposit 5,000 silvers into your account.',
+                'The teller carefully records the transaction, and then hands you a note.',
+                'You deposit 5,000 silvers into your account.',
+                before: ->(cmd) { hands[:right] = note if cmd =~ /note/ })
+        expect(described_class.deposit(10_000)).to eq(10_000)
+        expect(sent).to eq(['deposit 5000', 'withdraw 100000 note', 'deposit 5000'])
+      end
+
+      it 'counts only what the bank confirmed' do
+        allow(Lich::Util).to receive(:issue_command).and_return(
+          ['You currently have an account in the amount of 10,000 silver.',
+           'Your account may hold a maximum of 100,000 silvers.']
+        )
+        Lich::Gemstone::Currency.silver = 5_000
+        replies(nil)
+        expect(described_class.deposit).to be_nil
+      end
+
       it 'is nil without access' do
         allow(Lich::Util).to receive(:issue_command).and_return(["you don't have access to an account here."])
         expect(described_class.deposit).to be_nil
@@ -257,6 +283,19 @@ RSpec.describe Lich::Gemstone::Bank do
         replies('The teller carefully records the transaction, and then hands you 8,000 silver.')
         expect(described_class.withdraw(8000)).to eq(8000)
         expect(sent).to eq(['withdraw 8000 silver'])
+      end
+
+      it 'is nil when the teller refuses' do
+        allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 9,000 silver.'])
+        replies("The teller says, \"You don't seem to have that much in your account.\"")
+        expect(described_class.withdraw(8000)).to be_nil
+      end
+
+      it 'reports only what was actually handed over when a later step fails' do
+        allow(Lich::Util).to receive(:issue_command).and_return(['You currently have an account in the amount of 3,000 silver.'])
+        allow(sack).to receive(:contents).and_return([note])
+        replies('The teller hands you 3,000 silver.', nil)
+        expect(described_class.withdraw(8000)).to eq(3000)
       end
 
       it 'drains the balance, deposits a stowed note, and withdraws the rest' do

--- a/spec/lib/gemstone/currency_spec.rb
+++ b/spec/lib/gemstone/currency_spec.rb
@@ -22,12 +22,27 @@ RSpec.describe Lich::Gemstone::Currency do
     expect(described_class.silver).to eq(1500)
   end
 
-  it 'sends WEALTH QUIET quietly when asked to refresh' do
-    expect(Lich::Util).to receive(:issue_command).with('wealth quiet', Lich::Gemstone::Infomon::Parser::Pattern::WealthSilver, silent: true, quiet: true) do
+  it 'sends WEALTH quietly when asked to refresh' do
+    expect(Lich::Util).to receive(:issue_command).with('wealth', Lich::Gemstone::Infomon::Parser::Pattern::WealthSilver, silent: true, quiet: true) do
       Lich::Gemstone::Infomon.silver = 2000
       ['You have 2,000 silver with you.']
     end
     expect(described_class.silver(refresh: true)).to eq(2000)
+  end
+
+  it 'sends WEALTH ALL for the alternative currencies' do
+    expect(Lich::Util).to receive(:issue_command).with('wealth all', anything, silent: true, quiet: true)
+    described_class.refresh(all: true)
+  end
+
+  it 'reads the total and note figures, refreshing on request' do
+    stub_const('Lich::Gemstone::Infomon', Module.new do
+      def self.get(key) = { 'currency.silver_total' => 15_571, 'currency.notes' => 100_000 }[key]
+    end)
+    expect(described_class.silver_total).to eq(15_571)
+    expect(described_class.notes).to eq(100_000)
+    expect(Lich::Util).to receive(:issue_command).with('wealth notes', anything, anything, silent: true, quiet: true)
+    expect(described_class.notes(refresh: true)).to eq(100_000)
   end
 
   it 'refresh returns the re-read value' do

--- a/spec/lib/gemstone/currency_spec.rb
+++ b/spec/lib/gemstone/currency_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require 'gemstone/currency'
+
+RSpec.describe Lich::Gemstone::Currency do
+  before do
+    stub_const('Lich::Gemstone::Infomon', Module.new do
+      def self.get(_key) = @silver
+
+      def self.silver=(v)
+        @silver = v
+      end
+    end)
+    stub_const('Lich::Gemstone::Infomon::Parser::Pattern::WealthSilver', /^You have (?<silver>no|[,\d]+|but one) silver with you\./)
+    Lich::Gemstone::Infomon.silver = 1500
+    allow(Lich::Util).to receive(:issue_command).and_return([])
+  end
+
+  it 'reads Infomon without sending anything by default' do
+    expect(Lich::Util).not_to receive(:issue_command)
+    expect(described_class.silver).to eq(1500)
+  end
+
+  it 'sends WEALTH QUIET quietly when asked to refresh' do
+    expect(Lich::Util).to receive(:issue_command).with('wealth quiet', Lich::Gemstone::Infomon::Parser::Pattern::WealthSilver, silent: true, quiet: true) do
+      Lich::Gemstone::Infomon.silver = 2000
+      ['You have 2,000 silver with you.']
+    end
+    expect(described_class.silver(refresh: true)).to eq(2000)
+  end
+
+  it 'refresh returns the re-read value' do
+    expect(Lich::Util).to receive(:issue_command) { Lich::Gemstone::Infomon.silver = 7 }
+    expect(described_class.refresh).to eq(7)
+  end
+end

--- a/spec/lib/gemstone/infomon_spec.rb
+++ b/spec/lib/gemstone/infomon_spec.rb
@@ -272,6 +272,7 @@ RSpec.describe Lich::Gemstone::Infomon::Parser, ".parse" do
       output = <<~WEALTH
         You have 5,585 silver with you.
         You are carrying 6,112 silver stored within your coin pouch.
+        You are carrying a total of 11,697 silver.
 
         You are carrying 16 gigas artifact fragments.
       WEALTH
@@ -283,6 +284,20 @@ RSpec.describe Lich::Gemstone::Infomon::Parser, ".parse" do
       expect(Lich::Gemstone::Currency.silver).to eq(5585)
       expect(Lich::Gemstone::Currency.silver_container).to eq(6112)
       expect(Lich::Gemstone::Currency.gigas_artifact_fragments).to eq(16)
+      expect(Lich::Gemstone::Currency.silver_total).to eq(11697)
+    end
+
+    it "handles wealth notes" do
+      output = <<~NOTES
+        Listing accessible bank notes in your inventory...
+
+        Total note value: 100,000
+      NOTES
+      output.split("
+").map { |line| Lich::Gemstone::Infomon::Parser.parse(line) }
+
+      expect(Lich::Gemstone::Infomon.get("currency.notes")).to eq(100000)
+      expect(Lich::Gemstone::Currency.notes).to eq(100000)
     end
 
     it "handles ticket balance info" do


### PR DESCRIPTION
## Summary

Moves the bank handling that eloot, eherbs and ebounty each duplicate into core, and gives Currency a way to refresh on demand.

**`Lich::Gemstone::Bank`** (new, `lib/gemstone/bank.rb`)
- `here?`, `pinefar?`, `f2p?`
- `account` parses the per-town BANK ACCOUNT listing into `{ balance:, max:, banks:, total: }`, with `balance` being this town's bank matched by room location; nil where the bank refuses access.
- `deposit(amount = :all)`, `deposit_note`, `withdraw(amount, note: false)`, `note_value`, `note_in_hand`, `notes_in(container)`.
- Pinefar depository wording (give/ask banker, `wait_for_banker`) and the free-to-play cap path (`deposit_f2p` fills to the cap and takes notes; `withdraw_f2p` deposits stowed notes to cover a shortfall).
- All replies are sent through `dothistimeout` against one `Pattern` set, so a reworded game line is a one-place fix.

**`Lich::Gemstone::Currency`**
- `silver(refresh: false)`, `refresh(all: false)` sending plain `wealth` (QUIET is now the default; LOUD is the option) or `wealth all`.
- `silver_total(refresh:)`, `notes(refresh:)`, `refresh_notes` sending `wealth notes`.

**Infomon parser**
- `WealthSilverTotal` ("You are carrying a total of N silver.") to `currency.silver_total`
- `WealthNotes` ("Total note value: N") to `currency.notes`

Both are anchored patterns in the fast-path list. Requests go through `Lich::Util.issue_command` quietly; Infomon parses before downstream hooks, so hiding the response from the front end does not hide it from Infomon.

## Test plan

- [x] `spec/lib/gemstone/bank_spec.rb`, 30 examples
- [x] `spec/lib/gemstone/currency_spec.rb`, 6 examples
- [x] `spec/lib/gemstone/infomon_spec.rb` extended for the two new lines
- [x] rubocop clean on touched files
- [x] In game: `Currency.refresh`, `silver_total`, `notes`, `Bank.account`, deposit, withdraw, note withdraw/read/deposit. Pinefar and F2P paths are spec-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
