### PR TITLE
fix(gs): combat module - hunt-log audit: interrupted-swing resume, status attribution by event, spell-loss cause, live defs

### DIFF
--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -338,6 +338,11 @@ module Lich
               # whip's miss rides the same line (:miss outcome)
               /(?<attacker>.+?) manifests a thick pseudopod and brings it smashing down at (?<target>you|.+?)!/,
               /(?<attacker>.+?) whips a thick pseudopod at (?<target>you|.+?)!/,
+              # the ooze's vitality drain: touch, then "Dizziness rushes
+              # through you..." and the damage line
+              /(?<attacker>.+?) whips a pseudopod toward (?<target>you|.+?), brushing/,
+              # halfling cannibal ambush swing (hunt log 2026-09-07 23:34)
+              /With an ululating shriek, (?<attacker>.+?) leaps from the shadows and hammers blindly at (?<target>you|.+?) with grimy little fists!/,
               /(?<attacker>.+?) snaps at (?<target>.+?) with its (?<weapon>[^!]+)!/,
               /(?<attacker>.+?) pounds at (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .*?fists?!/,
               /(?<attacker>.+?) tries to bite (?<target>[^!]+)!/,
@@ -471,7 +476,13 @@ module Lich
             AttackDef.new(:bleed, [
               /Blood weeps from (?<target>.+?)'s#{MK_POST} open .+? wound\./,
               /(?<target>.+?)'s#{MK_POST} .+? drips as #{MK_PRE}(?:he|she|it)#{MK_POST} continues to bleed\./,
+              /Trickles of blood course from (?<target>.+?)'s#{MK_POST} .+?\./,
               /(?<target>Your) .+? drips as you continue to bleed\./
+            ].freeze),
+            # Rot tick (a nearby player's curse on a creature; hunt log
+            # 2026-09-07 23:36). Unowned like bleed.
+            AttackDef.new(:rot, [
+              /Skin peels off (?<target>.+?)'s#{MK_POST} body, exposing rotting flesh\./
             ].freeze)
           ].freeze
 

--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -378,7 +378,11 @@ module Lich
               /(?<attacker>.+?) leaps from the shadows and (?:throws #{MK_PRE}(?:his|her|its)#{MK_POST} .+? around|hurtles at) (?<target>[^,!]+)/
             ].freeze),
             # PSM maneuvers, third person
