### PR TITLE
fix(gs): QStrike prices MSTRIKE's own stamina cost

### DIFF
--- a/lib/gemstone/psms/qstrike.rb
+++ b/lib/gemstone/psms/qstrike.rb
@@ -50,6 +50,16 @@ module Lich
       # Maximum seconds of RT reduction (reasonable upper bound)
       MAX_REDUCTION = 8
 
+      # MSTRIKE's own stamina cost (Multi Opponent Combat/Multistrike):
+      # nothing outside its recovery period; during it, base + per * weapon
+      # speed, where a second weapon adds (its speed - 2, at least 0).
+      MSTRIKE_COST = {
+        open: { base: 20, per_speed: 3 },
+        focused: { base: 30, per_speed: 4 }
+      }.freeze
+      # The cooldown Effects names while MSTRIKE is in its recovery period
+      MSTRIKE_COOLDOWN = 'Multi-Strike'
+
       # Valid combat actions that can use QSTRIKE
       VALID_ACTIONS = %w[
         ascension ambush attack cheapshot cman cock disarm feat fire
@@ -258,7 +268,8 @@ module Lich
         adaptive = default(:adaptive) if adaptive.nil?
 
         attack_name = normalize_attack_name(attack)
-        attack_cost = lookup_attack_cost(attack_name)
+        # A targeted mstrike is a focused one, whatever the name says
+        attack_cost = attack_name == 'mstrike' && target ? mstrike_cost(focused: true) : lookup_attack_cost(attack_name)
 
         # Determine the actual reduction to attempt
         actual_reduction = resolve_reduction(reduction, reserve, attack_cost)
@@ -630,12 +641,53 @@ module Lich
         [:Shield, :@@shield_techniques, :shield],
       ].freeze
 
-      # Look up stamina cost for a CMan or Weapon technique
+      # === MSTRIKE ===
+
+      # MSTRIKE's stamina cost right now: free outside its recovery period
+      # (the Multi-Strike cooldown), else MSTRIKE_COST by kind and weapon
+      # speed. Not in the technique tables, so priced here.
+      #
+      # @param focused [Boolean] a focused (single target) strike, else open
+      # @return [Integer] Stamina cost
+      def self.mstrike_cost(focused: false)
+        return 0 unless mstrike_recovering?
+
+        cost = MSTRIKE_COST.fetch(focused ? :focused : :open)
+        cost[:base] + cost[:per_speed] * mstrike_weapon_speed
+      end
+
+      # Is MSTRIKE in its recovery period (its cooldown active)?
+      #
+      # @return [Boolean]
+      def self.mstrike_recovering?
+        return false unless defined?(Effects::Cooldowns)
+
+        Effects::Cooldowns.active?(MSTRIKE_COOLDOWN)
+      end
+
+      # The weapon speed MSTRIKE's cost is priced on: the primary weapon's
+      # base speed, plus (offhand speed - 2, at least 0) for a second
+      # weapon; a shield or an empty hand adds nothing.
+      #
+      # @return [Integer]
+      def self.mstrike_weapon_speed
+        primary = ranged_weapon? ? GameObj.left_hand : GameObj.right_hand
+        offhand = ranged_weapon? ? GameObj.right_hand : GameObj.left_hand
+        speed = weapon_speed_for(primary)[:base_rt]
+        off = weapon_speed_for(offhand)[:base_rt]
+        speed += [off - 2, 0].max if off.positive?
+        speed
+      end
+
+      # Look up stamina cost for a CMan or Weapon technique, or for MSTRIKE
+      # ("mstrike" is an open strike, "mstrike_focused" / "focused_mstrike"
+      # a focused one)
       #
       # @param name [String, Symbol] Attack name
       # @return [Integer] Stamina cost, or 0 if not found
       def self.lookup_attack_cost(name)
         name = name.to_s.downcase.gsub(/[\s-]+/, '_')
+        return mstrike_cost(focused: name.include?('focus')) if name =~ /\Amstrike(?:_|\z)|_mstrike\z/
 
         # Handle explicit type prefixes for disambiguation
         TECHNIQUE_MODULES.each do |_, _, type|

--- a/spec/lib/gemstone/psms/qstrike_spec.rb
+++ b/spec/lib/gemstone/psms/qstrike_spec.rb
@@ -226,6 +226,48 @@ describe Lich::Gemstone::QStrike do
     end
   end
 
