### PR TITLE
feat(gs): society command readers, factored out of use

### DIFF
--- a/lib/gemstone/societies/council_of_light.rb
+++ b/lib/gemstone/societies/council_of_light.rb
@@ -323,13 +323,26 @@ module Lich
           end
 
           if available?(sign_name)
-            command = sign[:usage] || "sign of #{sign[:short_name]}"
             waitrt?
             waitcastrt?
-            fput "#{command} #{target}".strip
+            fput Society.command(sign, "sign of", target)
           else
             Lich::Messaging.msg("warn", "You cannot use the #{sign_name} sign right now.")
           end
+        end
+
+        ##
+        # The command {use} sends for a sign, without sending it.
+        #
+        # @param sign_name [String] The short or long name of the sign
+        # @param target [String, Integer, GameObj, nil] Optional target (a GameObj or id as `#id`)
+        # @return [String, nil] e.g. "sign of striking", nil when the sign is unknown
+        #
+        def self.command(sign_name, target = nil)
+          sign = self[sign_name]
+          return nil unless sign
+
+          Society.command(sign, "sign of", target)
         end
 
         ##

--- a/lib/gemstone/societies/guardians_of_sunfist.rb
+++ b/lib/gemstone/societies/guardians_of_sunfist.rb
@@ -286,13 +286,26 @@ module Lich
           end
 
           if available?(sigil_name)
-            command = sigil[:usage] || "sigil of #{sigil[:short_name]}"
             waitrt?
             waitcastrt?
-            fput "#{command} #{target}".strip
+            fput Society.command(sigil, "sigil of", target)
           else
             Lich::Messaging.msg("warn", "You cannot use the #{sigil_name} sigil right now.")
           end
+        end
+
+        ##
+        # The command {use} sends for a sigil, without sending it.
+        #
+        # @param sigil_name [String] The short or long name of the sigil
+        # @param target [String, Integer, GameObj, nil] Optional target (a GameObj or id as `#id`)
+        # @return [String, nil] e.g. "sigil of contact", nil when the sigil is unknown
+        #
+        def self.command(sigil_name, target = nil)
+          sigil = self[sigil_name]
+          return nil unless sigil
+
+          Society.command(sigil, "sigil of", target)
         end
 
         ##

--- a/lib/gemstone/societies/order_of_voln.rb
+++ b/lib/gemstone/societies/order_of_voln.rb
@@ -425,13 +425,26 @@ module Lich
           end
 
           if self.available?(symbol_name)
-            command = symbol[:usage] || "symbol of #{symbol[:short_name]}"
             waitrt?
             waitcastrt?
-            fput "#{command} #{target}".strip
+            fput Society.command(symbol, "symbol of", target)
           else
             Lich::Messaging.msg("warn", "You cannot use the #{symbol_name} symbol right now.")
           end
+        end
+
+        ##
+        # The command {use} sends for a symbol, without sending it.
+        #
+        # @param symbol_name [String] The short or long name of the symbol
+        # @param target [String, Integer, GameObj, nil] Optional target (a GameObj or id as `#id`)
+        # @return [String, nil] e.g. "symbol of holiness", nil when the symbol is unknown
+        #
+        def self.command(symbol_name, target = nil)
+          symbol = self[symbol_name]
+          return nil unless symbol
+
+          Society.command(symbol, "symbol of", target)
         end
 
         ##

--- a/lib/gemstone/society.rb
+++ b/lib/gemstone/society.rb
@@ -134,6 +134,25 @@ module Lich
       end
 
       ##
+      # The command a society ability's +use+ sends, without sending it.
+      #
+      # An entry with a `:usage` string sends that verb ("signal", "smite");
+      # any other sends `<prefix> <short_name>` ("sign of striking"). A
+      # GameObj or Integer target is appended as `#id`, a String as given.
+      #
+      # @param entry [Hash] The resolved ability metadata (from the reader's `[]`)
+      # @param prefix [String] "sign of", "sigil of" or "symbol of"
+      # @param target [String, Integer, GameObj, nil] Optional target
+      # @return [String] e.g. "symbol of holiness", "sigil of contact #12345"
+      #
+      def self.command(entry, prefix, target = nil)
+        base = entry[:usage] || "#{prefix} #{entry[:short_name]}"
+        target = "##{target.id}" if target.respond_to?(:id) && !target.is_a?(String)
+        target = "##{target}" if target.is_a?(Integer)
+        "#{base} #{target}".strip
+      end
+
+      ##
       # Defines singleton accessors for both short and long names on a given target class.
       #
       # Method names are normalized using {Lich::Util.normalize_name}, which ensures

--- a/spec/lib/gemstone/society_command_spec.rb
+++ b/spec/lib/gemstone/society_command_spec.rb
@@ -26,7 +26,13 @@ RSpec.describe Lich::Gemstone::Society do
   describe 'the readers' do
     # The readers' [] resolves every lambda in an entry (durations and
     # costs read the level), so a level has to exist to build a command.