-            AttackDef.new(:hamstring, [/(?<attacker>.+?) lunges forward and tries to hamstring (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .+?!/].freeze),
+            AttackDef.new(:hamstring, [
+              /(?<attacker>.+?) lunges forward and tries to hamstring (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .+?!/,
+              # warg jaws form (hunt log 2026-09-07)
+              /With a quick lunge, (?<attacker>.+?) tries to hamstring (?<target>you|.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} jaws!/
+            ].freeze),
             AttackDef.new(:shield_bash, [
               /(?<attacker>.+?) lunges forward at (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .+? and attempts a shield bash!/,
               /(?<attacker>.+?) launches a quick bash with (?<weapon>.+?) at (?<target>[^!]+)!/,

--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -287,11 +287,23 @@ module Lich
             # Creature fear maneuvers (SSR follows, then our save/fail line).
             # Room-wide, no target named - ROOM_TARGETED classifies them
             # inbound (hunt log 2026-09-07: Ojandhaart warg / mastodon).
+            # (the pronouns are links in the live feed: "sits back on <its>
+            # haunches" - hence MK_PRE/MK_POST; the bare form never matched)
             AttackDef.new(:howl, [
-              /(?<attacker>.+?) sits back on its haunches and unleashes a long, high-pitched howl that sends a shiver of primal terror down your spine\./
+              /(?<attacker>.+?) sits back on #{MK_PRE}its#{MK_POST} haunches and unleashes a long, high-pitched howl that sends a shiver of primal terror down your spine\./
             ].freeze),
             AttackDef.new(:trumpet, [
-              /(?<attacker>.+?) raises its trunk and rears back onto its immense hind legs, blaring out a note of sheer fury!/
+              /(?<attacker>.+?) raises #{MK_PRE}its#{MK_POST} trunk and rears back onto #{MK_PRE}its#{MK_POST} immense hind legs, blaring out a note of sheer fury!/
+            ].freeze),
+            # Shield-maiden targe push (SMR follows; hunt log 2026-09-07)
+            AttackDef.new(:shield_push, [
+              /(?<attacker>.+?) raises #{MK_PRE}(?:his|her|its)#{MK_POST} (?<weapon>.+?) and attempts to push (?<target>you|.+?) away!/
+            ].freeze),
+            # 3p feint: the result line is the only line ("X feints high, but
+            # you aren't fooled") - target captured as "you" so it classifies
+            # inbound; the same line is the :evade outcome
+            AttackDef.new(:feint, [
+              /(?<attacker>.+?) feints (?:high|low|to the (?:left|right)), but (?<target>you) aren't fooled for a second\./
             ].freeze),
             # Maneuver-style strike opener (round-14 sweep: 40/40 resolve
             # in the very next line, usually the target's evanescent
@@ -312,7 +324,7 @@ module Lich
               # no comma in the target: "Fear still claws at your heart, but
               # you stand fast..." is a fear-save outcome, not a claw swing
               /(?<attacker>.+?) claws at (?<target>[^!,]+)!/,
-              /(?<attacker>.+?) tries to spear (?<target>.+?) with its enormous tusks!/,
+              /(?<attacker>.+?) tries to spear (?<target>.+?) with #{MK_PRE}its#{MK_POST} enormous tusks!/,
               /(?<attacker>.+?) snaps at (?<target>.+?) with its (?<weapon>[^!]+)!/,
               /(?<attacker>.+?) pounds at (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .*?fists?!/,
               /(?<attacker>.+?) tries to bite (?<target>[^!]+)!/,

--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -295,6 +295,15 @@ module Lich
             AttackDef.new(:trumpet, [
               /(?<attacker>.+?) raises #{MK_PRE}its#{MK_POST} trunk and rears back onto #{MK_PRE}its#{MK_POST} immense hind legs, blaring out a note of sheer fury!/
             ].freeze),
+            # Mutant-farm room maneuvers (hunt log 2026-09-07 23:19-23:20):
+            # sanguine ooze crystalline shrapnel burst (SMR, then our dodge)
+            AttackDef.new(:shrapnel_spray, [
+              /Froth disturbs the surface of (?<attacker>.+?) as bubbling bulges form over #{MK_PRE}its#{MK_POST} surface/
+            ].freeze),
+            # flayed gigas disciple's spatial rift (SMR follows)
+            AttackDef.new(:rift_tentacles, [
+              /Zeal twisting #{MK_PRE}(?:his|her|its)#{MK_POST} features, (?<attacker>.+?) raises a raw and fleshless hand overhead and draws it down/
+            ].freeze),
             # Shield-maiden targe push (SMR follows; hunt log 2026-09-07)
             AttackDef.new(:shield_push, [
               /(?<attacker>.+?) raises #{MK_PRE}(?:his|her|its)#{MK_POST} (?<weapon>.+?) and attempts to push (?<target>you|.+?) away!/
@@ -325,6 +334,10 @@ module Lich
               # you stand fast..." is a fear-save outcome, not a claw swing
               /(?<attacker>.+?) claws at (?<target>[^!,]+)!/,
               /(?<attacker>.+?) tries to spear (?<target>.+?) with #{MK_PRE}its#{MK_POST} enormous tusks!/,
+              # sanguine ooze (mutant farm, hunt log 2026-09-07 23:20); the
+              # whip's miss rides the same line (:miss outcome)
+              /(?<attacker>.+?) manifests a thick pseudopod and brings it smashing down at (?<target>you|.+?)!/,
+              /(?<attacker>.+?) whips a thick pseudopod at (?<target>you|.+?)!/,
               /(?<attacker>.+?) snaps at (?<target>.+?) with its (?<weapon>[^!]+)!/,
               /(?<attacker>.+?) pounds at (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .*?fists?!/,
               /(?<attacker>.+?) tries to bite (?<target>[^!]+)!/,
@@ -494,7 +507,7 @@ module Lich
           # Creature maneuvers aimed at the whole room, us included: the line
           # names the attacker and no target, and the SSR that follows is
           # OUR save. The parser classifies these inbound.
-          ROOM_TARGETED = %i[howl trumpet].freeze
+          ROOM_TARGETED = %i[howl trumpet shrapnel_spray rift_tentacles].freeze
 
           # The tracker's chunk gate only forwards chunks holding a bolded
           # creature link; an environmental tick names no creature, so its

--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -284,6 +284,15 @@ module Lich
             # ".+?" not "[^!]+" for target: the cman form appends " and
             # connects!" which a greedy class would swallow into the target
             AttackDef.new(:tackle, [/(?<attacker>.+?) hurls #{MK_PRE}(?:himself|herself|itself)#{MK_POST} at (?<target>.+?)(?: and connects)?!/].freeze),
+            # Creature fear maneuvers (SSR follows, then our save/fail line).
+            # Room-wide, no target named - ROOM_TARGETED classifies them
+            # inbound (hunt log 2026-09-07: Ojandhaart warg / mastodon).
+            AttackDef.new(:howl, [
+              /(?<attacker>.+?) sits back on its haunches and unleashes a long, high-pitched howl that sends a shiver of primal terror down your spine\./
+            ].freeze),
+            AttackDef.new(:trumpet, [
+              /(?<attacker>.+?) raises its trunk and rears back onto its immense hind legs, blaring out a note of sheer fury!/
+            ].freeze),
             # Maneuver-style strike opener (round-14 sweep: 40/40 resolve
             # in the very next line, usually the target's evanescent
             # shield absorb or an outmaneuver outcome, then the swing
@@ -300,7 +309,10 @@ module Lich
             ].freeze),
             # creature natural weapons and maneuvers
             AttackDef.new(:natural, [
-              /(?<attacker>.+?) claws at (?<target>[^!]+)!/,
+              # no comma in the target: "Fear still claws at your heart, but
+              # you stand fast..." is a fear-save outcome, not a claw swing
+              /(?<attacker>.+?) claws at (?<target>[^!,]+)!/,
+              /(?<attacker>.+?) tries to spear (?<target>.+?) with its enormous tusks!/,
               /(?<attacker>.+?) snaps at (?<target>.+?) with its (?<weapon>[^!]+)!/,
               /(?<attacker>.+?) pounds at (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .*?fists?!/,
               /(?<attacker>.+?) tries to bite (?<target>[^!]+)!/,
@@ -397,7 +409,7 @@ module Lich
           ].freeze
 
           # Environmental / self-inflicted damage. No attacker, no target
-          # capture: the parser classifies every name in SELF_INFLICTED as
+          # capture: the parser classifies every name in ATTACKERLESS as
           # inbound (damage to US), so the "... N points of damage!" line that
           # follows lands on our taken ledger instead of orphaning or, worse,
           # attaching to whatever creature event was open (real-feed
@@ -439,19 +451,33 @@ module Lich
             nil
           end
 
-          # Def names whose lines describe damage to US with no attacker: the
-          # parser reports them inbound without needing a "you" capture.
-          SELF_INFLICTED = %i[frigid_wind thorn_recoil].freeze
+          # Def names whose lines describe damage to US with no creature
+          # attacker: the parser reports them inbound without needing a "you"
+          # capture, and names the attacker for the ledger.
+          #   ENVIRONMENTAL - the world did it (weather ticks); attacker
+          #                   'environment'
+          #   SELF_INFLICTED - our own gear did it (thorn bow recoil);
+          #                    attacker 'self'
+          # (owner 2026-09-07: "frigid wind is environmental, it's not self
+          # inflicted" - the two must stay distinguishable in reports)
+          ENVIRONMENTAL = %i[frigid_wind].freeze
+          SELF_INFLICTED = %i[thorn_recoil].freeze
+          ATTACKERLESS = (ENVIRONMENTAL + SELF_INFLICTED).freeze
+
+          # Creature maneuvers aimed at the whole room, us included: the line
+          # names the attacker and no target, and the SSR that follows is
+          # OUR save. The parser classifies these inbound.
+          ROOM_TARGETED = %i[howl trumpet].freeze
 
           # The tracker's chunk gate only forwards chunks holding a bolded
           # creature link; an environmental tick names no creature, so its
           # chunk was discarded before the parser ever saw it (real-feed
           # 2026-09-07: zero frigid_wind rows against 10 log ticks). This
           # union lets the gate pass such chunks.
-          SELF_INFLICTED_PATTERN = Regexp.union(ENVIRONMENTAL_ATTACKS.flat_map(&:patterns)).freeze
+          ATTACKERLESS_PATTERN = Regexp.union(ENVIRONMENTAL_ATTACKS.flat_map(&:patterns)).freeze
 
-          def self.self_inflicted_line?(line)
-            SELF_INFLICTED_PATTERN.match?(line)
+          def self.attackerless_line?(line)
+            ATTACKERLESS_PATTERN.match?(line)
           end
 
           # AMBUSH PREFIXES - modifiers, not attacks.

--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -444,6 +444,17 @@ module Lich
             # put it away")
             AttackDef.new(:thorn_recoil, [
               /As (?:a|an|your) .+? leaves your (?:left|right) hand, the thorns embedded in your skin painfully rip away/
+            ].freeze),
+            # Bleed ticks from open wounds. Nobody's ability: the processor
+            # marks a creature's tick :unowned (UNOWNED_TICK_ATTACKS) so the
+            # damage lands on the creature without joining our rollup; ours
+            # ("Your right leg drips...") is inbound via the "Your" capture.
+            # Lives in this list so the chunk gate passes our own tick, which
+            # carries no creature link.
+            AttackDef.new(:bleed, [
+              /Blood weeps from (?<target>.+?)'s#{MK_POST} open .+? wound\./,
+              /(?<target>.+?)'s#{MK_POST} .+? drips as #{MK_PRE}(?:he|she|it)#{MK_POST} continues to bleed\./,
+              /(?<target>Your) .+? drips as you continue to bleed\./
             ].freeze)
           ].freeze
 

--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -343,6 +343,9 @@ module Lich
               /(?<attacker>.+?) whips a pseudopod toward (?<target>you|.+?), brushing/,
               # halfling cannibal ambush swing (hunt log 2026-09-07 23:34)
               /With an ululating shriek, (?<attacker>.+?) leaps from the shadows and hammers blindly at (?<target>you|.+?) with grimy little fists!/,
+              # gigas disciple leech fling: the SMR roll prints BEFORE this
+              # line and the evade rides on it (hunt log 2026-09-07 23:52)
+              /(?<attacker>.+?) reaches into a pouch at #{MK_PRE}(?:his|her|its)#{MK_POST} waist and draws back a hand covered in fat leeches.*?flings the parasites at (?<target>you|.+?)!/,
               /(?<attacker>.+?) snaps at (?<target>.+?) with its (?<weapon>[^!]+)!/,
               /(?<attacker>.+?) pounds at (?<target>.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .*?fists?!/,
               /(?<attacker>.+?) tries to bite (?<target>[^!]+)!/,

--- a/lib/gemstone/combat/defs/outcomes.rb
+++ b/lib/gemstone/combat/defs/outcomes.rb
@@ -53,10 +53,16 @@ module Lich
               /Your (?<weapon>.+?) flies wide, narrowly missing (?<target>[^!]+)./,
               /The net flies past you and collapses into a useless heap./,
               /(?<attacker>.+?) stumbles behind you like a top out of control./,
-              /The enormous hand attempts to grab you, but you manage to avoid it at the last moment./
+              /The enormous hand attempts to grab you, but you manage to avoid it at the last moment./,
+              # shield push whiff (hunt log 2026-09-07)
+              /(?<attacker>.+?) completely misses you, stumbles, and flails around!/
             ].freeze),
             OutcomeDef.new(:hit, [
               /(?:A|Good) hit!/,
+              # creature fear maneuvers that got us (SSR precedes; the save
+              # forms are :resisted)
+              /(?<attacker>.+?)'s#{MK_POST} angry trumpeting startles you!/,
+              /Your heart quavers in your chest and you find yourself unable to focus on defending yourself!/,
               # Nature's Fury per-target hit lines (round-13 sweep: 52/52
               # follow the natures_fury initiation + Warding failed! in
               # the same chunk, damage always follows). The adjective is
@@ -133,6 +139,8 @@ module Lich
               # pre-emptive evade (warg, hunt log 2026-09-07): prints INSTEAD
               # of the attack line, so this is the only record of the swing
               /With preternatural speed, (?<target>.+?) bounds to safety as you move to attack #{MK_PRE}(?:him|her|it)#{MK_POST}, leaving you off-balance!/,
+              # 3p feint we saw through (also the :feint initiation line)
+              /(?<attacker>.+?) feints (?:high|low|to the (?:left|right)), but you aren't fooled for a second\./,
               /Unable to focus clearly, you blindly evade the attack!/,
               /You barely dodge the attack!/,
               /Unfortunately, your aim is off and your attack goes wide!/,
@@ -321,6 +329,23 @@ module Lich
 
             OUTCOME_LOOKUP.each { |rx, type| return type if rx.match?(line) }
             nil
+          end
+
+          # True when the outcome line names who attacked US ("The thorny
+          # barrier surrounding you blocks the attack from <X>!"): the def
+          # carries an (?<attacker>) capture. A fully-intercepted inbound
+          # swing prints no initiation line, so this is the only record of
+          # it - the processor opens it inbound, not as an attack ON X
+          # (hunt log 2026-09-07: barrier blocks filed as unknown vs warg).
+          def self.inbound_line?(line)
+            return false unless GATE.match?(line) || ALWAYS_SCAN.any? { |rx| rx.match?(line) }
+
+            OUTCOME_LOOKUP.each do |rx, _type|
+              next unless rx.match?(line)
+
+              return rx.names.include?('attacker')
+            end
+            false
           end
         end
 

--- a/lib/gemstone/combat/defs/outcomes.rb
+++ b/lib/gemstone/combat/defs/outcomes.rb
@@ -382,6 +382,22 @@ module Lich
           # holds the few patterns the gate cannot cover.
           GATE, ALWAYS_SCAN = PatternGate.build(RESOLUTION_LOOKUP.map(&:first))
 
+          # Crit RIDER maneuvers: a leg/knockdown crit rolls an SMR of its
+          # own AFTER the damage settles, then prints the fall. That roll
+          # belongs to the hit that caused it, not to the next attack -
+          # without this it was orphaned into a synthetic :unknown attack
+          # against whatever creature was current (2026-09-07 hunt log,
+          # spectral_bloom leg crit on a skald -> "unknown" on the mastodon).
+          CRIT_RIDER_PATTERNS = [
+            /Despite desperate windmilling to catch (?:his|her|its|their) balance, .+? topples/
+          ].freeze
+
+          # @param line [String] the line right after a roll
+          # @return [Boolean] true when it narrates a crit-knockdown rider
+          def self.crit_rider_line?(line)
+            CRIT_RIDER_PATTERNS.any? { |rx| rx.match?(line) }
+          end
+
           # Parses a single roll line into its numeric components.
           #
           # @param line [String] one line of game text

--- a/lib/gemstone/combat/defs/outcomes.rb
+++ b/lib/gemstone/combat/defs/outcomes.rb
@@ -139,6 +139,7 @@ module Lich
               # pre-emptive evade (warg, hunt log 2026-09-07): prints INSTEAD
               # of the attack line, so this is the only record of the swing
               /With preternatural speed, (?<target>.+?) bounds to safety as you move to attack #{MK_PRE}(?:him|her|it)#{MK_POST}, leaving you off-balance!/,
+              /You avoid the push!/,
               # 3p feint we saw through (also the :feint initiation line)
               /(?<attacker>.+?) feints (?:high|low|to the (?:left|right)), but you aren't fooled for a second\./,
               /Unable to focus clearly, you blindly evade the attack!/,
@@ -422,7 +423,8 @@ module Lich
           # against whatever creature was current (2026-09-07 hunt log,
           # spectral_bloom leg crit on a skald -> "unknown" on the mastodon).
           CRIT_RIDER_PATTERNS = [
-            /Despite desperate windmilling to catch (?:his|her|its|their) balance, .+? topples/
+            # (the pronoun is a link in the live feed - hunt log 2026-09-07 21:03)
+            /Despite desperate windmilling to catch #{MK_PRE}(?:his|her|its|their)#{MK_POST} balance, .+? topples/
           ].freeze
 
           # @param line [String] the line right after a roll

--- a/lib/gemstone/combat/defs/outcomes.rb
+++ b/lib/gemstone/combat/defs/outcomes.rb
@@ -55,7 +55,9 @@ module Lich
               /(?<attacker>.+?) stumbles behind you like a top out of control./,
               /The enormous hand attempts to grab you, but you manage to avoid it at the last moment./,
               # shield push whiff (hunt log 2026-09-07)
-              /(?<attacker>.+?) completely misses you, stumbles, and flails around!/
+              /(?<attacker>.+?) completely misses you, stumbles, and flails around!/,
+              # sanguine ooze pseudopod whiff, same line as its initiation
+              /The goopy appendage flies wide before retracting back into the central mass of/
             ].freeze),
             OutcomeDef.new(:hit, [
               /(?:A|Good) hit!/,
@@ -140,6 +142,8 @@ module Lich
               # of the attack line, so this is the only record of the swing
               /With preternatural speed, (?<target>.+?) bounds to safety as you move to attack #{MK_PRE}(?:him|her|it)#{MK_POST}, leaving you off-balance!/,
               /You avoid the push!/,
+              # sanguine ooze shrapnel burst dodged
+              /Bobbing and weaving, you dodge the spray of shrapnel!/,
               # 3p feint we saw through (also the :feint initiation line)
               /(?<attacker>.+?) feints (?:high|low|to the (?:left|right)), but you aren't fooled for a second\./,
               /Unable to focus clearly, you blindly evade the attack!/,

--- a/lib/gemstone/combat/defs/outcomes.rb
+++ b/lib/gemstone/combat/defs/outcomes.rb
@@ -42,7 +42,8 @@ module Lich
               /An arrow falls to the (?:ground|floor), narrowly missing (?<target>[^!]+)./,
               /(?<target>.+?) moves at the last moment to avoid an incoming arrow./,
               /The spray of arrows leaves (?<target>.+?) unscathed and undeterred./,
-              /The .+? vine#{MK_POST} (?:lashes out at|grabs at) (?<target>.+?),? (?:but is unable to grasp|unable to find a purchase)/,
+              # 610 tangleweed: "vine" (tangle) or "briar" (Ojandhaart form)
+              /The .+? (?:vine|briar)#{MK_POST} (?:lashes out at|grabs at) (?<target>.+?),? (?:but is unable to grasp|unable to find a purchase)/,
               /Your strike misses its mark./,
               /(?<attacker>.+?) whacks your legs to no effect./,
               /You whack (?<target>.+?'s)#{MK_POST} legs futilely./,
@@ -129,6 +130,9 @@ module Lich
               /You outmaneuver the attack and completely avoid it!/,
               /(?<target>.+?) dodges an incoming arrow!/,
               /Sensing your attack coming, (?<target>.+?) leaps to safety as you move to attack (?:him|her|it), leaving you out of position!/,
+              # pre-emptive evade (warg, hunt log 2026-09-07): prints INSTEAD
+              # of the attack line, so this is the only record of the swing
+              /With preternatural speed, (?<target>.+?) bounds to safety as you move to attack #{MK_PRE}(?:him|her|it)#{MK_POST}, leaving you off-balance!/,
               /Unable to focus clearly, you blindly evade the attack!/,
               /You barely dodge the attack!/,
               /Unfortunately, your aim is off and your attack goes wide!/,
@@ -231,7 +235,11 @@ module Lich
               /(?<target>.+?) aura absorbs some of the damage!/,
               /(?<target>.+?) manages to block some of the (?:elemental )?damage with #{MK_PRE}(?:his|her|its)#{MK_POST} .+?!/,
               /(?<armor>.+?) partially deflects the onslaught of the \w+ attack\./,
-              /Your body resists the \w+ damage and lessens the severity of the attack!/
+              /Your body resists the \w+ damage and lessens the severity of the attack!/,
+              # creature fear maneuvers we saved against (SSR precedes these;
+              # hunt log 2026-09-07: warg howl, mastodon trumpet)
+              /Fear still claws at your heart, but you stand fast against .+? unnerving howl!/,
+              /You keep your wits amidst .+? angry trumpeting!/
             ].freeze),
             # Immunity: the spell simply has no effect - no CS/TD roll is
             # printed at all (e.g. 501 Sleep vs a troll wraith, forge

--- a/lib/gemstone/combat/defs/outcomes.rb
+++ b/lib/gemstone/combat/defs/outcomes.rb
@@ -144,6 +144,8 @@ module Lich
               /You avoid the push!/,
               # sanguine ooze shrapnel burst dodged
               /Bobbing and weaving, you dodge the spray of shrapnel!/,
+              # gigas disciple leech fling dodged (same line as the fling)
+              /You duck to narrowly avoid the flying vermiforms!/,
               # 3p feint we saw through (also the :feint initiation line)
               /(?<attacker>.+?) feints (?:high|low|to the (?:left|right)), but you aren't fooled for a second\./,
               /Unable to focus clearly, you blindly evade the attack!/,

--- a/lib/gemstone/combat/defs/spell_losses.rb
+++ b/lib/gemstone/combat/defs/spell_losses.rb
@@ -62,6 +62,11 @@ module Lich
             # "You become solid again." - 911 only, no standalone Blur
             # entry exists; 1605's end names the same warmth+spiritual
             # force around the arms the third person describes)
+            # effect-list end message "A white glow rushes away from you."
+            # (owner report 2026-09-09: a skald's death dropped it and the
+            # report showed a "dispelled" status with no dispel flare)
+            SpellLossDef.new(303, 'Prayer of Protection',
+                             [/A white glow rushes away from (?<target>[^.]+)\./].freeze),
             SpellLossDef.new(513, 'Elemental Focus',
                              [/(?<target>.+?) no longer bristles with energy\./].freeze),
             SpellLossDef.new(911, 'Mass Blur',

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -183,11 +183,7 @@ module Lich
               # 611 evoked: "Tapping the moons above, you draw down a shaft of
               # swirling moonlight and bathe X in its muted glow." then SMR
               # (hunt log 2026-09-09 10:45); the moon adjectives vary
-              # [Yy]ou: the log line has the "Tapping the moons above," prefix
-              # so `you` is mid-sentence there, but the prefix is not
-              # guaranteed - sentence-initial "You draw down..." would
-              # otherwise fall through to :unknown
-              /[Yy]ou draw down a shaft of \w+ moonlight and bathes? (?<target>.+?) in its \w+ glow\./
+              /you draw down a shaft of \w+ moonlight and bathes? (?<target>.+?) in its \w+ glow\./
             ].freeze),
             AttackDef.new(:pestilence, [
               /You exhale a virulent green mist toward (?<target>[^,]+), instantly infecting/,

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -56,7 +56,9 @@ module Lich
               # the miss: same line is the :miss outcome (defs/outcomes.rb).
               # Without an attack def the SMR before it was orphaned into a
               # targetless :unknown (hunt log 2026-09-07 19:21:44)
-              /The (?<weed>.+?) lashes out at (?<target>[^,]+), but is unable to grasp/
+              /The (?<weed>.+?) lashes out at (?<target>[^,]+), but is unable to grasp/,
+              # the other miss form (no SMR printed; hunt log 2026-09-07 21:30)
+              /The (?<weed>.+?) grabs at (?<target>[^,]+), unable to find a purchase\./
             ].freeze),
             AttackDef.new(:tonis_bolt, [/You unleash a bolt of churning air at (?<target>[^!]+)!/].freeze),
             AttackDef.new(:unbalance, [/Bands of spectral mist ripple and surge beneath (?<target>[^!]+)!/].freeze),

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -52,7 +52,11 @@ module Lich
               # ground|floor: indoor rooms print "floor" (Ojandhaart great hall,
               # real-feed 2026-09-07) - the ground-only form orphaned every
               # indoor entangle tick as an unknown attack with no target
-              /The (?<weed>.+?) lashes out at (?<target>[^,]+), wraps itself around .+? body and entangles .+? on the (?:ground|floor)\./
+              /The (?<weed>.+?) lashes out at (?<target>[^,]+), wraps itself around .+? body and entangles .+? on the (?:ground|floor)\./,
+              # the miss: same line is the :miss outcome (defs/outcomes.rb).
+              # Without an attack def the SMR before it was orphaned into a
+              # targetless :unknown (hunt log 2026-09-07 19:21:44)
+              /The (?<weed>.+?) lashes out at (?<target>[^,]+), but is unable to grasp/
             ].freeze),
             AttackDef.new(:tonis_bolt, [/You unleash a bolt of churning air at (?<target>[^!]+)!/].freeze),
             AttackDef.new(:unbalance, [/Bands of spectral mist ripple and surge beneath (?<target>[^!]+)!/].freeze),

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -178,7 +178,13 @@ module Lich
             # matched OUR OWN limb ("Your right leg explodes!") and opened an
             # attack event against us.
             AttackDef.new(:limb_disruption, [/The (?<target>.+?)'s#{MK_POST} (?:right|left) (?:leg|arm|hand|eye) explodes!/].freeze),
-            AttackDef.new(:moonbeam, [/You level a nebulous beam of shadowy luminescence at (?<target>[^!]+)!/].freeze),
+            AttackDef.new(:moonbeam, [
+              /You level a nebulous beam of shadowy luminescence at (?<target>[^!]+)!/,
+              # 611 evoked: "Tapping the moons above, you draw down a shaft of
+              # swirling moonlight and bathe X in its muted glow." then SMR
+              # (hunt log 2026-09-09 10:45); the moon adjectives vary
+              /you draw down a shaft of \w+ moonlight and bathes? (?<target>.+?) in its \w+ glow\./
+            ].freeze),
             AttackDef.new(:pestilence, [
               /You exhale a virulent green mist toward (?<target>[^,]+), instantly infecting/,
               # 3p: a group member casts it. Without this the per-target
@@ -274,6 +280,19 @@ module Lich
               /(?<attacker>.+?) directs the force of #{MK_PRE}(?:his|her|its)#{MK_POST} voice at (?<target>[^!]+)!/
             ].freeze),
             AttackDef.new(:channel, [/(?<attacker>.+?) channels at (?<target>[^.]+)\./].freeze),
+            # Nearby players' spells on creatures we can see (hunt log
+            # 2026-09-09, gigas village). Each names the caster, so the
+            # foreign latch keeps the CS/TD, SMR/SSR and damage lines that
+            # follow off our ledger - a bard's sonic disruption kill was
+            # credited to us before the 3p spellsong form existed.
+            AttackDef.new(:spellsong, [
+              /(?<attacker>.+?) skillfully weaves another verse into #{MK_PRE}(?:his|her)#{MK_POST} harmony, directing the sound of #{MK_PRE}(?:his|her)#{MK_POST} voice at (?<target>[^.]+)\./
+            ].freeze),
+            # bard fear AoE: one cry, then an SSR + "X looks at <bard> in
+            # utter terror!" per creature in the room
+            AttackDef.new(:fear_cry, [/(?<attacker>.+?) lets loose an eerie, modulating cry!/].freeze),
+            AttackDef.new(:golden_waves, [/Golden brown waves billow outward from (?<attacker>.+?) to buffet (?<target>[^!]+)!/].freeze),
+            AttackDef.new(:moonbeam, [/(?<attacker>.+?) draws down a shaft of \w+ moonlight and bathes (?<target>.+?) in its \w+ glow\./].freeze),
             # creature wand flourish - the erupt tail rides the same line
             AttackDef.new(:wand, [/(?<attacker>.+?) flourishes (?<weapon>.+?) at (?<target>[^.]+)\.\s+A .+? erupts toward/].freeze),
             # "hurls a/an <bolt>" - bolt spells from players AND creatures;

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -183,7 +183,11 @@ module Lich
               # 611 evoked: "Tapping the moons above, you draw down a shaft of
               # swirling moonlight and bathe X in its muted glow." then SMR
               # (hunt log 2026-09-09 10:45); the moon adjectives vary
-              /you draw down a shaft of \w+ moonlight and bathes? (?<target>.+?) in its \w+ glow\./
+              # [Yy]ou: the log line has the "Tapping the moons above," prefix
+              # so `you` is mid-sentence there, but the prefix is not
+              # guaranteed - sentence-initial "You draw down..." would
+              # otherwise fall through to :unknown
+              /[Yy]ou draw down a shaft of \w+ moonlight and bathes? (?<target>.+?) in its \w+ glow\./
             ].freeze),
             AttackDef.new(:pestilence, [
               /You exhale a virulent green mist toward (?<target>[^,]+), instantly infecting/,

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -74,6 +74,13 @@ module Lich
             AttackDef.new(:weapon_infusion, [
               /As (?<attacker>.+?) attempts to strike with .+?, a surge of power flows out of it, through .+?, and leaps out at (?<target>[^!]+)!/
             ].freeze),
+            # A nearby player's shadow-barb spell (SMR + damage follow; the
+            # caster is the player link, so foreign_caster). Hunt log
+            # 2026-09-07: Burns vs a shield-maiden, recorded as a targetless
+            # unknown with an orphaned SMR.
+            AttackDef.new(:fiery_barbs, [
+              /Fiery red barbs uncoil from the shadows near (?<attacker>.+?) and lash out at (?<target>[^!]+)!/
+            ].freeze),
           ].freeze
 
           # Spell initiations catalogued from the wiki Messaging sections

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -83,6 +83,19 @@ module Lich
             AttackDef.new(:fiery_barbs, [
               /Fiery red barbs uncoil from the shadows near (?<attacker>.+?) and lash out at (?<target>[^!]+)!/
             ].freeze),
+            # A nearby player's flaming aura lashing a creature (SMR + damage
+            # follow; hunt log 2026-09-07 23:20, Meb)
+            AttackDef.new(:flaming_aura, [
+              /The flaming aura surrounding (?<attacker>.+?) lashes out at (?<target>[^!]+)!/
+            ].freeze),
+            # DoT tick naming the victim, never the caster (unowned unless
+            # our cast is in the blob - see UNOWNED_TICK_ATTACKS). Its
+            # "causing N" is a summary: the "... N points of damage!" line
+            # that follows carries the hit and its crit, so the inline
+            # number is NOT applied (see SUMMARY_DAMAGE_ATTACKS).
+            AttackDef.new(:spiritual_malady, [
+              /A spiritual malady wracks (?<target>.+?) causing \d+ points? of damage!/
+            ].freeze),
           ].freeze
 
           # Spell initiations catalogued from the wiki Messaging sections

--- a/lib/gemstone/combat/defs/statuses.rb
+++ b/lib/gemstone/combat/defs/statuses.rb
@@ -180,9 +180,12 @@ module Lich
 
             # Dispel landing - a spell stripped from the target (round-6:
             # 44k; follows the dispel/sigil_dispel flare + its SMR)
+            # "A white glow rushes away from X." is NOT a dispel: it is
+            # 303 Prayer of Protection ending (effect-list end message
+            # "A white glow rushes away from you."), most often printed as
+            # a creature's buffs drop on death - see spell_losses.rb
             StatusDef.new(:dispelled,
                           [
-                            /A white glow rushes away from (?<target>[^.]+)\./,
                             # dispel-flare landing confirmation (exchange
                             # evidence 2026-09-03: directly follows dispel/
                             # sigil_dispel flares in all captured exchanges;

--- a/lib/gemstone/combat/parser.rb
+++ b/lib/gemstone/combat/parser.rb
@@ -193,7 +193,7 @@ module Lich
             # attacker as "his").
             links = text.to_enum(:scan, TARGET_LINK_PATTERN).map { Regexp.last_match }
             if (link = links.last)
-              { id: link[:id].to_i, noun: link[:noun], name: link[:name] }
+              { id: link[:id].to_i, noun: link[:noun], name: link_name(link) }
             else
               { name: strip_links(text).strip }
             end
@@ -202,6 +202,14 @@ module Lich
           # Drop XML link/bold markup from a captured fragment
           def strip_links(text)
             text.gsub(/<[^>]+>/, '')
+          end
+
+          # A creature's display name from its link. The game sometimes puts
+          # the possessive INSIDE the link ("<a>grim gigas skald's</a> mastery
+          # of music"), which registered a second creature named "grim gigas
+          # skald's" (hunt log 2026-09-07). Same id, same creature: strip it.
+          def link_name(link)
+            link[:name].sub(/'s\z/, '')
           end
 
           # Parse damage amounts using damage definitions
@@ -314,7 +322,7 @@ module Lich
             {
               id: id,
               noun: link_match[:noun],
-              name: link_match[:name]
+              name: link_name(link_match)
             }
           end
 
@@ -332,7 +340,7 @@ module Lich
               return {
                 id: id,
                 noun: target_match[:noun],
-                name: target_match[:name]
+                name: link_name(target_match)
               }
             end
 

--- a/lib/gemstone/combat/parser.rb
+++ b/lib/gemstone/combat/parser.rb
@@ -208,8 +208,10 @@ module Lich
           # the possessive INSIDE the link ("<a>grim gigas skald's</a> mastery
           # of music"), which registered a second creature named "grim gigas
           # skald's" (hunt log 2026-09-07). Same id, same creature: strip it.
+          # A hidden adjective leaves a doubled space ("halfling  cannibal"),
+          # squeezed for the same reason.
           def link_name(link)
-            link[:name].sub(/'s\z/, '')
+            link[:name].sub(/'s\z/, '').squeeze(' ').strip
           end
 
           # Parse damage amounts using damage definitions

--- a/lib/gemstone/combat/parser.rb
+++ b/lib/gemstone/combat/parser.rb
@@ -48,18 +48,24 @@ module Lich
                 # fallback below would install the attacker as its own
                 # target and apply its damage/crits to itself. Resolve the
                 # target as us and stop - never fall through.
-                # Environmental / self-inflicted defs (SELF_INFLICTED) are
+                # Environmental / self-inflicted defs (ATTACKERLESS) are
                 # damage to us by construction - no attacker, no "you"
                 # capture - unless this particular pattern named someone
-                # else (a nearby player taking the same tick).
-                self_inflicted = Definitions::Attacks::SELF_INFLICTED.include?(name) &&
-                                 !(match.names.include?('target') && match[:target])
-                if self_target?(match) || self_inflicted
+                # else (a nearby player taking the same tick). They name
+                # their source for the ledger: 'environment' (weather) or
+                # 'self' (our own gear), so reports can tell them apart.
+                attackerless = Definitions::Attacks::ATTACKERLESS.include?(name) &&
+                               !(match.names.include?('target') && match[:target])
+                if self_target?(match) || attackerless || Definitions::Attacks::ROOM_TARGETED.include?(name)
+                  attacker = extract_attacker_from_match(match)
+                  if attackerless
+                    attacker ||= { name: Definitions::Attacks::ENVIRONMENTAL.include?(name) ? 'environment' : 'self' }
+                  end
                   return {
                     name: name,
                     target: {},
                     inbound: true,
-                    attacker: extract_attacker_from_match(match),
+                    attacker: attacker,
                     damaging: true
                   }
                 end
@@ -164,9 +170,9 @@ module Lich
           def inbound_attack?(line)
             return false if Definitions::Attacks.rejects?(line)
 
-            Definitions::Attacks::ATTACK_LOOKUP.each do |pattern, _name|
+            Definitions::Attacks::ATTACK_LOOKUP.each do |pattern, name|
               if (match = pattern.match(line))
-                return self_target?(match)
+                return self_target?(match) || Definitions::Attacks::ROOM_TARGETED.include?(name)
               end
             end
             false
@@ -181,7 +187,12 @@ module Lich
             text = match[:attacker]
             return nil if text.nil? || text.strip.empty?
 
-            if (link = TARGET_LINK_PATTERN.match(text))
+            # The LAST link: a flavor prefix can carry the attacker's own
+            # pronoun link first ("Froth bubbling on <his> lips, <a tattooed
+            # gigas berserker> swings..." - hunt log 2026-09-07 recorded the
+            # attacker as "his").
+            links = text.to_enum(:scan, TARGET_LINK_PATTERN).map { Regexp.last_match }
+            if (link = links.last)
               { id: link[:id].to_i, noun: link[:noun], name: link[:name] }
             else
               { name: strip_links(text).strip }

--- a/lib/gemstone/combat/parser.rb
+++ b/lib/gemstone/combat/parser.rb
@@ -21,6 +21,9 @@ module Lich
       module Parser
         # Target link pattern - extract creatures/players from XML
         TARGET_LINK_PATTERN = /<a exist="(?<id>[^"]+)" noun="(?<noun>[^"]+)">(?<name>[^<]+)<\/a>/i.freeze
+        # A link whose closing tag lies beyond the captured text (see
+        # extract_attacker_from_match)
+        OPEN_LINK_TAIL_PATTERN = /<a exist="(?<id>[^"]+)" noun="(?<noun>[^"]+)">(?<name>[^<]+)\z/i.freeze
 
         # Bold tag pattern - creatures are wrapped in bold tags
         # Non-greedy match to avoid spanning multiple creatures
@@ -192,6 +195,10 @@ module Lich
             # gigas berserker> swings..." - hunt log 2026-09-07 recorded the
             # attacker as "his").
             links = text.to_enum(:scan, TARGET_LINK_PATTERN).map { Regexp.last_match }
+            # A possessive INSIDE the link ("<a>flayed gigas disciple's</a>
+            # power warps the air") leaves the capture ending mid-link: the
+            # def's 's sits inside the <a>. Take the unterminated link too.
+            links << Regexp.last_match if links.empty? && OPEN_LINK_TAIL_PATTERN.match(text)
             if (link = links.last)
               { id: link[:id].to_i, noun: link[:noun], name: link_name(link) }
             else

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -36,6 +36,14 @@ module Lich
         # "... N points of damage!" line that follows (that line carries the
         # crit) - applying both doubled the tick (hunt log 2026-09-07 23:20).
         SUMMARY_DAMAGE_ATTACKS = %i[spiritual_malady].freeze
+        # Side effects of another attack that land exactly ONE hit and then
+        # hand the line back to the attack they interrupted: a mount toppled
+        # by our briar pins its rider ("X is pinned beneath Y as it falls!",
+        # one damage line + crit), then the briar's own grapple damage on the
+        # mount prints. Without this the mount's damage landed on the pin row
+        # and the nettles line spawned an empty pin copy on the mount (hunt
+        # log 2026-09-08 00:25).
+        SINGLE_HIT_ATTACKS = %i[mount_collapse].freeze
 
         # Sequence brackets (Definitions::Sequences) whose rounds are attack
         # events of the SAME name: a round that prints no initiation line of
@@ -308,6 +316,8 @@ module Lich
           # (disciple's wither: "A nebulous haze shimmers into view around
           # you", hunt log 2026-09-07 23:50) - the effect is that caster's.
           last_inbound_attacker = nil
+          # the event a SINGLE_HIT_ATTACKS side effect cut in front of (see decl)
+          single_hit_parent = nil
           current_event = nil
           parse_state = :seeking_attack
           current_target = nil
@@ -1014,6 +1024,16 @@ module Lich
                 superseded_cast = true
                 current_event = nil
               end
+              # A one-hit side effect remembers the event it cut in front of
+              # (see SINGLE_HIT_ATTACKS); anything else clears it. The side
+              # effect's own line names ITS victim, so the target switcher
+              # has already saved the real parent and left a same-line
+              # artifact copy in current_event - the parent is the saved one.
+              single_hit_parent = nil
+              if SINGLE_HIT_ATTACKS.include?(attack[:name])
+                cand = current_event && current_event[:_line] == index ? events.last : current_event
+                single_hit_parent = cand if cand && !cand[:inbound] && !cand[:foreign_caster] && !cand[:foreign_target]
+              end
               # Save previous event before starting a new one - unless the
               # target-switcher created it on this very line (see _line)
               if event_savable?(current_event) && current_event[:_line] != index
@@ -1327,6 +1347,16 @@ module Lich
                                                              wound_rank: nil, fatal: true } }
                 respond '[Combat] Coup de grace kill' if Tracker.debug?(:verbose)
               elsif (damage = Parser.parse_damage(line))
+                # a one-hit side effect already has its hit: this damage is
+                # the interrupted attack's (see SINGLE_HIT_ATTACKS)
+                if !flare_ctx && current_event && single_hit_parent &&
+                   SINGLE_HIT_ATTACKS.include?(current_event[:name]) && current_event[:hits].any?
+                  save_event.call(current_event)
+                  current_event = single_hit_parent
+                  single_hit_parent = nil
+                  current_target = current_event[:target] if current_event[:target] && current_event[:target][:id]
+                  respond "[Combat] Resumed #{current_event[:name]} after its one-hit side effect" if Tracker.debug?(:verbose)
+                end
                 sink = flare_ctx || current_event
                 # ONE record per landed hit, damage bound to the crit it
                 # produced. Parallel :damages/:crits arrays could not express

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -87,6 +87,16 @@ module Lich
             event.delete(:root_ref)
             event.delete(:parent_ref)
           end
+          # Parse-phase status facts remember the event they rode (:_event,
+          # an object ref). Resolve it to that event's _uid so the recorder
+          # files the status under THAT attack, not under whatever attack it
+          # emitted last: a creature's cast that interrupted our swing emits
+          # after it, and the swing's blinds fell off the swing (hunt log
+          # 2026-09-07 23:50, cloak of shadows).
+          @deferred_emits&.each do |_, payload|
+            ev = payload.delete(:_event)
+            payload[:attack_uid] = uids[ev] if ev && uids.key?(ev)
+          end
           events.each do |event|
             event[:at] = at
             persist_event(event)
@@ -112,6 +122,7 @@ module Lich
           if @deferred_emits
             @deferred_emits << [type, payload]
           else
+            payload.delete(:_event)
             Observers.emit(type, payload)
           end
         end
@@ -119,7 +130,10 @@ module Lich
         def flush_deferred_emits
           pending = @deferred_emits
           @deferred_emits = nil
-          pending&.each { |type, payload| Observers.emit(type, payload) }
+          pending&.each do |type, payload|
+            payload.delete(:_event) # unresolved (no events emitted this chunk)
+            Observers.emit(type, payload)
+          end
         end
 
         PROMPT_TIME_PATTERN = /<prompt time="(\d+)"/.freeze
@@ -288,6 +302,12 @@ module Lich
           # log 2026-09-07 23:18, flayed gigas disciple). Our next own flare
           # line resumes the interrupted event.
           interrupted_own = nil
+          # Attacker of the last inbound event saved this blob. A creature's
+          # warding spell that lands prints its effect as an attackerless
+          # spell-result line right after the cast's "Warding failed!"
+          # (disciple's wither: "A nebulous haze shimmers into view around
+          # you", hunt log 2026-09-07 23:50) - the effect is that caster's.
+          last_inbound_attacker = nil
           current_event = nil
           parse_state = :seeking_attack
           current_target = nil
@@ -475,12 +495,31 @@ module Lich
                 status_flare_seq = lambda do |cid|
                   next nil unless current_event && cid
                   flares = current_event[:flares] || []
+                  # A line that is itself a flare AND a status (nature's
+                  # decay's "earthy, sweet aroma ... grows more pervasive")
+                  # rides the flare it announces - which the flare branch
+                  # below has not appended yet, so it is the NEXT position.
+                  # Without this the status sat on the flare before it
+                  # (breeze, hunt log 2026-09-07 23:50). Not when the flare
+                  # is about to resume an interrupted swing (see
+                  # interrupted_own): the positions belong to another event.
+                  if (lf = Parser.parse_flare(line)) && !(current_event[:inbound] && interrupted_own)
+                    lf_id = lf[:target].to_s[/exist="(-?\d+)"/, 1]&.to_i
+                    if lf_id == cid || (lf_id.nil? && current_event[:target] && current_event[:target][:id] == cid)
+                      next flares.size + 1
+                    end
+                  end
                   f = if flare_ctx && flare_ctx[:target_info]
                         flare_ctx if flare_ctx[:target_info][:id] == cid
                       elsif flare_ctx && current_event[:target] && current_event[:target][:id] == cid
                         flare_ctx
                       end
-                  f ||= flares.reverse.find { |x| x[:target_info] && x[:target_info][:id] == cid }
+                  # Only flares that printed AFTER the swing line: a status
+                  # right after the swing's crit ("Strike pierces forearm!
+                  # The mutant is stunned!") is the swing's, even when a
+                  # pre-flare (dispel, ensorcell) named the creature first
+                  # (hunt log 2026-09-07 23:51).
+                  f ||= flares.reverse.find { |x| !x[:_pre] && x[:target_info] && x[:target_info][:id] == cid }
                   f && (i = flares.index(f)) ? i + 1 : nil
                 end
                 if line_target && line_target[:id]
@@ -488,7 +527,7 @@ module Lich
                   line_status_id = line_target[:id]
                   if status_result.is_a?(Hash)
                     apply_status_to_target(status_result[:status], line_target[:name], line_target[:id], status_result[:action],
-                                           flare_seq: status_flare_seq.call(line_target[:id]))
+                                           flare_seq: status_flare_seq.call(line_target[:id]), event: current_event)
                   else
                     # Legacy format - status_result is just the status symbol
                     apply_status_to_target(status_result, line_target[:name], line_target[:id], :add)
@@ -511,7 +550,7 @@ module Lich
                   line_status_id = subject[:id]
                   apply_status_to_target(status_result[:status], subject[:name],
                                          subject[:id], status_result[:action],
-                                         flare_seq: status_flare_seq.call(subject[:id]))
+                                         flare_seq: status_flare_seq.call(subject[:id]), event: current_event)
                 elsif status_result.is_a?(Hash) && line.match?(/\A\s*Your?\b/)
                   # 2p: the status is OURS ("You are stunned!"). Never a
                   # creature application - but it IS a fact (inbound
@@ -597,10 +636,17 @@ module Lich
               # The reject clause still matters: when two weapons' flares
               # fire back to back with no attack line between them, the
               # weapon name is the ONLY thing telling them apart.
-              # Our own flare ("your <weapon>") arriving while a creature's
-              # inbound attack is the open event: it belongs to the own swing
-              # that attack interrupted - resume it (see interrupted_own).
-              if current_event && current_event[:inbound] && interrupted_own && line.match?(/\byour\b/i)
+              # Our own flare arriving while a creature's inbound attack is
+              # the open event: it belongs to the own swing that attack
+              # interrupted - resume it (see interrupted_own). Not only the
+              # "your <weapon>" lines: the disciple's cloak-of-shadows cast
+              # also cut in front of our nature's decay ("Soot brown specks
+              # ... in the wake of <creature>"), breeze and arcane reflex
+              # ("Vital energy infuses you") lines, which name no weapon
+              # (hunt log 2026-09-07 23:50). A creature's cast has no flares
+              # of its own; anything the swing could own resumes it.
+              if current_event && current_event[:inbound] && interrupted_own &&
+                 !flare_contradicts_weapon?(flare, interrupted_own)
                 save_event.call(current_event)
                 current_event = interrupted_own
                 interrupted_own = nil
@@ -978,6 +1024,7 @@ module Lich
                 if attack[:inbound] && !(current_event[:inbound] || current_event[:foreign_caster] || current_event[:foreign_target])
                   interrupted_own = current_event
                 end
+                last_inbound_attacker = current_event[:attacker] if current_event[:inbound] && current_event[:attacker]
               end
               # A same-line artifact event may have claimed held rolls in
               # the switch branch above (volley: the arrow's own SMR) -
@@ -1089,6 +1136,11 @@ module Lich
                 # attaching here even after outcomes/damage (see roll routing)
                 _attack_born: true
               }
+              # see last_inbound_attacker decl
+              if current_event[:inbound] && current_event[:attacker].nil? && last_inbound_attacker &&
+                 !Definitions::Attacks.attackerless_line?(line)
+                current_event[:attacker] = last_inbound_attacker
+              end
 
               # Spawn-tree lineage (see spawn_root decl). We stamp ONLY lineage
               # we can assert, never a positional guess:
@@ -1231,6 +1283,10 @@ module Lich
                   still_pending = []
                   pending_flares.each do |f|
                     if flare_matches_weapon?(f, current_event[:weapon]) || !flare_contradicts_weapon?(f, current_event)
+                      # fired BEFORE the swing line (dispel-on-nock, ensorcell's
+                      # veil): never the cause of a status the swing's own crit
+                      # inflicts afterwards (see status_flare_seq)
+                      f[:_pre] = true
                       current_event[:flares] << f
                     else
                       still_pending << f
@@ -1877,7 +1933,10 @@ module Lich
         end
 
         # Apply status effect directly to a creature (outside combat events)
-        def apply_status_to_target(status, target_name_or_id, target_id = nil, action = :add, flare_seq: nil)
+        # flare_seq / event: which flare (1-based position) of which parse
+        # event the status rode on; process() turns the event ref into an
+        # :attack_uid for the recorder.
+        def apply_status_to_target(status, target_name_or_id, target_id = nil, action = :add, flare_seq: nil, event: nil)
           # Handle both name lookup and direct ID
           if target_id
             creature = Creature[target_id.to_i]
@@ -1916,6 +1975,7 @@ module Lich
             payload = { id: creature.id, name: creature.name,
                         status: status, action: action == :remove ? :remove : :add }
             payload[:flare_seq] = flare_seq if flare_seq
+            payload[:_event] = event if event
             emit_fact(:status, payload)
           else
             respond "[Combat] Could not find creature for status: #{status} -> #{target_name_or_id}" if Tracker.debug?(:verbose)

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -372,6 +372,13 @@ module Lich
           # spell_loss cause - a wear-off riding a dispel strip means
           # something different from natural expiry or death cleanup.
           chunk_dispels = []
+          # Creatures THIS chunk killed (fatal crit, coup kill), by exist id.
+          # The registry learns of the death only when the chunk persists,
+          # but the wear-off lines that follow a death line are already in
+          # this chunk - without this a skald's 303 dropping on her death
+          # was a cause-less loss (owner 2026-09-09: "spells falling off
+          # during death versus being removed by a dispel").
+          chunk_deaths = []
           # Ownership of DoT/effect casts we saw in this blob, keyed PER VICTIM
           # as [spell_name, target_key] (target_key = the victim's exist id, or
           # its name when unresolved). :self when our 2p cast line fired ("You
@@ -590,8 +597,9 @@ module Lich
                 cause = nil
                 if chunk_dispels.include?(loss[:id]) || chunk_dispels.include?(:any)
                   cause = :dispel
-                elsif loss[:id] && defined?(Creature) && (c = Creature[loss[:id]]) &&
-                      (c.dead? || (c.respond_to?(:crtr_flag?) && c.crtr_flag?(:dead)))
+                elsif chunk_deaths.include?(loss[:id]) ||
+                      (loss[:id] && defined?(Creature) && (c = Creature[loss[:id]]) &&
+                       (c.dead? || (c.respond_to?(:crtr_flag?) && c.crtr_flag?(:dead))))
                   cause = :death
                 end
                 emit_fact(:spell_loss, id: loss[:id], name: loss[:name],
@@ -1345,6 +1353,7 @@ module Lich
                  (coup_loc = Definitions::Attacks.coup_kill_location(line))
                 current_event[:hits] << { damage: 0, crit: { location: coup_loc, type: 'coup_de_grace', rank: nil,
                                                              wound_rank: nil, fatal: true } }
+                chunk_deaths << current_event[:target][:id] if current_event[:target] && current_event[:target][:id]
                 respond '[Combat] Coup de grace kill' if Tracker.debug?(:verbose)
               elsif (damage = Parser.parse_damage(line))
                 # a one-hit side effect already has its hit: this damage is
@@ -1411,6 +1420,10 @@ module Lich
                       # documents which table row matched, and it makes the
                       # payload unserialisable for any recorder downstream.
                       hit[:crit] = c.reject { |k, _| k == :regex }
+                      if c[:fatal]
+                        victim = flare_ctx ? flare_ctx[:target_info] : (sink[:target_info] || sink[:target])
+                        chunk_deaths << victim[:id] if victim && victim[:id]
+                      end
                       respond "[Combat] Found critical hit: #{c[:location]} rank #{c[:wound_rank]}" if Tracker.debug?(:verbose)
                       break # Only take first crit found after this damage
                     end

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -30,7 +30,12 @@ module Lich
         # 2026-09-06). A tick IS ours only when our own cast of that spell
         # is visible in the same blob (see cast_owner tracking below).
         # :bleed has no cast at all, so it is always unowned (owner 2026-09-07).
-        UNOWNED_TICK_ATTACKS = %i[pestilence web bleed].freeze
+        UNOWNED_TICK_ATTACKS = %i[pestilence web bleed spiritual_malady].freeze
+
+        # Initiations whose inline "causing N points of damage!" restates the
+        # "... N points of damage!" line that follows (that line carries the
+        # crit) - applying both doubled the tick (hunt log 2026-09-07 23:20).
+        SUMMARY_DAMAGE_ATTACKS = %i[spiritual_malady].freeze
 
         # Sequence brackets (Definitions::Sequences) whose rounds are attack
         # events of the SAME name: a round that prints no initiation line of
@@ -159,6 +164,12 @@ module Lich
           / is forced out of hiding!/,
           # post-kill/rage emotes naming the creature
           / gurgles out an animalistic shriek of rage, /,
+          # a sanguine ooze splitting on the hit - names the new oozeling
+          # between the damage line and the next arrow (hunt log 2026-09-07
+          # 23:19: phantom fires on the oozeling, volley rounds split)
+          / splatter across the ground, wobbling disconcertingly as they twitch together to form /,
+          / pulses larger, bubbling grotesquely with new mass\./,
+          / pulses monstrously as .+? swells to its full size!/,
           /\AYou are now targeting /
         ).freeze
 
@@ -266,6 +277,17 @@ module Lich
         # State machine parser
         def parse_events(lines)
           events = []
+          # Identity-guarded push: an event RESUMED after an inbound
+          # interruption (see interrupted_own) was already saved once.
+          save_event = ->(ev) { events << ev unless events.any? { |e| e.equal?(ev) } }
+          # Our own event that an inbound attack cut into mid-swing. A
+          # creature's reactive cast (cloak of shadows: our arrow lands, its
+          # tendril lashes back, CS/TD, "Warded off!") prints BETWEEN our hit
+          # and our bow's flares; without this the phosphorescence and its
+          # damage/crit attached to the creature's cast as damage to US (hunt
+          # log 2026-09-07 23:18, flayed gigas disciple). Our next own flare
+          # line resumes the interrupted event.
+          interrupted_own = nil
           current_event = nil
           parse_state = :seeking_attack
           current_target = nil
@@ -575,6 +597,17 @@ module Lich
               # The reject clause still matters: when two weapons' flares
               # fire back to back with no attack line between them, the
               # weapon name is the ONLY thing telling them apart.
+              # Our own flare ("your <weapon>") arriving while a creature's
+              # inbound attack is the open event: it belongs to the own swing
+              # that attack interrupted - resume it (see interrupted_own).
+              if current_event && current_event[:inbound] && interrupted_own && line.match?(/\byour\b/i)
+                save_event.call(current_event)
+                current_event = interrupted_own
+                interrupted_own = nil
+                current_target = current_event[:target] if current_event[:target] && current_event[:target][:id]
+                parse_state = :seeking_damage
+                respond "[Combat] Resumed interrupted #{current_event[:name]} for its flare" if Tracker.debug?(:verbose)
+              end
               if current_event && !flare_contradicts_weapon?(flare, current_event)
                 current_event[:flares] << flare
               else
@@ -661,7 +694,7 @@ module Lich
               if current_target && current_target[:id] != line_target[:id]
                 # Save previous event if it has data
                 if event_savable?(current_event)
-                  events << current_event
+                  save_event.call(current_event)
                   respond "[Combat] Saved event for #{current_event[:target][:name]}: #{current_event[:hits].size} hits, #{current_event[:statuses].size} statuses" if Tracker.debug?(:verbose)
                 end
 
@@ -938,8 +971,13 @@ module Lich
               # Save previous event before starting a new one - unless the
               # target-switcher created it on this very line (see _line)
               if event_savable?(current_event) && current_event[:_line] != index
-                events << current_event
+                save_event.call(current_event)
                 respond "[Combat] Completed event for #{current_event[:target][:name]}: #{current_event[:hits].size} hits" if Tracker.debug?(:verbose)
+                # an inbound attack cutting into our own open swing: remember
+                # the swing so its trailing flares can resume it
+                if attack[:inbound] && !(current_event[:inbound] || current_event[:foreign_caster] || current_event[:foreign_target])
+                  interrupted_own = current_event
+                end
               end
               # A same-line artifact event may have claimed held rolls in
               # the switch branch above (volley: the arrow's own SMR) -
@@ -1170,7 +1208,7 @@ module Lich
               # No track_damage gate: the main damage branch has none, and
               # gating only here made inline-damage events vanish under
               # configs that omit the key (replay 2026-09-05, pestilence)
-              if (inline = Parser.parse_damage(line))
+              if !SUMMARY_DAMAGE_ATTACKS.include?(current_event[:name]) && (inline = Parser.parse_damage(line))
                 current_event[:hits] << { damage: inline, crit: nil }
                 respond "[Combat] Found inline damage: #{inline}" if Tracker.debug?(:verbose)
               end
@@ -1321,7 +1359,7 @@ module Lich
           if bare_cast?(current_event) && !current_event[:_held] && current_event[:attacker].nil?
             @held_cast = current_event
           elsif event_savable?(current_event)
-            events << current_event
+            save_event.call(current_event)
           end
 
           # Orphaned rolls: no attack ever claimed them (trailing rider

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -152,6 +152,13 @@ module Lich
         NARRATION_PATTERN = Regexp.union(
           / leaps from the back of .+? as .+? topples, narrowly avoiding being pinned/,
           / looks a little bit more wary after that display!/,
+          # a hidden creature revealed by an AoE flare - printed BEFORE the
+          # bloom line that names it, so it switched the target early and the
+          # bloom's damage landed on a phantom `fire` (hunt log 2026-09-07
+          # 22:14:27, the cannibal)
+          / is forced out of hiding!/,
+          # post-kill/rage emotes naming the creature
+          / gurgles out an animalistic shriek of rage, /,
           /\AYou are now targeting /
         ).freeze
 

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -318,6 +318,12 @@ module Lich
           last_inbound_attacker = nil
           # the event a SINGLE_HIT_ATTACKS side effect cut in front of (see decl)
           single_hit_parent = nil
+          # Weapon named by a "You nock <ammo> in your <bow>." line this chunk,
+          # cleared by the swing that follows. A pre-emptive evade ("bounds
+          # to safety as you move to attack it") prints INSTEAD of the fire
+          # line, so the only clue that the swing was a fire is the nock
+          # (hunt log 2026-09-09 16:00: the shroud then rode an "unknown").
+          nocked = nil
           current_event = nil
           parse_state = :seeking_attack
           current_target = nil
@@ -663,6 +669,17 @@ module Lich
               # ("Vital energy infuses you") lines, which name no weapon
               # (hunt log 2026-09-07 23:50). A creature's cast has no flares
               # of its own; anything the swing could own resumes it.
+              # A one-hit side effect (mount collapse) has its hit: the flare
+              # that follows is the interrupted swing's (see SINGLE_HIT_ATTACKS;
+              # hunt log 2026-09-09 13:44, chameleon shroud on the pin row)
+              if current_event && single_hit_parent && SINGLE_HIT_ATTACKS.include?(current_event[:name]) &&
+                 current_event[:hits].any?
+                save_event.call(current_event)
+                current_event = single_hit_parent
+                single_hit_parent = nil
+                current_target = current_event[:target] if current_event[:target] && current_event[:target][:id]
+                respond "[Combat] Resumed #{current_event[:name]} after its one-hit side effect (flare)" if Tracker.debug?(:verbose)
+              end
               if current_event && current_event[:inbound] && interrupted_own &&
                  !flare_contradicts_weapon?(flare, interrupted_own)
                 save_event.call(current_event)
@@ -922,10 +939,13 @@ module Lich
                     # it and seat it in the volley's spawn tree (the first arrow
                     # of the round becomes the root the later arrows point at).
                     round_name = SEQUENCE_ROUND_NAMES.include?(active_sequence) ? active_sequence : nil
+                    # a nocked bow with no fire line printed: the outcome IS
+                    # the fire (pre-emptive evade, see nocked decl)
+                    nock_fire = nocked && !pending_ambush && round_name.nil?
                     current_event = {
-                      name: pending_ambush ? :ambush : (round_name || :unknown),
+                      name: pending_ambush ? :ambush : (round_name || (nock_fire ? :fire : :unknown)),
                       target: line_target, attacker: nil,
-                      weapon: nil, parent: nil, hits: [],
+                      weapon: nock_fire ? nocked : nil, parent: nil, hits: [],
                       statuses: [], flares: [], outcomes: [outcome],
                       # A wholly-negated ambush prints its prefix and then an
                       # intercept, with no attack line between - this is the
@@ -941,6 +961,7 @@ module Lich
                     end
                     pending_ambush = nil
                     pending_resolutions = []
+                    nocked = nil if nock_fire
                     current_target = line_target
                     parse_state = :seeking_damage
                   end
@@ -1003,6 +1024,9 @@ module Lich
             # above on the same line and double-applied their effects.
             attack = (amb || rdr) ? nil : line_attack
 
+            if (nock = line.gsub(/<[^>]+>/, '').match(/\AYou nock .+? in your (?<weapon>[^.]+)\.\s*\z/))
+              nocked = nock[:weapon]
+            end
             if attack
               # A bare gesture :cast event is the WRAPPER for whatever
               # spell-specific initiation follows in the same chunk (searing
@@ -1164,6 +1188,7 @@ module Lich
                 # attaching here even after outcomes/damage (see roll routing)
                 _attack_born: true
               }
+              nocked = nil # the swing the nock announced has printed (see decl)
               # see last_inbound_attacker decl
               if current_event[:inbound] && current_event[:attacker].nil? && last_inbound_attacker &&
                  !Definitions::Attacks.attackerless_line?(line)

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -32,6 +32,11 @@ module Lich
         # :bleed has no cast at all, so it is always unowned (owner 2026-09-07).
         UNOWNED_TICK_ATTACKS = %i[pestilence web bleed].freeze
 
+        # Sequence brackets (Definitions::Sequences) whose rounds are attack
+        # events of the SAME name: a round that prints no initiation line of
+        # its own (a missed volley arrow: roll + dodge only) is still one.
+        SEQUENCE_ROUND_NAMES = %i[volley].freeze
+
         module_function
 
         # Process a chunk of game lines for combat events. Parses the chunk
@@ -286,6 +291,9 @@ module Lich
           # nil (root still known) rather than guessed. See recorder root/
           # parent_attack_id.
           spawn_root = nil
+          # The sequence bracket (Definitions::Sequences) currently open in
+          # this blob, when its rounds are events of the same name (volley).
+          active_sequence = nil
           # Rolls that could not claim a virgin sink. An array: several can
           # stack up (volley's per-arrow SMRs, trailing rider maneuvers) and
           # the old single slot silently overwrote all but the last.
@@ -570,13 +578,23 @@ module Lich
             # Spawn-class flares (Blink) fire an imbedded spell whose cast
             # unfolds as a bracketed sequence. Events inside the bracket are
             # children of the flare, not independent casts.
-            if spawn_pending && (seq = Parser.parse_sequence_start(line))
-              active_spawn = { flare: spawn_pending[:name], sequence: seq, weapon: spawn_pending[:weapon] }
-              spawn_pending = nil
-              respond "[Combat] Spawn sequence started: #{seq} from #{active_spawn[:flare]}" if Tracker.debug?(:verbose)
-            elsif active_spawn && Parser.parse_sequence_end(line) == active_spawn[:sequence]
-              respond "[Combat] Spawn sequence ended: #{active_spawn[:sequence]}" if Tracker.debug?(:verbose)
-              active_spawn = nil
+            if (seq = Parser.parse_sequence_start(line))
+              # Any sequence bracket names the rounds inside it that print no
+              # initiation of their own (a volley arrow that MISSED prints
+              # only roll + dodge line; hunt log 2026-09-07: two such arrows
+              # recorded as :unknown outside the volley tree).
+              active_sequence = seq
+              if spawn_pending
+                active_spawn = { flare: spawn_pending[:name], sequence: seq, weapon: spawn_pending[:weapon] }
+                spawn_pending = nil
+                respond "[Combat] Spawn sequence started: #{seq} from #{active_spawn[:flare]}" if Tracker.debug?(:verbose)
+              end
+            elsif (seq_end = Parser.parse_sequence_end(line))
+              active_sequence = nil if active_sequence == seq_end
+              if active_spawn && seq_end == active_spawn[:sequence]
+                respond "[Combat] Spawn sequence ended: #{active_spawn[:sequence]}" if Tracker.debug?(:verbose)
+                active_spawn = nil
+              end
             end
 
             # Assault brackets (single-target multi-round attacks: flurry,
@@ -785,8 +803,12 @@ module Lich
                     pending_resolutions = []
                     parse_state = :seeking_damage
                   else
+                    # Inside a volley bracket the round IS a volley arrow: name
+                    # it and seat it in the volley's spawn tree (the first arrow
+                    # of the round becomes the root the later arrows point at).
+                    round_name = SEQUENCE_ROUND_NAMES.include?(active_sequence) ? active_sequence : nil
                     current_event = {
-                      name: pending_ambush ? :ambush : :unknown,
+                      name: pending_ambush ? :ambush : (round_name || :unknown),
                       target: line_target, attacker: nil,
                       weapon: nil, parent: nil, hits: [],
                       statuses: [], flares: [], outcomes: [outcome],
@@ -796,6 +818,12 @@ module Lich
                       ambush: !pending_ambush.nil?,
                       resolutions: pending_resolutions
                     }
+                    if round_name
+                      # lineage as the attack branch would stamp it: first own
+                      # event of the blob roots the tree, later ones point at it
+                      spawn_root ||= current_event
+                      current_event[:root_ref] = spawn_root
+                    end
                     pending_ambush = nil
                     pending_resolutions = []
                     current_target = line_target
@@ -1460,16 +1488,22 @@ module Lich
 
         # -- death watch ---------------------------------------------------
 
-        # How many sweeps a touched creature stays watched without dying.
-        # Two chunks covers the room-refresh lag seen in real feeds; anything
-        # longer is a creature that simply survived.
-        DEATH_WATCH_SWEEPS = 3
+        # A touched creature stays watched until it dies or leaves the
+        # registry. It used to expire after three sweeps ("a much later death
+        # is not this event's"), which left creatures we fought and someone
+        # else finished minutes later marked alive (hunt log 2026-09-07: two
+        # mastodons dead in the room feed, both "Alive: true"). Credit is the
+        # recorder's call - a dead status outside any attack window credits
+        # nobody - so watching longer only fixes killed_at. Bounded FIFO.
+        DEATH_WATCH_MAX = 256
 
         def watch_for_death(id)
           return unless id
 
           @death_watch ||= {}
-          @death_watch[id.to_i] = DEATH_WATCH_SWEEPS
+          @death_watch.delete(id.to_i) # re-insert at the tail (most recent)
+          @death_watch[id.to_i] = true
+          @death_watch.shift while @death_watch.size > DEATH_WATCH_MAX
         end
 
         # Emits :status dead (add) for any watched creature whose registry
@@ -1494,8 +1528,6 @@ module Lich
               Observers.emit(:status, id: creature.id, name: creature.name,
                                       status: 'dead', action: :add)
               respond "[Combat] #{creature.name} (#{id}) confirmed dead" if Tracker.debug?(:verbose)
-            elsif (@death_watch[id] -= 1) <= 0
-              @death_watch.delete(id)
             end
           end
         end

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -942,6 +942,12 @@ module Lich
                 elsif flare_ctx || (current_event && !preempts_open_inbound)
                   (flare_ctx || current_event)[:outcomes] << outcome
                 elsif line_target && line_target[:id]
+                  # Reached with an open event only via preempts_open_inbound:
+                  # the creature's swing that interleaved between our nock and
+                  # the pre-emptive evade. Save it before opening ours, as the
+                  # single_hit_parent / interrupted_own resumptions do - it
+                  # may carry a fully resolved hit on us.
+                  save_event.call(current_event) if event_savable?(current_event)
                   # An outcome with a named target and no event at all: the
                   # first arrow of a volley round can be a miss - roll +
                   # outcome, no attack line, at the top of the chunk. Open

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -684,8 +684,18 @@ module Lich
                 # already dealt its damage is complete - an acid proc must
                 # not steal the next swing's AS/DS (real-feed replay,
                 # logs/examples/weapon_pulverize.txt).
-                flare_ctx = nil if flare_ctx && flare_ctx[:hits].any?
+                settled_flare = flare_ctx if flare_ctx && flare_ctx[:hits].any?
+                flare_ctx = nil if settled_flare
                 sink = flare_ctx
+                # Crit RIDER roll: a knockdown crit rolls its own SMR after
+                # the damage and then narrates the fall on the very next
+                # line. It belongs to the hit that caused it (the flare or
+                # the swing), not to the next attack - held, it became a
+                # synthetic :unknown on the wrong creature.
+                if sink.nil? && %i[smr maneuver_roll].include?(resolution[:type]) &&
+                   (peek = lines[index + 1]) && Definitions::Resolutions.crit_rider_line?(peek)
+                  sink = settled_flare || (current_event && current_event[:hits].any? ? current_event : nil)
+                end
                 # Roll routing differs by roll class (fixture-verified,
                 # logs/examples/):
                 #   SMR/SSR/maneuver rolls PRECEDE their per-target line

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -1175,14 +1175,23 @@ module Lich
               # produced by OUR weapon and still belong to our next swing.
               unless current_event[:inbound]
                 unless pending_flares.empty?
-                  # A flare held over from the previous chunk names the BOW
-                  # while the shot names the ARROW; it belongs to this swing
-                  # unless a different weapon's flare already proves otherwise.
-                  claimed, pending_flares = pending_flares.partition do |f|
-                    flare_matches_weapon?(f, current_event[:weapon]) ||
-                      (f[:_held] && !flare_contradicts_weapon?(f, current_event))
+                  # A bow's pre-flare (dispel on the nock) names the BOW while
+                  # the shot names the ARROW, so a weapon-name match cannot be
+                  # required (hunt log 2026-09-07: 16 of 16 dispels became
+                  # their own attacks, in-chunk, right before "You fire"). A
+                  # pre-flare belongs to this swing unless a flare from a
+                  # DIFFERENT weapon already sits on it - the back-to-back
+                  # dual-wield signature (see flare_contradicts_weapon?).
+                  # Sequential so the first claimed flare guards the second.
+                  still_pending = []
+                  pending_flares.each do |f|
+                    if flare_matches_weapon?(f, current_event[:weapon]) || !flare_contradicts_weapon?(f, current_event)
+                      current_event[:flares] << f
+                    else
+                      still_pending << f
+                    end
                   end
-                  current_event[:flares].concat(claimed)
+                  pending_flares = still_pending
                 end
                 unless pending_resolutions.empty?
                   current_event[:resolutions].concat(pending_resolutions)

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -367,6 +367,17 @@ module Lich
             current_target = held[:target] if held[:target] && held[:target][:id]
             parse_state = :seeking_damage
           end
+          # Pre-flares held over from the previous chunk (see the end of this
+          # method): a bow's dispel fires on the NOCK, resolves (SMR, damage,
+          # crit) and the chunk ends at the prompt before "You fire" prints.
+          # Re-seed them so this chunk's swing claims them like any pre-flare
+          # (hunt log 2026-09-07: eight dispels recorded as their own
+          # "dispel" attacks instead of riding the shot).
+          if (held_flares = @held_pre_flares)
+            @held_pre_flares = nil
+            held_flares.each { |f| f[:_held] = true }
+            pending_flares.concat(held_flares)
+          end
 
           lines.each_with_index do |line, index|
             next if line.strip.empty?
@@ -1164,7 +1175,13 @@ module Lich
               # produced by OUR weapon and still belong to our next swing.
               unless current_event[:inbound]
                 unless pending_flares.empty?
-                  claimed, pending_flares = pending_flares.partition { |f| flare_matches_weapon?(f, current_event[:weapon]) }
+                  # A flare held over from the previous chunk names the BOW
+                  # while the shot names the ARROW; it belongs to this swing
+                  # unless a different weapon's flare already proves otherwise.
+                  claimed, pending_flares = pending_flares.partition do |f|
+                    flare_matches_weapon?(f, current_event[:weapon]) ||
+                      (f[:_held] && !flare_contradicts_weapon?(f, current_event))
+                  end
                   current_event[:flares].concat(claimed)
                 end
                 unless pending_resolutions.empty?
@@ -1324,9 +1341,14 @@ module Lich
           end
 
           # Pre-flares no swing claimed (e.g. the chunk ended first). Ones
-          # that resolved damage against a known target still count - wrap
-          # each as its own event so the damage is applied, not dropped.
-          pending_flares.each do |f|
+          # that resolved damage against a known target still count. First
+          # time round they are HELD for one chunk - the swing they belong
+          # to is usually the next chunk's first line (dispel-on-nock). A
+          # flare already held once is wrapped as its own event so the
+          # damage is applied, not dropped.
+          hold, wrap = pending_flares.partition { |f| f[:target_info] && !f[:hits].empty? && !f[:_held] }
+          @held_pre_flares = hold unless hold.empty?
+          wrap.each do |f|
             next unless f[:target_info] && !f[:hits].empty?
 
             # Data stays on the flare (persist_event applies flare damage

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -545,12 +545,29 @@ module Lich
                   f ||= flares.reverse.find { |x| !x[:_pre] && x[:target_info] && x[:target_info][:id] == cid }
                   f && (i = flares.index(f)) ? i + 1 : nil
                 end
+                # The event a status rides on (the recorder's attack_uid) -
+                # ONLY when that event touched the subject: it is the
+                # target, the attacker of an inbound swing, a flare named
+                # it, or the flare-and-status line about to be appended
+                # did (seq). An ambient line sharing the chunk ("A troll
+                # shakes off the stun!" while we shoot an orc) belongs to
+                # no event and stays an independent observation - the
+                # recorder must not be told otherwise (review 2026-09-10).
+                status_event_for = lambda do |cid, seq|
+                  next nil unless current_event && cid
+                  next current_event if seq
+                  ids = [current_event[:target] && current_event[:target][:id],
+                         current_event[:attacker].is_a?(Hash) ? current_event[:attacker][:id] : nil]
+                  ids.concat((current_event[:flares] || []).map { |x| x[:target_info] && x[:target_info][:id] })
+                  ids.compact.include?(cid) ? current_event : nil
+                end
                 if line_target && line_target[:id]
                   # Use ID-based lookup - this is most reliable
                   line_status_id = line_target[:id]
                   if status_result.is_a?(Hash)
+                    seq = status_flare_seq.call(line_target[:id])
                     apply_status_to_target(status_result[:status], line_target[:name], line_target[:id], status_result[:action],
-                                           flare_seq: status_flare_seq.call(line_target[:id]), event: current_event)
+                                           flare_seq: seq, event: status_event_for.call(line_target[:id], seq))
                   else
                     # Legacy format - status_result is just the status symbol
                     apply_status_to_target(status_result, line_target[:name], line_target[:id], :add)
@@ -571,9 +588,10 @@ module Lich
                   # 2p lines ("You are stunned!") describe US, never
                   # the creature - the Your?/You guard keeps them out.
                   line_status_id = subject[:id]
+                  seq = status_flare_seq.call(subject[:id])
                   apply_status_to_target(status_result[:status], subject[:name],
                                          subject[:id], status_result[:action],
-                                         flare_seq: status_flare_seq.call(subject[:id]), event: current_event)
+                                         flare_seq: seq, event: status_event_for.call(subject[:id], seq))
                 elsif status_result.is_a?(Hash) && line.match?(/\A\s*Your?\b/)
                   # 2p: the status is OURS ("You are stunned!"). Never a
                   # creature application - but it IS a fact (inbound

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -30,7 +30,7 @@ module Lich
         # 2026-09-06). A tick IS ours only when our own cast of that spell
         # is visible in the same blob (see cast_owner tracking below).
         # :bleed has no cast at all, so it is always unowned (owner 2026-09-07).
-        UNOWNED_TICK_ATTACKS = %i[pestilence web bleed spiritual_malady].freeze
+        UNOWNED_TICK_ATTACKS = %i[pestilence web bleed rot spiritual_malady].freeze
 
         # Initiations whose inline "causing N points of damage!" restates the
         # "... N points of damage!" line that follows (that line carries the

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -406,15 +406,40 @@ module Lich
             # through event_savable? (statuses live on the creature, not the
             # event, so the fields alone can't show it).
             line_status_id = nil
+            # An outcome printed ON an initiation line (tangleweed's "lashes
+            # out at X, but is unable to grasp her") belongs to the event that
+            # line opens below, not to whatever event is open now.
+            same_line_outcome = nil
 
             # Always check for status effects on every line (even outside combat)
             if Tracker.settings[:track_statuses]
               if (status_result = Parser.parse_status(line))
+                # Which of this event's flares the status rides on, as a
+                # 1-based position in event[:flares] (the recorder maps it
+                # to the flare row): the active damaging flare when it names
+                # this creature (or names nobody and the creature is the
+                # swing target), else the latest flare that named it - a
+                # glowbark bloom's "You blinded <bloom creature>!" follows
+                # the bloom. Without this every blind sat on the swing row
+                # (owner 2026-09-07: "tagged to the root attack instead of
+                # the bloom flare").
+                status_flare_seq = lambda do |cid|
+                  next nil unless current_event && cid
+                  flares = current_event[:flares] || []
+                  f = if flare_ctx && flare_ctx[:target_info]
+                        flare_ctx if flare_ctx[:target_info][:id] == cid
+                      elsif flare_ctx && current_event[:target] && current_event[:target][:id] == cid
+                        flare_ctx
+                      end
+                  f ||= flares.reverse.find { |x| x[:target_info] && x[:target_info][:id] == cid }
+                  f && (i = flares.index(f)) ? i + 1 : nil
+                end
                 if line_target && line_target[:id]
                   # Use ID-based lookup - this is most reliable
                   line_status_id = line_target[:id]
                   if status_result.is_a?(Hash)
-                    apply_status_to_target(status_result[:status], line_target[:name], line_target[:id], status_result[:action])
+                    apply_status_to_target(status_result[:status], line_target[:name], line_target[:id], status_result[:action],
+                                           flare_seq: status_flare_seq.call(line_target[:id]))
                   else
                     # Legacy format - status_result is just the status symbol
                     apply_status_to_target(status_result, line_target[:name], line_target[:id], :add)
@@ -436,7 +461,8 @@ module Lich
                   # the creature - the Your?/You guard keeps them out.
                   line_status_id = subject[:id]
                   apply_status_to_target(status_result[:status], subject[:name],
-                                         subject[:id], status_result[:action])
+                                         subject[:id], status_result[:action],
+                                         flare_seq: status_flare_seq.call(subject[:id]))
                 elsif status_result.is_a?(Hash) && line.match?(/\A\s*Your?\b/)
                   # 2p: the status is OURS ("You are stunned!"). Never a
                   # creature application - but it IS a fact (inbound
@@ -730,7 +756,9 @@ module Lich
                 end
                 respond "[Combat] Found resolution: #{resolution[:type]} = #{resolution[:result]}" if Tracker.debug?(:verbose)
               elsif (outcome = Parser.parse_outcome(line))
-                if flare_ctx || current_event
+                if line_attack
+                  same_line_outcome = outcome
+                elsif flare_ctx || current_event
                   (flare_ctx || current_event)[:outcomes] << outcome
                 elsif line_target && line_target[:id]
                   # An outcome with a named target and no event at all: the
@@ -1080,6 +1108,7 @@ module Lich
                 current_event[:hits] << { damage: inline, crit: nil }
                 respond "[Combat] Found inline damage: #{inline}" if Tracker.debug?(:verbose)
               end
+              current_event[:outcomes] << same_line_outcome if same_line_outcome
 
               # A new swing claims any held pre-flares whose weapon matches it
               # (they resolved before this swing but belong to it). An inbound
@@ -1712,7 +1741,7 @@ module Lich
         end
 
         # Apply status effect directly to a creature (outside combat events)
-        def apply_status_to_target(status, target_name_or_id, target_id = nil, action = :add)
+        def apply_status_to_target(status, target_name_or_id, target_id = nil, action = :add, flare_seq: nil)
           # Handle both name lookup and direct ID
           if target_id
             creature = Creature[target_id.to_i]
@@ -1748,8 +1777,10 @@ module Lich
               creature.add_status(status)
               respond "[Combat] Applied status #{status} to #{creature.name} (#{creature.id})" if Tracker.debug?(:verbose)
             end
-            emit_fact(:status, id: creature.id, name: creature.name,
-                               status: status, action: action == :remove ? :remove : :add)
+            payload = { id: creature.id, name: creature.name,
+                        status: status, action: action == :remove ? :remove : :add }
+            payload[:flare_seq] = flare_seq if flare_seq
+            emit_fact(:status, payload)
           else
             respond "[Combat] Could not find creature for status: #{status} -> #{target_name_or_id}" if Tracker.debug?(:verbose)
           end

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -766,21 +766,40 @@ module Lich
                   # outcome, no attack line, at the top of the chunk. Open
                   # the event here (chunk-locally the maneuver name is
                   # unknowable) so the miss and its roll survive.
-                  current_event = {
-                    name: pending_ambush ? :ambush : :unknown,
-                    target: line_target, attacker: nil,
-                    weapon: nil, parent: nil, hits: [],
-                    statuses: [], flares: [], outcomes: [outcome],
-                    # A wholly-negated ambush prints its prefix and then an
-                    # intercept, with no attack line between - this is the
-                    # only record that the ambush was attempted.
-                    ambush: !pending_ambush.nil?,
-                    resolutions: pending_resolutions
-                  }
-                  pending_ambush = nil
-                  pending_resolutions = []
-                  current_target = line_target
-                  parse_state = :seeking_damage
+                  # When the line names who attacked US instead ("the thorny
+                  # barrier ... blocks the attack from <X>"), the swing was
+                  # intercepted before it printed: an INBOUND unknown with X
+                  # as the attacker, never an attack on X.
+                  if Definitions::Outcomes.inbound_line?(line)
+                    # (a creature's wholly-negated ambush on us is this shape
+                    # too: prefix, then the intercept, no attack line)
+                    current_event = {
+                      name: pending_ambush ? :ambush : :unknown, target: {}, inbound: true,
+                      attacker: line_target, weapon: nil, parent: nil,
+                      hits: [], statuses: [], flares: [], outcomes: [outcome],
+                      ambush: !pending_ambush.nil?,
+                      resolutions: pending_resolutions
+                    }
+                    pending_ambush = nil
+                    pending_resolutions = []
+                    parse_state = :seeking_damage
+                  else
+                    current_event = {
+                      name: pending_ambush ? :ambush : :unknown,
+                      target: line_target, attacker: nil,
+                      weapon: nil, parent: nil, hits: [],
+                      statuses: [], flares: [], outcomes: [outcome],
+                      # A wholly-negated ambush prints its prefix and then an
+                      # intercept, with no attack line between - this is the
+                      # only record that the ambush was attempted.
+                      ambush: !pending_ambush.nil?,
+                      resolutions: pending_resolutions
+                    }
+                    pending_ambush = nil
+                    pending_resolutions = []
+                    current_target = line_target
+                    parse_state = :seeking_damage
+                  end
                 else
                   # No event, no named target: an outcome for an
                   # initiation we have no def for. Orphan-sink it.
@@ -1123,6 +1142,14 @@ module Lich
                   current_event[:resolutions].concat(pending_resolutions)
                   pending_resolutions = []
                 end
+              end
+              # Exception: an inbound maneuver whose initiation IS its result
+              # line (3p feint: "[SMR] X feints high, but you aren't fooled")
+              # rolled BEFORE it printed - that held maneuver roll is its own,
+              # not our next swing's.
+              if current_event[:inbound] && same_line_outcome && !pending_resolutions.empty?
+                mine, pending_resolutions = pending_resolutions.partition { |r| %i[smr ssr maneuver_roll].include?(r[:type]) }
+                current_event[:resolutions].concat(mine)
               end
               flare_ctx = nil
 

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -29,7 +29,8 @@ module Lich
         # adjudication - missing def vs genuine drive-by (owner ruling
         # 2026-09-06). A tick IS ours only when our own cast of that spell
         # is visible in the same blob (see cast_owner tracking below).
-        UNOWNED_TICK_ATTACKS = %i[pestilence web].freeze
+        # :bleed has no cast at all, so it is always unowned (owner 2026-09-07).
+        UNOWNED_TICK_ATTACKS = %i[pestilence web bleed].freeze
 
         module_function
 

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -925,9 +925,21 @@ module Lich
                 end
                 respond "[Combat] Found resolution: #{resolution[:type]} = #{resolution[:result]}" if Tracker.debug?(:verbose)
               elsif (outcome = Parser.parse_outcome(line))
+                # A pre-emptive evade ("bounds to safety as you move to attack
+                # it") is OUR swing resolving, and it names the creature we
+                # swung at. A creature's inbound swing is never closed by the
+                # target-switcher, so one left open across the nock swallowed
+                # the evade and our own swing was never opened - the nocked
+                # bow had nothing to name. Scoped to a live nock: only there
+                # do we know an outbound swing is outstanding, so inbound
+                # maneuvers whose resist line names their own caster
+                # possessively ("the warg's unnerving howl") still attach.
+                preempts_open_inbound = nocked && current_event && current_event[:inbound] &&
+                                        !flare_ctx && line_target && line_target[:id] &&
+                                        !Definitions::Outcomes.inbound_line?(line)
                 if line_attack
                   same_line_outcome = outcome
-                elsif flare_ctx || current_event
+                elsif flare_ctx || (current_event && !preempts_open_inbound)
                   (flare_ctx || current_event)[:outcomes] << outcome
                 elsif line_target && line_target[:id]
                   # An outcome with a named target and no event at all: the
@@ -1206,7 +1218,14 @@ module Lich
                 # attaching here even after outcomes/damage (see roll routing)
                 _attack_born: true
               }
-              nocked = nil # the swing the nock announced has printed (see decl)
+              # The swing the nock announced has printed (see decl). Only OUR
+              # own attack can be that swing - "You nock" is first-person - so
+              # a creature's inbound swing or another player's attack
+              # interleaving between the nock and the fire must not clear it,
+              # or the fire (or the pre-emptive evade standing in for it)
+              # loses its weapon and falls back to :unknown, which is the very
+              # failure the nock tracking exists to prevent.
+              nocked = nil unless current_event[:inbound] || eff_foreign
               # see last_inbound_attacker decl
               if current_event[:inbound] && current_event[:attacker].nil? && last_inbound_attacker &&
                  !Definitions::Attacks.attackerless_line?(line)

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -292,6 +292,7 @@ module Lich
           @session_id = @db.last_insert_row_id
           @seq = 0
           @creature_cache = {}
+          @closed_session = nil # a new hunt: the previous one takes no more facts
           @session_id
         end
 
@@ -305,6 +306,11 @@ module Lich
 
           @db.execute('UPDATE sessions SET ended_at = ? WHERE id = ?', [at.to_f, @session_id])
           finished = @session_id
+          # Remember what the closed session fought. A death confirmed by the
+          # room feed can arrive after the idle gap has already closed the
+          # hunt, and that kill belongs to THIS session's creature rows - see
+          # trailing_fact? / reopen_closed_session_locked!.
+          @closed_session = { id: finished, ended_at: at.to_f, cache: (@creature_cache || {}).dup }
           @session_id = nil
           @open_attack = nil
           # A closed session's rows are not addressable by the next session's
@@ -364,19 +370,79 @@ module Lich
         # a hunt, but it neither opens a session nor keeps one alive
         # (2026-09-07: Tijay's cast in town opened "session 2" of a hunt
         # that had ended).
+        #
+        # A non-attack event is a bare fact (:status/:stun/:roundtime/
+        # :spell_loss/:ucs) with no ownership flags of its own, so it cannot
+        # be judged on its own contents. It counts as ours when it is keyed
+        # to a creature THIS session already touched - see known_creature?.
+        # Blanket-treating every non-attack as foreign dropped the delayed
+        # room-feed death confirmation that sweep_death_watch exists to emit:
+        # a creature someone else finished minutes later reports `dead` as a
+        # bare :status long after our last swing, and with the session idled
+        # out that row (and the creature's killed_at) was lost outright.
         def foreign_event?(type, data)
-          return true unless type == :attack
+          return !known_creature?(data) unless type == :attack
 
           !!(data[:foreign_caster] || data[:foreign_target] || data[:unowned] || data[:_orphan])
+        end
+
+        # True when this event is keyed to a creature we have already recorded
+        # against - in the open session, or in the one the idle gap just
+        # closed (@closed_session, so a lagged death confirmation still finds
+        # its own hunt). A bystander's fact about a creature we never fought
+        # matches neither and stays foreign, opening nothing.
+        def known_creature?(data)
+          exist_id = data[:id]
+          return false unless exist_id
+
+          key = exist_id.to_i
+          return true if @creature_cache&.key?(key) || @pending_cache&.key?(key)
+
+          !!@closed_session&.fetch(:cache, nil)&.key?(key)
+        end
+
+        # A bare fact (not an :attack) about a creature we fought. It belongs
+        # to the hunt that fought it, so it must never open a fresh session:
+        # killed_at has to land on the creature row the attack already wrote.
+        def trailing_fact?(type, ours)
+          ours && type != :attack
+        end
+
+        # Re-open the session the idle gap just closed so a trailing fact
+        # files against its rows. ended_at is left where finish_session_locked
+        # put it - the last real attack - and re-stamped on the next close, so
+        # a lagged death never pads the hunt's duration.
+        def reopen_closed_session_locked!
+          return false unless @closed_session
+
+          @session_id = @closed_session[:id]
+          # Re-stamped by the next finish_session_locked, which closes at
+          # @last_event_at - untouched by a trailing fact, so ended_at comes
+          # back to the last real attack.
+          @db.execute('UPDATE sessions SET ended_at = NULL WHERE id = ?', [@session_id])
+          # Restore the cache so the trailing fact resolves to the creature
+          # row the attack wrote, instead of inserting a duplicate.
+          @creature_cache = @closed_session[:cache].dup
+          true
         end
 
         def record_locked(type, data)
           if @idle_timeout
             now = Time.now
-            check_idle_locked!(now)
+            # Judge ownership BEFORE the idle close: check_idle_locked! ends
+            # the session and start_session_locked wipes @creature_cache, so
+            # asking afterwards would call every delayed fact foreign.
             ours = !foreign_event?(type, data)
+            trailing = trailing_fact?(type, ours)
+            # A trailing fact holds the open session rather than letting the
+            # idle gap split it; if the gap already closed the hunt, re-open
+            # that same session instead of starting a new one.
+            check_idle_locked!(now) unless trailing && @session_id
+            reopen_closed_session_locked! if trailing && !@session_id
             start_session_locked(character: @character, source: @source, at: now) if ours && !@session_id
-            @last_event_at = now if ours
+            # A trailing fact does not extend the hunt: ended_at stays at the
+            # last real attack, so town time never pads a session.
+            @last_event_at = now if ours && !trailing
           end
           return unless @session_id
 

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -251,6 +251,7 @@ module Lich
           @open_attack = nil # { id:, creature_ids: Set, inbound: bool }
           @chunk_rows = {}   # per-chunk _uid -> attack row id, for spawn-tree links
           @chunk_flares = {} # per-chunk _uid -> [flare row ids], for status attack_uid/flare_seq
+          @chunk_batch = nil # the processor's observation_batch id for the chunk above
           @pending_cache = nil      # creature-cache entries staged during a txn (see in_txn)
           @pending_chunk_rows = nil # chunk-row entries staged during a txn (see in_txn)
           @character = character
@@ -306,6 +307,14 @@ module Lich
           finished = @session_id
           @session_id = nil
           @open_attack = nil
+          # A closed session's rows are not addressable by the next session's
+          # per-chunk uids. Leaving these populated let an event in the new
+          # session resolve a uid to the OLD session's attack row (real db:
+          # a status linked to the previous hunt's attack across an idle
+          # timeout).
+          @chunk_rows = {}
+          @chunk_flares = {}
+          @chunk_batch = nil
           finished
         end
 
@@ -516,14 +525,28 @@ module Lich
           # Spawn-tree links: the processor stamps a per-chunk _uid on every
           # event and points :root_uid/:parent_uid at other events in the same
           # chunk (root/parent always emit BEFORE their children). We map uid ->
-          # row id in @chunk_rows, resetting when a new chunk's first event
-          # (_uid == 0) arrives. A root points at itself; an ambiguous spawn has
-          # parent_uid nil.
+          # row id in @chunk_rows. A root points at itself; an ambiguous spawn
+          # has parent_uid nil.
+          #
+          # The chunk is identified by the processor's monotonic
+          # observation_batch id when the payload carries one, NOT by "a uid-0
+          # event arrived": the first event of a chunk can be one we never
+          # record (a foreign cast, an orphan), and the uid-0 reset then never
+          # ran, leaving the previous chunk's - or the previous SESSION's - map
+          # addressable by this chunk's uids. The uid-0 test remains the
+          # fallback for payloads with no batch stamp.
           uid = event[:_uid]
-          if uid.nil? || uid.zero?
+          batch = event[:observation_batch].is_a?(Hash) ? event[:observation_batch][:id] : nil
+          new_chunk = if batch
+                        batch != @chunk_batch
+                      else
+                        uid.nil? || uid.zero?
+                      end
+          if new_chunk
             @chunk_rows = {}
             @chunk_flares = {}
           end
+          @chunk_batch = batch
           root_uid = event[:root_uid]
           parent_uid = event[:parent_uid]
           # parent/root were committed by an earlier record in this chunk (they

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -399,8 +399,14 @@ module Lich
         # existed. CREATE TABLE IF NOT EXISTS never alters an existing table,
         # so each column added after first release is listed here and ALTERed
         # in when absent. Keep entries append-only.
+        # Columns added to the schema after the first release. A database
+        # created before one existed gains it on open; every column here must
+        # be nullable, since existing rows cannot supply a value. Anything the
+        # SCHEMA gained but this map did not would fail on the first INSERT
+        # that names it (statuses.flare_id did exactly that).
         ADDED_COLUMNS = {
-          'attacks' => { 'redirected_from' => 'TEXT' }
+          'attacks'  => { 'redirected_from' => 'TEXT' },
+          'statuses' => { 'flare_id' => 'INTEGER REFERENCES flares(id)' }
         }.freeze
 
         def migrate!

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -349,12 +349,24 @@ module Lich
           @mutex.synchronize { record_locked(type, data) }
         end
 
+        # An event that is not ours: a nearby player's attack, a creature
+        # swinging at a third party, an orphan. Recorded for context inside
+        # a hunt, but it neither opens a session nor keeps one alive
+        # (2026-09-07: Tijay's cast in town opened "session 2" of a hunt
+        # that had ended).
+        def foreign_event?(type, data)
+          return true unless type == :attack
+
+          !!(data[:foreign_caster] || data[:foreign_target] || data[:unowned] || data[:_orphan])
+        end
+
         def record_locked(type, data)
           if @idle_timeout
             now = Time.now
             check_idle_locked!(now)
-            start_session_locked(character: @character, source: @source, at: now) unless @session_id
-            @last_event_at = now
+            ours = !foreign_event?(type, data)
+            start_session_locked(character: @character, source: @source, at: now) if ours && !@session_id
+            @last_event_at = now if ours
           end
           return unless @session_id
 

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -214,6 +214,7 @@ module Lich
             creature_id INTEGER REFERENCES creatures(id), -- NULL = self or unresolved
             subject     TEXT,                             -- name as printed ('self' for us)
             attack_id   INTEGER REFERENCES attacks(id),   -- window attribution
+            flare_id    INTEGER REFERENCES flares(id),    -- the flare it rode on (glowbark blind), else NULL
             occurred_at REAL NOT NULL,
             kind        TEXT NOT NULL,
             status      TEXT,
@@ -360,7 +361,8 @@ module Lich
           case type
           when :attack then record_attack(data)
           when :status then record_status(kind: 'status', id: data[:id], name: data[:name],
-                                          status: data[:status].to_s, action: data[:action].to_s)
+                                          status: data[:status].to_s, action: data[:action].to_s,
+                                          flare_seq: data[:flare_seq])
           when :stun then record_status(kind: 'stun', id: data[:id], name: data[:name],
                                         status: 'stunned', action: 'add', value: data[:rounds].to_i)
           when :roundtime then record_status(kind: 'roundtime', id: data[:id], name: data[:name],
@@ -553,6 +555,7 @@ module Lich
             end
 
             touched = Set.new([target[:id]].compact.map(&:to_i))
+            flare_ids = []
             (event[:flares] || []).each_with_index do |flare, i|
               f_target = flare[:target_info]
               f_creature = f_target ? ensure_creature(f_target, at) : nil
@@ -566,13 +569,14 @@ module Lich
                 VALUES (?, ?, ?, ?, ?, ?, ?)
               SQL
               flare_id = @db.last_insert_row_id
+              flare_ids << flare_id
               (flare[:resolutions] || []).each { |r| insert_resolution(attack_id, flare_id, res_seq += 1, r) }
               (flare[:hits] || []).each do |hit|
                 insert_hit(attack_id, flare_id, f_creature || creature_row, hit_seq += 1, hit, at)
               end
             end
 
-            @open_attack = { id: attack_id, creature_ids: touched, inbound: !!event[:inbound] }
+            @open_attack = { id: attack_id, creature_ids: touched, inbound: !!event[:inbound], flare_ids: flare_ids }
           end
         end
 
@@ -643,7 +647,7 @@ module Lich
         end
 
         def record_status(kind:, id:, name:, status: nil, action: nil, value: nil,
-                          spell: nil, spell_name: nil, cause: nil)
+                          spell: nil, spell_name: nil, cause: nil, flare_seq: nil)
           at = Time.now.to_f
           # Atomic like record_attack: the creature upsert, the status insert
           # and the kill-stamp are one unit, so a mid-write failure can't leave
@@ -653,21 +657,25 @@ module Lich
           in_txn do
             creature_row = id ? ensure_creature({ id: id, name: name }, at) : nil
             attack_id = nil
+            flare_id = nil
             source = 'direct'
             if @open_attack && id && @open_attack[:creature_ids].include?(id.to_i)
               attack_id = @open_attack[:id]
               source = 'window'
+              # the processor says which of the attack's flares the status
+              # rode on (1-based position in the event's flare list)
+              flare_id = @open_attack[:flare_ids]&.[](flare_seq - 1) if flare_seq.is_a?(Integer) && flare_seq.positive?
             elsif @open_attack && name == 'self' && @open_attack[:inbound]
               attack_id = @open_attack[:id]
               source = 'window'
             end
 
-            params = [@session_id, creature_row, txt(name), attack_id, at, kind,
+            params = [@session_id, creature_row, txt(name), attack_id, flare_id, at, kind,
                       txt(status), action, value, spell, txt(spell_name), cause, source]
             @db.execute(<<~SQL, params)
-              INSERT INTO statuses (session_id, creature_id, subject, attack_id, occurred_at,
+              INSERT INTO statuses (session_id, creature_id, subject, attack_id, flare_id, occurred_at,
                                     kind, status, action, value, spell, spell_name, cause, source)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             SQL
 
             # A death confirmed by the room feed (processor death watch) rather

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -250,6 +250,7 @@ module Lich
           @seq = 0
           @open_attack = nil # { id:, creature_ids: Set, inbound: bool }
           @chunk_rows = {}   # per-chunk _uid -> attack row id, for spawn-tree links
+          @chunk_flares = {} # per-chunk _uid -> [flare row ids], for status attack_uid/flare_seq
           @pending_cache = nil      # creature-cache entries staged during a txn (see in_txn)
           @pending_chunk_rows = nil # chunk-row entries staged during a txn (see in_txn)
           @character = character
@@ -374,7 +375,7 @@ module Lich
           when :attack then record_attack(data)
           when :status then record_status(kind: 'status', id: data[:id], name: data[:name],
                                           status: data[:status].to_s, action: data[:action].to_s,
-                                          flare_seq: data[:flare_seq])
+                                          flare_seq: data[:flare_seq], attack_uid: data[:attack_uid])
           when :stun then record_status(kind: 'stun', id: data[:id], name: data[:name],
                                         status: 'stunned', action: 'add', value: data[:rounds].to_i)
           when :roundtime then record_status(kind: 'roundtime', id: data[:id], name: data[:name],
@@ -513,7 +514,10 @@ module Lich
           # (_uid == 0) arrives. A root points at itself; an ambiguous spawn has
           # parent_uid nil.
           uid = event[:_uid]
-          @chunk_rows = {} if uid.nil? || uid.zero?
+          if uid.nil? || uid.zero?
+            @chunk_rows = {}
+            @chunk_flares = {}
+          end
           root_uid = event[:root_uid]
           parent_uid = event[:parent_uid]
           # parent/root were committed by an earlier record in this chunk (they
@@ -588,6 +592,7 @@ module Lich
               end
             end
 
+            @chunk_flares[uid] = flare_ids if uid
             @open_attack = { id: attack_id, creature_ids: touched, inbound: !!event[:inbound], flare_ids: flare_ids }
           end
         end
@@ -659,7 +664,7 @@ module Lich
         end
 
         def record_status(kind:, id:, name:, status: nil, action: nil, value: nil,
-                          spell: nil, spell_name: nil, cause: nil, flare_seq: nil)
+                          spell: nil, spell_name: nil, cause: nil, flare_seq: nil, attack_uid: nil)
           at = Time.now.to_f
           # Atomic like record_attack: the creature upsert, the status insert
           # and the kill-stamp are one unit, so a mid-write failure can't leave
@@ -671,12 +676,20 @@ module Lich
             attack_id = nil
             flare_id = nil
             source = 'direct'
-            if @open_attack && id && @open_attack[:creature_ids].include?(id.to_i)
+            flare_at = ->(ids) { ids&.[](flare_seq - 1) if flare_seq.is_a?(Integer) && flare_seq.positive? }
+            if attack_uid && (uid_row = chunk_row(attack_uid))
+              # the processor named the parse event the status rode on -
+              # authoritative over the last-attack window (the last attack
+              # of a chunk may be a creature's cast that interrupted ours)
+              attack_id = uid_row
+              source = 'event'
+              flare_id = flare_at.call(@chunk_flares[attack_uid])
+            elsif @open_attack && id && @open_attack[:creature_ids].include?(id.to_i)
               attack_id = @open_attack[:id]
               source = 'window'
               # the processor says which of the attack's flares the status
               # rode on (1-based position in the event's flare list)
-              flare_id = @open_attack[:flare_ids]&.[](flare_seq - 1) if flare_seq.is_a?(Integer) && flare_seq.positive?
+              flare_id = flare_at.call(@open_attack[:flare_ids])
             elsif @open_attack && name == 'self' && @open_attack[:inbound]
               attack_id = @open_attack[:id]
               source = 'window'

--- a/lib/gemstone/combat/tracker.rb
+++ b/lib/gemstone/combat/tracker.rb
@@ -373,7 +373,7 @@ module Lich
                 # creature at all (frigid wind, thorn-bow recoil).
                 if chunk.any? { |line|
                   (line.include?('<pushBold/>') && line.include?('<a exist=')) ||
-                  Definitions::Attacks.self_inflicted_line?(line)
+                  Definitions::Attacks.attackerless_line?(line)
                 }
                   process(chunk) unless chunk.empty?
                   respond "[Combat] Processed chunk with creatures (#{chunk.size} lines)" if debug?

--- a/spec/fixtures/bloom_forced_out_of_hiding.txt
+++ b/spec/fixtures/bloom_forced_out_of_hiding.txt
@@ -1,0 +1,34 @@
+You fire a faewood arrow at <pushBold/>a <a exist="128242975" noun="skald">grim gigas skald</a><popBold/>!
+  AS: +639 vs DS: +416 with AvD: +32 + d100 roll: +85 = +340
+   ... and hit for 138 points of damage!
+   Quick, powerful slash!
+   <pushBold/>The <a exist="128242975" noun="skald">gigas skald</a><popBold/>'s chest is ripped open!
+An earthy, sweet aroma wafts from <pushBold/>a <a exist="128242975" noun="skald">grim gigas skald</a><popBold/> in a murky haze.
+Vital energy infuses you, hastening your arcane reflexes!
+
+** Countless points of pale phosphorescence awaken across your <a exist="127036411" noun="bow">glowbark long bow</a>, rapidly brightening before bursting into brilliant light around <pushBold/>a <a exist="128242975" noun="skald">grim gigas skald</a><popBold/>! **
+<pushBold/>A <a exist="128242975" noun="skald">grim gigas skald</a><popBold/> is unharmed by the plasma!
+You blinded <pushBold/>a <a exist="128242975" noun="skald">grim gigas skald</a><popBold/>!
+
+** Phosphorescent light races through the glowbark as its entire surface blossoms with dazzling radiance, flooding the surroundings in ghostly light! **
+
+** A bloom of spectral light blossoms around <pushBold/>a <a exist="128242963" noun="skald">grim gigas skald</a><popBold/>, engulfing it in searing brilliance! **
+   ... 15 points of damage!
+   <pushBold/>The <a exist="128242963" noun="skald">gigas skald</a><popBold/>'s hand blisters and bleeds from intense heat.
+You blinded <pushBold/>a <a exist="128242963" noun="skald">grim gigas skald</a><popBold/>!
+
+** A bloom of spectral light blossoms around <pushBold/>a <a exist="128244773" noun="mastodon">heavily armored battle mastodon</a><popBold/>, engulfing it in searing brilliance! **
+   ... 7 points of damage!
+   Light burns to <pushBold/>the <a exist="128244773" noun="mastodon">armored battle mastodon</a><popBold/>'s leg.
+You blinded <pushBold/>a <a exist="128244773" noun="mastodon">heavily armored battle mastodon</a><popBold/>!
+<pushBold/>A <a exist="128104042" noun="cannibal">bloody halfling cannibal</a><popBold/> is forced out of hiding!
+
+** A bloom of spectral light blossoms around <pushBold/>a <a exist="128104042" noun="cannibal">bloody halfling cannibal</a><popBold/>, engulfing it in searing brilliance! **
+   ... 25 points of damage!
+   Muscle and blood explode from <pushBold/>the <a exist="128104042" noun="cannibal">halfling cannibal</a><popBold/>'s abdomen in a steaming spray!
+   The <pushBold/><a exist="128104042" noun="cannibal">halfling cannibal</a><popBold/> is stunned!
+You blinded <pushBold/>a <a exist="128104042" noun="cannibal">bloody halfling cannibal</a><popBold/>!
+A tenebrous shroud stitches itself into existence around you as you gracefully retreat into the shadows!
+The arrow sticks in <pushBold/>a <a exist="128242975" noun="skald">grim gigas skald</a><popBold/>'s chest!
+Roundtime: 3 sec.
+Roundtime changed to 1 second.

--- a/spec/fixtures/cloak_of_shadows_interrupt.txt
+++ b/spec/fixtures/cloak_of_shadows_interrupt.txt
@@ -7,6 +7,8 @@ The force of <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disc
   CS: +497 - TD: +501 + CvA: +13 + d100: +57 - -5 == +71
   Warded off!
 A few nebulous wisps coalesce about you before dissipating in a confused spiral.
+Soot brown specks of leaf mold trail in the wake of <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disciple's</a><popBold/> movements, distorted by a murky haze.
+Vital energy infuses you, hastening your arcane reflexes!
 
 ** Countless points of pale phosphorescence awaken across your <a exist="129604585" noun="bow">glowbark long bow</a>, rapidly brightening before bursting into brilliant light around <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disciple</a><popBold/>! **
    ... 25 points of damage!

--- a/spec/fixtures/cloak_of_shadows_interrupt.txt
+++ b/spec/fixtures/cloak_of_shadows_interrupt.txt
@@ -1,0 +1,17 @@
+You fire a faewood arrow at <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disciple</a><popBold/>!
+  AS: +612 vs DS: +582 with AvD: +32 + d100 roll: +94 = +156
+   ... and hit for 21 points of damage!
+   Minor puncture to the right arm.
+A dark shadowy tendril rises up from <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disciple</a><popBold/>, writhes its way up a <a exist="129604585" noun="bow">scorched glowbark long bow</a> towards you and lashes out malevolently...
+The force of <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disciple's</a><popBold/> power warps the air as it surges toward you!
+  CS: +497 - TD: +501 + CvA: +13 + d100: +57 - -5 == +71
+  Warded off!
+A few nebulous wisps coalesce about you before dissipating in a confused spiral.
+
+** Countless points of pale phosphorescence awaken across your <a exist="129604585" noun="bow">glowbark long bow</a>, rapidly brightening before bursting into brilliant light around <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disciple</a><popBold/>! **
+   ... 25 points of damage!
+   Muscle and blood explode from <pushBold/>the <a exist="129623615" noun="disciple">gigas disciple</a><popBold/>'s abdomen in a steaming spray!
+You blinded <pushBold/>a <a exist="129623615" noun="disciple">flayed gigas disciple</a><popBold/>!
+The arrow breaks into tiny fragments.
+Roundtime: 3 sec.
+Roundtime changed to 1 second.

--- a/spec/fixtures/dispel_on_nock.txt
+++ b/spec/fixtures/dispel_on_nock.txt
@@ -1,0 +1,18 @@
+  a <a exist="127036542" noun="arcarium">dark sapphire vangaris arcarium</a>
+<dialogData id='minivitals'><skin id='staminaSkin' name='staminaBar' controls='stamina' left='50%' top='0%' width='25%' height='100%'/><progressBar id='stamina' value='49' text='stamina 78/159' left='50%' customText='t' top='0%' width='25%' height='100%'/></dialogData>You nock a faewood <a exist="127452232" noun="arrow">arrow</a> fletched with plain white feathers in your <a exist="127036411" noun="bow">glowbark long bow</a>.
+You feel drained.
+
+ ** Your <a exist="127036411" noun="bow">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around <pushBold/>the <a exist="127450732" noun="mastodon">armored battle mastodon</a><popBold/>! **
+ [SMR result: 175 (Open d100: 29, Bonus: 73)]
+   ... 15 points of damage!
+   <pushBold/>The <a exist="127450732" noun="mastodon">armored battle mastodon</a><popBold/>'s skull cracks with an audible "Pop"!
+
+You fire a faewood arrow at <pushBold/>a <a exist="127450732" noun="mastodon">heavily armored battle mastodon</a><popBold/>!
+  AS: +630 vs DS: +291 with AvD: +20 + d100 roll: +100 = +459
+   ... and hit for 90 points of damage!
+   Attack punctures the eye and connects with something really vital!
+As <pushBold/>a <a exist="127450732" noun="mastodon">heavily armored battle mastodon</a><popBold/> collapses, <pushBold/><a exist="127450732" noun="mastodon">it</a><popBold/> lets out a shrill trumpet of despair.  <pushBold/><a exist="127450732" noun="mastodon">Its</a><popBold/> trunk flails futilely before slamming to the ground, still.
+<pushBold/>A <a exist="127450732" noun="mastodon">heavily armored battle mastodon</a><popBold/> appears to recover some strength.
+The arrow sticks in <pushBold/>a <a exist="127450732" noun="mastodon">heavily armored battle mastodon</a><popBold/>'s left eye!
+Roundtime: 3 sec.
+Roundtime changed to 1 second.

--- a/spec/fixtures/ooze_splatter_fire.txt
+++ b/spec/fixtures/ooze_splatter_fire.txt
@@ -1,0 +1,10 @@
+You fire a faewood arrow at <pushBold/>a <a exist="129622136" noun="ooze">quivering sanguine ooze</a><popBold/>!
+  AS: +594 vs DS: +468 with AvD: +25 + d100 roll: +58 = +209
+   ... and hit for 51 points of damage!
+Pieces of the ooze splatter across the ground, wobbling disconcertingly as they twitch together to form <pushBold/>a <a exist="129638108" noun="oozeling">quivering sanguine oozeling</a><popBold/>.
+
+ ** Necrotic energy from your <a exist="129604585" noun="bow">glowbark long bow</a> overflows into you! **
+   You feel healed!
+The arrow breaks into tiny fragments.
+Roundtime: 3 sec.
+Roundtime changed to 1 second.

--- a/spec/fixtures/replay/natures_fury.txt
+++ b/spec/fixtures/replay/natures_fury.txt
@@ -1,5 +1,5 @@
 ##### natures_fury 2601f4ed53411b53
-# expect: attacks=natures_fury | res=cs_td | flares=none | outcomes=ward_failed,hit | dmg=2 | statuses=dispelled/add
+# expect: attacks=natures_fury | res=cs_td | flares=none | outcomes=ward_failed,hit | dmg=2 | statuses=none
 The surroundings advance upon <pushBold/>a <a exist="67597902" noun="radical">triton radical</a><popBold/> with relentless fury!
 The dull golden nimbus surrounding <pushBold/>a <a exist="67597902" noun="radical">triton radical</a><popBold/> suddenly begins to glow brightly.
   CS: +484 - TD: +293 + CvA: +25 + d100: +93 == +309

--- a/spec/fixtures/replay/shield_throw.txt
+++ b/spec/fixtures/replay/shield_throw.txt
@@ -1,5 +1,5 @@
 ##### shield_throw c697c02779ed78c5
-# expect: attacks=shield_throw | res=smr | flares=none | outcomes=none | dmg=7 | statuses=dispelled/add,prone/add,stunned/add
+# expect: attacks=shield_throw | res=smr | flares=none | outcomes=none | dmg=7 | statuses=prone/add,stunned/add
 Your faewood buckler flashes toward <pushBold/>a <a exist="67597902" noun="radical">triton radical</a><popBold/>!
 [SMR result: 302 (Open d100: 71, Bonus: 133)]
    ... 100 points of damage!

--- a/spec/fixtures/volley_miss_first.txt
+++ b/spec/fixtures/volley_miss_first.txt
@@ -1,0 +1,35 @@
+An ominous shadow falls over your surroundings as a whistling hail of arrows arcs down from above!
+[SMR result: 29 (Open d100: -56)]
+<pushBold/>A <a exist="126382122" noun="warg">niveous giant warg</a><popBold/> dodges an incoming arrow!
+[SMR result: 197 (Open d100: 81, Bonus: 25)]
+An arrow finds its mark!  <pushBold/>A <a exist="126394827" noun="mastodon">heavily armored battle mastodon</a><popBold/> is hit!
+<pushBold/>A <a exist="126394827" noun="mastodon">heavily armored battle mastodon's</a><popBold/> aura absorbs some of the damage!
+   ... 10 points of damage!
+   Strike pierces upper arm!
+The arrow breaks into tiny fragments.
+[SMR result: 221 (Open d100: 20, Bonus: 103)]
+<pushBold/>A <a exist="126396667" noun="shield-maiden">brawny gigas shield-maiden</a><popBold/> is transfixed by an arrow's descent!
+<pushBold/>A <a exist="126396667" noun="shield-maiden">brawny gigas shield-maiden's</a><popBold/> aura absorbs some of the damage!
+   ... 35 points of damage!
+   Blow shatters knee and severs lower leg!
+The arrow breaks into tiny fragments.
+[SMR result: 157 (Open d100: 75, Bonus: 1)]
+<pushBold/>A <a exist="126531776" noun="warg">niveous giant warg</a><popBold/> is struck by a falling arrow!
+   ... 15 points of damage!
+   Beautiful head shot!
+  That ear will be missed!
+   The <pushBold/><a exist="126531776" noun="warg">giant warg</a><popBold/> is stunned!
+The arrow breaks into tiny fragments.
+[SMR result: 101 (Open d100: 18, Bonus: 1)]
+An arrow pierces <pushBold/>a <a exist="126402254" noun="warg">niveous giant warg</a><popBold/>!
+<pushBold/>A <a exist="126402254" noun="warg">niveous giant warg's</a><popBold/> aura absorbs some of the damage!
+   ... 10 points of damage!
+   Wild slash scratches the back of <pushBold/>the <a exist="126402254" noun="warg">giant warg</a><popBold/>'s hand.
+The arrow breaks into tiny fragments.
+[SMR result: 252 (Open d100: 86, Bonus: 75)]
+<pushBold/>A <a exist="126485476" noun="mastodon">heavily armored battle mastodon</a><popBold/> is struck by a falling arrow!
+   ... 30 points of damage!
+   Fine shot pierces jugular vein!  The brain wonders where all its oxygen went, briefly.
+As <pushBold/>a <a exist="126485476" noun="mastodon">heavily armored battle mastodon</a><popBold/> collapses, <pushBold/><a exist="126485476" noun="mastodon">it</a><popBold/> lets out a shrill trumpet of despair.  <pushBold/><a exist="126485476" noun="mastodon">Its</a><popBold/> trunk flails futilely before slamming to the ground, still.
+The arrow breaks into tiny fragments.
+The air clears as the deadly volley of arrows abates.

--- a/spec/lib/gemstone/combat/attack_defs_spec.rb
+++ b/spec/lib/gemstone/combat/attack_defs_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Lich::Gemstone::Combat::Parser do
 
     it 'flags environmental tick lines for the tracker chunk gate (they carry no creature link)' do
       defs = Lich::Gemstone::Combat::Definitions::Attacks
-      expect(defs.self_inflicted_line?('Bitter cold leaches warmth from your skin.')).to be true
-      expect(defs.self_inflicted_line?('You feel more refreshed.')).to be false
+      expect(defs.attackerless_line?('Bitter cold leaches warmth from your skin.')).to be true
+      expect(defs.attackerless_line?('You feel more refreshed.')).to be false
     end
 
     it 'reports the thorn bow recoil as inbound damage to us' do

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -649,6 +649,23 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
         .to eq([[:tangleweed, 123259310, [5], 1]])
     end
 
+    it "hands the line back to the lash after the pinned rider's single hit (mount collapse)" do
+      masto = bolded(130483104, 'mastodon', 'a heavily armored battle mastodon')
+      maiden = bolded(130483100, 'shield-maiden', 'a brawny gigas shield-maiden')
+      events = described_class.parse_events([
+                                              '<pushBold/>[SMR result: 125 (Open d100: 12, Bonus: 9)]<popBold/>',
+                                              "The lashing emerald briar lashes out violently at #{masto}, dragging it to the ground!",
+                                              "#{maiden} is pinned beneath #{masto} as it falls!",
+                                              '   ... 5 points of damage!',
+                                              "   Blow raises a welt on #{bolded(130483100, 'shield-maiden', "the gigas shield-maiden's")} left arm.",
+                                              '   ... 5 points of damage!',
+                                              '   Attempt to grab from behind shrugged off.',
+                                              "You notice a number of the briar's nettles scrape into #{bolded(130483104, 'mastodon', "a heavily armored battle mastodon's")} skin.  It suddenly looks very weak!"
+                                            ])
+      expect(events.map { |e| [e[:name], e[:target][:id], e[:hits].map { |h| h[:damage] }, e[:resolutions].size] })
+        .to contain_exactly([:tangleweed, 130483104, [5], 1], [:mount_collapse, 130483100, [5], 0])
+    end
+
     it 'still supersedes in-blob when gesture and lash share a chunk' do
       events = described_class.parse_events(gesture_chunk + lash_chunk)
       expect(events.map { |e| e[:name] }).to eq([:tangleweed])

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -1118,6 +1118,26 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(rift.map { |e| [e[:name], e[:inbound], e[:attacker][:id], e[:resolutions].map { |r| r[:result] }] }).to eq([[:rift_tentacles, true, 129629246, [61]]])
     end
 
+    it 'marks a spell wearing off in the same chunk as the fatal crit as a death drop, not a dispel' do
+      registry = Class.new { def self.[](_id); end }
+      stub_const('Lich::Gemstone::Combat::Creature', registry)
+      emitted = []
+      allow(Lich::Gemstone::Combat::Observers).to receive(:emit) { |type, payload| emitted << [type, payload] }
+      described_class.instance_variable_set(:@deferred_emits, nil)
+      skald = bolded(160902365, 'skald', 'a grim gigas skald')
+      described_class.parse_events([
+                                     "You take aim and fire a faewood arrow at #{skald}!",
+                                     '  AS: +632 vs DS: +500 with AvD: +32 + d100 roll: +70 = +234',
+                                     '   ... and hit for 75 points of damage!',
+                                     '   Incredible shot to the eye penetrates deep into skull!',
+                                     "#{skald} raises a hand as if to grasp for support as he collapses, life going out of his form.",
+                                     "A white glow rushes away from #{skald}."
+                                   ])
+      loss = emitted.find { |t, _| t == :spell_loss }&.last
+      expect(loss).to include(id: 160902365, spell: 303, spell_name: 'Prayer of Protection', cause: :death)
+      expect(emitted.none? { |t, p| t == :status && p[:status].to_s == 'dispelled' }).to be(true)
+    end
+
     it "keeps nearby players' gigas-village spells foreign: spellsong (and its sonic kill), fear cry, golden waves, 3p moonbeam" do
       kal = '<a exist="-10930001" noun="Kalithra">Kalithra</a>'
       skald = bolded(130610001, 'skald', 'a grim gigas skald')

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -888,6 +888,25 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
         .to eq([[:fire, 'glowbark long bow', 123985834, :evade, [:chameleon_shroud]]])
     end
 
+    # Regression: the nock used to be cleared by ANY new attack event, so a
+    # creature's inbound swing landing between our nock and our fire lost the
+    # bow and the pre-empted swing fell back to :unknown. "You nock" is
+    # first-person, so only our own outbound attack can be the swing it
+    # announced.
+    it "keeps the nocked bow when a creature's inbound swing interleaves before the fire" do
+      other = bolded(123985999, 'warg', 'A warg')
+      events = described_class.parse_events([
+                                              'You nock a faewood arrow fletched with plain white feathers in your <a exist="129604585" noun="bow">glowbark long bow</a>.',
+                                              "#{other} claws at you!",
+                                              '   ... but the attack is foiled by your armor.',
+                                              "With preternatural speed, #{warg} bounds to safety as you move to attack #{bolded(123985834, 'warg', 'it')}, leaving you off-balance!",
+                                              'The arrow streaks off into the distance!'
+                                            ])
+      fire = events.find { |e| !e[:inbound] }
+      expect(fire).not_to be_nil
+      expect([fire[:name], fire[:weapon], fire[:target][:id]]).to eq([:fire, 'glowbark long bow', 123985834])
+    end
+
     it "gives the swing, not the pinned rider's one-hit row, the flare that follows the pin" do
       masto2 = bolded(130490001, 'mastodon', 'a heavily armored battle mastodon')
       bers = bolded(130490002, 'berserker', 'a tattooed gigas berserker')
@@ -1255,6 +1274,14 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
                                          ])
       expect(own.map { |e| [e[:name], e[:via], e[:target][:id], e[:resolutions].map { |r| r[:result] }] })
         .to eq([[:moonbeam, :cast, 130610003, [322]]])
+
+      # the "Tapping the moons above," prefix is not guaranteed - sentence-
+      # initial "You draw down..." must name the spell too, not fall to :unknown
+      sentence_initial = described_class.parse_events([
+                                                        "You draw down a shaft of swirling moonlight and bathe #{maiden} in its muted glow.",
+                                                        '<pushBold/>[SMR result: 322 (Open d100: 61, Bonus: 159)]<popBold/>'
+                                                      ])
+      expect(sentence_initial.map { |e| [e[:name], e[:target][:id]] }).to eq([[:moonbeam, 130610003]])
     end
 
     it "attributes a nearby player's flaming aura to that player, and a spiritual malady tick once, unowned" do

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -1118,6 +1118,66 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(rift.map { |e| [e[:name], e[:inbound], e[:attacker][:id], e[:resolutions].map { |r| r[:result] }] }).to eq([[:rift_tentacles, true, 129629246, [61]]])
     end
 
+    it "keeps nearby players' gigas-village spells foreign: spellsong (and its sonic kill), fear cry, golden waves, 3p moonbeam" do
+      kal = '<a exist="-10930001" noun="Kalithra">Kalithra</a>'
+      skald = bolded(130610001, 'skald', 'a grim gigas skald')
+      song = described_class.parse_events([
+                                            "#{kal} skillfully weaves another verse into her harmony, directing the sound of her voice at #{skald}.",
+                                            '  CS: +527 - TD: +469 + CvA: +19 + d100: +68 == +145',
+                                            '  Warding failed!',
+                                            "#{skald} reels under the force of the sonic vibrations!",
+                                            '   Sound waves disrupt for 63 damage!',
+                                            '   ... 70 points of damage!',
+                                            "   #{bolded(130610001, 'skald', "The gigas skald's")} midsection swells painfully then bursts, sending the gigas skald everywhere."
+                                          ])
+      expect(song.map { |e| [e[:name], !!e[:foreign_caster], e[:outcomes], e[:hits].map { |h| h[:damage] }] })
+        .to eq([[:spellsong, true, [:ward_failed], []], [:sonic_disruption, true, [], [63, 70]]])
+
+      rain = '<a exist="-10930002" noun="Raincail">Raincail</a>'
+      masto = bolded(130610002, 'mastodon', 'a heavily armored battle mastodon')
+      maiden = bolded(130610003, 'shield-maiden', 'a brawny gigas shield-maiden')
+      cry = described_class.parse_events([
+                                           "#{rain} lets loose an eerie, modulating cry!",
+                                           '<pushBold/>[SSR result: 67 (Open d100: -62)]<popBold/>',
+                                           "#{masto} is unaffected!",
+                                           '<pushBold/>[SSR result: 162 (Open d100: 45)]<popBold/>',
+                                           "#{maiden} looks at #{rain} in utter terror!",
+                                           "#{bolded(130610003, 'shield-maiden', 'The gigas shield-maiden')} freezes in place, quivering with fright!"
+                                         ])
+      expect(cry.map { |e| e[:name] }.uniq).to eq([:fear_cry])
+      expect(cry).to all(satisfy { |e| e[:foreign_caster] })
+      expect(cry.sum { |e| e[:resolutions].size }).to eq(2)
+
+      emyle = '<a exist="-10930003" noun="Emyle">Emyle</a>'
+      warg = bolded(130610004, 'warg', 'a niveous giant warg')
+      waves = described_class.parse_events([
+                                             "Golden brown waves billow outward from #{emyle} to buffet #{warg}!",
+                                             '<pushBold/>[SMR result: 118 (Open d100: 18, Bonus: 46)]<popBold/>',
+                                             '   ... 5 points of damage!',
+                                             '   Minor puncture to the back.'
+                                           ])
+      expect(waves.map { |e| [e[:name], !!e[:foreign_caster], e[:target][:id], e[:hits].map { |h| h[:damage] }, e[:resolutions].map { |r| r[:result] }] })
+        .to eq([[:golden_waves, true, 130610004, [5], [118]]])
+
+      gal = '<a exist="-10930004" noun="Galactic">Galactic</a>'
+      beam = described_class.parse_events([
+                                            "#{gal} draws down a shaft of dappled moonlight and bathes #{masto} in its lambent glow.",
+                                            '<pushBold/>[SMR result: 243 (Open d100: 75, Bonus: 56)]<popBold/>',
+                                            "#{masto} is caught fast, the light of Liabo arresting its movements."
+                                          ])
+      expect(beam.map { |e| [e[:name], !!e[:foreign_caster], e[:target][:id], e[:resolutions].map { |r| r[:result] }] })
+        .to eq([[:moonbeam, true, 130610002, [243]]])
+
+      own = described_class.parse_events([
+                                           "You gesture at #{maiden}.",
+                                           "Tapping the moons above, you draw down a shaft of swirling moonlight and bathe #{maiden} in its muted glow.",
+                                           '<pushBold/>[SMR result: 322 (Open d100: 61, Bonus: 159)]<popBold/>',
+                                           "#{maiden} is caught fast, the light of Lornon arresting her movements."
+                                         ])
+      expect(own.map { |e| [e[:name], e[:via], e[:target][:id], e[:resolutions].map { |r| r[:result] }] })
+        .to eq([[:moonbeam, :cast, 130610003, [322]]])
+    end
+
     it "attributes a nearby player's flaming aura to that player, and a spiritual malady tick once, unowned" do
       oozeling = bolded(129648792, 'oozeling', 'a quivering sanguine oozeling')
       aura = described_class.parse_events([

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -898,13 +898,23 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       events = described_class.parse_events([
                                               'You nock a faewood arrow fletched with plain white feathers in your <a exist="129604585" noun="bow">glowbark long bow</a>.',
                                               "#{other} claws at you!",
-                                              '   ... but the attack is foiled by your armor.',
+                                              '  AS: +176 vs DS: +76 with AvD: +20 + d100 roll: +64 = +184',
+                                              '   ... and hits for 28 points of damage!',
+                                              '   Smack to the eye bursts blood vessels.',
                                               "With preternatural speed, #{warg} bounds to safety as you move to attack #{bolded(123985834, 'warg', 'it')}, leaving you off-balance!",
                                               'The arrow streaks off into the distance!'
                                             ])
+      expect(events.size).to eq(2)
       fire = events.find { |e| !e[:inbound] }
       expect(fire).not_to be_nil
       expect([fire[:name], fire[:weapon], fire[:target][:id]]).to eq([:fire, 'glowbark long bow', 123985834])
+
+      # The interleaved swing is a fully resolved hit on us - it must survive
+      # the pre-emption, not be discarded when our fire opens.
+      swing = events.find { |e| e[:inbound] }
+      expect(swing).not_to be_nil
+      expect(swing[:attacker][:id]).to eq(123985999)
+      expect(swing[:hits].map { |h| h[:damage] }).to eq([28])
     end
 
     it "gives the swing, not the pinned rider's one-hit row, the flare that follows the pin" do

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -1072,6 +1072,32 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(malady.map { |e| [e[:name], e[:unowned], e[:target][:id], e[:hits].map { |h| h[:damage] }] }).to eq([[:spiritual_malady, true, 129575116, [5]]])
     end
 
+    it 'parses the ooze vitality drain, the cannibal ambush swing, and rot / neck-bleed ticks' do
+      ooze = bolded(129635928, 'ooze', 'a quivering sanguine ooze')
+      drain = described_class.parse_events([
+                                             "#{ooze} whips a pseudopod toward you, brushing your exposed flesh.  The layer of bark on you hardens and absorbs the magical energy!  The bark crackles, but maintains its form.",
+                                             "  Dizziness rushes through you as #{bolded(129635928, 'ooze', "the ooze's")} appendage siphons away your vitality!",
+                                             '   ... 20 points of damage!'
+                                           ])
+      expect(drain.map { |e| [e[:name], e[:inbound], e[:attacker][:id], e[:hits].map { |h| h[:damage] }] }).to eq([[:natural, true, 129635928, [20]]])
+      cannibal = bolded(129776223, 'cannibal', 'a bloody halfling cannibal')
+      ambush = described_class.parse_events([
+                                              "With an ululating shriek, #{cannibal} leaps from the shadows and hammers blindly at you with grimy little fists!",
+                                              '  AS: +476 vs DS: +585 with AvD: +25 + d100 roll: +48 = -36',
+                                              '   A clean miss.'
+                                            ])
+      expect(ambush.map { |e| [e[:name], e[:inbound], e[:outcomes], e[:resolutions].size] }).to eq([[:natural, true, [:miss], 1]])
+      mutant = bolded(129870380, 'mutant', 'a squamous reptilian mutant')
+      ticks = described_class.parse_events([
+                                             "Skin peels off #{mutant}'s body, exposing rotting flesh.",
+                                             '   ... 2 points of damage!',
+                                             '   Unpleasant wound to left arm!',
+                                             "Trickles of blood course from #{bolded(129870380, 'mutant', 'the reptilian mutant')}'s neck.",
+                                             '   ... 4 points of damage!'
+                                           ])
+      expect(ticks.map { |e| [e[:name], e[:unowned], e[:hits].map { |h| h[:damage] }] }).to eq([[:rot, true, [2]], [:bleed, true, [4]]])
+    end
+
     it 'wraps a held pre-flare as its own event when no swing follows in the next chunk' do
       nock_chunk = [
         " ** Your <a exist=\"125479289\" noun=\"bow\">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}! **",

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -708,6 +708,25 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(bloom[:hits].map { |h| h[:damage] }).to eq([5])
       expect(ev[:flares].first[:hits].map { |h| h[:damage] }).to eq([20])
     end
+
+    # A knockdown crit (leg blown off) rolls its own SMR AFTER the damage
+    # and narrates the fall on the next line (hunt log 2026-09-07 19:10:54).
+    # That roll rides on the hit that caused it; held, it became a synthetic
+    # :unknown attack on the swing target with the swing's blind status.
+    it 'keeps a crit-rider SMR (topple) on the bloom instead of orphaning it' do
+      lines = chunk.dup
+      i = lines.index { |l| l.include?('Plasma scalds') }
+      lines[i] = "   Fiery blast of plasma blows the #{bolded(121678494, 'mastodon', 'armored battle mastodon')}'s leg into a bloody spray!"
+      lines.insert(i + 1,
+                   '<pushBold/>[SMR result: 35 (Open d100: 55, Penalty: 23)]<popBold/>',
+                   "Despite desperate windmilling to catch its balance, #{masto} topples toward you!  You stumble into visibility as you try to dodge.",
+                   "   The #{bolded(121678494, 'mastodon', 'armored battle mastodon')} is stunned!")
+      events = described_class.parse_events(lines)
+      expect(events.map { |e| e[:name] }).to eq([:fire])
+      bloom = events.first[:flares].last
+      expect(bloom[:name]).to eq(:spectral_bloom)
+      expect(bloom[:resolutions].map { |r| r[:result] }).to eq([35])
+    end
   end
 
   # Parse-phase facts (message statuses, UCS, spell loss) used to be emitted

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -1109,6 +1109,36 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(blind).not_to have_key(:_event)
     end
 
+    it "leaves an ambient recovery line off the current attack's event (review 2026-09-10)" do
+      registry = Class.new { def self.[](_id); end }
+      stub_const('Lich::Gemstone::Combat::Creature', registry)
+      # explicit doubles: a null object answers crtr_flag?(:dead) truthily
+      # and the death watch would bury the orc
+      live = { add_damage: nil, add_status: nil, remove_status: nil, add_injury: nil, add_stun_estimate: nil,
+               mark_fatal_crit!: nil, dead?: false, crtr_flag?: false, has_status?: false }
+      allow(registry).to receive(:[]).with(700001).and_return(double('Creature', id: 700001, name: 'a grizzled orc', **live))
+      allow(registry).to receive(:[]).with(700002).and_return(double('Creature', id: 700002, name: 'a hulking troll', **live))
+      emitted = []
+      allow(Lich::Gemstone::Combat::Observers).to receive(:emit) { |type, payload| emitted << [type, payload] }
+      orc = bolded(700001, 'orc', 'a grizzled orc')
+      troll = bolded(700002, 'troll', 'a hulking troll')
+      described_class.process([
+                                "You fire a faewood arrow at #{orc}!",
+                                '  AS: +651 vs DS: +355 with AvD: +20 + d100 roll: +49 = +365',
+                                '   ... and hit for 70 points of damage!',
+                                '   Strike pierces forearm!',
+                                "   The #{orc} is stunned!",
+                                "#{troll} shakes off the stun!"
+                              ])
+      statuses = emitted.select { |t, _| t == :status }.map(&:last)
+      orc_stun = statuses.find { |s| s[:id] == 700001 }
+      troll_rec = statuses.find { |s| s[:id] == 700002 }
+      # the orc's stun is the fire's; the troll's recovery names no event
+      expect(orc_stun).to include(status: :stunned, action: :add, attack_uid: 0)
+      expect(troll_rec).to include(status: :stunned, action: :remove)
+      expect(troll_rec[:attack_uid]).to be_nil
+    end
+
     it 'keeps an ooze splitting on the hit off the target switcher (raw chunk 23:19:53)' do
       lines = File.readlines(File.join(__dir__, '../../../fixtures/ooze_splatter_fire.txt'), chomp: true)
       events = described_class.parse_events(lines)

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -979,6 +979,17 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(events.first[:hits].map { |h| h[:damage] }).to eq([88])
     end
 
+    it 'claims an in-chunk dispel-on-nock pre-flare for the shot that follows (raw hunt chunk 21:44:41)' do
+      lines = File.readlines(File.join(__dir__, '../../../fixtures/dispel_on_nock.txt'), chomp: true)
+      events = described_class.parse_events(lines)
+      expect(events.map { |e| e[:name] }).to eq([:fire])
+      fire = events.first
+      expect(fire[:hits].map { |h| h[:damage] }).to eq([90])
+      dispel = fire[:flares].find { |f| f[:name] == :dispel }
+      expect(dispel[:hits].map { |h| h[:damage] }).to eq([15])
+      expect(dispel[:resolutions].map { |r| r[:result] }).to eq([175])
+    end
+
     it 'wraps a held pre-flare as its own event when no swing follows in the next chunk' do
       nock_chunk = [
         " ** Your <a exist=\"125479289\" noun=\"bow\">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}! **",

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -908,6 +908,51 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(Lich::Gemstone::Combat::Definitions::Attacks.attackerless_line?('Your right leg drips as you continue to bleed.')).to be true
     end
 
+    it 'names a missed first volley arrow :volley and roots the round on it (hunt log 21:03:43)' do
+      lines = File.readlines(File.join(__dir__, '../../../fixtures/volley_miss_first.txt'), chomp: true)
+      events = described_class.parse_events(lines)
+      expect(events.map { |e| e[:name] }.uniq).to eq([:volley])
+      miss = events.first
+      expect(miss[:target][:id]).to eq(126382122)
+      expect(miss[:outcomes]).to eq([:evade])
+      expect(miss[:resolutions].map { |r| r[:result] }).to eq([29])
+      expect(miss[:root_ref]).to equal(miss)
+      expect(events[1..].map { |e| e[:root_ref] }.uniq).to eq([miss])
+      expect(events.map { |e| e[:hits].sum { |h| h[:damage] } }).to eq([0, 10, 35, 15, 10, 30])
+    end
+
+    it 'keeps a crit-rider topple whose pronoun is a link on the swing (hunt log 21:03:06)' do
+      her = bolded(124194699, 'shield-maiden', 'her')
+      events = described_class.parse_events([
+                                              "You fire a faewood arrow at #{maiden}!",
+                                              '  AS: +646 vs DS: +414 with AvD: +38 + d100 roll: +42 = +312',
+                                              '   ... and hit for 54 points of damage!',
+                                              "   Deft slash to the #{bolded(124194699, 'shield-maiden', 'gigas shield-maiden')}'s left leg digs deep!",
+                                              '   Bone is chipped!',
+                                              '<pushBold/>[SMR result: -84 (Open d100: 45, Penalty: 26)]<popBold/>',
+                                              "Despite desperate windmilling to catch #{her} balance, #{maiden} topples toward you!  You stumble into visibility as you try to dodge the falling shield-maiden."
+                                            ])
+      expect(events.map { |e| e[:name] }).to eq([:fire])
+      expect(events.first[:resolutions].map { |r| r[:result] }).to eq([312, -84])
+    end
+
+    it 'parses the warg jaw hamstring as an inbound hamstring with its miss' do
+      events = described_class.parse_events([
+                                              "With a quick lunge, #{warg} tries to hamstring you with #{bolded(123985834, 'warg', 'its')} jaws!",
+                                              '<pushBold/>[SMR result: 33 (Open d100: 37, Penalty: 29)]<popBold/>',
+                                              "#{bolded(123985834, 'warg', 'A niveous giant warg')}'s swing goes wide!"
+                                            ])
+      expect(events.map { |e| [e[:name], e[:inbound]] }).to eq([[:hamstring, true]])
+      expect(events.first[:outcomes]).to include(:miss)
+    end
+
+    it 'strips a possessive baked into the creature link' do
+      events = described_class.parse_events([
+                                              "The thorny barrier surrounding you blocks the attack from the #{bolded(126564429, 'skald', "gigas skald's")}!"
+                                            ])
+      expect(events.first[:attacker][:name]).to eq('gigas skald')
+    end
+
     it 'labels environmental and self-inflicted damage by source' do
       cold = described_class.parse_events(['The burn of the cold tears precious warmth from your flesh.', '   ... 6 points of damage!'])
       thorn = described_class.parse_events(['As a darkened ruic longbow etched with thorns leaves your left hand, the thorns embedded in your skin painfully rip away, vines quickly retreating.',
@@ -1050,13 +1095,21 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
         .with(:status, hash_including(id: 900, status: 'dead', action: :add)).once
     end
 
-    it 'stops watching a survivor after a few sweeps' do
+    it 'keeps watching a survivor until it dies (someone else finishing it minutes later still counts)' do
       described_class.persist_event(hp_kill_event)
-      4.times { described_class.process([]) }
+      8.times { described_class.process([]) }
       dead_flag[:value] = true
-      described_class.process([]) # no longer watched - a much later death is not this event's
-      expect(Lich::Gemstone::Combat::Observers).not_to have_received(:emit)
-        .with(:status, hash_including(status: 'dead'))
+      described_class.process([])
+      expect(Lich::Gemstone::Combat::Observers).to have_received(:emit)
+        .with(:status, hash_including(id: 900, status: 'dead', action: :add)).once
+    end
+
+    it 'stops watching a creature that left the registry' do
+      described_class.persist_event(hp_kill_event)
+      registry = Lich::Gemstone::Combat::Creature
+      allow(registry).to receive(:[]).with(900).and_return(nil)
+      described_class.process([])
+      expect(described_class.instance_variable_get(:@death_watch)).to be_empty
     end
   end
 

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -990,6 +990,17 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(dispel[:resolutions].map { |r| r[:result] }).to eq([175])
     end
 
+    it 'keeps a bloom on a creature "forced out of hiding" on the flare, not a phantom fire (raw hunt chunk 22:14:27)' do
+      lines = File.readlines(File.join(__dir__, '../../../fixtures/bloom_forced_out_of_hiding.txt'), chomp: true)
+      events = described_class.parse_events(lines)
+      expect(events.map { |e| e[:name] }).to eq([:fire])
+      fire = events.first
+      expect(fire[:hits].map { |h| h[:damage] }).to eq([138])
+      blooms = fire[:flares].select { |f| f[:name] == :spectral_bloom }
+      expect(blooms.map { |f| f[:hits].sum { |h| h[:damage] } }).to eq([15, 7, 25])
+      expect(blooms.last[:target_info][:name]).to eq('bloody halfling cannibal')
+    end
+
     it 'wraps a held pre-flare as its own event when no swing follows in the next chunk' do
       nock_chunk = [
         " ** Your <a exist=\"125479289\" noun=\"bow\">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}! **",

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -727,6 +727,118 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(bloom[:name]).to eq(:spectral_bloom)
       expect(bloom[:resolutions].map { |r| r[:result] }).to eq([35])
     end
+
+    # "You blinded X!" rides the flare that blinded X: the primary's blind
+    # on the swing target, the bloom's blind on the bloom creature. The fact
+    # carries the flare's 1-based position so the recorder can file it on
+    # the flare row (owner 2026-09-07: blinds sat on the root attack).
+    it 'emits each blind with the flare_seq of the flare that caused it' do
+      registry = Class.new { def self.[](_id); end }
+      stub_const('Lich::Gemstone::Combat::Creature', registry)
+      { 121654846 => 'a tattooed gigas berserker', 121678494 => 'a heavily armored battle mastodon' }.each do |cid, cname|
+        dbl = instance_double('Creature', id: cid, name: cname)
+        allow(dbl).to receive(:add_status)
+        allow(registry).to receive(:[]).with(cid).and_return(dbl)
+      end
+      emitted = []
+      allow(Lich::Gemstone::Combat::Observers).to receive(:emit) { |type, payload| emitted << [type, payload] }
+      described_class.instance_variable_set(:@deferred_emits, nil)
+      described_class.parse_events(chunk)
+      blinds = emitted.select { |t, p| t == :status && p[:status] == :blind }
+      expect(blinds.map { |_, p| [p[:id], p[:flare_seq]] }).to eq([[121654846, 1], [121678494, 3]])
+    end
+  end
+
+  describe 'hunt-log defs 2026-09-07 (session 4 audit)' do
+    let(:skald) { bolded(123995203, 'skald', 'a grim gigas skald') }
+    let(:masto) { bolded(123956079, 'mastodon', 'a heavily armored battle mastodon') }
+    let(:warg) { bolded(123985834, 'warg', 'a niveous giant warg') }
+    let(:maiden) { bolded(124194699, 'shield-maiden', 'a brawny gigas shield-maiden') }
+
+    before do
+      allow(Lich::Gemstone::Combat::Tracker).to receive(:settings).and_return(
+        track_statuses: true, track_ucs: false, emit_attacks: true, track_damage: true, track_wounds: true
+      )
+      registry = Class.new { def self.[](_id); end }
+      stub_const('Lich::Gemstone::Combat::Creature', registry)
+    end
+
+    it 'names a tangleweed miss (unable to grasp) as a tangleweed attack with its SMR, not a targetless unknown' do
+      events = described_class.parse_events([
+                                              '<pushBold/>[SMR result: 71 (Open d100: -86, Bonus: 62)]<popBold/>',
+                                              "The lashing emerald briar lashes out at #{maiden}, but is unable to grasp her."
+                                            ])
+      expect(events.map { |e| e[:name] }).to eq([:tangleweed])
+      ev = events.first
+      expect(ev[:target][:id]).to eq(124194699)
+      expect(ev[:outcomes]).to include(:miss)
+      expect(ev[:resolutions].map { |r| r[:result] }).to eq([71])
+    end
+
+    it 'records a warg howl as an inbound fear maneuver with its SSR and our save' do
+      events = described_class.parse_events([
+                                              "#{warg} sits back on its haunches and unleashes a long, high-pitched howl that sends a shiver of primal terror down your spine.",
+                                              '<pushBold/>[SSR result: 86 (Open d100: 18)]<popBold/>',
+                                              "Fear still claws at your heart, but you stand fast against the #{bolded(123985834, 'warg', 'warg')}'s unnerving howl!"
+                                            ])
+      expect(events.map { |e| e[:name] }).to eq([:howl])
+      ev = events.first
+      expect(ev[:inbound]).to be(true)
+      expect(ev[:attacker][:id]).to eq(123985834)
+      expect(ev[:resolutions].map { |r| r[:type] }).to eq([:ssr])
+      expect(ev[:outcomes]).to include(:resisted)
+    end
+
+    it 'records a mastodon trumpet as an inbound fear maneuver' do
+      events = described_class.parse_events([
+                                              "#{masto} raises its trunk and rears back onto its immense hind legs, blaring out a note of sheer fury!",
+                                              '<pushBold/>[SSR result: 79 (Open d100: 52)]<popBold/>',
+                                              "You keep your wits amidst the #{bolded(123956079, 'mastodon', 'mastodon')}'s angry trumpeting!"
+                                            ])
+      expect(events.map { |e| [e[:name], e[:inbound]] }).to eq([[:trumpet, true]])
+      expect(events.first[:outcomes]).to include(:resisted)
+    end
+
+    it 'parses the mastodon tusk attack as inbound natural' do
+      events = described_class.parse_events([
+                                              "#{masto} tries to spear you with its enormous tusks!",
+                                              '  AS: +537 vs DS: +516 with AvD: +37 + d100 roll: +10 = +68',
+                                              '   A clean miss.'
+                                            ])
+      expect(events.map { |e| [e[:name], e[:inbound]] }).to eq([[:natural, true]])
+      expect(events.first[:outcomes]).to include(:miss)
+    end
+
+    it 'names the attacker from the creature link, not a pronoun link in the flavor prefix' do
+      zerk_his = bolded(123957785, 'berserker', 'his')
+      zerk = bolded(123957785, 'berserker', 'a tattooed gigas berserker')
+      events = described_class.parse_events([
+                                              "Froth bubbling on #{zerk_his} lips, #{zerk} swings an immense fel-hafted handaxe at you in a murderous arc!",
+                                              'You evade the attack by a hair!'
+                                            ])
+      expect(events.size).to eq(1)
+      expect(events.first[:attacker][:name]).to eq('a tattooed gigas berserker')
+    end
+
+    it 'keeps a pre-emptive warg evade on the warg instead of a targetless unknown' do
+      events = described_class.parse_events([
+                                              "With preternatural speed, #{warg} bounds to safety as you move to attack #{bolded(123985834, 'warg', 'it')}, leaving you off-balance!",
+                                              'The arrow streaks off into the distance!'
+                                            ])
+      expect(events.size).to eq(1)
+      expect(events.first[:target][:id]).to eq(123985834)
+      expect(events.first[:outcomes]).to include(:evade)
+    end
+
+    it 'labels environmental and self-inflicted damage by source' do
+      cold = described_class.parse_events(['The burn of the cold tears precious warmth from your flesh.', '   ... 6 points of damage!'])
+      thorn = described_class.parse_events(['As a darkened ruic longbow etched with thorns leaves your left hand, the thorns embedded in your skin painfully rip away, vines quickly retreating.',
+                                            '   ... 1 point of damage!'])
+      expect(cold.first.values_at(:name, :inbound)).to eq([:frigid_wind, true])
+      expect(cold.first[:attacker]).to eq({ name: 'environment' })
+      expect(thorn.first.values_at(:name, :inbound)).to eq([:thorn_recoil, true])
+      expect(thorn.first[:attacker]).to eq({ name: 'self' })
+    end
   end
 
   # Parse-phase facts (message statuses, UCS, spell loss) used to be emitted

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -874,6 +874,35 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(events.size).to eq(1)
       expect(events.first[:target][:id]).to eq(123985834)
       expect(events.first[:outcomes]).to include(:evade)
+      expect(events.first[:name]).to eq(:unknown)
+    end
+
+    it 'names a nocked-then-pre-empted swing as the fire it was, and keeps the shroud on it' do
+      events = described_class.parse_events([
+                                              'You nock a faewood arrow fletched with plain white feathers in your <a exist="129604585" noun="bow">glowbark long bow</a>.',
+                                              "With preternatural speed, #{warg} bounds to safety as you move to attack #{bolded(123985834, 'warg', 'it')}, leaving you off-balance!",
+                                              'A tenebrous shroud stitches itself into existence around you as you gracefully retreat into the shadows!',
+                                              'The arrow streaks off into the distance!'
+                                            ])
+      expect(events.map { |e| [e[:name], e[:weapon], e[:target][:id], e[:outcomes].first, e[:flares].map { |f| f[:name] }] })
+        .to eq([[:fire, 'glowbark long bow', 123985834, :evade, [:chameleon_shroud]]])
+    end
+
+    it "gives the swing, not the pinned rider's one-hit row, the flare that follows the pin" do
+      masto2 = bolded(130490001, 'mastodon', 'a heavily armored battle mastodon')
+      bers = bolded(130490002, 'berserker', 'a tattooed gigas berserker')
+      events = described_class.parse_events([
+                                              "You take aim and fire a faewood arrow at #{masto2}!",
+                                              '  AS: +651 vs DS: +355 with AvD: +20 + d100 roll: +49 = +365',
+                                              '   ... and hit for 70 points of damage!',
+                                              '   Attack punctures the eye and connects with something really vital!',
+                                              "#{bers} is pinned beneath #{masto2} as it falls!",
+                                              '   ... 5 points of damage!',
+                                              "   Blow leaves an imprint on #{bolded(130490002, 'berserker', "the gigas berserker's")} chest!",
+                                              'A tenebrous shroud stitches itself into existence around you as you gracefully retreat into the shadows!'
+                                            ])
+      expect(events.map { |e| [e[:name], e[:target][:id], e[:hits].map { |h| h[:damage] }, e[:flares].map { |f| f[:name] }] })
+        .to contain_exactly([:fire, 130490001, [70], [:chameleon_shroud]], [:mount_collapse, 130490002, [5], []])
     end
 
     it 'matches the live trumpet line, whose pronouns are links, and takes the fail line as a hit' do

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -1274,14 +1274,6 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
                                          ])
       expect(own.map { |e| [e[:name], e[:via], e[:target][:id], e[:resolutions].map { |r| r[:result] }] })
         .to eq([[:moonbeam, :cast, 130610003, [322]]])
-
-      # the "Tapping the moons above," prefix is not guaranteed - sentence-
-      # initial "You draw down..." must name the spell too, not fall to :unknown
-      sentence_initial = described_class.parse_events([
-                                                        "You draw down a shaft of swirling moonlight and bathe #{maiden} in its muted glow.",
-                                                        '<pushBold/>[SMR result: 322 (Open d100: 61, Bonus: 159)]<popBold/>'
-                                                      ])
-      expect(sentence_initial.map { |e| [e[:name], e[:target][:id]] }).to eq([[:moonbeam, 130610003]])
     end
 
     it "attributes a nearby player's flaming aura to that player, and a spiritual malady tick once, unowned" do

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -830,6 +830,68 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(events.first[:outcomes]).to include(:evade)
     end
 
+    it 'matches the live trumpet line, whose pronouns are links, and takes the fail line as a hit' do
+      its = bolded(123956079, 'mastodon', 'its')
+      events = described_class.parse_events([
+                                              "#{masto} raises #{its} trunk and rears back onto #{its} immense hind legs, blaring out a note of sheer fury!",
+                                              '<pushBold/>[SSR result: 174 (Open d100: 182)]<popBold/>',
+                                              "The #{bolded(123956079, 'mastodon', 'mastodon')}'s angry trumpeting startles you!",
+                                              'Roundtime: 20 sec.'
+                                            ])
+      expect(events.map { |e| [e[:name], e[:inbound]] }).to eq([[:trumpet, true]])
+      expect(events.first[:outcomes]).to include(:hit)
+      expect(events.first[:resolutions].map { |r| r[:result] }).to eq([174])
+    end
+
+    it 'records a 3p feint we saw through as an inbound feint with an evade outcome' do
+      events = described_class.parse_events([
+                                              '<pushBold/>[SMR result: 20 (Open d100: 134, Penalty: 4)]<popBold/>',
+                                              "#{maiden} feints high, but you aren't fooled for a second."
+                                            ])
+      expect(events.map { |e| [e[:name], e[:inbound]] }).to eq([[:feint, true]])
+      expect(events.first[:outcomes]).to include(:evade)
+      expect(events.first[:resolutions].map { |r| r[:result] }).to eq([20])
+    end
+
+    it 'records a shield push and its whiff' do
+      her = bolded(124194699, 'shield-maiden', 'her')
+      events = described_class.parse_events([
+                                              "#{maiden} raises #{her} <a exist=\"124194700\" noun=\"targe\">golden targe</a> and attempts to push you away!",
+                                              '<pushBold/>[SMR result: 17 (Open d100: 9, Penalty: 3)]<popBold/>',
+                                              "#{maiden} completely misses you, stumbles, and flails around!"
+                                            ])
+      expect(events.map { |e| [e[:name], e[:inbound]] }).to eq([[:shield_push, true]])
+      expect(events.first[:outcomes]).to include(:miss)
+    end
+
+    it "attributes a nearby player's fiery barbs to that player (foreign_caster), with its SMR and damage" do
+      events = described_class.parse_events([
+                                              "Fiery red barbs uncoil from the shadows near <a exist=\"-11152917\" noun=\"Burns\">Burns</a> and lash out at #{maiden}!",
+                                              '<pushBold/>[SMR result: 104 (Open d100: 40, Bonus: 15)]<popBold/>',
+                                              '   ... 15 points of damage!',
+                                              '   Burst of flames to right arm toasts skin to elbows.'
+                                            ])
+      expect(events.size).to eq(1)
+      ev = events.first
+      expect(ev[:name]).to eq(:fiery_barbs)
+      expect(ev[:foreign_caster]).to be(true)
+      expect(ev[:target][:id]).to eq(124194699)
+      expect(ev[:hits].map { |h| h[:damage] }).to eq([15])
+      expect(ev[:resolutions].map { |r| r[:result] }).to eq([104])
+    end
+
+    it 'opens a barrier block with no attack line as an INBOUND unknown, not an attack on the creature' do
+      events = described_class.parse_events([
+                                              "The thorny barrier surrounding you blocks the attack from the #{bolded(123985834, 'warg', 'giant warg')}!"
+                                            ])
+      expect(events.size).to eq(1)
+      ev = events.first
+      expect(ev[:inbound]).to be(true)
+      expect(ev[:target]).to eq({})
+      expect(ev[:attacker][:id]).to eq(123985834)
+      expect(ev[:outcomes]).to eq([:intercept])
+    end
+
     it 'labels environmental and self-inflicted damage by source' do
       cold = described_class.parse_events(['The burn of the cold tears precious warmth from your flesh.', '   ... 6 points of damage!'])
       thorn = described_class.parse_events(['As a darkened ruic longbow etched with thorns leaves your left hand, the thorns embedded in your skin painfully rip away, vines quickly retreating.',

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
     allow(Lich::Gemstone::Combat::Observers).to receive(:emit)
     # cross-chunk state lives in module ivars; never let one example's
     # death watch or held cast leak into another
-    %i[@death_watch @death_announced @held_cast @deferred_emits].each do |iv|
+    %i[@death_watch @death_announced @held_cast @held_pre_flares @deferred_emits].each do |iv|
       described_class.instance_variable_set(iv, nil)
     end
   end
@@ -951,6 +951,55 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
                                               "The thorny barrier surrounding you blocks the attack from the #{bolded(126564429, 'skald', "gigas skald's")}!"
                                             ])
       expect(events.first[:attacker][:name]).to eq('gigas skald')
+    end
+
+    it 'holds a dispel-on-nock pre-flare across the chunk boundary so the next shot claims it' do
+      nock_chunk = [
+        'You nock a faewood <a exist="127300001" noun="arrow">arrow</a> fletched with plain white feathers in your <a exist="125479289" noun="bow">glowbark long bow</a>.',
+        'You feel drained.',
+        " ** Your <a exist=\"125479289\" noun=\"bow\">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}! **",
+        ' <pushBold/>[SMR result: 225 (Open d100: 40, Bonus: 110)]<popBold/>',
+        '   ... 20 points of damage!',
+        "   The #{bolded(123956079, 'mastodon', 'armored battle mastodon')}'s neck bones snap.",
+        '   Head looks precariously balanced now.'
+      ]
+      fire_chunk = [
+        "You fire a faewood arrow at #{masto}!",
+        '  AS: +644 vs DS: +301 with AvD: +20 + d100 roll: +90 = +453',
+        '   ... and hit for 88 points of damage!',
+        "   Quick, powerful slash to the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}'s left knee!"
+      ]
+      expect(described_class.parse_events(nock_chunk)).to eq([])
+      events = described_class.parse_events(fire_chunk)
+      expect(events.map { |e| e[:name] }).to eq([:fire])
+      dispel = events.first[:flares].find { |f| f[:name] == :dispel }
+      expect(dispel).not_to be_nil
+      expect(dispel[:hits].map { |h| h[:damage] }).to eq([20])
+      expect(dispel[:resolutions].map { |r| r[:result] }).to eq([225])
+      expect(events.first[:hits].map { |h| h[:damage] }).to eq([88])
+    end
+
+    it 'wraps a held pre-flare as its own event when no swing follows in the next chunk' do
+      nock_chunk = [
+        " ** Your <a exist=\"125479289\" noun=\"bow\">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}! **",
+        '   ... 20 points of damage!'
+      ]
+      expect(described_class.parse_events(nock_chunk)).to eq([])
+      events = described_class.parse_events(['You are now in a defensive stance.'])
+      expect(events.map { |e| [e[:name], e[:target][:id]] }).to eq([[:dispel, 123956079]])
+    end
+
+    it 'names the "grabs at ... unable to find a purchase" tangleweed miss' do
+      golem = bolded(127053510, 'golem', 'a behemothic gorefrost golem')
+      events = described_class.parse_events(["The lashing emerald briar grabs at #{golem}, unable to find a purchase."])
+      expect(events.map { |e| [e[:name], e[:target][:id], e[:outcomes]] }).to eq([[:tangleweed, 127053510, [:miss]]])
+    end
+
+    it 'squeezes the doubled space a hidden adjective leaves in a creature link' do
+      events = described_class.parse_events([
+                                              'The thorny barrier surrounding you blocks the attack from the <pushBold/><a exist="127089942" noun=" cannibal">halfling  cannibal</a><popBold/>!'
+                                            ])
+      expect(events.first[:attacker][:name]).to eq('halfling cannibal')
     end
 
     it 'labels environmental and self-inflicted damage by source' do

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -892,6 +892,22 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(ev[:outcomes]).to eq([:intercept])
     end
 
+    it 'records bleed ticks: a creature\'s as an unowned attack on it, ours as inbound' do
+      theirs = described_class.parse_events([
+                                              "Blood weeps from the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}'s open left arm wound.",
+                                              '   ... 8 points of damage!'
+                                            ])
+      drips = described_class.parse_events([
+                                             "The #{bolded(123985834, 'warg', 'giant warg')}'s chest drips as #{bolded(123985834, 'warg', 'it')} continues to bleed.",
+                                             '   ... 14 points of damage!'
+                                           ])
+      ours = described_class.parse_events(['Your right leg drips as you continue to bleed.', '   ... 3 points of damage!'])
+      expect(theirs.map { |e| [e[:name], e[:target][:id], e[:unowned], e[:hits].map { |h| h[:damage] }] }).to eq([[:bleed, 123956079, true, [8]]])
+      expect(drips.map { |e| [e[:name], e[:target][:id], e[:unowned], e[:hits].map { |h| h[:damage] }] }).to eq([[:bleed, 123985834, true, [14]]])
+      expect(ours.map { |e| [e[:name], e[:inbound], e[:hits].map { |h| h[:damage] }] }).to eq([[:bleed, true, [3]]])
+      expect(Lich::Gemstone::Combat::Definitions::Attacks.attackerless_line?('Your right leg drips as you continue to bleed.')).to be true
+    end
+
     it 'labels environmental and self-inflicted damage by source' do
       cold = described_class.parse_events(['The burn of the cold tears precious warmth from your flesh.', '   ... 6 points of damage!'])
       thorn = described_class.parse_events(['As a darkened ruic longbow etched with thorns leaves your left hand, the thorns embedded in your skin painfully rip away, vines quickly retreating.',

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -747,6 +747,35 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       blinds = emitted.select { |t, p| t == :status && p[:status] == :blind }
       expect(blinds.map { |_, p| [p[:id], p[:flare_seq]] }).to eq([[121654846, 1], [121678494, 3]])
     end
+
+    it "files a flare-and-status line (nature's decay) on its own flare, not the one before it" do
+      registry = Class.new { def self.[](_id); end }
+      stub_const('Lich::Gemstone::Combat::Creature', registry)
+      dbl = instance_double('Creature', id: 129649881, name: 'a flayed gigas disciple')
+      allow(dbl).to receive(:add_status)
+      allow(registry).to receive(:[]).with(129649881).and_return(dbl)
+      emitted = []
+      allow(Lich::Gemstone::Combat::Observers).to receive(:emit) { |type, payload| emitted << [type, payload] }
+      described_class.instance_variable_set(:@deferred_emits, nil)
+      disc = bolded(129649881, 'disciple', 'a flayed gigas disciple')
+      events = described_class.parse_events([
+                                              "** Your <a exist=\"129604585\" noun=\"bow\">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around #{bolded(129649881, 'disciple', 'the gigas disciple')}! **",
+                                              "You fire a faewood arrow at #{disc}!",
+                                              '  AS: +652 vs DS: +602 with AvD: +32 + d100 roll: +95 = +177',
+                                              '   ... and hit for 30 points of damage!',
+                                              "   Strike pierces #{bolded(129649881, 'disciple', "the gigas disciple's")} forearm!",
+                                              "   #{bolded(129649881, 'disciple', 'The gigas disciple')} is stunned!",
+                                              "#{disc} is buffeted by a burst of wind and pushed back!",
+                                              "The earthy, sweet aroma clinging to #{disc} grows more pervasive.",
+                                              'Vital energy infuses you, hastening your arcane reflexes!'
+                                            ])
+      expect(events.first[:flares].map { |f| f[:name] }).to eq(%i[dispel breeze natures_decay arcane_reflex])
+      decay = emitted.select { |t, p| t == :status && p[:status].to_s == 'natures_decay' }
+      expect(decay.map { |_, p| [p[:id], p[:flare_seq]] }).to eq([[129649881, 3]])
+      # the swing's own crit stun is not the dispel pre-flare's doing
+      stun = emitted.select { |t, p| t == :status && p[:status].to_s == 'stunned' }
+      expect(stun.map { |_, p| [p[:id], p[:flare_seq]] }).to eq([[129649881, nil]])
+    end
   end
 
   describe 'hunt-log defs 2026-09-07 (session 4 audit)' do
@@ -1009,11 +1038,29 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(fire[:hits].map { |h| h[:damage] }).to eq([21])
       phos = fire[:flares].find { |f| f[:name] == :phosphorescence }
       expect(phos[:hits].map { |h| h[:damage] }).to eq([25])
+      # weaponless flares (nature's decay, arcane reflex) resume the shot too
+      expect(fire[:flares].map { |f| f[:name] }).to contain_exactly(:natures_decay, :arcane_reflex, :phosphorescence)
       expect(cast[:hits]).to be_empty
       expect(cast[:flares]).to be_empty
       expect(cast[:outcomes]).to eq([:warded])
       expect(cast[:resolutions].map { |r| r[:type] }).to eq([:cs_td])
       expect(cast[:attacker]).to include(id: 129623615, name: 'flayed gigas disciple')
+    end
+
+    it 'names the resumed shot (attack_uid) on the blind its flare inflicted, though the cast emits last' do
+      registry = Class.new { def self.[](_id); end }
+      stub_const('Lich::Gemstone::Combat::Creature', registry)
+      dbl = double('Creature', id: 129623615, name: 'a flayed gigas disciple').as_null_object
+      allow(registry).to receive(:[]).with(129623615).and_return(dbl)
+      emitted = []
+      allow(Lich::Gemstone::Combat::Observers).to receive(:emit) { |type, payload| emitted << [type, payload] }
+      lines = File.readlines(File.join(__dir__, '../../../fixtures/cloak_of_shadows_interrupt.txt'), chomp: true)
+      described_class.process(lines)
+      attacks = emitted.select { |t, _| t == :attack }.map { |_, e| [e[:name], e[:_uid]] }
+      expect(attacks).to eq([[:fire, 0], [:cast, 1]])
+      blind = emitted.find { |t, p| t == :status && p[:status] == :blind }.last
+      expect(blind).to include(attack_uid: 0, flare_seq: 3)
+      expect(blind).not_to have_key(:_event)
     end
 
     it 'keeps an ooze splitting on the hit off the target switcher (raw chunk 23:19:53)' do
@@ -1070,6 +1117,37 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
                                               '   Unpleasant wound to right arm!'
                                             ])
       expect(malady.map { |e| [e[:name], e[:unowned], e[:target][:id], e[:hits].map { |h| h[:damage] }] }).to eq([[:spiritual_malady, true, 129575116, [5]]])
+    end
+
+    it "parses the disciple's leech fling with its held roll and same-line dodge" do
+      disc = bolded(129649883, 'disciple', 'a flayed gigas disciple')
+      events = described_class.parse_events([
+                                              'The layer of bark on you hardens and absorbs the attack!  The bark crackles, but maintains its form.',
+                                              '<pushBold/>[SMR result: 0 (Open d100: 81, Penalty: 3)]<popBold/>',
+                                              "#{disc} reaches into a pouch at #{bolded(129649883, 'disciple', 'her')} waist and draws back a hand covered in fat leeches, so deep a violet in hue as to be almost black.  With a fleshless sneer, she flings the parasites at you!  You duck to narrowly avoid the flying vermiforms!"
+                                            ])
+      # the barkskin absorb stays its own intercepted unknown (an attack
+      # the bark ate whole); the fling owns the roll and the dodge
+      expect(events.map { |e| [e[:name], e[:outcomes]] }).to contain_exactly([:natural, [:evade]], [:unknown, [:intercept]])
+      fling = events.find { |e| e[:name] == :natural }
+      expect([fling[:inbound], fling[:attacker][:id], fling[:resolutions].map { |r| r[:result] }]).to eq([true, 129649883, [0]])
+    end
+
+    it "gives a creature's warding-spell effect line the caster of the cast it follows (disciple's wither)" do
+      disc = bolded(129649881, 'disciple', 'a flayed gigas disciple')
+      events = described_class.parse_events([
+                                              "A dark shadowy tendril rises up from #{disc}, writhes its way up a <a exist=\"129604585\" noun=\"bow\">scorched glowbark long bow</a> towards you and lashes out malevolently...",
+                                              "The force of #{bolded(129649881, 'disciple', "a flayed gigas disciple's")} power warps the air as it surges toward you!",
+                                              '  CS: +497 - TD: +485 + CvA: +13 + d100: +92 - -5 == +122',
+                                              '  Warding failed!',
+                                              'The layer of bark on you hardens and absorbs the magical energy!  The bark crackles, but maintains its form.',
+                                              'A nebulous haze shimmers into view around you, plunging inward to envelop your left eye!',
+                                              '   ... 10 points of damage!',
+                                              '   Left eyelid turns to dust, causing you to blink rapidly, or try to.',
+                                              'Cloudy tendrils writhe throughout your form, ravaging you for 15 points of damage!'
+                                            ])
+      expect(events.map { |e| [e[:name], e[:inbound], e[:attacker]&.[](:id), e[:hits].map { |h| h[:damage] }] })
+        .to eq([[:cast, true, 129649881, []], [:wither, true, 129649881, [10, 15]]])
     end
 
     it 'parses the ooze vitality drain, the cannibal ambush swing, and rot / neck-bleed ticks' do

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -1001,6 +1001,77 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(blooms.last[:target_info][:name]).to eq('bloody halfling cannibal')
     end
 
+    it "resumes our shot after a disciple's cloak-of-shadows retaliation so our flare stays ours (raw chunk 23:18:38)" do
+      lines = File.readlines(File.join(__dir__, '../../../fixtures/cloak_of_shadows_interrupt.txt'), chomp: true)
+      events = described_class.parse_events(lines)
+      expect(events.map { |e| [e[:name], e[:inbound]] }).to eq([[:fire, nil], [:cast, true]])
+      fire, cast = events
+      expect(fire[:hits].map { |h| h[:damage] }).to eq([21])
+      phos = fire[:flares].find { |f| f[:name] == :phosphorescence }
+      expect(phos[:hits].map { |h| h[:damage] }).to eq([25])
+      expect(cast[:hits]).to be_empty
+      expect(cast[:flares]).to be_empty
+      expect(cast[:outcomes]).to eq([:warded])
+      expect(cast[:resolutions].map { |r| r[:type] }).to eq([:cs_td])
+      expect(cast[:attacker]).to include(id: 129623615, name: 'flayed gigas disciple')
+    end
+
+    it 'keeps an ooze splitting on the hit off the target switcher (raw chunk 23:19:53)' do
+      lines = File.readlines(File.join(__dir__, '../../../fixtures/ooze_splatter_fire.txt'), chomp: true)
+      events = described_class.parse_events(lines)
+      expect(events.map { |e| [e[:name], e[:hits].map { |h| h[:damage] }] }).to eq([[:fire, [51]]])
+    end
+
+    it 'parses the sanguine ooze pseudopod attacks and their misses' do
+      ooze = bolded(129583295, 'ooze', 'a quivering sanguine ooze')
+      smash = described_class.parse_events([
+                                             "#{ooze} manifests a thick pseudopod and brings it smashing down at you!",
+                                             '  AS: +556 vs DS: +585 with AvD: +38 + d100 roll: +39 = +48',
+                                             '   A clean miss.'
+                                           ])
+      whip = described_class.parse_events([
+                                            '<pushBold/>[SMR result: 47 (Open d100: 70, Penalty: 10)]<popBold/>',
+                                            "#{ooze} whips a thick pseudopod at you!  The goopy appendage flies wide before retracting back into the central mass of #{bolded(129583295, 'ooze', 'the ooze')}."
+                                          ])
+      expect(smash.map { |e| [e[:name], e[:inbound], e[:outcomes]] }).to eq([[:natural, true, [:miss]]])
+      expect(whip.map { |e| [e[:name], e[:inbound], e[:outcomes], e[:resolutions].map { |r| r[:result] }] }).to eq([[:natural, true, [:miss], [47]]])
+    end
+
+    it 'records the ooze shrapnel burst and the disciple rift as inbound room maneuvers with their rolls' do
+      ooze = bolded(129583295, 'ooze', 'a quivering sanguine ooze')
+      shrap = described_class.parse_events([
+                                             "Froth disturbs the surface of #{ooze} as bubbling bulges form over #{bolded(129583295, 'ooze', 'its')} surface, rapidly coagulating into red-black crystalline spikes.  With a convulsive shudder, the ooze flings them outward!",
+                                             '<pushBold/>[SMR result: -32 (Open d100: -36, Penalty: 13)]<popBold/>',
+                                             'Bobbing and weaving, you dodge the spray of shrapnel!'
+                                           ])
+      disc = bolded(129629246, 'disciple', 'a flayed gigas disciple')
+      rift = described_class.parse_events([
+                                            "Zeal twisting #{bolded(129629246, 'disciple', 'her')} features, #{disc} raises a raw and fleshless hand overhead and draws it down, #{bolded(129629246, 'disciple', 'her')} shattered fingernails slicing open a tear in the fabric of the world.",
+                                            'Writhing, milky tentacles burst forth from the tortured spatial anomaly, grasping blindly through the areas they glisten with vile humors.',
+                                            '<pushBold/>[SMR result: 61 (Open d100: 67, Penalty: 53)]<popBold/>'
+                                          ])
+      expect(shrap.map { |e| [e[:name], e[:inbound], e[:outcomes], e[:resolutions].map { |r| r[:result] }] }).to eq([[:shrapnel_spray, true, [:evade], [-32]]])
+      expect(rift.map { |e| [e[:name], e[:inbound], e[:attacker][:id], e[:resolutions].map { |r| r[:result] }] }).to eq([[:rift_tentacles, true, 129629246, [61]]])
+    end
+
+    it "attributes a nearby player's flaming aura to that player, and a spiritual malady tick once, unowned" do
+      oozeling = bolded(129648792, 'oozeling', 'a quivering sanguine oozeling')
+      aura = described_class.parse_events([
+                                            "The flaming aura surrounding <a exist=\"-10174607\" noun=\"Meb\">Meb</a> lashes out at #{oozeling}!",
+                                            '<pushBold/>[SMR result: 153 (Open d100: 76, Bonus: 8)]<popBold/>',
+                                            '   ... 25 points of damage!'
+                                          ])
+      expect(aura.map { |e| [e[:name], e[:foreign_caster], e[:target][:id], e[:hits].map { |h| h[:damage] }, e[:resolutions].map { |r| r[:result] }] })
+        .to eq([[:flaming_aura, true, 129648792, [25], [153]]])
+      mutant = bolded(129575116, 'mutant', 'a squamous reptilian mutant')
+      malady = described_class.parse_events([
+                                              "A spiritual malady wracks #{mutant} causing 5 points of damage!",
+                                              '   ... 5 points of damage!',
+                                              '   Unpleasant wound to right arm!'
+                                            ])
+      expect(malady.map { |e| [e[:name], e[:unowned], e[:target][:id], e[:hits].map { |h| h[:damage] }] }).to eq([[:spiritual_malady, true, 129575116, [5]]])
+    end
+
     it 'wraps a held pre-flare as its own event when no swing follows in the next chunk' do
       nock_chunk = [
         " ** Your <a exist=\"125479289\" noun=\"bow\">glowbark long bow</a> glows brightly for a moment, consuming the magical energies around the #{bolded(123956079, 'mastodon', 'armored battle mastodon')}! **",

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -109,6 +109,25 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       rec.close
     end
 
+    it "does not open a session for a nearby player's attack, nor keep one alive with it" do
+      rec = new_recorder(idle_timeout: 300)
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000))
+      rec.record(:attack, attack_event(name: 'cast', foreign_caster: true))
+      expect(count('sessions')).to eq(0)
+      expect(count('attacks')).to eq(0)
+
+      rec.record(:attack, attack_event)
+      expect(count('sessions')).to eq(1)
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000 + 250))
+      rec.record(:attack, attack_event(name: 'cast', foreign_caster: true)) # recorded, but no heartbeat
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000 + 350))
+      rec.check_idle!
+      rec.close
+
+      expect(count('attacks')).to eq(2)
+      expect(query('SELECT ended_at FROM sessions').first['ended_at']).to eq(3_000_000.0)
+    end
+
     it 'closes the session after the idle gap, stamped at the last event time' do
       rec = new_recorder(idle_timeout: 300)
       # first event opens the session; stub Time so last_event_at is controlled

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -270,6 +270,37 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       expect(chunk_b['parent_attack_id']).to be_nil
     end
 
+    # A session boundary is a chunk boundary: rows from the closed session
+    # are not addressable by this one's uids. The maps used to survive it,
+    # so a chunk whose FIRST event never reached record_attack (a foreign
+    # event, skipped before the uid-0 reset) left the previous session's
+    # uid -> row map in place for the next event to link into.
+    it 'never links across a session boundary, even when a foreign event held uid 0' do
+      rec = new_recorder(idle_timeout: 300)
+      now = Time.now
+      # hunt one: a real chunk, root at uid 0
+      rec.record(:attack, attack_event(name: 'fire', _uid: 0, root_uid: 0))
+      first_session = query('SELECT id FROM attacks ORDER BY id').size
+      expect(first_session).to eq(1)
+
+      # idle past the timeout, then a new chunk whose first event is foreign
+      # (recorded by nobody: it neither opens a session nor resets the maps)
+      allow(Time).to receive(:now).and_return(now + 301)
+      rec.record(:attack, attack_event(name: 'cast', _uid: 0, root_uid: 0, foreign_caster: true))
+      # ...and our own event, uid 1, which opens hunt two
+      rec.record(:attack, attack_event(name: 'jab', _uid: 1, root_uid: 0, parent_uid: 0))
+      rec.close
+
+      rows = query('SELECT id, session_id, name, root_attack_id, parent_attack_id FROM attacks ORDER BY id')
+      expect(rows.size).to eq(2)
+      old_row, new_row = rows
+      expect(new_row['session_id']).not_to eq(old_row['session_id'])
+      expect(new_row['parent_attack_id']).not_to eq(old_row['id']),
+                                                 'linked to the previous session\'s attack'
+      expect(new_row['root_attack_id']).not_to eq(old_row['id']),
+                                               'rooted in the previous session\'s attack'
+    end
+
     it 'leaves an ambiguous echo (no parent_uid) rooted but parentless' do
       rec = new_recorder
       rec.start_session(at: Time.at(1))

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -429,6 +429,23 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       expect(query('SELECT DISTINCT source FROM statuses').map { |r| r['source'] }).to eq(['window'])
     end
 
+    it 'files a status under the attack the processor names (attack_uid), not the last one emitted' do
+      rec = new_recorder
+      rec.start_session(at: Time.at(1))
+      fire = attack_event(target_id: 202, target_name: 'an orc', _uid: 0, root_uid: 0)
+      fire[:flares] = [{ name: :phosphorescence, damaging: true, target_info: { id: 202, name: 'an orc' }, hits: [{ damage: 5, crit: nil }] }]
+      cast = attack_event(name: 'cast', target_id: nil, target_name: nil, inbound: true, _uid: 1, root_uid: 1,
+                          attacker: { id: 202, name: 'an orc' })
+      cast[:hits] = []
+      rec.record(:attack, fire)
+      rec.record(:attack, cast)
+      rec.record(:status, { id: 202, name: 'an orc', status: :blind, action: :add, flare_seq: 1, attack_uid: 0 })
+      rec.close
+
+      row = query('SELECT s.source, a.name AS attack, f.name AS flare FROM statuses s JOIN attacks a ON a.id = s.attack_id LEFT JOIN flares f ON f.id = s.flare_id').first
+      expect([row['source'], row['attack'], row['flare']]).to eq(['event', 'fire', 'phosphorescence'])
+    end
+
     it 'marks a status with no matching open attack as direct' do
       rec = new_recorder
       rec.start_session(at: Time.at(1))

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -321,6 +321,43 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
     end
   end
 
+  # statuses.flare_id ships in the SCHEMA and every status INSERT names it,
+  # so a database created BEFORE the column existed has to gain it on open -
+  # otherwise the first status of the hunt fails with "no column named
+  # flare_id" and the whole status stream is lost on upgrade.
+  describe 'statuses.flare_id migration' do
+    def legacy_database_without_flare_id
+      legacy = SQLite3::Database.new(@db_path)
+      pre = described_class::SCHEMA.gsub(/\n\s*flare_id    INTEGER REFERENCES flares\(id\),[^\n]*/, '')
+      expect(pre).not_to include('flare_id')
+      legacy.execute_batch(pre)
+      cols = legacy.execute('PRAGMA table_info(statuses)').map { |r| r[1] }
+      legacy.close
+      expect(cols).not_to include('flare_id')
+    end
+
+    it 'adds the column to a database created before it existed' do
+      legacy_database_without_flare_id
+
+      rec = new_recorder
+      rec.close
+      expect(query('PRAGMA table_info(statuses)').map { |r| r['name'] }).to include('flare_id')
+    end
+
+    it 'records a status into an upgraded database instead of failing the insert' do
+      legacy_database_without_flare_id
+
+      rec = new_recorder
+      rec.start_session(at: Time.at(1))
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'prone', action: 'add')
+      rec.close
+
+      row = query('SELECT status, action, flare_id FROM statuses').first
+      expect(row['status']).to eq('prone')
+      expect(row['flare_id']).to be_nil
+    end
+  end
+
   describe 'creature-cache rollback safety' do
     # Re-review finding (PR #1559): ensure_creature cached a creature id inside
     # a transaction; if that transaction rolled back, the DB row was undone but

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -128,6 +128,50 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       expect(query('SELECT ended_at FROM sessions').first['ended_at']).to eq(3_000_000.0)
     end
 
