### PR TITLE
feat(gs): Lich::Gemstone::Fog, the ways home on the spell and society readers

### DIFF
--- a/lib/common/gameloader.rb
+++ b/lib/common/gameloader.rb
@@ -27,6 +27,7 @@ module Lich
         require File.join(LIB_DIR, 'attributes', 'skills.rb')
         require File.join(LIB_DIR, 'attributes', 'enhancive.rb')
         require File.join(LIB_DIR, 'gemstone', 'society.rb')
+        require File.join(LIB_DIR, 'gemstone', 'fog.rb')
         require File.join(LIB_DIR, 'gemstone', 'infomon', 'status.rb')
         require File.join(LIB_DIR, 'gemstone', 'experience.rb')
         require File.join(LIB_DIR, 'attributes', 'spellsong.rb')

--- a/lib/gemstone/fog.rb
+++ b/lib/gemstone/fog.rb
@@ -204,15 +204,24 @@ module Lich
         moved_from?(start)
       end
 
-      # Where we are, as the server reports it: the room counter (which
-      # steps on every move) and the server room id. Both are set for an
-      # unmapped room, where Room.current is nil and a map id would compare
-      # nil to nil and call a real move a failure.
+      # Where we are, as the server reports it: the server room id, which
+      # is set for an unmapped room too (Room.current is nil there, and a
+      # map id would compare nil to nil and call a real move a failure),
+      # with the room counter alongside for the rare stream that carries
+      # no id.
       # @api private
-      def self.here = [XMLData.room_count, XMLData.room_id]
+      def self.here = { id: XMLData.room_id.to_s, count: XMLData.room_count }
 
+      # A move is a different server room id. The counter alone is not
+      # evidence: it steps on every room refresh, moved or not, so it is
+      # consulted only when an id is missing on either side.
       # @api private
-      def self.moved_from?(start) = here != start
+      def self.moved_from?(start)
+        now = here
+        return now[:id] != start[:id] unless now[:id].empty? || start[:id].empty?
+
+        now[:count] != start[:count]
+      end
 
       # The map id, for the Rift check only.
       # @api private

