### PR TITLE
feat(gs): PSM command and results_regex readers, factored out of use

### DIFF
--- a/lib/gemstone/psms.rb
+++ b/lib/gemstone/psms.rb
@@ -218,6 +218,50 @@ module Lich
         /^You can't reach .+!$/,
         / attempting to .+ would be a rather awkward proposition\.$/,
       )
+
+      # The command a technique is sent with, as each category's +use+ sends
+      # it: the verb, the technique's usage word, an optional target, and
+      # FORCERT. Exposed so a script that sends and confirms on its own
+      # terms (an engine with its own roundtime and timeout discipline)
+      # still gets the exact command +use+ would send.
+      #
+      # @param verb [String, nil] "cman", "shield", ... or nil for a bare command (FEAT GUARD)
+      # @param usage [String] the technique's usage word
+      # @param target [String, Integer, GameObj] a GameObj or id is sent as #id; a String as given
+      # @param forcert_count [Integer] more than 0 appends FORCERT
+      # @return [String]
+      #
+      # @example
+      #   PSMS.command("cman", "bullrush", GameObj.targets.first)  # => "cman bullrush #12345"
+      def self.command(verb, usage, target = "", forcert_count: 0)
+        cmd = verb.nil? || verb.to_s.empty? ? usage.to_s : "#{verb} #{usage}"
+        if target.is_a?(GameObj)
+          cmd += " ##{target.id}"
+        elsif target.is_a?(Integer)
+          cmd += " ##{target}"
+        elsif target.to_s != ""
+          cmd += " #{target}"
+        end
+        cmd += " forcert" if forcert_count > 0
+        cmd
+      end
+
+      # Every line that answers a technique command: the shared failures, the
+      # "X what?" and cooldown refusals for this technique, its own result
+      # messaging, and any extra patterns. This is the regex each category's
+      # +use+ waits on, so a caller confirming the command itself matches the
+      # same lines +use+ would.
+      #
+      # @param name [String] the technique name as the caller gave it
+      # @param patterns [Array<Regexp, nil>] the technique's result regex and friends; nils are skipped
+      # @param results_of_interest [Regexp, nil] extra lines the caller wants to see
+      # @return [Regexp]
+      def self.results_regex(name, *patterns, results_of_interest: nil)
+        parts = [FAILURES_REGEXES, /^#{name} what\?$/i, /^#{name} is still in cooldown\./i]
+        parts.concat(patterns.compact)
+        parts << results_of_interest if results_of_interest.is_a?(Regexp)
+        Regexp.union(*parts)
+      end
     end
   end
 end

--- a/lib/gemstone/psms/armor.rb
+++ b/lib/gemstone/psms/armor.rb
@@ -210,36 +210,13 @@ module Lich
       def Armor.use(name, target = "", results_of_interest: nil, forcert_count: 0)
         return unless Armor.available?(name, forcert_count: forcert_count)
 
-        name_normalized = PSMS.name_normal(name)
-        technique = @@armor_techniques.fetch(PSMS.find_name(name_normalized, "Armor")[:long_name])
-        usage = technique[:usage]
-        return if usage.nil?
+        usage_cmd = Armor.command(name, target, forcert_count: forcert_count)
+        return if usage_cmd.nil?
 
-        in_cooldown_regex = /^#{name} is still in cooldown\./i
+        results_regex = Armor.results_regex(name, results_of_interest: results_of_interest)
 
-        results_regex = Regexp.union(
-          PSMS::FAILURES_REGEXES,
-          /^#{name} what\?$/i,
-          in_cooldown_regex,
-          technique[:regex],
-          /^Roundtime: [0-9]+ sec\.$/,
-          /^\w+ [a-z]+ not wearing any armor that you can work with\.$/
-        )
-
-        results_regex = Regexp.union(results_regex, results_of_interest) if results_of_interest.is_a?(Regexp)
-
-        usage_cmd = "armor #{usage}"
-        if target.is_a?(GameObj)
-          usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
-          usage_cmd += " ##{target}"
-        elsif target != ""
-          usage_cmd += " #{target}"
-        end
-
-        if forcert_count > 0
-          usage_cmd += " forcert"
-        else # if we're using forcert, we don't want to wait for rt, but we need to otherwise
+        # with forcert we don't want to wait for rt, but we need to otherwise
+        unless forcert_count > 0
           waitrt?
           waitcastrt?
         end
@@ -250,6 +227,31 @@ module Lich
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
         usage_result
+      end
+
+      # The command {Armor.use} sends for a technique, without sending it.
+      #
+      # @param name [String] The name of the armor technique
+      # @param target [String, Integer, GameObj] The target (optional)
+      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
+      # @return [String, nil] e.g. "armor blessing", nil when the technique has no usage
+      def Armor.command(name, target = "", forcert_count: 0)
+        technique = @@armor_techniques.fetch(PSMS.find_name(PSMS.name_normal(name), "Armor")[:long_name])
+        return nil if technique[:usage].nil?
+
+        PSMS.command("armor", technique[:usage], target, forcert_count: forcert_count)
+      end
+
+      # Every line that answers the technique's command: the regex {Armor.use} waits on.
+      #
+      # @param name [String] The name of the armor technique
+      # @param results_of_interest [Regexp, nil] Additional lines to match (optional)
+      # @return [Regexp]
+      def Armor.results_regex(name, results_of_interest: nil)
+        technique = @@armor_techniques.fetch(PSMS.find_name(PSMS.name_normal(name), "Armor")[:long_name])
+        PSMS.results_regex(name, technique[:regex], /^Roundtime: [0-9]+ sec\.$/,
+                           /^\w+ [a-z]+ not wearing any armor that you can work with\.$/,
+                           results_of_interest: results_of_interest)
       end
 
       # Returns the "success" regex associated with a given armor technique name.

--- a/lib/gemstone/psms/cman.rb
+++ b/lib/gemstone/psms/cman.rb
@@ -771,35 +771,13 @@ module Lich
       def CMan.use(name, target = "", ignore_cooldown: false, results_of_interest: nil, forcert_count: 0)
         return unless CMan.available?(name, ignore_cooldown: ignore_cooldown, forcert_count: forcert_count)
 
-        name_normalized = PSMS.name_normal(name)
-        technique = @@combat_mans.fetch(PSMS.find_name(name_normalized, "CMan")[:long_name])
-        usage = technique[:usage]
-        return if usage.nil?
+        usage_cmd = CMan.command(name, target, forcert_count: forcert_count)
+        return if usage_cmd.nil?
 
-        in_cooldown_regex = /^#{name} is still in cooldown\./i
+        results_regex = CMan.results_regex(name, results_of_interest: results_of_interest)
 
-        results_regex = Regexp.union(
-          PSMS::FAILURES_REGEXES,
-          /^#{name} what\?$/i,
-          in_cooldown_regex,
-          technique[:regex],
-          /^Roundtime: [0-9]+ sec\.$/,
-        )
-
-        results_regex = Regexp.union(results_regex, results_of_interest) if results_of_interest.is_a?(Regexp)
-
-        usage_cmd = "cman #{usage}"
-        if target.is_a?(GameObj)
-          usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
-          usage_cmd += " ##{target}"
-        elsif target != ""
-          usage_cmd += " #{target}"
-        end
-
-        if forcert_count > 0
-          usage_cmd += " forcert"
-        else # if we're using forcert, we don't want to wait for rt, but we need to otherwise
+        # with forcert we don't want to wait for rt, but we need to otherwise
+        unless forcert_count > 0
           waitrt?
           waitcastrt?
         end
@@ -811,6 +789,31 @@ module Lich
         end
 
         usage_result
+      end
+
+      # The command {CMan.use} sends for a maneuver, without sending it.
+      #
+      # @param name [String] The name of the combat maneuver
+      # @param target [String, Integer, GameObj] The target (optional)
+      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
+      # @return [String, nil] e.g. "cman bullrush #12345", nil when the maneuver has no usage
+      # @example
+      #   CMan.command("bullrush", GameObj.targets.first) => "cman bullrush #12345"
+      def CMan.command(name, target = "", forcert_count: 0)
+        technique = @@combat_mans.fetch(PSMS.find_name(PSMS.name_normal(name), "CMan")[:long_name])
+        return nil if technique[:usage].nil?
+
+        PSMS.command("cman", technique[:usage], target, forcert_count: forcert_count)
+      end
+
+      # Every line that answers the maneuver's command: the regex {CMan.use} waits on.
+      #
+      # @param name [String] The name of the combat maneuver
+      # @param results_of_interest [Regexp, nil] Additional lines to match (optional)
+      # @return [Regexp]
+      def CMan.results_regex(name, results_of_interest: nil)
+        technique = @@combat_mans.fetch(PSMS.find_name(PSMS.name_normal(name), "CMan")[:long_name])
+        PSMS.results_regex(name, technique[:regex], /^Roundtime: [0-9]+ sec\.$/, results_of_interest: results_of_interest)
       end
 
       # Returns the "success" regex associated with a given combat maneuver name.

--- a/lib/gemstone/psms/feat.rb
+++ b/lib/gemstone/psms/feat.rb
@@ -364,35 +364,13 @@ module Lich
       def Feat.use(name, target = "", results_of_interest: nil, forcert_count: 0)
         return unless Feat.available?(name, forcert_count: forcert_count)
 
-        name_normalized = PSMS.name_normal(name)
-        technique = @@feats.fetch(PSMS.find_name(name_normalized, "Feat")[:long_name])
-        usage = technique[:usage]
-        return if usage.nil?
+        usage_cmd = Feat.command(name, target, forcert_count: forcert_count)
+        return if usage_cmd.nil?
 
-        in_cooldown_regex = /^#{name} is still in cooldown\./i
+        results_regex = Feat.results_regex(name, results_of_interest: results_of_interest)
 
-        results_regex = Regexp.union(
-          PSMS::FAILURES_REGEXES,
-          /^#{name} what\?$/i,
-          in_cooldown_regex,
-          technique[:regex],
-          /^Roundtime: [0-9]+ sec\.$/,
-        )
-
-        results_regex = Regexp.union(results_regex, results_of_interest) if results_of_interest.is_a?(Regexp)
-
-        usage_cmd = (['guard', 'protect'].include?(usage) ? "#{usage}" : "feat #{usage}")
-        if target.is_a?(GameObj)
-          usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
-          usage_cmd += " ##{target}"
-        elsif target != ""
-          usage_cmd += " #{target}"
-        end
-
-        if forcert_count > 0
-          usage_cmd += " forcert"
-        else # if we're using forcert, we don't want to wait for rt, but we need to otherwise
+        # with forcert we don't want to wait for rt, but we need to otherwise
+        unless forcert_count > 0
           waitrt?
           waitcastrt?
         end
@@ -403,6 +381,33 @@ module Lich
           usage_result = dothistimeout usage_cmd, 5, results_regex
         end
         usage_result
+      end
+
+      # Feats sent as their own verb rather than FEAT <usage>.
+      BARE_COMMANDS = ['guard', 'protect'].freeze
+
+      # The command {Feat.use} sends for a feat, without sending it.
+      #
+      # @param name [String] The name of the Feat
+      # @param target [String, Integer, GameObj] The target (optional)
+      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
+      # @return [String, nil] e.g. "feat dispel #12345" or "guard Dissonance", nil when the feat has no usage
+      def Feat.command(name, target = "", forcert_count: 0)
+        technique = @@feats.fetch(PSMS.find_name(PSMS.name_normal(name), "Feat")[:long_name])
+        usage = technique[:usage]
+        return nil if usage.nil?
+
+        PSMS.command(BARE_COMMANDS.include?(usage) ? nil : "feat", usage, target, forcert_count: forcert_count)
+      end
+
+      # Every line that answers the feat's command: the regex {Feat.use} waits on.
+      #
+      # @param name [String] The name of the Feat
+      # @param results_of_interest [Regexp, nil] Additional lines to match (optional)
+      # @return [Regexp]
+      def Feat.results_regex(name, results_of_interest: nil)
+        technique = @@feats.fetch(PSMS.find_name(PSMS.name_normal(name), "Feat")[:long_name])
+        PSMS.results_regex(name, technique[:regex], /^Roundtime: [0-9]+ sec\.$/, results_of_interest: results_of_interest)
       end
 
       # Returns the "success" regex associated with a given Feat technique name.

--- a/lib/gemstone/psms/shield.rb
+++ b/lib/gemstone/psms/shield.rb
@@ -350,35 +350,13 @@ module Lich
       def Shield.use(name, target = "", results_of_interest: nil, forcert_count: 0)
         return unless Shield.available?(name, forcert_count: forcert_count)
 
-        name_normalized = PSMS.name_normal(name)
-        technique = @@shield_techniques.fetch(PSMS.find_name(name_normalized, "Shield")[:long_name])
-        usage = technique[:usage]
-        return if usage.nil?
+        usage_cmd = Shield.command(name, target, forcert_count: forcert_count)
+        return if usage_cmd.nil?
 
-        in_cooldown_regex = /^#{name} is still in cooldown\./i
+        results_regex = Shield.results_regex(name, results_of_interest: results_of_interest)
 
-        results_regex = Regexp.union(
-          PSMS::FAILURES_REGEXES,
-          /^#{name} what\?$/i,
-          in_cooldown_regex,
-          technique[:regex],
-          /^Roundtime: [0-9]+ sec\.$/,
-        )
-
-        results_regex = Regexp.union(results_regex, results_of_interest) if results_of_interest.is_a?(Regexp)
-
-        usage_cmd = "shield #{usage}"
-        if target.is_a?(GameObj)
-          usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
-          usage_cmd += " ##{target}"
-        elsif target != ""
-          usage_cmd += " #{target}"
-        end
-
-        if forcert_count > 0
-          usage_cmd += " forcert"
-        else # if we're using forcert, we don't want to wait for rt, but we need to otherwise
+        # with forcert we don't want to wait for rt, but we need to otherwise
+        unless forcert_count > 0
           waitrt?
           waitcastrt?
         end
@@ -390,6 +368,29 @@ module Lich
         end
 
         usage_result
+      end
+
+      # The command {Shield.use} sends for a technique, without sending it.
+      #
+      # @param name [String] The name of the Shield technique
+      # @param target [String, Integer, GameObj] The target (optional)
+      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
+      # @return [String, nil] e.g. "shield bash #12345", nil when the technique has no usage
+      def Shield.command(name, target = "", forcert_count: 0)
+        technique = @@shield_techniques.fetch(PSMS.find_name(PSMS.name_normal(name), "Shield")[:long_name])
+        return nil if technique[:usage].nil?
+
+        PSMS.command("shield", technique[:usage], target, forcert_count: forcert_count)
+      end
+
+      # Every line that answers the technique's command: the regex {Shield.use} waits on.
+      #
+      # @param name [String] The name of the Shield technique
+      # @param results_of_interest [Regexp, nil] Additional lines to match (optional)
+      # @return [Regexp]
+      def Shield.results_regex(name, results_of_interest: nil)
+        technique = @@shield_techniques.fetch(PSMS.find_name(PSMS.name_normal(name), "Shield")[:long_name])
+        PSMS.results_regex(name, technique[:regex], /^Roundtime: [0-9]+ sec\.$/, results_of_interest: results_of_interest)
       end
 
       # Returns the "success" regex associated with a given Shield technique name.

--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -179,35 +179,13 @@ module Lich
         return unless Warcry.available?(name, forcert_count: forcert_count)
         return if Warcry.buff_active?(name)
 
-        name_normalized = PSMS.name_normal(name)
-        technique = @@warcries.fetch(PSMS.find_name(name_normalized, "Warcry")[:long_name])
-        usage = name_normalized
-        return if usage.nil?
+        usage_cmd = Warcry.command(name, target, forcert_count: forcert_count)
+        return if usage_cmd.nil?
 
-        in_cooldown_regex = /^#{name} is still in cooldown\./i
+        results_regex = Warcry.results_regex(name, results_of_interest: results_of_interest)
 
-        results_regex = Regexp.union(
-          PSMS::FAILURES_REGEXES,
-          /^#{name} what\?$/i,
-          in_cooldown_regex,
-          technique[:regex],
-          /^Roundtime: [0-9]+ sec\.$/,
-        )
-
-        results_regex = Regexp.union(results_regex, results_of_interest) if results_of_interest.is_a?(Regexp)
-
-        usage_cmd = "warcry #{usage}"
-        if target.is_a?(GameObj)
-          usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
-          usage_cmd += " ##{target}"
-        elsif target != ""
-          usage_cmd += " #{target}"
-        end
-
-        if forcert_count > 0
-          usage_cmd += " forcert"
-        else # if we're using forcert, we don't want to wait for rt, but we need to otherwise
+        # with forcert we don't want to wait for rt, but we need to otherwise
+        unless forcert_count > 0
           waitrt?
           waitcastrt?
         end
@@ -218,6 +196,27 @@ module Lich
           usage_result = dothistimeout(usage_cmd, 5, results_regex)
         end
         usage_result
+      end
+
+      # The command {Warcry.use} sends for a warcry, without sending it. Warcries
+      # are sent by their normalized name.
+      #
+      # @param name [String] The name of the warcry
+      # @param target [String, Integer, GameObj] The target (optional)
+      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
+      # @return [String] e.g. "warcry holler"
+      def Warcry.command(name, target = "", forcert_count: 0)
+        PSMS.command("warcry", PSMS.name_normal(name), target, forcert_count: forcert_count)
+      end
+
+      # Every line that answers the warcry's command: the regex {Warcry.use} waits on.
+      #
+      # @param name [String] The name of the warcry
+      # @param results_of_interest [Regexp, nil] Additional lines to match (optional)
+      # @return [Regexp]
+      def Warcry.results_regex(name, results_of_interest: nil)
+        technique = @@warcries.fetch(PSMS.find_name(PSMS.name_normal(name), "Warcry")[:long_name])
+        PSMS.results_regex(name, technique[:regex], /^Roundtime: [0-9]+ sec\.$/, results_of_interest: results_of_interest)
       end
 
       # Returns the "success" regex associated with a given warcry name.

--- a/lib/gemstone/psms/warcry.rb
+++ b/lib/gemstone/psms/warcry.rb
@@ -205,7 +205,11 @@ module Lich
       # @param target [String, Integer, GameObj] The target (optional)
       # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
       # @return [String] e.g. "warcry holler"
+      # @raise [StandardError] if the name matches no warcry
       def Warcry.command(name, target = "", forcert_count: 0)
+        # Warcries carry no :usage, so the command word is the normalized name itself.
+        # The fetch is here to reject an unknown name, as the other categories' .command do.
+        @@warcries.fetch(PSMS.find_name(PSMS.name_normal(name), "Warcry")[:long_name])
         PSMS.command("warcry", PSMS.name_normal(name), target, forcert_count: forcert_count)
       end
 

--- a/lib/gemstone/psms/weapon.rb
+++ b/lib/gemstone/psms/weapon.rb
@@ -298,33 +298,14 @@ module Lich
       def Weapon.use(name, target = "", results_of_interest: nil, forcert_count: 0)
         return unless Weapon.available?(name, forcert_count: forcert_count)
 
-        name_normalized = PSMS.name_normal(name)
-        technique = @@weapon_techniques.fetch(PSMS.find_name(name_normalized, "Weapon")[:long_name])
-        usage = technique.key?(:usage) ? technique[:usage] : name_normalized
-        return if usage.nil?
-
+        technique = @@weapon_techniques.fetch(PSMS.find_name(PSMS.name_normal(name), "Weapon")[:long_name])
         in_cooldown_regex = /^#{name} is still in cooldown\./i
 
-        results_regex = Regexp.union(
-          PSMS::FAILURES_REGEXES,
-          /^#{name} what\?$/i,
-          in_cooldown_regex
-        )
-
-        results_regex = Regexp.union(results_regex, results_of_interest) if results_of_interest
-
-        usage_cmd = "weapon #{usage}"
-        if target.is_a?(GameObj)
-          usage_cmd += " ##{target.id}"
-        elsif target.is_a?(Integer)
-          usage_cmd += " ##{target}"
-        elsif target != ""
-          usage_cmd += " #{target}"
-        end
-
         usage_result = nil
-        if (technique.key?(:assault_rx))
-          results_regex = Regexp.union(results_regex, technique[:assault_rx])
+        if technique.key?(:assault_rx)
+          # assault-style techniques take no FORCERT and settle their own roundtime
+          usage_cmd = Weapon.command(name, target)
+          results_regex = Weapon.results_regex(name, results_of_interest: results_of_interest)
           break_out = Time.now() + 12
           loop {
             usage_result = dothistimeout(usage_cmd, 10, results_regex)
@@ -340,11 +321,11 @@ module Lich
             sleep 0.25
           }
         else
-          results_regex = Regexp.union(results_regex, technique[:regex], /^Roundtime: [0-9]+ sec\.$/)
+          usage_cmd = Weapon.command(name, target, forcert_count: forcert_count)
+          results_regex = Weapon.results_regex(name, results_of_interest: results_of_interest)
 
-          if forcert_count > 0
-            usage_cmd += " forcert"
-          else # if we're using forcert, we don't want to wait for rt, but we need to otherwise
+          # with forcert we don't want to wait for rt, but we need to otherwise
+          unless forcert_count > 0
             waitrt?
             waitcastrt?
           end
@@ -357,6 +338,36 @@ module Lich
         end
 
         usage_result
+      end
+
+      # The command {Weapon.use} sends for a technique, without sending it. A
+      # technique without a usage word is sent by its normalized name.
+      #
+      # @param name [String] The name of the Weapon technique
+      # @param target [String, Integer, GameObj] The target (optional)
+      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
+      # @return [String] e.g. "weapon twinhammer #12345"
+      def Weapon.command(name, target = "", forcert_count: 0)
+        name_normalized = PSMS.name_normal(name)
+        technique = @@weapon_techniques.fetch(PSMS.find_name(name_normalized, "Weapon")[:long_name])
+        usage = technique.key?(:usage) ? technique[:usage] : name_normalized
+        PSMS.command("weapon", usage, target, forcert_count: forcert_count)
+      end
+
+      # Every line that answers the technique's command: the regex {Weapon.use}
+      # waits on. Assault-style techniques answer with their assault line
+      # instead of a result line and roundtime.
+      #
+      # @param name [String] The name of the Weapon technique
+      # @param results_of_interest [Regexp, nil] Additional lines to match (optional)
+      # @return [Regexp]
+      def Weapon.results_regex(name, results_of_interest: nil)
+        technique = @@weapon_techniques.fetch(PSMS.find_name(PSMS.name_normal(name), "Weapon")[:long_name])
+        if technique.key?(:assault_rx)
+          PSMS.results_regex(name, technique[:assault_rx], results_of_interest: results_of_interest)
+        else
+          PSMS.results_regex(name, technique[:regex], /^Roundtime: [0-9]+ sec\.$/, results_of_interest: results_of_interest)
+        end
       end
 
       # Returns the "success" regex associated with a given Weapon technique name.

--- a/lib/gemstone/psms/weapon.rb
+++ b/lib/gemstone/psms/weapon.rb
@@ -341,16 +341,18 @@ module Lich
       end
 
       # The command {Weapon.use} sends for a technique, without sending it. A
-      # technique without a usage word is sent by its normalized name.
+      # technique without a usage word is sent by its normalized name, and an
+      # assault-style technique never takes FORCERT.
       #
       # @param name [String] The name of the Weapon technique
       # @param target [String, Integer, GameObj] The target (optional)
-      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0)
+      # @param forcert_count [Integer] Number of FORCERTs to use (default: 0); ignored for assaults
       # @return [String] e.g. "weapon twinhammer #12345"
       def Weapon.command(name, target = "", forcert_count: 0)
         name_normalized = PSMS.name_normal(name)
         technique = @@weapon_techniques.fetch(PSMS.find_name(name_normalized, "Weapon")[:long_name])
         usage = technique.key?(:usage) ? technique[:usage] : name_normalized
