### PR TITLE
feat(all): Spell.results_regex, the lines cast waits on, exposed

### DIFF
--- a/lib/common/spell.rb
+++ b/lib/common/spell.rb
@@ -143,6 +143,17 @@ module Lich
         # self # rubocop Lint/Void: self used in void context
       end
 
+      # Every line that answers a cast: the regex {#cast} waits on, exposed
+      # so a caller that sends and confirms on its own terms can wait on
+      # the same lines instead of copying them.
+      #
+      # @param results_of_interest [Regexp, nil] extra lines to match, as {#cast} takes
+      # @return [Regexp]
+      def Spell.results_regex(results_of_interest: nil)
+        return @@results_regex unless results_of_interest.is_a?(Regexp)
+        Regexp.union(@@results_regex, results_of_interest)
+      end
+
       def Spell.after_stance=(val)
         @@after_stance = val
       end

--- a/spec/lib/common/spell_spec.rb
+++ b/spec/lib/common/spell_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe Lich::Common::Spell do
     end
   end
 
+  describe '.results_regex' do
+    it 'is the union of lines cast waits on, plus any extra lines' do
+      regex = Lich::Common::Spell.results_regex
+      expect(regex).to match('Cast Roundtime 3 Seconds.')
+      expect(regex).to match('Cast at what?')
+      expect(regex).to match("But you don't have any mana!")
+      expect(regex).to match('Your magic fizzles ineffectually.')
+      expect(regex).to match('You do not currently have a target.')
+      expect(regex).not_to match('You swing a broadsword at an orc!')
+
+      extra = Lich::Common::Spell.results_regex(results_of_interest: /^Roundtime: \d+ sec\.$/)
+      expect(extra).to match('Roundtime: 3 sec.')
+      expect(extra).to match('Cast at what?')
+    end
+  end
+
   describe '.[]' do
     context 'when looking up by number' do
       it 'finds Spirit Warding I by number 101' do


### PR DESCRIPTION
## Summary
- `Spell#cast` waits on `@@results_regex`, a private class variable with no reader. A script that sends a cast itself and confirms on its own terms (the eohunter engine, with its own roundtime cap and interrupt) had to copy those lines, and the copy has already drifted from core.
- `Spell.results_regex(results_of_interest: nil)` returns the same union `cast` builds, with the optional extra pattern merged the way `cast` merges it. No change to `cast`.

## Test plan
- [x] `spec/lib/common/spell_spec.rb` gained an example covering the union and the extra-pattern merge; 36 examples green
- [x] `bundle exec rubocop` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
