### PR TITLE
feat(gs): emit post-commit combat recorder receipts

### DIFF
--- a/lib/gemstone/combat/observers.rb
+++ b/lib/gemstone/combat/observers.rb
@@ -41,6 +41,12 @@
 #                 chunk), :death (subject already known dead - stack
 #                 cleanup, not meaningful expiry), or nil (natural
 #                 expiry, or cause not visible in this chunk)
+#   :recorded_attack { protocol:, recorder_id:, database:, file_identity:,
+#                      session_id:, attack_id:, source: } - emitted by
+#                 Combat::Recorder only after the complete attack transaction
+#                 commits. Local observers can use the opaque IDs and trusted
+#                 local database identity to read that exact row. source is
+#                 validated ingestion provenance when available, otherwise nil.
 #
 # @example
 #   Combat::Tracker.on(:damage) { |type, data| my_queue << data }

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -369,12 +369,7 @@ module Lich
           # recorder lock so consumers may inspect the database without deadlock.
           # This is evidence only, not command ownership or a combat-complete flag.
           if type == :attack && result.is_a?(Hash) && result[:protocol] == RECEIPT_PROTOCOL
-            begin
-              Lich::Gemstone::Combat::Observers.emit(:recorded_attack, result)
-            rescue StandardError
-              # Optional receipt delivery cannot undo or break a committed record.
-              nil
-            end
+            Lich::Gemstone::Combat::Observers.emit(:recorded_attack, result)
           end
           result
         end
@@ -540,7 +535,8 @@ module Lich
           parent_row = (parent_uid && chunk_row(parent_uid))
           parent_conf = event[:parent_confidence]&.to_s
 