--- a/lib/gemstone/fog.rb
+++ b/lib/gemstone/fog.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+# Fog: the ways home. Spirit Guide (130), Symbol of Return (Voln), Traveler's
+# Song (1020), Sigil of Escape (Sunfist) and Familiar Gate (930) each take a
+# character out of the field to a known room. Every hunting script carries a
+# copy of the same routine (bigshot's fog_return family, and the copies in the
+# scripts that grew out of it); this is that routine once, on the spell and
+# society readers, with the answer confirmed on the room changing rather than
+# assumed.
+#
+#   Lich::Gemstone::Fog.available                        # => [:spirit_guide, :symbol_of_return]
+#   Lich::Gemstone::Fog.return(:spirit_guide)            # => true when the room changed
+#   Lich::Gemstone::Fog.return(2, rift: true, resting_room: 4)   # bigshot's numbering
+#
+# Policy stays with the caller: which method a profile picks, whether to fog at
+# all, and any custom command list are the script's. What each method is, what
+# it costs, how it is sent and how it is confirmed are here.
+module Lich
+  module Gemstone
+    module Fog
+      # The Rift's exit: a fog that lands here needs a second cast to go on
+      # (bigshot fog_return_spirit, fog_return_voln).
+      RIFT_ROOM = 2635
+
+      # Seconds to wait for the room to change after a send. A fog resolves
+      # in one server pulse; a Traveler's Song walk takes longer.
+      CONFIRM_TIMEOUT = 8
+
+      METHODS = %i[spirit_guide symbol_of_return travelers_song sigil_of_escape familiar_gate].freeze
+
+      # bigshot's fog_return setting (1-5; 6 is the profile's own commands)
+      NUMBERS = { 1 => :spirit_guide, 2 => :symbol_of_return, 3 => :travelers_song, 4 => :sigil_of_escape, 5 => :familiar_gate }.freeze
+
+      SPELLS = { spirit_guide: 130, travelers_song: 1020, familiar_gate: 930 }.freeze
+
+      # @param method [Symbol, Integer, String] a METHODS name or bigshot's number
+      # @return [Symbol, nil]
+      def self.normalize(method)
+        return NUMBERS[method] if method.is_a?(Integer)
+        return NUMBERS[method.to_i] if method.to_s =~ /\A\d+\z/
+
+        sym = method.to_s.downcase.to_sym
+        METHODS.include?(sym) ? sym : nil
+      end
+
+      # Does this character have the method at all.
+      def self.known?(method)
+        case normalize(method)
+        when :spirit_guide, :travelers_song, :familiar_gate then spell_known?(SPELLS[normalize(method)])
+        when :symbol_of_return then voln&.known?('return') || false
+        when :sigil_of_escape then sunfist&.known?('escape') || false
+        else false
+        end
+      end
+
+      # Known and affordable right now.
+      def self.available?(method)
+        case normalize(method)
+        when :spirit_guide, :travelers_song, :familiar_gate
+          num = SPELLS[normalize(method)]
+          spell_known?(num) && Spell[num].affordable?
+        when :symbol_of_return then voln&.available?('return') || false
+        when :sigil_of_escape then sunfist&.available?('escape') || false
+        else false
+        end
+      end
+
+      # @return [Array<Symbol>] every method the character can use right now
+      def self.available
+        METHODS.select { |m| available?(m) }
+      end
+
+      # Go home by +method+. Waits out roundtime first, pulses mana when the
+      # spell is known but unaffordable, and answers whether the room changed.
+      #
+      # Spirit Guide and Symbol of Return fall back to each other when the
+      # first does not move us, and cast a second time when the first cast
+      # lands in the Rift and the destination is elsewhere - bigshot's rules,
+      # kept.
+      #
+      # @param method [Symbol, Integer, String]
+      # @param rift [Boolean] the destination is reached through the Rift
+      # @param resting_room [Integer, nil] with +rift+, the room the fog is for
+      # @return [Boolean] whether the room changed
+      def self.return(method, rift: false, resting_room: nil)
+        method = normalize(method)
+        return false if method.nil?
+
+        start = room_id
+        sleep 0.5
+        waitcastrt?
+        waitrt?
+        case method
+        when :spirit_guide then spirit_guide(rift: rift, resting_room: resting_room)
+        when :symbol_of_return then symbol_of_return(rift: rift, resting_room: resting_room)
+        when :travelers_song then travelers_song
+        when :sigil_of_escape then sigil_of_escape
+        when :familiar_gate then familiar_gate
+        end
+        moved_from?(start)
+      end
+
+      # --- the five ------------------------------------------------------------
+
+      # @api private
+      def self.spirit_guide(rift: false, resting_room: nil, from_voln: false)
+        start = room_id
+        pulse_mana(130)
+        if available?(:spirit_guide)
+          cast_and_settle(130)
+          second_cast_from_rift(rift, resting_room, start) { cast_and_settle(130) if available?(:spirit_guide) }
+        end
+        return true if moved_from?(start)
+
+        # 130 did not move us: Symbol of Return, once (fog_return_spirit)
+        symbol_of_return(rift: rift, resting_room: resting_room, from_spirit: true) if !from_voln && known?(:symbol_of_return)
+        moved_from?(start)
+      end
+
+      # @api private
+      def self.symbol_of_return(rift: false, resting_room: nil, from_spirit: false)
+        start = room_id
+        if known?(:symbol_of_return)
+          fput 'symbol of return'
+          wait_for_move(start)
+          second_cast_from_rift(rift, resting_room, start) { fput 'symbol of return'; wait_for_move(RIFT_ROOM) }
+        end
+        return true if moved_from?(start)
+
+        # the symbol did not move us: Spirit Guide, once (fog_return_voln)
+        spirit_guide(rift: rift, resting_room: resting_room, from_voln: true) if !from_spirit && known?(:spirit_guide)
+        moved_from?(start)
+      end
+
+      # @api private
+      def self.travelers_song
+        pulse_mana(1020)
+        cast_and_settle(1020) if available?(:travelers_song)
+      end
+
+      # @api private
+      def self.sigil_of_escape
+        return unless available?(:sigil_of_escape)
+
+        fput 'sigil of escape'
+        sleep 0.5
+        waitcastrt?
+        waitrt?
+      end
+
+      # @api private
+      def self.familiar_gate
+        pulse_mana(930)
+        return unless available?(:familiar_gate)
+
+        Spell[930].cast
+        fput 'go portal'
+        sleep 0.5
+        waitcastrt?
+        waitrt?
+      end
+
+      # --- helpers ---------------------------------------------------------------
+
+      # @api private
+      def self.cast_and_settle(num)
+        start = room_id
+        Spell[num].cast
+        sleep 0.5
+        waitcastrt?
+        wait_for_move(start)
+      end
+
+      # A fog into the Rift with the destination elsewhere is cast again
+      # from 2635 (bigshot: @FOG_RIFT && @RESTING_ROOM_ID != 2635).
+      # @api private
+      def self.second_cast_from_rift(rift, resting_room, start)
+        return unless rift && resting_room.to_i != RIFT_ROOM
+        return unless moved_from?(start) && room_id == RIFT_ROOM
+
+        yield
+      end
+
+      # MANA PULSE before a known spell we cannot afford (bigshot mana_pulse).
+      # @api private
+      def self.pulse_mana(num)
+        return unless spell_known?(num) && !Spell[num].affordable?
+
+        dothistimeout 'mana pulse', 2, /An invigorating rush of mana pulses through you|You are too mentally fatigued|You're already at full mana|Your mana control skills are not yet advanced/i
+        sleep 0.2
+      end
+
+      # @api private
+      def self.wait_for_move(start)
+        deadline = Time.now + CONFIRM_TIMEOUT
+        sleep 0.25 until moved_from?(start) || Time.now > deadline
+        moved_from?(start)
+      end
+
+      # @api private
+      def self.moved_from?(start) = room_id != start
+
+      # @api private
+      def self.room_id = Room.current&.id
+
+      # @api private
+      def self.spell_known?(num)
+        spell = Spell[num]
+        !spell.nil? && spell.known?
+      end
+
+      # @api private
+      def self.voln
+        Societies::OrderOfVoln if defined?(Societies::OrderOfVoln)
+      end
+
+      # @api private
+      def self.sunfist
+        Societies::GuardiansOfSunfist if defined?(Societies::GuardiansOfSunfist)
+      end
+    end
+  end
+end