+        forcert_count = 0 if technique.key?(:assault_rx)
         PSMS.command("weapon", usage, target, forcert_count: forcert_count)
       end
 

--- a/spec/lib/gemstone/psms/command_spec.rb
+++ b/spec/lib/gemstone/psms/command_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+
+require 'util/util'
+require 'gemstone/psms'
+
+# The spec GameObj keeps its id but does not read it back; production does.
+class PsmTargetObj < GameObj
+  attr_reader :id
+end
+
+# The command and result regex each PSM category's +use+ sends and waits on,
+# exposed so a caller can send and confirm on its own terms.
+RSpec.describe Lich::Gemstone::PSMS do
+  describe '.command' do
+    it 'joins verb and usage, and sends a GameObj or id as #id' do
+      target = PsmTargetObj.new('12345', 'orc', 'an orc')
+      expect(described_class.command('cman', 'bullrush', target)).to eq('cman bullrush #12345')
+      expect(described_class.command('cman', 'bullrush', 12_345)).to eq('cman bullrush #12345')
+    end
+
+    it 'sends a String target as given and appends FORCERT' do
+      expect(described_class.command('shield', 'bash', 'Dissonance', forcert_count: 2)).to eq('shield bash Dissonance forcert')
+      expect(described_class.command('shield', 'bash')).to eq('shield bash')
+    end
+
+    it 'sends a bare usage with no verb' do
+      expect(described_class.command(nil, 'guard', 'Dissonance')).to eq('guard Dissonance')
+    end
+  end
+
+  describe '.results_regex' do
+    let(:regex) { described_class.results_regex('bullrush', /You dip your shoulder/, /^Roundtime: [0-9]+ sec\.$/, results_of_interest: /extra line/) }
+
+    it 'matches the shared failures, the technique refusals, its patterns and the extras' do
+      expect(regex).to match('You are still stunned.')
+      expect(regex).to match('Bullrush what?')
+      expect(regex).to match('bullrush is still in cooldown.')
+      expect(regex).to match('You dip your shoulder and rush towards an orc!')
+      expect(regex).to match('Roundtime: 5 sec.')
+      expect(regex).to match('an extra line here')
+      expect(regex).not_to match('You swing a broadsword at an orc!')
+    end
+
+    it 'skips nil patterns' do
+      expect(described_class.results_regex('holler', nil)).to match('Holler what?')
+    end
+  end
+end
+
+RSpec.describe 'PSM category commands' do
+  let(:orc) { PsmTargetObj.new('12345', 'orc', 'an orc') }
+
+  it 'CMan sends CMAN <usage>' do
+    expect(Lich::Gemstone::CMan.command('bullrush', orc)).to eq('cman bullrush #12345')
+    expect(Lich::Gemstone::CMan.command('bull_rush', orc, forcert_count: 1)).to eq('cman bullrush #12345 forcert')
+    expect(Lich::Gemstone::CMan.results_regex('bullrush')).to match('You dip your shoulder and rush towards an orc!')
+    expect(Lich::Gemstone::CMan.results_regex('bullrush')).to match('Roundtime: 3 sec.')
+  end
+
+  it 'Shield sends SHIELD <usage>' do
+    expect(Lich::Gemstone::Shield.command('bash', orc)).to eq('shield bash #12345')
+    expect(Lich::Gemstone::Shield.results_regex('bash')).to match('You lunge forward at an orc with your shield and attempt a shield bash!')
+  end
+
+  it 'Armor sends ARMOR <usage> and hears the no-armor refusal' do
+    expect(Lich::Gemstone::Armor.command('blessing')).to start_with('armor ')
+    expect(Lich::Gemstone::Armor.results_regex('blessing')).to match('Dissonance is not wearing any armor that you can work with.')
+  end
+
+  it 'Feat sends FEAT <usage>, and GUARD / PROTECT bare' do
+    expect(Lich::Gemstone::Feat.command('guard', 'Dissonance')).to eq('guard Dissonance')
+    expect(Lich::Gemstone::Feat.command('protect', orc)).to eq('protect #12345')
+    expect(Lich::Gemstone::Feat.results_regex('guard')).to match('You are already guarding Dissonance.')
+  end
+
+  it 'Warcry sends WARCRY <name>' do
+    expect(Lich::Gemstone::Warcry.command('holler', orc)).to eq('warcry holler #12345')
+    expect(Lich::Gemstone::Warcry.results_regex('holler')).to match('You throw back your head and let out a thundering holler!')
+  end
+
+  it 'Weapon sends WEAPON <usage> and waits on the assault line for assault techniques' do
+    expect(Lich::Gemstone::Weapon.command('twinhammer', orc)).to eq('weapon twinhammer #12345')
+    expect(Lich::Gemstone::Weapon.results_regex('twinhammer')).to match('Roundtime: 5 sec.')
+    assault = Lich::Gemstone::Weapon.results_regex('barrage')
+    expect(assault).to match('Your satisfying display of dexterity bolsters you and inspires those around you!')
+    expect(assault).not_to match('Roundtime: 5 sec.')
+  end
+end