-          receipt = nil
+          attack_id = nil
+          touched = Set.new([target[:id]].compact.map(&:to_i))
           in_txn do
             @seq += 1
             params = [@session_id, @seq, at, event[:name].to_s, parent&.to_s, txt(parent_weapon),
@@ -584,7 +580,6 @@ module Lich
               insert_hit(attack_id, nil, creature_row, hit_seq += 1, hit, at)
             end
 
-            touched = Set.new([target[:id]].compact.map(&:to_i))
             (event[:flares] || []).each_with_index do |flare, i|
               f_target = flare[:target_info]
               f_creature = f_target ? ensure_creature(f_target, at) : nil
@@ -603,19 +598,29 @@ module Lich
                 insert_hit(attack_id, flare_id, f_creature || creature_row, hit_seq += 1, hit, at)
               end
             end
-
-            @open_attack = { id: attack_id, creature_ids: touched, inbound: !!event[:inbound] }
-            provenance = if defined?(Processor) && Processor.respond_to?(:observation_source)
-                           Processor.observation_source(event[:source])
-                         end
-            receipt = {
-              protocol: RECEIPT_PROTOCOL, recorder_id: @recorder_id,
-              database: @receipt_path&.dup&.freeze, file_identity: @receipt_file,
-              session_id: @session_id, attack_id: attack_id,
-              source: provenance
-            }.freeze
           end
-          receipt
+          # Publish the attack window only after commit; a rollback must not
+          # leave statuses pointing at an attack row that no longer exists.
+          @open_attack = { id: attack_id, creature_ids: touched, inbound: !!event[:inbound] }
+          attack_receipt(attack_id, event)
+        end
+
+        def attack_receipt(attack_id, event)
+          provenance = if defined?(Processor) && Processor.respond_to?(:observation_source)
+                         Processor.observation_source(event[:source])
+                       end
+          {
+            protocol: RECEIPT_PROTOCOL, recorder_id: @recorder_id,
+            database: @receipt_path&.dup&.freeze, file_identity: @receipt_file,
+            session_id: @session_id, attack_id: attack_id,
+            source: provenance
+          }.freeze
+        rescue StandardError => e
+          # Receipt metadata is optional. The attack is already committed, so
+          # report this separately from a persistence failure and emit nothing.
+          msg = "CombatRecorder receipt for committed attack #{attack_id}: #{e.message}"
+          defined?(Lich) && Lich.respond_to?(:log) ? Lich.log("error: #{msg}") : warn(msg)
+          nil
         end
 
         def insert_resolution(attack_id, flare_id, seq, res)

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -87,12 +87,19 @@
 # town time never pads a hunt's duration.
 
 require 'sqlite3'
+require 'securerandom'
 
 module Lich
   module Gemstone
     module Combat
       class Recorder
         HANDLER_NAME = 'combat_recorder'
+        # :recorded_attack is an optional post-commit observer receipt. Its
+        # recorder/session/attack IDs identify rows; :source retains validated
+        # ingestion context (nil for legacy/replay input). :database and
+        # :file_identity are trusted-local locators, not remote protocol data.
+        # Receipts neither enable recording nor prove an encounter is complete.
+        RECEIPT_PROTOCOL = 1
 
         SCHEMA = <<~SQL
           CREATE TABLE IF NOT EXISTS sessions (
@@ -241,6 +248,10 @@ module Lich
         # one (see check_idle!). nil = explicit start_session/finish_session.
         def initialize(db_path, character: nil, source: 'live', idle_timeout: nil)
           @db = SQLite3::Database.new(db_path)
+          @receipt_path = File.realpath(db_path) if File.file?(db_path)
+          stat = File.stat(@receipt_path) if @receipt_path
+          @receipt_file = [stat.dev, stat.ino].freeze if stat
+          @recorder_id = SecureRandom.hex(16).freeze
           @db.busy_timeout = 5_000
           @db.execute('PRAGMA journal_mode = WAL')
           @db.execute('PRAGMA synchronous = NORMAL')
@@ -344,8 +355,28 @@ module Lich
           end
         end
 
+        # Persist one observer event. Attack events return and publish a frozen
+        # post-commit receipt; other event types preserve their existing return.
+        # Receipt delivery is optional and cannot roll back committed data.
+        #
+        # @param type [Symbol] observer event type
+        # @param data [Hash] observer event payload
+        # @return [Hash, Object, nil] an attack receipt, or the existing result
+        #   for non-attack events
         def record(type, data)
-          @mutex.synchronize { record_locked(type, data) }
+          result = @mutex.synchronize { record_locked(type, data) }
+          # Receipts name committed rows, never pending writes. Emit outside the
+          # recorder lock so consumers may inspect the database without deadlock.
+          # This is evidence only, not command ownership or a combat-complete flag.
+          if type == :attack && result.is_a?(Hash) && result[:protocol] == RECEIPT_PROTOCOL
+            begin
+              Lich::Gemstone::Combat::Observers.emit(:recorded_attack, result)
+            rescue StandardError
+              # Optional receipt delivery cannot undo or break a committed record.
+              nil
+            end
+          end
+          result
         end
 
         def record_locked(type, data)
@@ -509,6 +540,7 @@ module Lich
           parent_row = (parent_uid && chunk_row(parent_uid))
           parent_conf = event[:parent_confidence]&.to_s
 
+          receipt = nil
           in_txn do
             @seq += 1
             params = [@session_id, @seq, at, event[:name].to_s, parent&.to_s, txt(parent_weapon),
@@ -573,7 +605,17 @@ module Lich
             end
 
             @open_attack = { id: attack_id, creature_ids: touched, inbound: !!event[:inbound] }
+            provenance = if defined?(Processor) && Processor.respond_to?(:observation_source)
+                           Processor.observation_source(event[:source])
+                         end
+            receipt = {
+              protocol: RECEIPT_PROTOCOL, recorder_id: @recorder_id,
+              database: @receipt_path&.dup&.freeze, file_identity: @receipt_file,
+              session_id: @session_id, attack_id: attack_id,
+              source: provenance
+            }.freeze
           end
+          receipt
         end
 
         def insert_resolution(attack_id, flare_id, seq, res)

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -3,6 +3,7 @@
 require_relative '../../../spec_helper'
 require 'tmpdir'
 require 'gemstone/combat/recorder'
+require 'gemstone/combat/processor'
 
 # End-to-end coverage for the SQLite Combat::Recorder: the wiring the PR
 # shipped with zero first-party callers. These drive a real on-disk database
@@ -67,6 +68,53 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
   end
 
   describe 'session lifecycle' do
+    it 'keeps committed recording intact when optional receipt dispatch fails' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester')
+      allow(Lich::Gemstone::Combat::Observers).to receive(:emit).and_raise('observer failed')
+      expect { rec.record(:attack, attack_event) }.not_to raise_error
+      expect(count('attacks')).to eq(1)
+      rec.close
+    end
+
+    it 'preserves in-memory recorders without claiming a readable database file' do
+      rec = described_class.new(':memory:')
+      rec.start_session(character: 'Tester')
+      receipt = rec.record(:attack, attack_event)
+      expect(receipt[:database]).to be_nil
+      expect(receipt[:file_identity]).to be_nil
+      rec.close
+    end
+
+    it 'publishes a receipt only after the complete attack transaction is readable' do
+      rec = new_recorder
+      sid = rec.start_session(character: 'Tester')
+      received = []
+      allow(Lich::Gemstone::Combat::Observers).to receive(:emit) do |type, receipt|
+        next unless type == :recorded_attack
+        expect(receipt[:session_id]).to eq(sid)
+        expect(receipt[:database]).to eq(File.realpath(@db_path))
+        expect(receipt[:file_identity]).to eq([File.stat(@db_path).dev, File.stat(@db_path).ino])
+        expect(query('SELECT COUNT(*) AS n FROM hits WHERE attack_id = ?', receipt[:attack_id]).first['n']).to eq(1)
+        expect(receipt).to be_frozen
+        expect(receipt[:source]).to be_nil # replay/legacy input is not live provenance
+        received << receipt
+      end
+      rec.record(:attack, attack_event)
+      expect(received.size).to eq(1)
+      rec.close
+    end
+
+    it 'does not publish a receipt when an attack transaction rolls back' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester')
+      allow(rec).to receive(:insert_hit).and_raise(SQLite3::Exception, 'fixture failure')
+      expect(Lich::Gemstone::Combat::Observers).not_to receive(:emit)
+      rec.record(:attack, attack_event)
+      expect(count('attacks')).to eq(0)
+      rec.close
+    end
+
     it 'opens, records into, and closes a session' do
       rec = new_recorder
       sid = rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -4,6 +4,7 @@ require_relative '../../../spec_helper'
 require 'tmpdir'
 require 'gemstone/combat/recorder'
 require 'gemstone/combat/processor'
+require 'gemstone/combat/observers'
 
 # End-to-end coverage for the SQLite Combat::Recorder: the wiring the PR
 # shipped with zero first-party callers. These drive a real on-disk database
@@ -18,20 +19,14 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
   # Make a unique dir, run, then best-effort remove (ignoring locks that the
   # GC hasn't released yet; the OS reclaims the temp dir regardless).
   before do
-    # close calls unsubscribe! -> Observers.off; stub a no-op Observers so the
-    # recorder's lifecycle runs without the full pub/sub module loaded.
-    observers = Module.new do
-      def self.on(*, **, &_blk); end
-      def self.off(*); end
-      def self.emit(*); end
-    end
-    stub_const('Lich::Gemstone::Combat::Observers', observers)
+    Lich::Gemstone::Combat::Observers.clear!
 
     @tmpdir = Dir.mktmpdir('combat-recorder')
     @db_path = File.join(@tmpdir, 'test.db')
   end
 
   after do
+    Lich::Gemstone::Combat::Observers.clear!
     GC.start
     FileUtils.remove_entry(@tmpdir)
   rescue StandardError
@@ -68,12 +63,36 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
   end
 
   describe 'session lifecycle' do
-    it 'keeps committed recording intact when optional receipt dispatch fails' do
+    it 'isolates a raising receipt subscriber and still delivers to other subscribers' do
       rec = new_recorder
       rec.start_session(character: 'Tester')
-      allow(Lich::Gemstone::Combat::Observers).to receive(:emit).and_raise('observer failed')
+      received = []
+      allow(Lich).to receive(:log)
+      Lich::Gemstone::Combat::Observers.on(:recorded_attack) { raise 'observer failed' }
+      Lich::Gemstone::Combat::Observers.on(:recorded_attack) { |_, receipt| received << receipt }
       expect { rec.record(:attack, attack_event) }.not_to raise_error
       expect(count('attacks')).to eq(1)
+      expect(received.size).to eq(1)
+      expect(Lich).to have_received(:log).with(/Combat::Observers subscriber \(recorded_attack\): observer failed/)
+      rec.close
+    end
+
+    it 'keeps committed attacks and status attribution when receipt provenance fails' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester')
+      allow(Lich).to receive(:log)
+      allow(Lich::Gemstone::Combat::Processor).to receive(:observation_source).and_raise('provenance failed')
+      expect(Lich::Gemstone::Combat::Observers).not_to receive(:emit)
+
+      expect(rec.record(:attack, attack_event)).to be_nil
+      rec.record(:status, { id: 101, name: 'a cave lizard', status: :prone, action: :add })
+
+      expect(count('attacks')).to eq(1)
+      expect(count('hits')).to eq(1)
+      attack = query('SELECT id FROM attacks').first
+      status = query('SELECT attack_id, source FROM statuses').first
+      expect(status.values_at('attack_id', 'source')).to eq([attack['id'], 'window'])
+      expect(Lich).to have_received(:log).with('error: CombatRecorder receipt for committed attack 1: provenance failed')
       rec.close
     end
 
@@ -90,14 +109,16 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       rec = new_recorder
       sid = rec.start_session(character: 'Tester')
       received = []
-      allow(Lich::Gemstone::Combat::Observers).to receive(:emit) do |type, receipt|
-        next unless type == :recorded_attack
+      Lich::Gemstone::Combat::Observers.on(:recorded_attack) do |_, receipt|
         expect(receipt[:session_id]).to eq(sid)
         expect(receipt[:database]).to eq(File.realpath(@db_path))
         expect(receipt[:file_identity]).to eq([File.stat(@db_path).dev, File.stat(@db_path).ino])
         expect(query('SELECT COUNT(*) AS n FROM hits WHERE attack_id = ?', receipt[:attack_id]).first['n']).to eq(1)
         expect(receipt).to be_frozen
         expect(receipt[:source]).to be_nil # replay/legacy input is not live provenance
+        # Re-enter a public method that takes the recorder mutex. Calling this
+        # callback under that mutex would raise a recursive-lock error.
+        rec.check_idle!
         received << receipt
       end
       rec.record(:attack, attack_event)
@@ -112,6 +133,28 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       expect(Lich::Gemstone::Combat::Observers).not_to receive(:emit)
       rec.record(:attack, attack_event)
       expect(count('attacks')).to eq(0)
+      rec.close
+    end
+
+    it 'does not attribute statuses or emit receipts for a rollback after all attack writes' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester')
+      db = rec.instance_variable_get(:@db)
+      allow(db).to receive(:transaction).and_wrap_original do |original, &block|
+        original.call do
+          block.call
+          raise SQLite3::Exception, 'failure before commit'
+        end
+      end
+      expect(Lich::Gemstone::Combat::Observers).not_to receive(:emit)
+
+      rec.record(:attack, attack_event)
+      expect(count('attacks')).to eq(0)
+      expect(count('hits')).to eq(0)
+      allow(db).to receive(:transaction).and_call_original
+      rec.record(:status, { id: 101, name: 'a cave lizard', status: :prone, action: :add })
+      status = query('SELECT attack_id, source FROM statuses').first
+      expect(status.values_at('attack_id', 'source')).to eq([nil, 'direct'])
       rec.close
     end
 


### PR DESCRIPTION
## Summary

- emit a frozen `:recorded_attack` observer receipt only after an attack transaction commits
- identify the recorder, database file, session, and exact attack row without changing the seven-table schema
- carry validated ingestion provenance when the combat processor provides it, otherwise report `source: nil`
- isolate optional subscriber failures from recording and preserve rollback behavior
- document the new observer event contract

## Motivation

Trusted local consumers currently have no race-free way to learn which SQLite row a just-recorded combat event committed. Parsing player-facing report output or polling for the newest row loses attribution under concurrent, delayed, or foreign combat. This narrow observer receipt lets consumers bind evidence to exact committed rows without starting a recorder, changing its schema, or moving database work into the combat parser.

The database path and file identity are explicitly trusted-local locators. They are not intended for remote protocol exposure. A receipt is evidence that one attack row committed; it does not prove that an encounter or hunt is complete.

## Compatibility

The receipt contract is independently useful on current `main`. When combat observation provenance from PR #1576 is available, `source` contains that validated scalar context; on legacy/replay input it remains `nil`. No consumer is required and ordinary recording behavior is unchanged.

## Verification

- `bundle exec rspec spec/lib/gemstone/combat/recorder_spec.rb`: 34 examples, 0 failures
- `bundle exec rubocop lib/gemstone/combat/recorder.rb lib/gemstone/combat/observers.rb spec/lib/gemstone/combat/recorder_spec.rb`: no offenses
- `git diff --check`

Coverage verifies post-commit readability, rollback silence, immutable receipts, in-memory databases, and subscriber-failure isolation.
