### PR TITLE
fix(gs): Group.broken? waits on Lich::Claim::Lock, the constant that exists

### DIFF
--- a/lib/gemstone/group.rb
+++ b/lib/gemstone/group.rb
@@ -259,7 +259,7 @@ module Lich
       #
       # @return [Boolean] true if group state is inconsistent
       def self.broken?
-        sleep(0.1) while Lich::Gemstone::Claim::Lock.locked?
+        sleep(0.1) while Lich::Claim::Lock.locked?
         if Group.leader?
           return true if (GameObj.pcs.empty? || GameObj.pcs.nil?) && !@@members.empty?
           return false if (GameObj.pcs.empty? || GameObj.pcs.nil?) && @@members.empty?


### PR DESCRIPTION
## Summary
- `Group.broken?` waited on `Lich::Gemstone::Claim::Lock`, but Claim is defined at `Lich::Claim` (lib/gemstone/claim.rb), so the call raised `NameError` before the group check ran.
- One-line fix to the constant. Nothing in lib or scripts calls `broken?` today; scripts that do will now get the documented true/false instead of an exception.

## Test plan
- [x] Loaded claim.rb standalone: `Lich::Claim::Lock` resolves, `Lich::Gemstone::Claim` raises NameError
- [x] `bundle exec rubocop lib/gemstone/group.rb` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)