+    # Regression: foreign_event? used to call EVERY non-:attack type foreign,
+    # so a death confirmed by the room feed after the idle gap (exactly what
+    # the processor's watch-until-death sweep emits, as a bare :status) was
+    # dropped outright - no status row, no killed_at.
+    it 'records a delayed death for a creature this session fought, into that same session' do
+      rec = new_recorder(idle_timeout: 300)
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000))
+      rec.record(:attack, attack_event(at: Time.at(3_000_000)))
+
+      # the room feed confirms the kill well past the idle gap
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000 + 301))
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: :add)
+
+      expect(count('sessions')).to eq(1) # no spurious second session
+      expect(query("SELECT status FROM statuses WHERE kind = 'status'").map { |r| r['status'] }).to eq(['dead'])
+      # the kill lands on the SAME creature row the attack created, not a
+      # duplicate under a new session
+      creatures = query('SELECT id, exist_id, killed_at FROM creatures')
+      expect(creatures.size).to eq(1)
+      expect(creatures.first['killed_at']).to eq(3_000_301.0)
+      rec.close
+    end
+
+    it 'does not let a trailing fact extend the hunt or resurrect it for a stranger' do
+      rec = new_recorder(idle_timeout: 300)
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000))
+      rec.record(:attack, attack_event(at: Time.at(3_000_000)))
+
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000 + 301))
+      # a bystander's creature we never touched: still foreign, still dropped
+      rec.record(:status, id: 999, name: 'a passing sprite', status: 'stunned', action: :add)
+      expect(query("SELECT * FROM statuses WHERE kind = 'status'")).to be_empty
+
+      # our own creature's delayed fact is kept, but does not push ended_at out
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: :add)
+      allow(Time).to receive(:now).and_return(Time.at(3_000_000 + 900))
+      rec.check_idle!
+      rec.close
+
+      expect(count('sessions')).to eq(1)
+      # ended_at is still the last real attack - town time never pads a hunt
+      expect(query('SELECT ended_at FROM sessions').first['ended_at']).to eq(3_000_000.0)
+    end
+
     it 'closes the session after the idle gap, stamped at the last event time' do
       rec = new_recorder(idle_timeout: 300)
       # first event opens the session; stub Time so last_event_at is controlled

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -386,6 +386,30 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       expect(st['attack_id']).not_to be_nil
     end
 