--- a/lib/gemstone/fog.rb
+++ b/lib/gemstone/fog.rb
@@ -21,9 +21,16 @@ module Lich
       # (bigshot fog_return_spirit, fog_return_voln).
       RIFT_ROOM = 2635
 
-      # Seconds to wait for the room to change after a send. A fog resolves
-      # in one server pulse; a Traveler's Song walk takes longer.
+      # Seconds to wait for the room to change after a send. A fog resolves in
+      # one server pulse, so 8 is generous for the four that fog; a Traveler's
+      # Song is a walk to the destination and gets its own, longer budget.
       CONFIRM_TIMEOUT = 8
+      TRAVELERS_SONG_TIMEOUT = 60
+
+      # Real room UIDs are small integers. Above this the id is xmlparser's
+      # MD5 stand-in for a room that arrived with no UID (xmlparser.rb, the
+      # <compass> branch), which is not unique across same-text rooms.
+      MAX_ROOM_UID = 1_000_000_000
 
       METHODS = %i[spirit_guide symbol_of_return travelers_song sigil_of_escape familiar_gate].freeze
 
@@ -44,8 +51,9 @@ module Lich
 
       # Does this character have the method at all.
       def self.known?(method)
-        case normalize(method)
-        when :spirit_guide, :travelers_song, :familiar_gate then spell_known?(SPELLS[normalize(method)])
+        name = normalize(method)
+        case name
+        when :spirit_guide, :travelers_song, :familiar_gate then spell_known?(SPELLS[name])
         when :symbol_of_return then voln&.known?('return') || false
         when :sigil_of_escape then sunfist&.known?('escape') || false
         else false
@@ -54,9 +62,10 @@ module Lich
 
       # Known and affordable right now.
       def self.available?(method)
-        case normalize(method)
+        name = normalize(method)
+        case name
         when :spirit_guide, :travelers_song, :familiar_gate
-          num = SPELLS[normalize(method)]
+          num = SPELLS[name]
           spell_known?(num) && Spell[num].affordable?
         when :symbol_of_return then voln&.available?('return') || false
         when :sigil_of_escape then sunfist&.available?('escape') || false
@@ -142,7 +151,7 @@ module Lich
       # @api private
       def self.travelers_song
         pulse_mana(1020)
-        cast_and_settle(1020) if available?(:travelers_song)
+        cast_and_settle(1020, timeout: TRAVELERS_SONG_TIMEOUT) if available?(:travelers_song)
       end
 
       # @api private
@@ -170,12 +179,12 @@ module Lich
       # --- helpers ---------------------------------------------------------------
 
       # @api private
-      def self.cast_and_settle(num)
+      def self.cast_and_settle(num, timeout: CONFIRM_TIMEOUT)
         start = here
         Spell[num].cast
         sleep 0.5
         waitcastrt?
-        wait_for_move(start)
+        wait_for_move(start, timeout: timeout)
       end
 
       # A fog into the Rift with the destination elsewhere is cast again
@@ -198,29 +207,42 @@ module Lich
       end
 
       # @api private
-      def self.wait_for_move(start)
-        deadline = Time.now + CONFIRM_TIMEOUT
+      def self.wait_for_move(start, timeout: CONFIRM_TIMEOUT)
+        deadline = Time.now + timeout
         sleep 0.25 until moved_from?(start) || Time.now > deadline
         moved_from?(start)
       end
 
