### PR TITLE
fix(gs): Injured cache lives on the class and keys on an injury fingerprint

### DIFF
--- a/lib/gemstone/injured.rb
+++ b/lib/gemstone/injured.rb
@@ -4,25 +4,38 @@ module Lich
   module Gemstone
     # Injured class for checking ability to perform actions based on wounds and scars
     class Injured < Gemstone::CharacterStatus
-      class << self
-        BODY_PART_GROUPS = {
-          eyes: %i[leftEye rightEye],
-          arms: %i[leftArm rightArm],
-          hands: %i[leftHand rightHand],
-          legs: %i[leftLeg rightLeg],
-          feet: %i[leftFoot rightFoot],
-          head_and_nerves: %i[head nsys]
-        }.freeze
+      BODY_PART_GROUPS = {
+        eyes: %i[leftEye rightEye],
+        arms: %i[leftArm rightArm],
+        hands: %i[leftHand rightHand],
+        legs: %i[leftLeg rightLeg],
+        feet: %i[leftFoot rightFoot],
+        head_and_nerves: %i[head nsys]
+      }.freeze
 
-        # Cache variables
-        @injury_cache_key = nil
-        @wounds_cache = nil
-        @scars_cache = nil
-        @cache_mutex = Mutex.new
+      # Cache variables. These must live on Injured itself (the class body),
+      # not inside `class << self`, where they would land on the singleton
+      # class and the methods below would read nil.
+      @injury_cache_key = nil
+      @wounds_cache = nil
+      @scars_cache = nil
+      @cache_mutex = Mutex.new
+
+      class << self
+        # Build an immutable fingerprint of the current injury state.
+        # XMLData.injuries is mutated in place by the parser, so the hash itself
+        # cannot serve as a cache key: it would always compare equal to itself.
+        # Note: this runs in injury mode 2 ('both'), where a scar underneath an
+        # active wound is not visible, so such a scar changing will not invalidate
+        # the cache. That is a narrow case and acceptable given each cache miss
+        # costs two _injury round trips in Scars.all_scars.
+        def injury_fingerprint
+          XMLData.injuries.map { |part, v| [part, v['wound'], v['scar']] }.freeze
+        end
 
         # Get cached or fresh injury data
         def get_injury_data
-          current_key = XMLData.injuries
+          current_key = injury_fingerprint
 
           # Fast path: return cached data if key hasn't changed
           if @injury_cache_key == current_key && @wounds_cache && @scars_cache
@@ -77,6 +90,11 @@ module Lich
         def bypasses_injuries?
           Effects::Buffs.active?("Sigil of Determination")
         end
+
+        # NOTE: every able_to_*? predicate calls fix_injury_mode('both') and, on a
+        # cache miss, Scars.all_scars toggles the injury mode. Each of those can
+        # send an _injury command and block for up to 7.5 seconds waiting on the
+        # game. These are not instantaneous checks; avoid calling them in tight loops.
 
         # Check if character is able to cast spells
         def able_to_cast?

--- a/lib/gemstone/injured.rb
+++ b/lib/gemstone/injured.rb
@@ -92,9 +92,11 @@ module Lich
         end
 
         # NOTE: every able_to_*? predicate calls fix_injury_mode('both') and, on a
-        # cache miss, Scars.all_scars toggles the injury mode. Each of those can
-        # send an _injury command and block for up to 7.5 seconds waiting on the
-        # game. These are not instantaneous checks; avoid calling them in tight loops.
+        # cache miss, Scars.all_scars toggles the injury mode to 'scar' and back.
+        # Each of those sends an _injury command and waits up to 7.5 seconds for the
+        # game to answer, so one cache miss can block for roughly 15 seconds if the
+        # round trips time out. These are not instantaneous checks; avoid calling
+        # them in tight loops.
 
         # Check if character is able to cast spells
         def able_to_cast?

