### PR TITLE
fix(gs): infomon - a spell's start message refreshes a refreshable timer

### DIFF
--- a/lib/common/spell.rb
+++ b/lib/common/spell.rb
@@ -345,6 +345,14 @@ module Lich
         (self.timeleft > 0) and @active
       end
 
+      # The cast-type predicates below (stackable?, refreshable?, multicastable?)
+      # and the duration formulas resolve against the 'self' cast-type unless a
+      # :caster or :target naming someone else is supplied. A bare call therefore
+      # answers for a self-cast only, which is not the same answer for spells
+      # whose target cast-type differs: in the current effect list 14 group buffs
+      # (Bravery 211 and Heroism 215 among them) are stackable when self-cast but
+      # refreshable when cast on someone else. Pass :caster/:target whenever the
+      # spell may have come from another character.
       def stackable?(options = {})
         if options[:caster] and (options[:caster] !~ /^(?:self|#{XMLData.name})$/i)
           if options[:target] and (options[:target].downcase == options[:caster].downcase)

--- a/lib/gemstone/infomon/parser.rb
+++ b/lib/gemstone/infomon/parser.rb
@@ -633,7 +633,10 @@ module Lich
               spell = Spell.list.find do |s|
                 line =~ /^#{s.msgup}$/
               end
-              spell.putup unless spell.active?
+              # A start message while the spell is already up is the game
+              # refreshing it: a refreshable timer resets to its full
+              # duration, anything else keeps the timer it has.
+              spell.putup if !spell.active? || spell.refreshable?
               # add various cooldowns back without affecting parse speed
               Spells.require_cooldown(spell)
               :ok

--- a/spec/lib/gemstone/infomon/spell_message_refresh_spec.rb
+++ b/spec/lib/gemstone/infomon/spell_message_refresh_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+
+# Load spell data for realistic testing
+load_spell_data
+
+require "common/sharedbuffer"
+require "common/buffer"
+require "games"
+require "gemstone/overwatch"
+require "gemstone/infomon"
+require "attributes/stats"
+require "attributes/resources"
+require "attributes/skills"
+require "attributes/spells"
+require "gemstone/currency"
+require "gemstone/infomon/status"
+require "gemstone/experience"
+require "util/util"
+require "gemstone/psms"
+require "gemstone/psms/ascension"
+
+# Top-level aliases the parser uses at runtime
+Skills = Lich::Gemstone::Skills unless defined?(Skills)
+Spell = Lich::Common::Spell unless defined?(Spell)
+Spells = Lich::Gemstone::Spells unless defined?(Spells)
+
+# A spell's start message while the spell is already up. The game sends
+# it when a refreshable effect is refreshed (a recast of Celerity, another
+# RAISE under Briar Betrayer), and the timer has to follow: before this
+# the parser skipped the message for an active spell, so Lich let its own
+# timer run out while the game's had two minutes to go.
+RSpec.describe Lich::Gemstone::Infomon::Parser, 'a start message for an active spell' do
+  let(:celerity) { Lich::Common::Spell[506] }   # refreshable in the effect list
+  let(:briar)    { Lich::Common::Spell[9105] }  # no span: keeps its timer
+
+  before do
+    allow(Lich::Gemstone::Infomon).to receive(:set)
+    allow(Lich::Gemstone::Spells).to receive(:require_cooldown)
+    celerity.putdown
+    briar.putdown
+  end
+
+  after do
+    celerity.putdown
+    briar.putdown
+  end
+
+  it 'puts an inactive spell up' do
+    described_class.parse('You suddenly start moving light-footedly.')
+    expect(celerity.active?).to be true
+    expect(celerity.timeleft).to be > 0.5
+  end
+
+  it 'resets a refreshable spell to its full duration' do
+    celerity.putup
+    celerity.timeleft = 0.05 # three seconds left on Lich's clock
+    described_class.parse('You suddenly start moving light-footedly.')
+    expect(celerity.timeleft).to be > 0.5
+  end
+
+  it 'leaves a non-refreshable spell on the timer it has' do
+    briar.putup
+    briar.timeleft = 0.05
+    described_class.parse('As you begin to raise your ruic longbow, the briars imbedded in your flesh release their stored blood in a massive pulse of power that you can feel in the core of your very being.  The vines lose all crimson hues, and strength courses through your blood.')
+    expect(briar.active?).to be true
+    expect(briar.timeleft).to be <= 0.05
+  end
+end


### PR DESCRIPTION
## Summary

The Infomon parser puts a spell up on its start message only when the spell is not already active (`spell.putup unless spell.active?`). When the game refreshes an effect that is still running, Lich keeps the old expiry. Effects the game lists in the spells window are corrected by ActiveSpell's duration sync, but timers that exist only through their start and end messages have no other source, and the effect list already marks which of those are refreshable (`span='refreshable'`); nobody was asking.

Where it showed: Briar Betrayer (9105) is a two-minute effect the game reports only through the BetrayerPanel, so Lich's timer runs from the RAISE pulse line. A raise inside the live window refreshes it in the game (no end line between, the end line two minutes after the last raise) while Lich's timer expired on the old schedule. On one character's logs since 2026-09-06 that happened 376 times, and 173 of those were followed within 30 seconds by a volley the script's `Spell[9105].active?` gate should have held.

The change: a start message for an active spell calls `putup` when the duration is refreshable, which resets it to the full duration. Anything else keeps the timer it has, exactly as before. Stackable durations are left alone here: those are real spells the window reports, and stacking them from the message as well would count a cast twice.

`data/effect-list.xml` in the scripts repo needs 9105's duration marked `span='refreshable'` to get this behaviour; that is a separate PR there.

## Test plan

- [x] `bundle exec rspec spec/lib/gemstone/infomon/spell_message_refresh_spec.rb` (3 examples: an inactive spell goes up, a refreshable one resets from near-expiry, a non-refreshable one keeps its timer)
- [x] `spec/lib/gemstone/infomon_spec.rb`, `spec/lib/gemstone/infomon/`, `spec/lib/common/spell_spec.rb`: 93 examples, 0 failures
- [x] rubocop clean
- [x] In game with the local effect list marked refreshable: 9105 reads two minutes after every raise, and volley no longer fires inside the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)