+    it 'files a status on the flare it rode when the processor names one (flare_seq)' do
+      rec = new_recorder
+      rec.start_session(at: Time.at(1))
+      ev = attack_event(target_id: 202, target_name: 'an orc')
+      ev[:flares] = [
+        { name: :phosphorescence, damaging: true, target_info: { id: 202, name: 'an orc' }, hits: [{ damage: 5, crit: nil }] },
+        { name: :glowbright, damaging: false, hits: [] },
+        { name: :spectral_bloom, damaging: true, target_info: { id: 303, name: 'a troll' }, hits: [{ damage: 7, crit: nil }] }
+      ]
+      rec.record(:attack, ev)
+      rec.record(:status, { id: 303, name: 'a troll', status: :blind, action: :add, flare_seq: 3 })
+      rec.record(:status, { id: 202, name: 'an orc', status: :blind, action: :add, flare_seq: 1 })
+      rec.record(:status, { id: 202, name: 'an orc', status: :prone, action: :add })
+      rec.close
+
+      rows = query('SELECT s.status, s.subject, f.name AS flare FROM statuses s LEFT JOIN flares f ON f.id = s.flare_id ORDER BY s.id')
+      expect(rows.map { |r| [r['status'], r['subject'], r['flare']] }).to eq([
+                                                                               ['blind', 'a troll', 'spectral_bloom'],
+                                                                               ['blind', 'an orc', 'phosphorescence'],
+                                                                               ['prone', 'an orc', nil]
+                                                                             ])
+      expect(query('SELECT DISTINCT source FROM statuses').map { |r| r['source'] }).to eq(['window'])
+    end
+
     it 'marks a status with no matching open attack as direct' do
       rec = new_recorder
       rec.start_session(at: Time.at(1))