-      # Where we are, as the server reports it: the server room id, which
-      # is set for an unmapped room too (Room.current is nil there, and a
-      # map id would compare nil to nil and call a real move a failure),
-      # with the room counter alongside for the rare stream that carries
-      # no id.
+      # Where we are, as the server reports it. XMLData.room_id is set for an
+      # unmapped room too - Room.current is nil there, and a map id would
+      # compare nil to nil and call a real move a failure - so it is the
+      # primary mark. It is never absent (xmlparser defaults it to 0 and every
+      # write goes through to_i), but it is not always unique: a room with no
+      # UID gets an MD5 of its title, description and exits, so two unmapped
+      # rooms whose text reads the same share an id. The room counter, which
+      # steps once per room stream, breaks that tie.
       # @api private
-      def self.here = { id: XMLData.room_id.to_s, count: XMLData.room_count }
+      def self.here = { id: XMLData.room_id.to_s, count: XMLData.room_count.to_i }
 
-      # A move is a different server room id. The counter alone is not
-      # evidence: it steps on every room refresh, moved or not, so it is
-      # consulted only when an id is missing on either side.
+      # A move is a different server room id. When the id is unchanged it may
+      # still be a move between two same-text unmapped rooms, so the counter
+      # decides: an MD5 id means the room has no UID, and a counter that has
+      # stepped there is a new room stream rather than a refresh of this one.
+      # A real UID is unique, so an unchanged one is never a move.
       # @api private
       def self.moved_from?(start)
         now = here
-        return now[:id] != start[:id] unless now[:id].empty? || start[:id].empty?
+        return true if now[:id] != start[:id]
+        return false unless uidless?(now[:id])
 
-        now[:count] != start[:count]
+        now[:count] > start[:count]
+      end
+
+      # A server room id that is not a real room UID: xmlparser substitutes an
+      # MD5 of the room text, far above any UID, when <nav> carries none.
+      # @api private
+      def self.uidless?(id)
+        id.to_i > MAX_ROOM_UID
       end
 
       # The map id, for the Rift check only.

--- a/lib/gemstone/fog.rb
+++ b/lib/gemstone/fog.rb
@@ -2,11 +2,10 @@
 
 # Fog: the ways home. Spirit Guide (130), Symbol of Return (Voln), Traveler's
 # Song (1020), Sigil of Escape (Sunfist) and Familiar Gate (930) each take a
-# character out of the field to a known room. Every hunting script carries a
-# copy of the same routine (bigshot's fog_return family, and the copies in the
-# scripts that grew out of it); this is that routine once, on the spell and
-# society readers, with the answer confirmed on the room changing rather than
-# assumed.
+# character out of the field to a known room. Getting home is a thing any
+# script may need, not a hunting rule, so it belongs in core: this is
+# bigshot's fog_return routine on the spell and society readers, with the
+# answer confirmed on the room changing rather than assumed.
 #
 #   Lich::Gemstone::Fog.available                        # => [:spirit_guide, :symbol_of_return]
 #   Lich::Gemstone::Fog.return(:spirit_guide)            # => true when the room changed

--- a/lib/gemstone/fog.rb
+++ b/lib/gemstone/fog.rb
@@ -85,7 +85,7 @@ module Lich
         method = normalize(method)
         return false if method.nil?
 
-        start = room_id
+        start = here
         sleep 0.5
         waitcastrt?
         waitrt?
@@ -103,11 +103,15 @@ module Lich
 
       # @api private
       def self.spirit_guide(rift: false, resting_room: nil, from_voln: false)
-        start = room_id
+        start = here
         pulse_mana(130)
         if available?(:spirit_guide)
           cast_and_settle(130)
-          second_cast_from_rift(rift, resting_room, start) { cast_and_settle(130) if available?(:spirit_guide) }
+          second_cast_from_rift(rift, resting_room, start) do
+            # the first cast may have spent the mana the second needs (bigshot pulses again here)
+            pulse_mana(130)
+            cast_and_settle(130) if available?(:spirit_guide)
+          end
         end
         return true if moved_from?(start)
 
@@ -118,11 +122,15 @@ module Lich
 
       # @api private
       def self.symbol_of_return(rift: false, resting_room: nil, from_spirit: false)
-        start = room_id
+        start = here
         if known?(:symbol_of_return)
           fput 'symbol of return'
           wait_for_move(start)
-          second_cast_from_rift(rift, resting_room, start) { fput 'symbol of return'; wait_for_move(RIFT_ROOM) }
+          second_cast_from_rift(rift, resting_room, start) do
+            rift_mark = here
+            fput 'symbol of return'
+            wait_for_move(rift_mark)
+          end
         end
         return true if moved_from?(start)
 