--- a/spec/lib/gemstone/psms/command_spec.rb
+++ b/spec/lib/gemstone/psms/command_spec.rb
@@ -80,6 +80,11 @@ RSpec.describe 'PSM category commands' do
     expect(Lich::Gemstone::Warcry.results_regex('holler')).to match('You throw back your head and let out a thundering holler!')
   end
 
+  it 'every category rejects an unknown technique name' do
+    expect { Lich::Gemstone::CMan.command('bullrus') }.to raise_error(StandardError)
+    expect { Lich::Gemstone::Warcry.command('hollar') }.to raise_error(StandardError)
+  end
+
   it 'Weapon sends WEAPON <usage> and waits on the assault line for assault techniques' do
     expect(Lich::Gemstone::Weapon.command('twinhammer', orc)).to eq('weapon twinhammer #12345')
     expect(Lich::Gemstone::Weapon.results_regex('twinhammer')).to match('Roundtime: 5 sec.')

--- a/spec/lib/gemstone/psms/command_spec.rb
+++ b/spec/lib/gemstone/psms/command_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe 'PSM category commands' do
   it 'Weapon sends WEAPON <usage> and waits on the assault line for assault techniques' do
     expect(Lich::Gemstone::Weapon.command('twinhammer', orc)).to eq('weapon twinhammer #12345')
     expect(Lich::Gemstone::Weapon.results_regex('twinhammer')).to match('Roundtime: 5 sec.')