+  describe ".mstrike_cost" do
+    def cooldown(active)
+      XMLData.save_dialogs("Cooldowns", active ? { "Multi-Strike" => Time.now.to_f + 60 } : {})
+    end
+
+    after { cooldown(false) }
+
+    it "is free outside the recovery period" do
+      GameObj.set_right_hand(MockGameObj.new(id: 1, noun: "broadsword", name: "a steel broadsword"))
+      expect(Lich::Gemstone::QStrike.mstrike_cost).to eq(0)
+      expect(Lich::Gemstone::QStrike.mstrike_cost(focused: true)).to eq(0)
+    end
+
+    it "prices open and focused strikes on the weapon speed during recovery" do
+      cooldown(true)
+      GameObj.set_right_hand(MockGameObj.new(id: 1, noun: "broadsword", name: "a steel broadsword")) # speed 5
+      expect(Lich::Gemstone::QStrike.mstrike_cost).to eq(35)                 # 20 + 3 * 5
+      expect(Lich::Gemstone::QStrike.mstrike_cost(focused: true)).to eq(50)  # 30 + 4 * 5
+    end
+
+    it "adds an offhand weapon's speed less two, never a shield or a dagger" do
+      cooldown(true)
+      GameObj.set_right_hand(MockGameObj.new(id: 1, noun: "broadsword", name: "a steel broadsword")) # 5
+      GameObj.set_left_hand(MockGameObj.new(id: 2, noun: "broadsword", name: "a steel broadsword"))  # 5 - 2 = 3
+      expect(Lich::Gemstone::QStrike.mstrike_weapon_speed).to eq(8)
+      expect(Lich::Gemstone::QStrike.mstrike_cost).to eq(44)
+      GameObj.set_left_hand(MockGameObj.new(id: 2, noun: "dagger", name: "a steel dagger")) # 1 - 2 < 0
+      expect(Lich::Gemstone::QStrike.mstrike_weapon_speed).to eq(5)
+      GameObj.set_left_hand(MockGameObj.new(id: 2, noun: "buckler", name: "a small buckler"))
+      expect(Lich::Gemstone::QStrike.mstrike_weapon_speed).to eq(5)
+    end
+
+    it "is what lookup_attack_cost and calculate price mstrike at" do
+      cooldown(true)
+      GameObj.set_right_hand(MockGameObj.new(id: 1, noun: "broadsword", name: "a steel broadsword"))
+      expect(Lich::Gemstone::QStrike.lookup_attack_cost("mstrike")).to eq(35)
+      expect(Lich::Gemstone::QStrike.lookup_attack_cost(:mstrike_focused)).to eq(50)
+      expect(Lich::Gemstone::QStrike.lookup_attack_cost("focused mstrike")).to eq(50)
+      expect(Lich::Gemstone::QStrike.calculate(attack_name: :mstrike_focused)[:attack_cost]).to eq(50)
+    end
+  end
+
   describe ".cost_per_second_reduction" do
     it "calculates correctly for sword + shield (10 + primary + 0)" do
       sword = MockGameObj.new(id: 1, noun: "broadsword", name: "a steel broadsword")


### PR DESCRIPTION
## Summary
`QStrike` prices a reduction from stamina minus a reserve minus the attack's own cost, but MSTRIKE is not in the CMan/Weapon/Shield tables, so `lookup_attack_cost('mstrike')` returned 0 and the "affordable" seconds ignored what the strike itself costs.

Per [Multi Opponent Combat/Multistrike](https://gswiki.play.net/Multi_Opponent_Combat/Multistrike): MSTRIKE costs nothing outside its recovery period; during it, `20 + 3 * weapon speed` for an open strike and `30 + 4 * weapon speed` for a focused one, where a second weapon adds `(its speed - 2, at least 0)`.

- `QStrike.mstrike_cost(focused:)` prices it from the Multi-Strike cooldown and the hands' base speeds (`weapon_speed_for`, already there); a shield or empty offhand adds nothing.
- `lookup_attack_cost` answers `mstrike` (open) and `mstrike_focused` / `focused mstrike`, so `calculate(attack_name: :mstrike_focused)` is correct.
- `use(attack: 'mstrike', target: x)` prices the strike as focused.

Consumer: eohunter's Mstrike action asks `QStrike.calculate` for the seconds and arms with `qstrike -N`.

## Test plan
- [x] New examples in `qstrike_spec.rb`: free outside recovery; 35/50 for a broadsword during recovery; a second broadsword adds 3 speed, a dagger or buckler adds none; `lookup_attack_cost` and `calculate` price both kinds.
- [x] `bundle exec rspec spec/lib/gemstone/psms/qstrike_spec.rb` (62 examples), `rubocop` on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)