@@ -163,7 +171,7 @@ module Lich
 
       # @api private
       def self.cast_and_settle(num)
-        start = room_id
+        start = here
         Spell[num].cast
         sleep 0.5
         waitcastrt?
@@ -196,9 +204,17 @@ module Lich
         moved_from?(start)
       end
 
+      # Where we are, as the server reports it: the room counter (which
+      # steps on every move) and the server room id. Both are set for an
+      # unmapped room, where Room.current is nil and a map id would compare
+      # nil to nil and call a real move a failure.
       # @api private
-      def self.moved_from?(start) = room_id != start
+      def self.here = [XMLData.room_count, XMLData.room_id]
 
+      # @api private
+      def self.moved_from?(start) = here != start
+
+      # The map id, for the Rift check only.
       # @api private
       def self.room_id = Room.current&.id
 

--- a/spec/lib/gemstone/fog_spec.rb
+++ b/spec/lib/gemstone/fog_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require 'gemstone/fog'
+
+# A stand-in for Spell[n]: known, affordable, and a cast that the example
+# can make move the room.
+FogSpell = Struct.new(:num, :known, :affordable, keyword_init: true) do
+  def known? = known
+  def affordable? = affordable
+
+  def cast(*_args)
+    @casts = (@casts || 0) + 1
+    @on_cast&.call
+    'Cast Roundtime 3 Seconds.'
+  end
+
+  def casts = @casts || 0
+  def on_cast(&block) = @on_cast = block
+end
+
+RSpec.describe Lich::Gemstone::Fog do
+  let(:spells) { {} }
+  let(:voln) { double('OrderOfVoln', known?: false, available?: false) }
+  let(:sunfist) { double('GuardiansOfSunfist', known?: false, available?: false) }
+  let(:sent) { [] }
+
+  def spell(num, known: true, affordable: true)
+    spells[num] = FogSpell.new(num: num, known: known, affordable: affordable)
+  end
+
+  def arrive(id)
+    Room.current = Room.room_double(id: id)
+  end
+
+  before do
+    stub_const('Spell', Class.new)
+    allow(Spell).to receive(:[]) { |n| spells[n] }
+    allow(described_class).to receive(:voln).and_return(voln)
+    allow(described_class).to receive(:sunfist).and_return(sunfist)
+    allow(described_class).to receive(:sleep)
+    # the confirm wait polls the clock; answer at once from the room
+    allow(described_class).to receive(:wait_for_move) { |start| described_class.moved_from?(start) }
+    allow(described_class).to receive(:waitrt?)
+    allow(described_class).to receive(:waitcastrt?)
+    allow(described_class).to receive(:fput) { |cmd| sent << cmd }
+    allow(described_class).to receive(:dothistimeout) { |cmd, *_| sent << cmd; 'An invigorating rush of mana pulses through you.' }
+    arrive(100)
+  end
+
+  describe '.normalize' do
+    it 'takes a name, a symbol or bigshot number' do
+      expect(described_class.normalize(:spirit_guide)).to eq(:spirit_guide)
+      expect(described_class.normalize('Symbol_of_Return')).to eq(:symbol_of_return)
+      expect(described_class.normalize(3)).to eq(:travelers_song)
+      expect(described_class.normalize('5')).to eq(:familiar_gate)
+      expect(described_class.normalize(6)).to be_nil
+      expect(described_class.normalize(:walk)).to be_nil
+    end
+  end
+
+  describe '.known? and .available' do
+    it 'reads the spells and the society readers' do
+      spell(130)
+      spell(1020, affordable: false)
+      allow(voln).to receive(:known?).with('return').and_return(true)
+      allow(voln).to receive(:available?).with('return').and_return(true)
+      expect(described_class.known?(:spirit_guide)).to be true
+      expect(described_class.known?(:travelers_song)).to be true
+      expect(described_class.known?(:sigil_of_escape)).to be false
+      expect(described_class.available).to eq(%i[spirit_guide symbol_of_return])
+    end
+
+    it 'is false for an unknown spell or a missing reader' do
+      allow(described_class).to receive(:voln).and_return(nil)
+      expect(described_class.known?(:spirit_guide)).to be false
+      expect(described_class.known?(:symbol_of_return)).to be false
+    end
+  end
+
+  describe '.return' do
+    it 'casts Spirit Guide and answers on the room changing' do
+      spell(130).on_cast { arrive(4) }
+      expect(described_class.return(:spirit_guide)).to be true
+      expect(spells[130].casts).to eq(1)
+    end
+
+    it 'answers false when nothing moved' do
+      spell(130)
+      expect(described_class.return(1)).to be false
+    end
+
+    it 'pulses mana before a known spell it cannot afford' do
+      spell(1020, affordable: false)
+      expect(described_class.return(:travelers_song)).to be false
+      expect(sent).to eq(['mana pulse'])
+      expect(spells[1020].casts).to eq(0)
+    end
+
+    it 'falls back from Spirit Guide to the Symbol of Return, once' do
+      spell(130)
+      allow(voln).to receive(:known?).with('return').and_return(true)
+      allow(described_class).to receive(:fput) { |cmd| sent << cmd; arrive(4) if cmd == 'symbol of return' }
+      expect(described_class.return(:spirit_guide)).to be true
+      expect(spells[130].casts).to eq(1)
+      expect(sent).to eq(['symbol of return'])
+    end
+
+    it 'falls back from the Symbol of Return to Spirit Guide, once' do
+      spell(130).on_cast { arrive(4) }
+      allow(voln).to receive(:known?).with('return').and_return(true)
+      expect(described_class.return(:symbol_of_return)).to be true
+      expect(sent).to eq(['symbol of return'])
+      expect(spells[130].casts).to eq(1)
+    end
+
+    it 'casts a second time when the first lands in the Rift and the destination is elsewhere' do
+      s = spell(130)
+      s.on_cast { arrive(s.casts == 1 ? described_class::RIFT_ROOM : 4) }
+      expect(described_class.return(:spirit_guide, rift: true, resting_room: 4)).to be true
+      expect(s.casts).to eq(2)
+    end
+
+    it 'stays in the Rift when that is the destination' do
+      s = spell(130)
+      s.on_cast { arrive(described_class::RIFT_ROOM) }
+      expect(described_class.return(:spirit_guide, rift: true, resting_room: described_class::RIFT_ROOM)).to be true
+      expect(s.casts).to eq(1)
+    end
+
+    it 'sends the Sigil of Escape only when the reader allows it' do
+      expect(described_class.return(:sigil_of_escape)).to be false
+      expect(sent).to be_empty
+      allow(sunfist).to receive(:available?).with('escape').and_return(true)
+      allow(described_class).to receive(:fput) { |cmd| sent << cmd; arrive(4) }
+      expect(described_class.return(4)).to be true
+      expect(sent).to eq(['sigil of escape'])
+    end
+
+    it 'gates for Familiar Gate and walks through the portal' do
+      spell(930)
+      allow(described_class).to receive(:fput) { |cmd| sent << cmd; arrive(4) }
+      expect(described_class.return(:familiar_gate)).to be true
+      expect(spells[930].casts).to eq(1)
+      expect(sent).to eq(['go portal'])
+    end
+
+    it 'refuses an unknown method without sending anything' do
+      expect(described_class.return(:walk)).to be false
+      expect(sent).to be_empty
+    end
+  end
+end