+    expect(Lich::Gemstone::Weapon.command('twinhammer', orc, forcert_count: 1)).to eq('weapon twinhammer #12345 forcert')
+    expect(Lich::Gemstone::Weapon.command('barrage', orc, forcert_count: 1)).to eq('weapon barrage #12345')
     assault = Lich::Gemstone::Weapon.results_regex('barrage')
     expect(assault).to match('Your satisfying display of dexterity bolsters you and inspires those around you!')
     expect(assault).not_to match('Roundtime: 5 sec.')


### PR DESCRIPTION
## Summary

Each PSM category's `.use` built its command string and result regex inline. This exposes both as readers and has `.use` call them, so the PSM modules stay the one source of truth for usage strings and result patterns while a caller that sends and confirms on its own terms (an engine with its own roundtime and timeout discipline) no longer has to copy the tables.

**Shared, in `PSMS`**
- `PSMS.command(verb, usage, target, forcert_count:)`: verb plus usage, a GameObj or Integer target as `#id`, a String target as given, FORCERT when the count is above zero, a bare command when the verb is nil.
- `PSMS.results_regex(name, *patterns, results_of_interest:)`: the shared failures, the "X what?" and cooldown refusals for that name, the technique's own patterns, and any extras.

**Per category**, `CMan`, `Armor`, `Feat`, `Shield`, `Warcry`, `Weapon`:
- `.command(name, target = "", forcert_count: 0)` returns the exact string `.use` would send (e.g. `cman bullrush #12345`, `guard Dissonance`).
- `.results_regex(name, results_of_interest: nil)` returns the union `.use` waits on. Armor keeps its "not wearing any armor" line; Weapon's assault techniques wait on the assault line rather than a result line and roundtime, as before.

`.use` behaviour is unchanged: same availability checks, RT waits, `dothistimeout` and stun retry, and Weapon's assault loop. Feat's bare `guard` / `protect` verbs are now a named constant.

## Test plan

- [x] `spec/lib/gemstone/psms/command_spec.rb` (new): the two helpers plus one real technique per category against the registry data
- [x] `psms_spec.rb` and `qstrike_spec.rb` still green (84 examples total)
- [x] rubocop clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