--- a/spec/lib/gemstone/injured_spec.rb
+++ b/spec/lib/gemstone/injured_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+require "ox"
+require "common/class_exts/synchronizedsocket"
+require "common/detachable_client_registry"
+require "common/sharedbuffer"
+require "common/shutdown_coordinator"
+require "common/xmlparser"
+require "common/downstreamhook"
+require "common/front-end"
+require "util/util"
+require "games"
+require "gemstone/wounds"
+require "gemstone/scars"
+require "gemstone/effects"
+require "gemstone/injured"
+
+RSpec.describe Lich::Gemstone::Injured do
+  include_context 'Gemstone injury data'
+
+  before do
+    XMLData.reset
+    set_injuries
+
+    # Never talk to the game from a spec: these would send _injury commands.
+    allow(described_class).to receive(:fix_injury_mode)
+    allow(Lich::Gemstone::Wounds).to receive(:fix_injury_mode)
+    allow(Lich::Gemstone::Scars).to receive(:fix_injury_mode)
+    allow(Lich::Gemstone::Effects::Buffs).to receive(:active?).and_return(false)
+
+    # Clear the cache between examples so tests are independent.
+    described_class.instance_variable_set(:@injury_cache_key, nil)
+    described_class.instance_variable_set(:@wounds_cache, nil)
+    described_class.instance_variable_set(:@scars_cache, nil)
+  end
+
+  it 'keeps its cache state and mutex on the class itself, not the singleton class' do
+    expect(described_class.instance_variable_get(:@cache_mutex)).to be_a(Mutex)
+    expect { described_class.able_to_cast? }.not_to raise_error
+  end
+
+  it 'returns true for a healthy character' do
+    expect(described_class.able_to_cast?).to be true
+    expect(described_class.able_to_sneak?).to be true
+    expect(described_class.able_to_search?).to be true
+    expect(described_class.able_to_use_ranged?).to be true
+  end
+
+  it 'notices an in-place injury update after a cached result' do
+    expect(described_class.able_to_cast?).to be true
+
+    # Mutate the live hash the way XMLParser does, without reassigning it.
+    XMLData.injuries['head']['wound'] = 3
+
+    expect(described_class.able_to_cast?).to be false
+    expect(described_class.able_to_search?).to be false
+  end
+
+  it 'notices healing after a cached rejection' do
+    XMLData.injuries['leftLeg']['wound'] = 2
+    expect(described_class.able_to_sneak?).to be false
+
+    XMLData.injuries['leftLeg']['wound'] = 0
+    expect(described_class.able_to_sneak?).to be true
+  end
+
+  it 'serves repeated calls from the cache when nothing changed' do
+    expect(Lich::Gemstone::Scars).to receive(:all_scars).once.and_call_original
+
+    3.times { described_class.able_to_cast? }
+  end
+
+  it 'refetches when the injury state changes' do
+    expect(Lich::Gemstone::Scars).to receive(:all_scars).twice.and_call_original
+
+    described_class.able_to_cast?
+    XMLData.injuries['rightArm']['wound'] = 1
+    described_class.able_to_cast?
+  end
+
+  it 'ignores rank 1 scars but not rank 2 scars' do
+    XMLData.injuries['head']['scar'] = 1
+    expect(described_class.able_to_cast?).to be true
+
+    XMLData.injuries['head']['scar'] = 2
+    expect(described_class.able_to_cast?).to be false
+  end
+
+  it 'lets Sigil of Determination bypass rank 2 but not rank 3' do
+    allow(Lich::Gemstone::Effects::Buffs).to receive(:active?).with("Sigil of Determination").and_return(true)
+
+    XMLData.injuries['head']['wound'] = 2
+    expect(described_class.able_to_cast?).to be true
+
+    XMLData.injuries['head']['wound'] = 3
+    expect(described_class.able_to_cast?).to be false
+  end
+end


### PR DESCRIPTION
## Summary

Two bugs made every `Injured.able_to_*?` predicate unusable:

- **First call raised `NoMethodError`.** The cache ivars and `@cache_mutex` were assigned inside `class << self`, so they landed on the singleton class. The methods read them on `Injured` itself, where the mutex was `nil`, so `get_injury_data` blew up on `nil.synchronize`.
- **Cache never invalidated.** The cache key was the live `XMLData.injuries` hash, which `XMLParser` mutates in place. The stored key and the current key were always the same object, so after the first fill a healthy character kept returning `true` for casting after taking a rank 3 head wound, and a cached rejection survived healing.

## Fix

- Move the constant, cache ivars, and mutex into the class body so they live on `Injured`.
- Key the cache on a frozen `[part, wound, scar]` fingerprint built from `XMLData.injuries`, so in-place parser updates invalidate it.
- Keep the cache rather than removing it: each miss calls `Scars.all_scars`, which toggles the injury mode and costs two `_injury` round trips.
- Document that the predicates call `fix_injury_mode` and can block waiting on the game. They are not instantaneous checks.

Known blind spot, noted in a comment: the fingerprint is built in injury mode 2, where a scar underneath an active wound is not visible, so such a scar changing will not trigger a refetch.

## Test plan

- [x] New `spec/lib/gemstone/injured_spec.rb`: mutex location, in-place injury update flips a cached `true`, healing flips a cached `false`, cache hit vs refetch counted via `all_scars`, rank 1 scar ignored / rank 2 not, Sigil of Determination bypasses rank 2 but not rank 3. All `fix_injury_mode` calls are stubbed so no `_injury` commands are sent.
- [x] `bundle exec rspec spec/lib/gemstone/injured_spec.rb spec/lib/games_spec.rb`: 170 examples, 0 failures
- [x] `bundle exec rubocop` on both files: no offenses
- [ ] In-game: call `Injured.able_to_cast?` before and after taking a head wound and confirm it flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