--- a/spec/lib/gemstone/fog_spec.rb
+++ b/spec/lib/gemstone/fog_spec.rb
@@ -159,6 +159,19 @@ RSpec.describe Lich::Gemstone::Fog do
       expect(sent).to be_empty # no fallback symbol after a move that worked
     end
 
+    it 'does not mistake a room refresh for a move' do
+      spell(130).on_cast { XMLData.room_count += 1 } # the parser refreshed the same room
+      allow(voln).to receive(:known?).with('return').and_return(true)
+      expect(described_class.return(:spirit_guide)).to be false
+      expect(sent).to eq(['symbol of return']) # the fallback still fires
+    end
+
+    it 'falls back to the room counter only when the server gives no room id' do
+      XMLData.room_id = nil
+      spell(130).on_cast { XMLData.room_count += 1 }
+      expect(described_class.return(:spirit_guide)).to be true
+    end
+
     it 'stays in the Rift when that is the destination' do
       s = spell(130)
       s.on_cast { arrive(described_class::RIFT_ROOM) }

--- a/spec/lib/gemstone/fog_spec.rb
+++ b/spec/lib/gemstone/fog_spec.rb
@@ -19,8 +19,9 @@ FogSpell = Struct.new(:num, :known, :affordable, keyword_init: true) do
   def on_cast(&block) = @on_cast = block
 end
 
-# Fog confirms a move on the server's room counter and room id; the spec
-# helper's XMLData carries room_id but not the counter.
+# Fog confirms a move on the server's room id, with the room counter breaking
+# the tie between same-text rooms that have no UID; the spec helper's XMLData
+# carries room_id but not the counter.
 module XMLData
   class << self
     attr_accessor :room_count unless method_defined?(:room_count)
