### PR TITLE
fix(all): setup_files uses content hash for cache freshness (#1596)

### DIFF
--- a/lib/common/setup_files.rb
+++ b/lib/common/setup_files.rb
@@ -8,12 +8,13 @@
   - Base YAML files (base.yaml, base-empty.yaml)
   - Character-specific YAML files ({character}-setup.yaml)
   - Include files with recursive resolution and circular dependency protection
-  - Automatic caching with modification-time checking
+  - Automatic caching with content-hash freshness checking
   - Deep-clone protection against in-memory mutation
 
   @see https://elanthipedia.play.net/Lich_script_development#dependency
 =end
 
+require 'digest'
 require 'monitor'
 require 'ostruct'
 require 'set' # rubocop:disable Lint/RedundantRequireStatement -- needed for Ruby < 3.2
@@ -27,13 +28,14 @@ module Lich
       include MonitorMixin
 
       class FileInfo
-        attr_reader :path, :name, :mtime
+        attr_reader :path, :name, :mtime, :digest
 
-        def initialize(path:, name:, data:, mtime:)
+        def initialize(path:, name:, data:, mtime:, digest: nil)
           @path = path
           @name = name
           @data = data
           @mtime = mtime
+          @digest = digest
         end
 
         # Deep clone of data to prevent scripts from mutating cached settings.
@@ -51,7 +53,7 @@ module Lich
         end
 
         def inspect
-          "#<SetupFiles::FileInfo @name=#{@name}, @path=#{@path}, @mtime=#{@mtime}>"
+          "#<SetupFiles::FileInfo @name=#{@name}, @path=#{@path}, @mtime=#{@mtime}, @digest=#{@digest}>"
         end
       end
 
@@ -254,26 +256,47 @@ module Lich
           end
 
           current_files.each do |filename, filepath|
-            last_modified_date = File.mtime(filepath)
+            # Freshness is decided by file content (SHA256), not mtime. mtime is
+            # unreliable: two writes within one filesystem timestamp tick share
+            # an mtime, so an mtime-only check serves stale data after a fast
+            # rewrite (see issue #1596). We also reload when the winning source
+            # path changes (e.g. a scripts/data/custom override is removed and
+            # the same basename now resolves to scripts/data), which an
+            # mtime-only check masks when the two files share an mtime.
+            current_digest = file_digest(filepath)
             cached_file = cache_get_by_filename(filename)
-            safe_log "#{self.class}::#{__callee__} filepath=#{filepath}, last_modified_date=#{last_modified_date}, cached_file=#{cached_file.inspect}" if @debug
-            if cached_file.nil? || cached_file.mtime != last_modified_date
-              cache_put_by_filepath(filepath)
+            safe_log "#{self.class}::#{__callee__} filepath=#{filepath}, current_digest=#{current_digest}, cached_file=#{cached_file.inspect}" if @debug
+            if cached_file.nil? ||
+               cached_file.path != File.dirname(filepath) ||
+               cached_file.digest != current_digest
+              cache_put_by_filepath(filepath, digest: current_digest)
             end
           end
         end
       end
 
-      def cache_put_by_filepath(filepath)
+      def cache_put_by_filepath(filepath, digest: nil)
         synchronize do
           safe_log "#{self.class}::#{__callee__} filepath=#{filepath}" if @debug
           @files_cache[File.basename(filepath)] = FileInfo.new(
             path: File.dirname(filepath),
             name: File.basename(filepath),
             mtime: File.mtime(filepath),
+            digest: digest || file_digest(filepath),
             data: safe_load_yaml(filepath)
           )
         end
+      end
+
+      # Content hash used as the cache freshness signal. Returns nil when the
+      # file cannot be read (e.g. it vanished between the glob and here); a nil
+      # digest never equals a stored digest, so the entry is treated as changed
+      # and reloaded on the next pass.
+      def file_digest(filepath)
+        Digest::SHA256.file(filepath).hexdigest
+      rescue => e
+        safe_log "#{self.class}::#{__callee__} could not hash #{filepath}: #{e.message}" if @debug
+        nil
       end
 
       def cache_get_by_filename(filename)

--- a/spec/lib/common/setup_files_spec.rb
+++ b/spec/lib/common/setup_files_spec.rb
@@ -122,6 +122,48 @@ RSpec.describe Lich::Common::SetupFiles do
     end
   end
 
+  # Regression coverage for issue #1596: the cache must key freshness on file
+  # content, not mtime. These specs pin File.mtime to a single frozen value so
+  # every write shares an mtime -- the exact same-tick collision that occurs on
+  # coarse-granularity filesystems (Windows, some CI mounts). They fail against
+  # the old mtime-only cache and pass with content-hash freshness, and they do
+  # not depend on the host filesystem's timestamp resolution or on sleeps.
+  describe 'cache freshness (filesystem-timing-independent)' do
+    before { allow(File).to receive(:mtime).and_return(Time.now) }
+
+    it 'reloads a rewritten data file whose mtime did not change' do
+      data_file = File.join(data_dir, 'base-spells.yaml')
+      File.write(data_file, { spell_data: { 'Shield' => { 'mana' => 3 } } }.to_yaml)
+      expect(setup_files.get_data('spells').spell_data).to eq({ 'Shield' => { 'mana' => 3 } })
+
+      File.write(data_file, { spell_data: { 'Shield' => { 'mana' => 7 } } }.to_yaml)
+      setup_files.reload
+      expect(setup_files.get_data('spells').spell_data).to eq({ 'Shield' => { 'mana' => 7 } })
+    end
+
+    it 'falls back to scripts/data after a same-mtime custom override is removed' do
+      FileUtils.mkdir_p(custom_data_dir)
+      File.write(File.join(data_dir, 'base-spells.yaml'), { spell_data: { 'Shield' => { 'mana' => 3 } } }.to_yaml)
+      custom_file = File.join(custom_data_dir, 'base-spells.yaml')
+      File.write(custom_file, { spell_data: { 'Shield' => { 'mana' => 99 } } }.to_yaml)
+      expect(setup_files.get_data('spells').spell_data).to eq({ 'Shield' => { 'mana' => 99 } })
+
+      File.delete(custom_file)
+      setup_files.reload
+      expect(setup_files.get_data('spells').spell_data).to eq({ 'Shield' => { 'mana' => 3 } })
+    end
+
+    it 'picks up a settings change when the profile mtime did not change' do
+      File.write(File.join(profiles_dir, 'base.yaml'), { version: 1 }.to_yaml)
+      File.write(File.join(profiles_dir, 'TestChar-setup.yaml'), {}.to_yaml)
+      expect(setup_files.get_settings.version).to eq(1)
+
+      File.write(File.join(profiles_dir, 'base.yaml'), { version: 2 }.to_yaml)
+      setup_files.reload
+      expect(setup_files.get_settings.version).to eq(2)
+    end
+  end
+
   describe '#reload' do
     before do
       File.write(File.join(profiles_dir, 'base.yaml'), { version: 1 }.to_yaml)
@@ -131,8 +173,6 @@ RSpec.describe Lich::Common::SetupFiles do
     it 'reloads changed files' do
       setup_files.get_settings
       File.write(File.join(profiles_dir, 'base.yaml'), { version: 2 }.to_yaml)
-      # Touch file to ensure mtime changes
-      FileUtils.touch(File.join(profiles_dir, 'base.yaml'), mtime: Time.now + 1)
       setup_files.reload
       result = setup_files.get_settings
       expect(result.version).to eq(2)


### PR DESCRIPTION
## Summary

Fixes #1596. `SetupFiles` decided cache freshness by comparing stored mtime against the file's current mtime. When two writes land within one filesystem timestamp tick — common on Windows and some CI mounts — the mtime is unchanged, so `get_data` / `get_settings` / `reload` serve the **previous** contents. This surfaces as intermittent, non-order-dependent `setup_files_spec.rb` failures on CI.

While tracing it I found a second, related manifestation: the `scripts/data/custom` → `scripts/data` fallback. The cache is keyed by basename, and after a custom override is deleted the reload compares the **base** file's mtime against the cached **custom** entry's mtime. If those two files share an mtime, the stale custom payload is served. This is the example that flakes most readily (`falls back to scripts/data after a custom file is removed`).

## Change

- Freshness is now keyed on a **SHA256 content digest** rather than mtime. Content is authoritative and independent of the filesystem clock.
- Additionally reload when the **winning source directory changes** (`cached.path != File.dirname(filepath)`), so a custom-override removal is never masked by a shared mtime.
- `mtime` is retained on `FileInfo` for debug/inspect output only.
- `file_digest` returns `nil` on read errors (file vanished between glob and hash), which never matches a stored digest, so the entry reloads — fail-safe.

Deleted-file eviction was already correct (glob-vs-disk) and is unchanged.

## Why not the other options from the issue

- `(mtime, size)` is cheap but silently misses same-size edits (e.g. flipping a boolean or swapping an equal-length value) — it wouldn't restore the correctness guarantee.
- "Full-precision mtime" is effectively a no-op: `File.mtime` already returns full-precision `Time`; the ceiling is the filesystem, not the stored value, so it does nothing on the ~1s-granularity filesystems that actually trigger this.

Content hashing is negligible for these tiny, infrequently-loaded YAML files.

## Tests

- New `cache freshness (filesystem-timing-independent)` block **pins `File.mtime` to a frozen value** to force the same-tick collision deterministically — no sleeps, no dependence on host timestamp resolution. Covers rewritten data file, custom-override removal, and profile settings change.
- Verified these fail against the pre-patch code and pass after it.
- Removed the `FileUtils.touch(..., mtime: Time.now + 1)` band-aid the existing `reloads changed files` spec needed — content hashing makes it unnecessary.
- Full file: 34 examples, 0 failures; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)