### PR TITLE
feat(gs): Combat::Messages - non-combat message families as observer events

### DIFF
--- a/lib/gemstone/combat/defs/messages.rb
+++ b/lib/gemstone/combat/defs/messages.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+#
+# Message Definitions - non-combat game lines scripts react to, as
+# observer events.
+#
+# The combat defs answer "what happened to whom in a fight". These answer
+# the other questions a hunting script keeps a DownstreamHook open for:
+# a weapon knocked away, a curse or infection taken, a trap sprung, an
+# ambusher arriving, a bolt, a bless shrugged off, an arrow stuck, a
+# charge counter, a spell mark on a creature. Every one of these was a
+# private regex in bigshot, ecleanse or eohunter; here each is one def in
+# a family, gated by PatternGate like the combat tables, scanned only
+# while something subscribes to the family (see Combat::Messages).
+#
+# A def is an event name, a pattern, and a data block that turns the
+# MatchData into the event payload. Payloads always also carry :raw, the
+# line. Patterns are pinned to the messaging the scripts were matching in
+# the wild (ecleanse set_hooks, bigshot hunt_monitor, eohunter watch
+# rules, 2026-09), one form per def so PatternGate can gate each; a
+# top-level alternation would gate nothing.
+#
+
+require_relative 'pattern_gate'
+
+module Lich
+  module Gemstone
+    module Combat
+      module Definitions
+        module Messages
+          MessageDef = Struct.new(:event, :pattern, :data)
+          Family = Struct.new(:name, :defs, :gate, :always_scan) do
+            # Every event this family can emit.
+            def events = defs.map(&:event).uniq
+
+            def rejects?(line) = PatternGate.rejects?(gate, always_scan, line)
+          end
+
+          LINK = /<a exist="(?<id>[^"]+)" noun="(?<noun>[^"]+)">[^<]+<\/a>/i.freeze
+
+          # Build a family from [event, pattern, data] rows.
+          def self.family(name, rows)
+            defs = rows.map { |event, pattern, data| MessageDef.new(event, pattern, data) }
+            gate, always = PatternGate.build(defs.map(&:pattern))
+            Family.new(name, defs.freeze, gate, always)
+          end
+
+          NONE = ->(_m) { {} }
+
+          FAMILIES = [
+            # ecleanse set_hooks 1618: the line-driven recoveries. The disarm
+            # lines carry the weapon's noun; what hand it was in and where
+            # we stood is the subscriber's to read at the moment.
+            family(:disarm, [
+                     [:disarm_seen, %r{Your <a exist="[^"]+" noun="(?<noun>[^"]+)">[^<]+</a> is knocked from your grasp}, ->(m) { { kind: :recover, noun: m[:noun] } }],
+                     [:disarm_seen, %r{your <a exist="[^"]+" noun="(?<noun>[^"]+)">[^<]+</a> at .+?\.  The weapon rebounds off of the hardened .+? and is wrenched from your hand\.  It slides along the ground and disappears into the shadows!}, ->(m) { { kind: :recover, noun: m[:noun] } }],
+                     [:disarm_seen, %r{^Your <a exist="[^"]+" noun="(?<noun>[^"]+)">[^<]+</a> strikes one of the bony protrusions on <pushBold/>an? <a exist="\d+" noun="[^"]+">[^<]+</a><popBold/> \w+ and it is wrenched out of your grasp!}, ->(m) { { kind: :recover, noun: m[:noun] } }],
+                     [:disarm_seen, %r{^You swing your <a exist="[^"]+" noun="(?<noun>[^"]+)">[^<]+</a> at <pushBold/>(?:an?|the) <a exist="[^"]+" noun="[^"]+">[^<]+</a><popBold/>\.  The weapon strikes one of the bony protrusions on the <pushBold/><a exist="[^"]+" noun="[^"]+">[^<]+</a><popBold/> \w+ and it is wrenched out of your grasp!}, ->(m) { { kind: :recover, noun: m[:noun] } }],
+                     [:disarm_seen, %r{Your <a exist="[^"]+" noun="(?<noun>[^"]+)">[^<]+</a> tears free from your hands and floats}, ->(m) { { kind: :telekinetic_recover, noun: m[:noun] } }],
+                     [:disarm_seen, %r{The webbing entangles your <a exist="[^"]+" noun="(?<noun>[^"]+)">[^<]+</a>, rendering it useless}, ->(m) { { kind: :recover_weapon_webbing, noun: m[:noun] } }],
+                     [:sanctum_transform, %r{Striking with a serpent's unsettling quickness, .*\.  Vile .*, kindling it into an unholy semblance of life\.  The .* form twists and mutates, sprouting scales and cold eyes as it transforms into a <a exist="\d+" noun="(?<noun>[^"]+)">[^<]+</a>!}, ->(m) { { noun: m[:noun] } }]
+                   ]),
+
+            # ecleanse: afflictions and traps that take a trip to clear.
+            family(:hazard, [
+                     [:itchy_curse, /You shiver slightly as an invisible rash covers your body/, NONE],
+                     [:infected_wound, /The flesh around the wound feels hot and cold at the same time, heavy with infection\./, NONE],
+                     [:hive_trap, /You notice a flickering glint in the shadows/, ->(_m) { { kind: :apparatus } }],
+                     [:hive_trap, /The apparatus flickers with deadly radiance/, ->(_m) { { kind: :apparatus } }],
+                     [:hive_trap, /The ground churns violently as flashes of chitin jut from its depths/, ->(_m) { { kind: :ground } }],
+                     [:hive_trap, /The ground underfoot churns violently and huge chitinous mandibles flash as the insectoid monstrosity below goes into a feeding frenzy!/, ->(_m) { { kind: :ground } }],
+                     [:hive_trap, /Hindered by the churning terrain, you are helpless as the concealed assailant's mandibles snap at you from the safety of its pit trap!/, ->(_m) { { kind: :ground } }],
+                     [:entangled, /^An unseen force entangles you, restricting your movement!/, NONE]
+                   ]),
+
+            # bigshot hunt_monitor 2322-2383: the flee rules' lines.
+            family(:ambush, [
+                     [:ambusher, %r{<a exist="-?\d+" noun="(?<noun>[a-zA-Z]*?)">[a-zA-Z]*?</a> leaps from hiding to attack!}i, ->(m) { { noun: m[:noun] } }],
+                     [:ambusher, /flies out of the shadows toward/i, ->(_m) { { noun: nil } }],
+                     [:ambusher, /A shadowy figure leaps from hiding to attack/i, ->(_m) { { noun: nil } }],
+                     [:bolted, /^You bolt/i, NONE]
+                   ]),
+
+            # bigshot hunt_monitor 2406-2416: held in place, freed, the item
+            # limit.
+            family(:hold, [
+                     [:rooted, /You don't seem to be able to move(?: your legs)? to do that\./, NONE],
+                     [:rooted, %r{You are unable to get out of the way as <pushBold/>the <a exist="(?<id>\d+)" noun="snake">snake</a><popBold/> coils tightly around you, holding you in place!}, ->(m) { { id: m[:id] } }],
+                     [:unrooted, %r{You're finally able to break free of <pushBold/>the <a exist="(?<id>\d+)" noun="snake">snake's</a><popBold/> coils!}, ->(m) { { id: m[:id] } }],
+                     [:item_limit, /^You are unable to hold the number of items /, NONE],
+                     [:item_limit, /^You note some treasure of interest but are unable to pick any up\./, NONE],
+                     [:item_limit, /^At your touch, the lit sigils marking your .+ ignite, then quickly sputter out again\./, NONE]
+                   ]),
+
+            # bigshot hunt_monitor 2359-2367: a blessing shrugged off or gone.
+            family(:bless, [
+                     [:bless_shrugged, %r{The <a exist="(?<id>[^"]+)" noun="(?<noun>[^"]+)">[^<]+</a> strikes? true.* shrugs off some of the damage!}i, ->(m) { { id: m[:id], noun: m[:noun] } }],
+                     [:bless_expired, %r{Your <a exist="(?<id>[^"]+)" noun="(?<noun>[^"]+)">[^<]+</a> returns? to normal\.}i, ->(m) { { id: m[:id], noun: m[:noun] } }]
+                   ]),
+
+            # bigshot's archery state (cmd_dislodge, archery aiming, the
+            # bonded weapon's return).
+            family(:archery, [
+                     [:arrow_stuck, %r{The .* sticks in <pushBold/>an? <a exist="(?<id>\d+)" noun="[^"]+">[^<]+</a><popBold/>'s (?:left |right )?(?<where>.*)!}i, ->(m) { { id: m[:id], where: m[:where] } }],
+                     [:aiming, /You're now aiming at the (?<where>.*) of/i, ->(m) { { where: m[:where] } }],
+                     [:aiming, /You're now no longer aiming at anything in particular/i, ->(_m) { { where: nil } }],
+                     [:bond_return, /^An? (?<what>.*) rises out of the shadows and flies back to your waiting hand!/i, ->(m) { { what: m[:what] } }]
+                   ]),
+
+            # Marks a spell leaves on a creature, and counters on us
+            # (bigshot hunt_monitor 2387-2405).
+            family(:marks, [
+                     [:haze_703, %r{<pushBold/>.*?<a exist="(?<id>[^"]+)" noun="[^"]+">[^<]+</a><popBold/>.*?is suddenly surrounded by a blood red haze\.}i, ->(m) { { id: m[:id], on: true } }],
+                     [:haze_703, %r{The blood red haze dissipates from around.*?<pushBold/>.*?<a exist="(?<id>[^"]+)" noun="[^"]+">[^<]+</a><popBold/>}i, ->(m) { { id: m[:id], on: false } }],
+                     [:rebuke_1614, %r{<pushBold/>.*?<a exist="(?<id>[^"]+)" noun="[^"]+">[^<]+</a><popBold/>.*?visibly struggling against your radiant aura!}i, ->(m) { { id: m[:id], on: true } }],
+                     [:rebuke_1614, %r{<pushBold/>.*?<a exist="(?<id>[^"]+)" noun="[^"]+">[^<]+</a><popBold/>.*?in awe of your radiant aura!}i, ->(m) { { id: m[:id], on: true } }],
+                     [:rebuke_1614, %r{<pushBold/>.*?<a exist="(?<id>[^"]+)" noun="[^"]+">[^<]+</a><popBold/>.*?recovers from being rebuked}i, ->(m) { { id: m[:id], on: false } }],
+                     [:swift_justice, /Your Swift Justice charges are increased to (?<n>\d+)\./i, ->(m) { { charges: m[:n].to_i } }],
+                     [:swift_justice, /Your Swift Justice surges through you! Its charges are reduced to (?<n>\d+)\./i, ->(m) { { charges: m[:n].to_i } }],
+                     [:arcane_reflex, /^Vital energy infuses you, hastening your arcane reflexes!/i, ->(_m) { { active: true } }],
+                     [:arcane_reflex, /^Nature's blessing of vitality departs as your arcane prowess returns to normal\./i, ->(_m) { { active: false } }]
+                   ]),
+
+            # The weapon reaction prompt (bigshot perform_reaction).
+            family(:reaction, [
+                     [:weapon_reaction, %r{^You could use this opportunity to <d cmd='WEAPON (?<reaction>\w+\s#\d+)'>.*</d>!}i, ->(m) { { reaction: m[:reaction] } }]
+                   ])
+          ].freeze
+
+          BY_NAME = FAMILIES.to_h { |f| [f.name, f] }.freeze
+          # event -> family, for subscription gating
+          FAMILY_OF = FAMILIES.each_with_object({}) { |f, h| f.events.each { |e| h[e] = f } }.freeze
+          EVENTS = FAMILY_OF.keys.freeze
+
+          # Every event a line yields across +families+, as [event, data].
+          #
+          # @param families [Array<Family>] the ones to scan (all by default)
+          # @return [Array<Array(Symbol, Hash)>]
+          def self.scan(line, families = FAMILIES)
+            found = []
+            families.each do |family|
+              next if family.rejects?(line)
+
+              family.defs.each do |d|
+                m = d.pattern.match(line)
+                next unless m
+
+                found << [d.event, (d.data.call(m) || {}).merge(raw: line)]
+              end
+            end
+            found
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gemstone/combat/defs/messages.rb
+++ b/lib/gemstone/combat/defs/messages.rb
@@ -36,8 +36,6 @@ module Lich
             def rejects?(line) = PatternGate.rejects?(gate, always_scan, line)
           end
 
-          LINK = /<a exist="(?<id>[^"]+)" noun="(?<noun>[^"]+)">[^<]+<\/a>/i.freeze
-
           # Build a family from [event, pattern, data] rows.
           def self.family(name, rows)
             defs = rows.map { |event, pattern, data| MessageDef.new(event, pattern, data) }

--- a/lib/gemstone/combat/messages.rb
+++ b/lib/gemstone/combat/messages.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+#
+# Combat Messages - the non-combat message families (defs/messages.rb)
+# delivered through Combat::Observers, scanned only while subscribed.
+#
+# The Tracker's hook chunks on the prompt and only hands a chunk to the
+# Processor when it names a creature; most of these lines arrive in
+# chunks that name none (an itchy curse, an item limit, a bolt). So the
+# messages have their own hook, one line at a time, installed the moment
+# the first subscription to a message event appears and removed with the
+# last. Scanning is gated twice: a family is only tried when one of its
+# events has a subscriber, and each family's PatternGate literal union
+# rejects most lines before any def pattern runs. With no subscribers the
+# hook is not even installed.
+#
+# Matching runs on a single worker thread fed by a queue, never on the
+# game stream. Subscribers therefore run on that worker: the
+# Combat::Observers contract applies - cheap, non-blocking, no game
+# commands from the callback.
+#
+# @example
+#   Combat::Tracker.on(:disarm_seen) { |_type, data| queue << data }
+#   Combat::Tracker.on(:ambusher, :bolted, name: 'myscript') { |type, data| ... }
+#
+# Combat::Messages.scan(line) matches one line synchronously and returns
+# what it would emit - for tools and specs.
+#
+require_relative 'observers'
+require_relative 'defs/messages'
+
+module Lich
+  module Gemstone
+    module Combat
+      module Messages
+        HOOK_ID = 'Combat::Messages::downstream'
+
+        @mutex = Mutex.new
+        @active = [].freeze
+        @queue = nil
+        @worker = nil
+        @hook = false
+        @scanned = 0
+        @matched = 0
+
+        class << self
+          def families = Definitions::Messages::FAMILIES
+          def events = Definitions::Messages::EVENTS
+
+          # A message event, as opposed to a combat fact.
+          def event?(type) = Definitions::Messages::FAMILY_OF.key?(type.to_sym)
+
+          # The families with a subscriber for at least one of their events.
+          def active_families = @active
+
+          # Recompute the active families from the subscriptions and put the
+          # hook up or take it down to match. Observers calls this on every
+          # change; harmless to call again.
+          def refresh!
+            active = families.select { |f| f.events.any? { |e| Observers.any_for?(e) } }
+            @mutex.synchronize { @active = active.freeze }
+            active.empty? ? uninstall! : install!
+            @active
+          end
+
+          # What one line yields, synchronously, over the given families
+          # (the active ones by default; pass +families+ to scan them all).
+          #
+          # @return [Array<Array(Symbol, Hash)>]
+          def scan(line, families: @active)
+            Definitions::Messages.scan(line, families)
+          end
+
+          # Scan and emit, synchronously. Used by the worker; tools may call
+          # it directly to replay a log.
+          def process(line)
+            found = scan(line)
+            @scanned += 1
+            @matched += found.size
+            found.each { |event, data| Observers.emit(event, data) }
+            found
+          end
+
+          # The hook's entry: enqueue for the worker, never block the stream.
+          def enqueue(line)
+            return if @active.empty?
+
+            @queue ||= Queue.new
+            @queue.push(line)
+            ensure_worker
+          end
+
+          def installed? = @hook
+
+          def stats
+            { installed: @hook, families: @active.map(&:name), scanned: @scanned, matched: @matched,
+              queued: @queue ? @queue.size : 0, worker_alive: !@worker.nil? && @worker.alive? }
+          end
+
+          # Drain and stop the worker (tests, shutdown).
+          def shutdown
+            return unless @worker&.alive?
+
+            @queue&.push(:shutdown)
+            @worker.join(2)
+            @worker = nil
+          end
+
+          private
+
+          def install!
+            return if @hook
+            return unless defined?(::DownstreamHook)
+
+            hook = proc do |server_string|
+              enqueue(server_string) if server_string.is_a?(String)
+              server_string
+            end
+            ::DownstreamHook.add(HOOK_ID, hook, persist: true)
+            @hook = true
+          end
+
+          def uninstall!
+            return unless @hook
+
+            ::DownstreamHook.remove(HOOK_ID) if defined?(::DownstreamHook)
+            @hook = false
+          end
+
+          # One ordered worker, respawned if a script's death took it (the
+          # same shape as AsyncProcessor).
+          def ensure_worker
+            return if @worker&.alive?
+
+            @mutex.synchronize do
+              next if @worker&.alive?
+
+              @worker = Thread.new { run_loop }
+            end
+          end
+
+          def run_loop
+            loop do
+              line = @queue.pop
+              break if line == :shutdown
+
+              begin
+                process(line)
+              rescue StandardError => e
+                Lich.log "error: Combat::Messages worker: #{e.message}\n\t#{e.backtrace&.first}"
+              end
+            end
+          end
+        end
+
+        Observers.on_change { refresh! }
+      end
+    end
+  end
+end

--- a/lib/gemstone/combat/messages.rb
+++ b/lib/gemstone/combat/messages.rb
@@ -56,11 +56,17 @@ module Lich
           # Recompute the active families from the subscriptions and put the
           # hook up or take it down to match. Observers calls this on every
           # change; harmless to call again.
+          #
+          # The whole read-decide-act sequence is held under @mutex: two
+          # scripts subscribing at once would otherwise interleave so that
+          # the last @active write is non-empty while the last hook call is
+          # uninstall!, silently leaving a live subscriber with no hook.
           def refresh!
-            active = families.select { |f| f.events.any? { |e| Observers.any_for?(e) } }
-            @mutex.synchronize { @active = active.freeze }
-            active.empty? ? uninstall! : install!
-            @active
+            @mutex.synchronize do
+              @active = families.select { |f| f.events.any? { |e| Observers.any_for?(e) } }.freeze
+              @active.empty? ? uninstall! : install!
+              @active
+            end
           end
 
           # What one line yields, synchronously, over the given families

--- a/lib/gemstone/combat/observers.rb
+++ b/lib/gemstone/combat/observers.rb
@@ -42,6 +42,21 @@
 #                 cleanup, not meaningful expiry), or nil (natural
 #                 expiry, or cause not visible in this chunk)
 #
+# Message events (defs/messages.rb, delivered by Combat::Messages; every
+# payload also carries :raw, the line). Scanned only while subscribed:
+#   :disarm_seen  { kind: :recover|:telekinetic_recover|:recover_weapon_webbing, noun: }
+#   :sanctum_transform { noun: }
+#   :itchy_curse, :infected_wound, :entangled   {}
+#   :hive_trap    { kind: :apparatus|:ground }
+#   :ambusher     { noun: }  (nil for the shadowy figure)
+#   :bolted       {}
+#   :rooted / :unrooted  { id: } (the snake's), :item_limit {}
+#   :bless_shrugged / :bless_expired  { id:, noun: }
+#   :arrow_stuck  { id:, where: }, :aiming { where: } (nil when cleared),
+#   :bond_return  { what: }
+#   :haze_703 / :rebuke_1614  { id:, on: }, :swift_justice { charges: },
+#   :arcane_reflex { active: }, :weapon_reaction { reaction: }
+#
 # @example
 #   Combat::Tracker.on(:damage) { |type, data| my_queue << data }
 #   handler = Combat::Tracker.on(:status, :wound) { |type, data| ... }
@@ -54,8 +69,17 @@ module Lich
         @mutex = Mutex.new
         @subscribers = Hash.new { |h, k| h[k] = [] }
         @named = {}
+        @on_change = []
 
         class << self
+          # A block run after every subscription change (on, off, clear!):
+          # how Combat::Messages learns which families to scan. Errors are
+          # isolated the way subscriber errors are.
+          def on_change(&block)
+            @mutex.synchronize { @on_change << block }
+            block
+          end
+
           # Subscribe to one or more event types (or :any for everything).
           # Returns the block; keep it to unsubscribe via .off.
           #
@@ -75,6 +99,7 @@ module Lich
               end
               types.each { |t| @subscribers[t.to_sym] << block }
             end
+            changed
             block
           end
 
@@ -90,6 +115,7 @@ module Lich
               @named.delete_if { |_, h| h == handler }
               @subscribers.each_value { |list| list.delete(handler) } if handler
             end
+            changed
             nil
           end
 
@@ -115,6 +141,20 @@ module Lich
             @mutex.synchronize do
               @subscribers.clear
               @named.clear
+            end
+            changed
+          end
+
+          private
+
+          def changed
+            callbacks = @mutex.synchronize { @on_change.dup }
+            callbacks.each do |cb|
+              begin
+                cb.call
+              rescue StandardError => e
+                Lich.log "error: Combat::Observers on_change: #{e.message}\n\t#{e.backtrace&.first}"
+              end
             end
           end
         end

--- a/lib/gemstone/combat/tracker.rb
+++ b/lib/gemstone/combat/tracker.rb
@@ -8,6 +8,7 @@
 require_relative 'parser'
 require_relative 'processor'
 require_relative 'async_processor'
+require_relative 'messages'
 require_relative '../../common/db_store'
 
 module Lich
@@ -70,6 +71,10 @@ module Lich
           # Subscribe to parsed combat events (see Combat::Observers for
           # event types, payloads, and the subscriber contract - callbacks
           # may run on worker threads; never send game commands from one).
+          # Message events (:disarm_seen, :ambusher, :bolted ... see
+          # Combat::Messages) subscribe the same way and need the tracker
+          # neither enabled nor scanning creatures: their hook goes up with
+          # the first subscription.
           #
           # @example
           #   Combat::Tracker.on(:damage) { |type, data| queue << data }

--- a/spec/lib/gemstone/combat/message_defs_spec.rb
+++ b/spec/lib/gemstone/combat/message_defs_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require 'gemstone/combat/defs/messages'
+
+# The message families, each pinned against the game line the scripts
+# were matching (ecleanse set_hooks, bigshot hunt_monitor, eohunter's
+# watch rules). scan over ALL families here; the subscription gate is
+# Combat::Messages' and tested there.
+RSpec.describe Lich::Gemstone::Combat::Definitions::Messages do
+  def link(id, noun, name = noun) = %(<a exist="#{id}" noun="#{noun}">#{name}</a>)
+  def bold(id, noun, name) = "<pushBold/>#{link(id, noun, name)}<popBold/>"
+  # the article outside the link, the game's form for "a kobold"
+  def bold_a(id, noun) = "<pushBold/>a #{link(id, noun)}<popBold/>"
+
+  def scan(line) = described_class.scan(line)
+
+  def only(line)
+    found = scan(line)
+    expect(found.size).to eq(1), "expected one event for #{line.inspect}, got #{found.inspect}"
+    found.first
+  end
+
+  it 'names every family once and maps every event to one family' do
+    expect(described_class::FAMILIES.map(&:name)).to eq(%i[disarm hazard ambush hold bless archery marks reaction])
+    described_class::FAMILIES.each do |family|
+      family.events.each { |e| expect(described_class::FAMILY_OF[e]).to equal(family) }
+    end
+  end
+
+  it 'gates every family on a literal (no def is a bare alternation)' do
+    described_class::FAMILIES.each do |family|
+      expect(family.gate).not_to be_nil, "#{family.name} has no gate"
+    end
+  end
+
+  describe 'disarm' do
+    it 'sees a weapon knocked away, wrenched, or floated off, with the noun and the recovery kind' do
+      event, data = only("Your #{link('1', 'falchion', 'vultite falchion')} is knocked from your grasp!")
+      expect(event).to eq(:disarm_seen)
+      expect(data).to include(kind: :recover, noun: 'falchion')
+      _, data = only("Your #{link('1', 'falchion', 'vultite falchion')} tears free from your hands and floats up into the air.")
+      expect(data).to include(kind: :telekinetic_recover, noun: 'falchion')
+      _, data = only("The webbing entangles your #{link('1', 'falchion', 'vultite falchion')}, rendering it useless.")
+      expect(data).to include(kind: :recover_weapon_webbing, noun: 'falchion')
+      line = "Your #{link('1', 'falchion', 'vultite falchion')} strikes one of the bony protrusions on #{bold_a('2', 'crawler')} back and it is wrenched out of your grasp!"
+      _, data = only(line)
+      expect(data).to include(kind: :recover, noun: 'falchion', raw: line)
+    end
+
+    it 'sees the sanctum transform with the new noun' do
+      line = "Striking with a serpent's unsettling quickness, the creature bites.  Vile venom courses, kindling it into an unholy semblance of life.  The dead form twists and mutates, sprouting scales and cold eyes as it transforms into a #{link('3', 'wyrm', 'scaled wyrm')}!"
+      expect(only(line)).to match([:sanctum_transform, { noun: 'wyrm', raw: line }])
+    end
+  end
+
+  describe 'hazard' do
+    it 'sees the itchy curse, the infected wound, the entangling force, and both hive traps' do
+      expect(only('You shiver slightly as an invisible rash covers your body.').first).to eq(:itchy_curse)
+      expect(only('The flesh around the wound feels hot and cold at the same time, heavy with infection.').first).to eq(:infected_wound)
+      expect(only('An unseen force entangles you, restricting your movement!').first).to eq(:entangled)
+      expect(only('You notice a flickering glint in the shadows.')).to include(:hive_trap, hash_including(kind: :apparatus))
+      expect(only('The ground churns violently as flashes of chitin jut from its depths!')).to include(:hive_trap, hash_including(kind: :ground))
+    end
+  end
+
+  describe 'ambush' do
+    it 'names the ambusher, or not, and sees the bolt' do
+      expect(only("#{link('-10', 'Bob')} leaps from hiding to attack!")).to match([:ambusher, { noun: 'Bob', raw: "#{link('-10', 'Bob')} leaps from hiding to attack!" }])
+      expect(only('A shadowy figure leaps from hiding to attack!').last).to include(noun: nil)
+      expect(only('You bolt out of the room!').first).to eq(:bolted)
+    end
+  end
+
+  describe 'hold' do
+    it 'sees the snake, the release, and the item limit' do
+      expect(only("You are unable to get out of the way as <pushBold/>the #{link('7', 'snake')}<popBold/> coils tightly around you, holding you in place!")).to match([:rooted, hash_including(id: '7')])
+      expect(only("You don't seem to be able to move to do that.").first).to eq(:rooted)
+      expect(only("You're finally able to break free of <pushBold/>the #{link('7', 'snake', "snake's")}<popBold/> coils!")).to match([:unrooted, hash_including(id: '7')])
+      expect(only('You are unable to hold the number of items you are trying to carry.').first).to eq(:item_limit)
+    end
+  end
+
+  describe 'bless' do
+    it 'sees a blessed strike shrugged off and a blessing gone' do
+      line = "The #{link('5', 'arrow', 'silver-tipped arrow')} strikes true, but the ghost shrugs off some of the damage!"
+      expect(only(line)).to match([:bless_shrugged, { id: '5', noun: 'arrow', raw: line }])
+      expect(only("Your #{link('5', 'arrow', 'silver-tipped arrow')} returns to normal.")).to match([:bless_expired, hash_including(id: '5', noun: 'arrow')])
+    end
+  end
+
+  describe 'archery' do
+    it 'sees where the arrow stuck, the aim, and the bonded return' do
+      expect(only("The arrow sticks in #{bold_a('9', 'kobold')}'s left leg!")).to match([:arrow_stuck, hash_including(id: '9', where: 'leg')])
+      expect(only("You're now aiming at the head of your target.")).to match([:aiming, hash_including(where: 'head')])
+      expect(only("You're now no longer aiming at anything in particular.")).to match([:aiming, hash_including(where: nil)])
+      expect(only('A vultite dagger rises out of the shadows and flies back to your waiting hand!')).to match([:bond_return, hash_including(what: 'vultite dagger')])
+    end
+  end
+
+  describe 'marks' do
+    it 'sees the haze, the rebuke, the charges and the reflexes' do
+      expect(only("#{bold('4', 'orc', 'an orc')} is suddenly surrounded by a blood red haze.")).to match([:haze_703, hash_including(id: '4', on: true)])
+      expect(only("The blood red haze dissipates from around #{bold('4', 'orc', 'an orc')}.")).to match([:haze_703, hash_including(id: '4', on: false)])
+      expect(only("#{bold('4', 'orc', 'an orc')} is visibly struggling against your radiant aura!")).to match([:rebuke_1614, hash_including(id: '4', on: true)])
+      expect(only("#{bold('4', 'orc', 'an orc')} recovers from being rebuked.")).to match([:rebuke_1614, hash_including(id: '4', on: false)])
+      expect(only('Your Swift Justice charges are increased to 3.')).to match([:swift_justice, hash_including(charges: 3)])
+      expect(only('Vital energy infuses you, hastening your arcane reflexes!')).to match([:arcane_reflex, hash_including(active: true)])
+    end
+  end
+
+  describe 'reaction' do
+    it 'sees the weapon reaction prompt with its command' do
+      expect(only("You could use this opportunity to <d cmd='WEAPON PARRY #123'>parry</d>!")).to match([:weapon_reaction, hash_including(reaction: 'PARRY #123')])
+    end
+  end
+
+  it 'yields nothing for ordinary lines' do
+    expect(scan('You swing a vultite falchion at a kobold!')).to eq([])
+    expect(scan('<prompt time="1">&gt;</prompt>')).to eq([])
+  end
+end

--- a/spec/lib/gemstone/combat/messages_spec.rb
+++ b/spec/lib/gemstone/combat/messages_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module Lich
+  def self.log(msg); (@logged ||= []) << msg; end
+
+  def self.logged = @logged ||= []
+  module Gemstone; module Combat; end; end
+end
+
+require_relative '../../../../lib/gemstone/combat/messages'
+
+# The subscription gate: nothing scans, and no hook exists, until a
+# message event has a subscriber; only the subscribed families scan.
+RSpec.describe Lich::Gemstone::Combat::Messages do
+  let(:observers) { Lich::Gemstone::Combat::Observers }
+
+  after do
+    observers.clear!
+    described_class.shutdown
+  end
+
+  it 'has no active family and no hook with nobody subscribed' do
+    expect(described_class.active_families).to eq([])
+    expect(described_class.installed?).to be(false)
+    expect(described_class.scan('You bolt!')).to eq([])
+  end
+
+  it 'activates only the subscribed family, and drops it on unsubscribe' do
+    handler = observers.on(:bolted) { nil }
+    expect(described_class.active_families.map(&:name)).to eq([:ambush])
+    expect(described_class.scan('You bolt!').map(&:first)).to eq([:bolted])
+    expect(described_class.scan('You shiver slightly as an invisible rash covers your body.')).to eq([]) # hazard not subscribed
+    observers.off(handler)
+    expect(described_class.active_families).to eq([])
+  end
+
+  it 'a combat subscription activates nothing' do
+    observers.on(:damage) { nil }
+    expect(described_class.active_families).to eq([])
+  end
+
+  it ':any activates every family' do
+    observers.on { nil }
+    expect(described_class.active_families.size).to eq(described_class.families.size)
+  end
+
+  it 'process emits the events with the raw line' do
+    seen = []
+    observers.on(:ambusher, :bolted) { |type, data| seen << [type, data] }
+    described_class.process('You bolt!')
+    expect(seen).to eq([[:bolted, { raw: 'You bolt!' }]])
+  end
+
+  it 'delivers enqueued lines through the worker' do
+    seen = Queue.new
+    observers.on(:itchy_curse) { |type, _| seen << type }
+    described_class.enqueue('You shiver slightly as an invisible rash covers your body.')
+    expect(seen.pop).to eq(:itchy_curse)
+    expect(described_class.stats[:matched]).to be >= 1
+  end
+
+  it 'knows which types are message events' do
+    expect(described_class.event?(:disarm_seen)).to be(true)
+    expect(described_class.event?(:damage)).to be(false)
+  end
+
+  it 'puts the hook up with the first subscription and takes it down with the last' do
+    hooks = {}
+    stub_const('DownstreamHook', Class.new do
+      define_singleton_method(:add) { |name, action, persist: nil| hooks[name] = [action, persist] }
+      define_singleton_method(:remove) { |name| hooks.delete(name) }
+    end)
+    handler = observers.on(:rooted) { nil }
+    expect(described_class.installed?).to be(true)
+    expect(hooks.keys).to eq([described_class::HOOK_ID])
+    expect(hooks.values.first.last).to be(true)
+    expect(hooks.values.first.first.call('a line')).to eq('a line')
+    observers.off(handler)
+    expect(described_class.installed?).to be(false)
+    expect(hooks).to be_empty
+  end
+end

--- a/spec/lib/gemstone/combat/messages_spec.rb
+++ b/spec/lib/gemstone/combat/messages_spec.rb
@@ -2,8 +2,13 @@
 
 require 'rspec'
 
+# Fine-grained guards, per spec_helper's convention: module reopening is
+# process-global for the rest of the run, so an unguarded definition here
+# would win permanently for every other spec that loads later. Nothing in
+# this file asserts on the captured messages - Lich.log only needs to
+# exist for the worker's rescue to call.
 module Lich
-  def self.log(msg); (@logged ||= []) << msg; end
+  def self.log(msg); (@logged ||= []) << msg; end unless respond_to?(:log)
 
   def self.logged = @logged ||= []
   module Gemstone; module Combat; end; end
@@ -80,5 +85,56 @@ RSpec.describe Lich::Gemstone::Combat::Messages do
     observers.off(handler)
     expect(described_class.installed?).to be(false)
     expect(hooks).to be_empty
+  end
+
+  # The stale-uninstall interleaving: a refresh! that computed an empty
+  # active set publishes it, is overtaken by a refresh! that subscribes and
+  # installs, then runs its own uninstall! afterwards. On the unfixed code
+  # that left @active non-empty with the hook gone, so no line ever reached
+  # a live subscriber again. Holding @mutex across read-decide-act makes the
+  # two serialize. The pause is injected into the mutex the production code
+  # uses, so the sequence is forced rather than hoped for.
+  it 'never leaves a live subscriber without a hook when refreshes interleave' do
+    hooks = {}
+    stub_const('DownstreamHook', Class.new do
+      define_singleton_method(:add) { |name, action, persist: nil| hooks[name] = [action, persist] }
+      define_singleton_method(:remove) { |name| hooks.delete(name) }
+    end)
+
+    real_mutex = described_class.instance_variable_get(:@mutex)
+    paused = Queue.new
+    resume = Queue.new
+    arm = { on: false }
+
+    pausing = Object.new
+    pausing.define_singleton_method(:synchronize) do |&blk|
+      result = real_mutex.synchronize(&blk)
+      # Release the lock first, then stall in the gap between publishing
+      # @active and acting on it - the window the old code left open.
+      if arm[:on]
+        arm[:on] = false
+        paused << :in_gap
+        resume.pop
+      end
+      result
+    end
+    described_class.instance_variable_set(:@mutex, pausing)
+
+    begin
+      arm[:on] = true
+      stale = Thread.new { described_class.refresh! }
+      paused.pop # stale has published its empty @active, not yet uninstalled
+
+      observers.on(:rooted) { nil } # subscribes, refreshes, installs
+
+      resume << :go
+      stale.join(2)
+    ensure
+      described_class.instance_variable_set(:@mutex, real_mutex)
+    end
+
+    expect(described_class.active_families.map(&:name)).to eq([:hold])
+    expect(described_class.installed?).to be(true)
+    expect(hooks.keys).to eq([described_class::HOOK_ID])
   end
 end


### PR DESCRIPTION
## Summary

Widens `Combat::Observers` into a general parser seam: the non-combat lines hunting and cleansing scripts keep private `DownstreamHook` regexes for become observer events, scanned only while something subscribes.

- **`defs/messages.rb`**: eight families (disarm, hazard, ambush, hold, bless, archery, marks, reaction), 40 defs. Every one is a line bigshot's `hunt_monitor`, ecleanse's `set_hooks` or eohunter's watch rules matched privately: a weapon knocked away or wrenched, the itchy curse, the infected wound, the hive traps, the ambusher and the bolt, the snake's coils, the item limit, a bless shrugged off, an arrow stuck, the aim, the bonded return, the 703 haze and 1614 rebuke marks, Swift Justice charges, arcane reflexes, the weapon reaction prompt. Each def is an event name, one pattern (no top-level alternations, so `PatternGate` gates every family), and a payload block; payloads carry `:raw`.
- **`Combat::Messages`**: delivers them through `Observers`. The Tracker's hook chunks on the prompt and drops chunks that name no creature, which is most of these lines, so Messages has its own hook: installed on the first subscription to a message event, removed with the last. A family is scanned only while one of its events has a subscriber; matching runs on one ordered worker thread, never on the game stream (the Observers subscriber contract applies).
- **`Observers.on_change`**: a callback after every `on`/`off`/`clear!`, which is how Messages recomputes the active families.
- `Tracker.on(:disarm_seen) { ... }` subscribes the same way as combat facts and needs the tracker neither enabled nor scanning.

## Cost

Measured on a 250k-line bigshot session log, first 100k lines, `Messages.scan` per line:

| subscribers | per line |
|---|---|
| none | 0.14 µs |
| one family | 0.52 µs |
| all eight | 4.54 µs |

With no subscribers the hook is not installed at all.

## Tests

`spec/lib/gemstone/combat/message_defs_spec.rb`: every family against the game line it was pinned to, every family gated, ordinary lines yield nothing. `messages_spec.rb`: no family, no hook and no scan without a subscriber; a combat subscription activates nothing; `:any` activates all; the worker delivers; the hook goes up with the first subscription and down with the last. The existing combat specs pass unchanged (265 examples).

## Follow-up

eohunter will replace its `watch.rb` rules with these subscriptions; ecleanse and bigshot can do the same one hook at a time. Two of eohunter's remaining rules (UAC positioning tier and followup) are already `:ucs` facts and were not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