@@ -32,6 +33,7 @@ RSpec.describe Lich::Gemstone::Fog do
   let(:voln) { double('OrderOfVoln', known?: false, available?: false) }
   let(:sunfist) { double('GuardiansOfSunfist', known?: false, available?: false) }
   let(:sent) { [] }
+  let(:waits) { [] }
 
   def spell(num, known: true, affordable: true)
     spells[num] = FogSpell.new(num: num, known: known, affordable: affordable)
@@ -41,8 +43,16 @@ RSpec.describe Lich::Gemstone::Fog do
   # server room id changes; the map id follows when the room is mapped.
   def arrive(id, mapped: true)
     XMLData.room_count = XMLData.room_count.to_i + 1
-    XMLData.room_id = "u#{id}"
+    XMLData.room_id = id
     Room.current = mapped ? Room.room_double(id: id) : nil
+  end
+
+  # A room that arrived with no UID: xmlparser hands out an MD5 of the room
+  # text, which two rooms reading the same way share. The counter still steps.
+  def arrive_uidless(text_hash)
+    XMLData.room_count = XMLData.room_count.to_i + 1
+    XMLData.room_id = described_class::MAX_ROOM_UID + text_hash
+    Room.current = nil
   end
 
   before do
@@ -51,8 +61,12 @@ RSpec.describe Lich::Gemstone::Fog do
     allow(described_class).to receive(:voln).and_return(voln)
     allow(described_class).to receive(:sunfist).and_return(sunfist)
     allow(described_class).to receive(:sleep)
-    # the confirm wait polls the clock; answer at once from the room
-    allow(described_class).to receive(:wait_for_move) { |start| described_class.moved_from?(start) }
+    # the confirm wait polls the clock; answer at once from the room, keeping
+    # the budget each leg asked for so a spec can assert on it
+    allow(described_class).to receive(:wait_for_move) do |start, timeout: described_class::CONFIRM_TIMEOUT|
+      waits << timeout
+      described_class.moved_from?(start)
+    end
     allow(described_class).to receive(:waitrt?)
     allow(described_class).to receive(:waitcastrt?)
     allow(described_class).to receive(:fput) { |cmd| sent << cmd }
@@ -108,6 +122,19 @@ RSpec.describe Lich::Gemstone::Fog do
       expect(described_class.return(:travelers_song)).to be false
       expect(sent).to eq(['mana pulse'])
       expect(spells[1020].casts).to eq(0)
+    end
+
+    it 'gives a Travelers Song walk a longer budget than a one-pulse fog' do
+      spell(1020).on_cast { arrive(4) }
+      expect(described_class.return(:travelers_song)).to be true
+      expect(waits).to eq([described_class::TRAVELERS_SONG_TIMEOUT])
+      expect(described_class::TRAVELERS_SONG_TIMEOUT).to be > described_class::CONFIRM_TIMEOUT
+    end
+
+    it 'confirms a fog on the shorter budget' do
+      spell(130).on_cast { arrive(4) }
+      expect(described_class.return(:spirit_guide)).to be true
+      expect(waits).to eq([described_class::CONFIRM_TIMEOUT])
     end
 
     it 'falls back from Spirit Guide to the Symbol of Return, once' do
@@ -166,10 +193,20 @@ RSpec.describe Lich::Gemstone::Fog do
       expect(sent).to eq(['symbol of return']) # the fallback still fires
     end
 
-    it 'falls back to the room counter only when the server gives no room id' do
-      XMLData.room_id = nil
-      spell(130).on_cast { XMLData.room_count += 1 }
+    it 'confirms a move between two unmapped rooms whose text hashes the same' do
+      arrive_uidless(7)
+      spell(130).on_cast { arrive_uidless(7) } # a different room, the same id
+      allow(voln).to receive(:known?).with('return').and_return(true)
       expect(described_class.return(:spirit_guide)).to be true
+      expect(sent).to be_empty
+    end
+
+    it 'does not call a refresh of an unmapped room a move' do
+      arrive_uidless(7)
+      spell(130).on_cast {} # no new room stream, so no counter step
+      allow(voln).to receive(:known?).with('return').and_return(true)
+      expect(described_class.return(:spirit_guide)).to be false
+      expect(sent).to eq(['symbol of return'])
     end
 
     it 'stays in the Rift when that is the destination' do

--- a/spec/lib/gemstone/fog_spec.rb
+++ b/spec/lib/gemstone/fog_spec.rb
@@ -19,6 +19,14 @@ FogSpell = Struct.new(:num, :known, :affordable, keyword_init: true) do
   def on_cast(&block) = @on_cast = block
 end
 
