### PR TITLE
fix(gs): combat module - a stand-up message later in the chunk outranks an earlier knockdown crit

### DIFF
--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -570,14 +570,15 @@ module Lich
                   if status_result.is_a?(Hash)
                     seq = status_flare_seq.call(line_target[:id])
                     apply_status_to_target(status_result[:status], line_target[:name], line_target[:id], status_result[:action],
-                                           flare_seq: seq, event: status_event_for.call(line_target[:id], seq))
+                                           flare_seq: seq, event: status_event_for.call(line_target[:id], seq), line: index)
                   else
                     # Legacy format - status_result is just the status symbol
-                    apply_status_to_target(status_result, line_target[:name], line_target[:id], :add)
+                    apply_status_to_target(status_result, line_target[:name], line_target[:id], :add, line: index)
                   end
                 elsif status_result.is_a?(Hash) && status_result[:target]
                   # Fallback to name-based lookup only if no ID available
-                  apply_status_to_target(status_result[:status], status_result[:target], nil, status_result[:action])
+                  apply_status_to_target(status_result[:status], status_result[:target], nil, status_result[:action],
+                                         line: index)
                 elsif status_result.is_a?(Hash) && !line.match?(/\A\s*Your?\b/) &&
                       (subject = (current_target && current_target[:id] ? current_target : nil) ||
                                  (flare_ctx && flare_ctx[:target_info]))
@@ -594,7 +595,7 @@ module Lich
                   seq = status_flare_seq.call(subject[:id])
                   apply_status_to_target(status_result[:status], subject[:name],
                                          subject[:id], status_result[:action],
-                                         flare_seq: seq, event: status_event_for.call(subject[:id], seq))
+                                         flare_seq: seq, event: status_event_for.call(subject[:id], seq), line: index)
                 elsif status_result.is_a?(Hash) && line.match?(/\A\s*Your?\b/)
                   # 2p: the status is OURS ("You are stunned!"). Never a
                   # creature application - but it IS a fact (inbound
@@ -1495,6 +1496,11 @@ module Lich
                         victim = flare_ctx ? flare_ctx[:target_info] : (sink[:target_info] || sink[:target])
                         chunk_deaths << victim[:id] if victim && victim[:id]
                       end
+                      # Where the crit TEXT sits in the chunk. Crit statuses
+                      # are applied after the whole chunk is parsed, so this
+                      # is the only record of where the crit stood relative
+                      # to the messages around it (see position_recovered?).
+                      hit[:_crit_line] = next_line_index
                       respond "[Combat] Found critical hit: #{c[:location]} rank #{c[:wound_rank]}" if Tracker.debug?(:verbose)
                       break # Only take first crit found after this damage
                     end
@@ -1752,12 +1758,25 @@ module Lich
         # pass can leave them alone. Per chunk: cleared at the top of
         # parse_events, before this chunk's messages are read.
 
+        # The recovery records WHERE in the chunk the stand-up was read, not
+        # merely that one happened. A bare flag cannot answer the question the
+        # crit pass actually asks - "did the creature stand up after THIS
+        # crit?" - so a second, genuine knockdown crit landing later in the
+        # same chunk was suppressed by an earlier stand-up.
+        #
         # @param id [Integer, String, nil] the creature a message stood up
-        def note_position_recovery(id)
+        # @param line [Integer, nil] index of the stand-up line in this chunk
+        def note_position_recovery(id, line)
           return unless id
 
           @position_recovered ||= {}
-          @position_recovered[id.to_i] = true
+          # A caller that cannot say WHERE the recovery was read still asserts
+          # that one happened. Infinity keeps that meaning "after every crit",
+          # the safe reading: never re-prone a creature the game stood up.
+          at = line.nil? ? Float::INFINITY : line
+          # Keep the LATEST recovery: it is the one a crit must beat.
+          prev = @position_recovered[id.to_i]
+          @position_recovered[id.to_i] = at if prev.nil? || at >= prev
         end
 
         # A later knockdown MESSAGE outranks the recovery: the crit pass may
@@ -1770,11 +1789,19 @@ module Lich
         end
 
         # @param id [Integer, String, nil]