--- a/spec/lib/gemstone/combat/spell_loss_defs_spec.rb
+++ b/spec/lib/gemstone/combat/spell_loss_defs_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Lich::Gemstone::Combat::Parser do
 
     it 'identifies the round-2 effect-list pins (513, 911, 1605)' do
       cases = {
+        'A white glow rushes away from a grim gigas skald.'                                                                           => 303,
         'A grim gigas skald no longer bristles with energy.'                                                                          => 513,
         'Laehna becomes solid again.'                                                                                                 => 911,
         "Talliver's movements no longer appear to be influenced by a divine power as the spiritual force fades from around his arms." => 1605


### PR DESCRIPTION
## Summary

Follow-up to #1559. Sixteen commits from auditing the combat recorder against raw XML hunt logs after each live hunt: the recorded database was compared line by line with the logs (fires incl. aimed shots and echoes, volleys, lashes, blinds, stuns, coups, deaths, damage lines) and every divergence was traced to a parser or def defect and fixed, each with a spec built from the offending log lines. Scope is `lib/gemstone/combat/**` and its specs only; nothing outside the module changes.

## Parser / processor

- **Interrupted swings resume correctly.** A creature's reactive cast, a cloak-of-shadows flare, or a one-hit side effect (a rider pinned under a collapsing mount) printing in the middle of our swing no longer swallows the rest of it: the swing is parked, the interloper is saved as its own event, and the following flare/hit lines return to the swing. `SINGLE_HIT_ATTACKS` (`mount_collapse`) formalises the one-hit case.
- **Statuses ride the event that caused them.** `apply_status_to_target` carries the originating event (`attack_uid`), so a status is filed on the flare or swing that inflicted it instead of on whatever event is current when the status line prints. Flare-and-status lines (`status_flare_seq`) resolve to the right flare index; pre-flares never claim statuses.
- **A nocked bow whose fire line is pre-empted** ("bounds to safety as you move to attack it") is recorded as a `:fire` with the bow as weapon, not an `:unknown`.
- **Crit-rider SMRs** (knockdown topple) stay on the hit that caused them.
- **Volley rounds that open with a miss**, death watch until the actual death line, possessive creature links, dispel-on-nock pre-flares held across a chunk boundary, bow pre-flares claimed regardless of arrow/bow name mismatch.
- Narration lines ("forced out of hiding", rage shriek) are not target switches; foreign (other players') events never open a session.
- **Spell wear-offs in the killing chunk carry `cause: :death`**, dispels carry `:dispel`, so "spells falling off a corpse" is distinguishable from a dispel flare. "A white glow rushes away from X" is the 303 Prayer of Protection end message, not a `:dispelled` status.

## Defs (all from live hunt logs, evidence in comments)

- Ticks: bleed, rot, neck bleed, ooze vitality drain (unowned on a creature, inbound on us).
- Attacks: cannibal ambush swing, leech fling, tangleweed grab miss, tusks, live fear maneuvers, feint and shield push, topple/hamstring/push variants, barrier-only inbound resolutions.
- Mutant-farm creatures: ooze, disciple, malady, flaming aura.
- Third-person casts by foreign casters: spellsong (Kalithra), fear cry, golden waves, moonbeam; second-person evoked moonbeam.
- Outcomes: "You duck to narrowly avoid the flying vermiforms!" evade.

## Recorder

- Statuses are routed by `attack_uid` with source `'event'` (authoritative) alongside the existing `'window'`/`'direct'` sources.
- Spell losses persist their cause.

## Tests

- `processor_inbound_spec.rb` +646 lines of log-derived examples; new fixtures `cloak_of_shadows_interrupt.txt`, `dispel_on_nock.txt`, `volley_miss_first.txt`, `bloom_forced_out_of_hiding.txt`, `ooze_splatter_fire.txt`.
- `bundle exec rspec spec/lib/gemstone/combat`: 289 examples, 0 failures. Rubocop clean on the touched files.

## Notes

- Touches only files that upstream has not changed since #1559 merged, so it rebases cleanly on `main`.
- Overlaps #1576 (observation provenance) in `processor.rb` at four mechanical hunks (the `save_event` dedup lambda vs `include_attack_events`, and `source:` on the outcome-opened event). Happy to rebase onto whichever lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