+# Fog confirms a move on the server's room counter and room id; the spec
+# helper's XMLData carries room_id but not the counter.
+module XMLData
+  class << self
+    attr_accessor :room_count unless method_defined?(:room_count)
+  end
+end
+
 RSpec.describe Lich::Gemstone::Fog do
   let(:spells) { {} }
   let(:voln) { double('OrderOfVoln', known?: false, available?: false) }
@@ -29,8 +37,12 @@ RSpec.describe Lich::Gemstone::Fog do
     spells[num] = FogSpell.new(num: num, known: known, affordable: affordable)
   end
 
-  def arrive(id)
-    Room.current = Room.room_double(id: id)
+  # A move as the server reports it: the room counter steps and the
+  # server room id changes; the map id follows when the room is mapped.
+  def arrive(id, mapped: true)
+    XMLData.room_count = XMLData.room_count.to_i + 1
+    XMLData.room_id = "u#{id}"
+    Room.current = mapped ? Room.room_double(id: id) : nil
   end
 
   before do
@@ -45,6 +57,7 @@ RSpec.describe Lich::Gemstone::Fog do
     allow(described_class).to receive(:waitcastrt?)
     allow(described_class).to receive(:fput) { |cmd| sent << cmd }
     allow(described_class).to receive(:dothistimeout) { |cmd, *_| sent << cmd; 'An invigorating rush of mana pulses through you.' }
+    XMLData.room_count = 0
     arrive(100)
   end
 
@@ -119,6 +132,31 @@ RSpec.describe Lich::Gemstone::Fog do
       s.on_cast { arrive(s.casts == 1 ? described_class::RIFT_ROOM : 4) }
       expect(described_class.return(:spirit_guide, rift: true, resting_room: 4)).to be true
       expect(s.casts).to eq(2)
+    end
+
+    it 'pulses mana again before the second cast out of the Rift' do
+      s = spell(130)
+      s.on_cast do
+        if s.casts == 1
+          s.affordable = false # the first cast took the mana
+          arrive(described_class::RIFT_ROOM)
+        else
+          arrive(4)
+        end
+      end
+      allow(described_class).to receive(:dothistimeout) { |cmd, *_| sent << cmd; s.affordable = true; 'An invigorating rush of mana pulses through you.' }
+      expect(described_class.return(:spirit_guide, rift: true, resting_room: 4)).to be true
+      expect(sent).to eq(['mana pulse'])
+      expect(s.casts).to eq(2)
+      expect(Room.current.id).to eq(4)
+    end
+
+    it 'confirms a move between unmapped rooms on the server room, not the map' do
+      Room.current = nil
+      spell(130).on_cast { arrive(9, mapped: false) }
+      allow(voln).to receive(:known?).with('return').and_return(true)
+      expect(described_class.return(:spirit_guide)).to be true
+      expect(sent).to be_empty # no fallback symbol after a move that worked
     end
 
     it 'stays in the Rift when that is the destination' do


### PR DESCRIPTION
## Summary

Getting home from the field is something any script may need, not a hunting rule, so it belongs in core. Today the only implementation is bigshot's `fog_return` / `fog_return_spirit` / `fog_return_voln`, which a script has to either run bigshot to get or copy. This is that routine in Lich, on the readers that already exist.

`Lich::Gemstone::Fog`:

- `known?(method)`, `available?(method)`, `available` for `:spirit_guide` (130), `:symbol_of_return` (Voln), `:travelers_song` (1020), `:sigil_of_escape` (Sunfist) and `:familiar_gate` (930), read from `Spell` and the `Societies::OrderOfVoln` / `Societies::GuardiansOfSunfist` readers.
- `return(method, rift:, resting_room:)`: waits out roundtime, pulses mana for a known spell it cannot afford, sends the method, and answers whether the room changed rather than assuming it did. Keeps bigshot's Spirit Guide <-> Symbol of Return fallback and the second cast when the first lands in the Rift with the destination elsewhere.
- Takes bigshot's `fog_return` numbering (1-5) as well as names, so a profile value can be passed straight through. 6 (custom commands) is the script's own business and is not here.

Policy stays with the caller: which method, whether to fog at all, and any custom command list.

Loaded from the GS branch of `gameloader.rb` after `society.rb`.

## Test plan

- [x] `bundle exec rspec spec/lib/gemstone/fog_spec.rb` (13 examples: normalize, the readers, each of the five, both fallbacks, the Rift second cast, the mana pulse, an unknown method)
- [x] rubocop clean
- [x] full suite: the 57 failures are the same frontend, launcher and setup-files examples that fail on a clean `origin/main` worktree here (Windows environment), none in this change
- [ ] In game: `Lich::Gemstone::Fog.available`, then `Lich::Gemstone::Fog.return(:spirit_guide)` from the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)