-        # @return [Boolean] a message in this chunk already stood the creature up
-        def position_recovered?(id)
+        # @param crit_line [Integer, nil] line the crit text sat on, when known
+        # @return [Boolean] a message stood the creature up AFTER this crit
+        def position_recovered?(id, crit_line = nil)
           return false unless id && @position_recovered
 
-          @position_recovered.key?(id.to_i)
+          recovered_at = @position_recovered[id.to_i]
+          return false if recovered_at.nil?
+          # No line on the crit: fall back to the old chunk-wide answer rather
+          # than silently re-proning a creature the game stood up.
+          return true if crit_line.nil?
+
+          # Only a stand-up read AFTER the crit outranks it.
+          recovered_at > crit_line
         end
 
         def watch_for_death(id)
@@ -1967,7 +1994,7 @@ module Lich
             event[:hits].each do |hit|
               crit = hit[:crit] or next
 
-              apply_hit_crit_statuses(creature, crit, event, at)
+              apply_hit_crit_statuses(creature, crit, event, at, crit_line: hit[:_crit_line])
             end
           end
 
@@ -1984,7 +2011,8 @@ module Lich
             (flare[:hits] || []).each do |hit|
               crit = hit[:crit] or next
 
-              apply_hit_crit_statuses(f_creature, crit, event, at, flare: flare[:name])
+              apply_hit_crit_statuses(f_creature, crit, event, at, flare: flare[:name],
+                                                                   crit_line: hit[:_crit_line])
             end
           end
         end
@@ -1992,7 +2020,7 @@ module Lich
         # Apply one crit's status effects (stun/roundtime/position/silence/...)
         # to a creature. Shared by direct-hit and flare-hit crits so both paths
         # stay identical; `flare` tags the observer/debug provenance.
-        def apply_hit_crit_statuses(creature, crit, event, at, flare: nil)
+        def apply_hit_crit_statuses(creature, crit, event, at, flare: nil, crit_line: nil)
           if crit[:stunned].to_i > 0
             # The boolean stays owned by <crtrStatus>/messaging; this records
             # the table-derived duration estimate beside it.
@@ -2019,7 +2047,7 @@ module Lich
           # is up. Messages apply during the parse and crits during persist,
           # so without this the EARLIER knockdown would overwrite the LATER
           # stand-up and latch the creature prone.
-          if (pos = crit[:position]) && !position_recovered?(creature.id)
+          if (pos = crit[:position]) && !position_recovered?(creature.id, crit_line)
             # Tables report "PRONE"/"KNEELING"/"SITTING"; the status
             # canon (messaging, <crtrStatus>, consumers) is lowercase.
             # add_status canonicalizes too, but the observer payload
@@ -2087,8 +2115,9 @@ module Lich
         # Apply status effect directly to a creature (outside combat events)
         # flare_seq / event: which flare (1-based position) of which parse
         # event the status rode on; process() turns the event ref into an
-        # :attack_uid for the recorder.
-        def apply_status_to_target(status, target_name_or_id, target_id = nil, action = :add, flare_seq: nil, event: nil)
+        # :attack_uid for the recorder. line: where the status message sat in
+        # the chunk, so a later knockdown crit can outrank an earlier stand-up.
+        def apply_status_to_target(status, target_name_or_id, target_id = nil, action = :add, flare_seq: nil, event: nil, line: nil)
           # Handle both name lookup and direct ID
           if target_id
             creature = Creature[target_id.to_i]
@@ -2117,7 +2146,8 @@ module Lich
                 # would be re-proned by that later pass, because the crit is
                 # earlier in the chunk but applied last. Note the recovery so
                 # the crit pass leaves it standing (see apply_hit_crit_statuses).
-                note_position_recovery(creature.id)
+                # The line is what lets a LATER knockdown crit still win.
+                note_position_recovery(creature.id, line)
               else
                 creature.remove_status(status)
               end

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -298,6 +298,9 @@ module Lich
 
         # State machine parser
         def parse_events(lines)