-    before { stub_const('Stats', double('Stats', level: 20)) }
+    # Inside the readers `Stats` is Lich::Gemstone::Stats once another
+    # spec has loaded it, and the bare constant otherwise; stub both.
+    before do
+      stats = double('Stats', level: 20)
+      stub_const('Stats', stats)
+      stub_const('Lich::Gemstone::Stats', stats)
+    end
 
     it 'build the same string use sends, by short or long name, nil for an unknown ability' do
       expect(Lich::Gemstone::Societies::CouncilOfLight.command('striking')).to eq('sign of striking')

--- a/spec/lib/gemstone/society_command_spec.rb
+++ b/spec/lib/gemstone/society_command_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+require 'util/util'
+require 'gemstone/society'
+
+# The command each society reader's +use+ sends, exposed so a caller can
+# send and confirm on its own terms.
+RSpec.describe Lich::Gemstone::Society do
+  SocietyTargetObj = Struct.new(:id, :noun, :name) unless defined?(SocietyTargetObj)
+
+  describe '.command' do
+    it 'prefixes the short name, or sends the entry usage verb as is' do
+      expect(described_class.command({ short_name: 'striking' }, 'sign of')).to eq('sign of striking')
+      expect(described_class.command({ short_name: 'signal', usage: 'signal' }, 'sign of')).to eq('signal')
+    end
+
+    it 'appends a GameObj or id as #id and a String as given' do
+      expect(described_class.command({ short_name: 'contact' }, 'sigil of', SocietyTargetObj.new('12345', 'orc', 'an orc'))).to eq('sigil of contact #12345')
+      expect(described_class.command({ short_name: 'contact' }, 'sigil of', 12_345)).to eq('sigil of contact #12345')
+      expect(described_class.command({ short_name: 'contact' }, 'sigil of', 'Dissonance')).to eq('sigil of contact Dissonance')
+    end
+  end
+
+  describe 'the readers' do
+    # The readers' [] resolves every lambda in an entry (durations and
+    # costs read the level), so a level has to exist to build a command.
+    before { stub_const('Stats', double('Stats', level: 20)) }
+
+    it 'build the same string use sends, by short or long name, nil for an unknown ability' do
+      expect(Lich::Gemstone::Societies::CouncilOfLight.command('striking')).to eq('sign of striking')
+      expect(Lich::Gemstone::Societies::CouncilOfLight.command('Sign of Signal')).to eq('signal')
+      expect(Lich::Gemstone::Societies::GuardiansOfSunfist.command('contact', 'Dissonance')).to eq('sigil of contact Dissonance')
+      expect(Lich::Gemstone::Societies::OrderOfVoln.command('holiness')).to eq('symbol of holiness')
+      expect(Lich::Gemstone::Societies::OrderOfVoln.command("Kai's Smite", 42)).to eq('smite #42')
+      expect(Lich::Gemstone::Societies::OrderOfVoln.command('no such symbol')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Each society reader's `use` built its command inline: the entry's `:usage` verb, else `sign of` / `sigil of` / `symbol of` plus the short name, then the target. This exposes it as `CouncilOfLight.command(name, target)`, `GuardiansOfSunfist.command` and `OrderOfVoln.command`, returning the exact string `use` sends and nil for an unknown ability.
- `Society.command(entry, prefix, target)` holds the shared rule and `use` calls it, so nothing is duplicated. A String target is sent as given, unchanged from before.
- Behavior change worth noting: a `GameObj` or `Integer` target is now appended as `#id`. The society `use` methods never formatted those targets before this PR, so this is new behavior riding along with the refactor, not a pure extraction. It differs from the PSM precedent in #1583, where the `#id` branch was already inline in `.use` and was genuinely just moved. No caller in dr-scripts or `scripts` passes a `GameObj`/`Integer` target here today, and `#id` targeting is the established convention elsewhere (`lib/common/spell.rb`, `lib/stash.rb`), so this reads as a latent-bug fix rather than a regression.
- Same shape as the PSM `command` readers in #1583, so an engine that sends and confirms on its own terms can consume the society tables instead of copying the prefix rule. A `results_regex` reader is not included: the society entries carry no result pattern yet, so `use` stays unverified until those are collected.

## Test plan
- [x] New `spec/lib/gemstone/society_command_spec.rb`: the shared rule, the three readers by short and long name, usage verbs (`signal`, `smite`), GameObj / id / String targets, nil for an unknown ability
- [x] `bundle exec rubocop` clean on the touched files
- [ ] In game: `;e echo Lich::Gemstone::Societies::OrderOfVoln.command('holiness')` prints `symbol of holiness`, and `use` still sends it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