+          # Position recoveries are per chunk: a stand-up here must not
+          # suppress a knockdown crit in the NEXT chunk.
+          @position_recovered = nil
           events = []
           # Identity-guarded push: an event RESUMED after an inbound
           # interruption (see interrupted_own) was already saved once.
@@ -1740,6 +1743,40 @@ module Lich
         # nobody - so watching longer only fixes killed_at. Bounded FIFO.
         DEATH_WATCH_MAX = 256
 
+        # --- position recovery within one chunk ---------------------------
+        # Message statuses mutate the creature while the chunk is parsed;
+        # crit-derived statuses mutate it afterwards, in persist_event. So a
+        # knockdown crit is applied AFTER a stand-up message that came later
+        # in the same chunk, and would re-prone a creature the game just said
+        # got up. These note which creatures a message stood up, so the crit
+        # pass can leave them alone. Per chunk: cleared at the top of
+        # parse_events, before this chunk's messages are read.
+
+        # @param id [Integer, String, nil] the creature a message stood up
+        def note_position_recovery(id)
+          return unless id
+
+          @position_recovered ||= {}
+          @position_recovered[id.to_i] = true
+        end
+
+        # A later knockdown MESSAGE outranks the recovery: the crit pass may
+        # act again.
+        # @param id [Integer, String, nil]
+        def clear_position_recovery(id)
+          return unless id
+
+          @position_recovered&.delete(id.to_i)
+        end
+
+        # @param id [Integer, String, nil]
+        # @return [Boolean] a message in this chunk already stood the creature up
+        def position_recovered?(id)
+          return false unless id && @position_recovered
+
+          @position_recovered.key?(id.to_i)
+        end
+
         def watch_for_death(id)
           return unless id
 
@@ -1978,7 +2015,11 @@ module Lich
           # Position changes carry better provenance than the messaging
           # equivalents: /It is knocked to the ground!/ has no target
           # capture, while this crit is already bound to a creature id.
-          if (pos = crit[:position])
+          # A recovery message later in this chunk already said the creature
+          # is up. Messages apply during the parse and crits during persist,
+          # so without this the EARLIER knockdown would overwrite the LATER
+          # stand-up and latch the creature prone.
+          if (pos = crit[:position]) && !position_recovered?(creature.id)
             # Tables report "PRONE"/"KNEELING"/"SITTING"; the status
             # canon (messaging, <crtrStatus>, consumers) is lowercase.
             # add_status canonicalizes too, but the observer payload
@@ -2070,6 +2111,13 @@ module Lich
               # one the pattern happened to name.
               if POSITION_STATUSES.include?(status.to_s)
                 POSITION_STATUSES.each { |s| creature.remove_status(s) }
+                # Message statuses apply HERE, during the parse; crit-derived
+                # statuses apply later, in persist_event. A creature knocked
+                # down by a crit and standing up afterwards in the same chunk
+                # would be re-proned by that later pass, because the crit is
+                # earlier in the chunk but applied last. Note the recovery so
+                # the crit pass leaves it standing (see apply_hit_crit_statuses).
+                note_position_recovery(creature.id)
               else
                 creature.remove_status(status)
               end
@@ -2079,6 +2127,10 @@ module Lich
               # sitting is prone, not both.
               if POSITION_STATUSES.include?(status.to_s)
                 (POSITION_STATUSES - [status.to_s]).each { |s| creature.remove_status(s) }
+                # A later knockdown MESSAGE outranks an earlier recovery, so
+                # the crit pass is free to act again (stood up, then knocked
+                # down again inside one chunk).
+                clear_position_recovery(creature.id)
               end
               creature.add_status(status)
               respond "[Combat] Applied status #{status} to #{creature.name} (#{creature.id})" if Tracker.debug?(:verbose)

--- a/spec/lib/gemstone/combat/status_order_spec.rb
+++ b/spec/lib/gemstone/combat/status_order_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require 'gemstone/combat/parser'
+require 'gemstone/combat/processor'
+
+# Message statuses are applied while the chunk is being PARSED; crit-derived
+# statuses are applied later, in persist_event. A creature knocked down by a
+# crit and then standing up in the same chunk was therefore left prone: the
+# stand-up removed the position during parsing, and the earlier knockdown
+# re-applied it afterwards. State must end where the LAST message in the
+# chunk left it.
+RSpec.describe Lich::Gemstone::Combat::Processor do
+  let(:creature) do
+    Class.new do
+      attr_reader :id, :name, :noun, :statuses
+
+      def initialize
+        @id = 777
+        @name = 'a cave lizard'
+        @noun = 'lizard'
+        @statuses = []
+      end
+
+      def add_status(status, _value = nil) = @statuses |= [status.to_s]
+      def remove_status(status) = @statuses.delete(status.to_s)
+      def has_status?(status) = @statuses.include?(status.to_s)
+      def add_damage(_amount); end
+      def add_injury(_part, _rank); end
+      def injuries = {}
+      def add_stun_estimate(_rounds, at: nil); end
+      def dead? = false
+      def crtr_flag?(_flag) = false
+      def prone? = has_status?('prone')
+    end.new
+  end
+
+  before do
+    stub_const('Lich::Gemstone::Combat::Tracker', Module.new)
+    allow(Lich::Gemstone::Combat::Tracker).to receive(:settings).and_return(
+      track_statuses: true, track_ucs: false, emit_attacks: false,
+      track_damage: true, track_wounds: true
+    )
+    allow(Lich::Gemstone::Combat::Tracker).to receive(:debug?).and_return(false)
+    stub_const('Lich::Gemstone::Combat::Observers', Module.new)
+    allow(Lich::Gemstone::Combat::Observers).to receive(:emit)
+    allow(Lich::Gemstone::Combat::Observers).to receive(:any_for?).and_return(false)
+    subject_creature = creature
+    registry = Class.new do
+      define_singleton_method(:[]) { |_id| subject_creature }
+      define_singleton_method(:all) { [subject_creature] }
+    end
+    stub_const('Lich::Gemstone::Combat::Creature', registry)
+    %i[@death_watch @death_announced @held_cast @held_pre_flares @deferred_emits].each do |iv|
+      described_class.instance_variable_set(iv, nil)
+    end
+  end
+
+  def bolded(id, noun, name)
+    %(<pushBold/><a exist="#{id}" noun="#{noun}">#{name}</a><popBold/>)
+  end
+
+  it 'leaves a creature that stood up after a knockdown crit standing' do
+    lizard = bolded(777, 'lizard', 'a cave lizard')
+    chunk = [
+      "You swing a broadsword at #{lizard}!",
+      '  AS: +300 vs DS: +100 with AvD: +30 + d100 roll: +50 = +280',
+      '   ... and hit for 40 points of damage!',
+      '   Hit on the leg chars the skin and eats into the underlying muscles.',
+      "#{lizard} stands up.",
+      '<prompt time="100">&gt;</prompt>'
+    ]
+    events = described_class.parse_events(chunk)
+    events.each { |event| described_class.persist_event(event) }
+
+    expect(creature.statuses).not_to include('prone'),
+                                     'the earlier knockdown was re-applied over the later stand-up'
+  end
+
+  it 'lets a knockdown message after the stand-up win, being later still' do
+    lizard = bolded(777, 'lizard', 'a cave lizard')
+    chunk = [
+      "You swing a broadsword at #{lizard}!",
+      '  AS: +300 vs DS: +100 with AvD: +30 + d100 roll: +50 = +280',
+      '   ... and hit for 40 points of damage!',
+      '   Hit on the leg chars the skin and eats into the underlying muscles.',
+      "#{lizard} stands up.",
+      "#{lizard} is knocked to the ground!",
+      '<prompt time="100">&gt;</prompt>'
+    ]
+    events = described_class.parse_events(chunk)
+    events.each { |event| described_class.persist_event(event) }
+
+    expect(creature.statuses).to include('prone')
+  end
+
+  it 'does not carry a recovery into the next chunk' do
+    lizard = bolded(777, 'lizard', 'a cave lizard')
+    described_class.parse_events(["#{lizard} stands up.", '<prompt time="100">&gt;</prompt>'])
+    chunk = [
+      "You swing a broadsword at #{lizard}!",
+      '  AS: +300 vs DS: +100 with AvD: +30 + d100 roll: +50 = +280',
+      '   ... and hit for 40 points of damage!',
+      '   Hit on the leg chars the skin and eats into the underlying muscles.',
+      '<prompt time="200">&gt;</prompt>'
+    ]
+    events = described_class.parse_events(chunk)
+    events.each { |event| described_class.persist_event(event) }
+
+    expect(creature.statuses).to include('prone')
+  end
+
+  it 'still applies a knockdown crit when nothing later reverses it' do
+    lizard = bolded(777, 'lizard', 'a cave lizard')
+    chunk = [
+      "You swing a broadsword at #{lizard}!",
+      '  AS: +300 vs DS: +100 with AvD: +30 + d100 roll: +50 = +280',
+      '   ... and hit for 40 points of damage!',
+      '   Hit on the leg chars the skin and eats into the underlying muscles.',
+      '<prompt time="100">&gt;</prompt>'
+    ]
+    events = described_class.parse_events(chunk)
+    events.each { |event| described_class.persist_event(event) }
+
+    expect(creature.statuses).to include('prone')
+  end
+end

--- a/spec/lib/gemstone/combat/status_order_spec.rb
+++ b/spec/lib/gemstone/combat/status_order_spec.rb
@@ -110,6 +110,31 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
     expect(creature.statuses).to include('prone')
   end
 
+  # A single per-chunk flag could not tell a crit that came BEFORE the
+  # stand-up from one that came after it, so a second genuine knockdown was
+  # dropped - the mirror image of the bug above. Ordering is compared by
+  # line, so each crit is judged against where the recovery actually sat.
+  it 'lets a knockdown crit after the stand-up win, being later still' do
+    lizard = bolded(777, 'lizard', 'a cave lizard')
+    chunk = [
+      "You swing a broadsword at #{lizard}!",
+      '  AS: +300 vs DS: +100 with AvD: +30 + d100 roll: +50 = +280',
+      '   ... and hit for 40 points of damage!',
+      '   Hit on the leg chars the skin and eats into the underlying muscles.',
+      "#{lizard} stands up.",
+      "You swing a broadsword at #{lizard}!",
+      '  AS: +300 vs DS: +100 with AvD: +30 + d100 roll: +50 = +280',
+      '   ... and hit for 40 points of damage!',
+      '   Hit on the leg chars the skin and eats into the underlying muscles.',
+      '<prompt time="100">&gt;</prompt>'
+    ]
+    events = described_class.parse_events(chunk)
+    events.each { |event| described_class.persist_event(event) }
+
+    expect(creature.statuses).to include('prone'),
+                                 'the later knockdown crit was suppressed by the earlier stand-up'
+  end
+
   it 'still applies a knockdown crit when nothing later reverses it' do
     lizard = bolded(777, 'lizard', 'a cave lizard')
     chunk = [


### PR DESCRIPTION
## Summary
Message statuses are applied while a chunk is parsed (`apply_status_to_target`), but crit-derived statuses are applied afterwards, in `persist_event`. So a creature knocked down by a crit and then standing up in the same chunk was left prone in the registry: the parse removed the position on "stands up.", then persistence re-applied the earlier knockdown. Found in the combined review of the open combat PRs; the behaviour is in the module as released, so it gets its own PR.

- A message that clears a position now notes the recovery for the chunk (`note_position_recovery`), and the crit pass leaves that creature's position alone.
- A later knockdown *message* clears the note, so the last message in the chunk wins either way.
- The note is per chunk, reset at the top of `parse_events`; a stand-up in one chunk never suppresses a knockdown crit in the next.

## Test plan
- [x] New `spec/lib/gemstone/combat/status_order_spec.rb`: knockdown crit then "stands up." leaves the creature standing (fails on main, passes here); knockdown, stand-up, knocked down again ends prone; a recovery does not carry into the next chunk; a knockdown with nothing later still applies.
- [x] `bundle exec rspec spec/lib/gemstone/combat` (249 examples), `rubocop` on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)