### PR TITLE
fix(gs): combat module - Rysk/Dreadt log audit: Holy Weapon release model, held maneuver rolls, AoE roll attribution, live defs

### DIFF
--- a/lib/gemstone/combat/defs/attacks.rb
+++ b/lib/gemstone/combat/defs/attacks.rb
@@ -154,6 +154,24 @@ module Lich
               /(?<attacker>.+?) springs upon (?<target>you|.+?) from behind and attempts to slit #{MK_PRE}(?:your|his|her|its)#{MK_POST} throat(?: with #{MK_PRE}(?:his|her|its)#{MK_POST} .+?)?!/
             ].freeze),
             AttackDef.new(:bearhug, [/(?<attacker>.+?) charges towards (?<target>you|.+?) and attempts to grasp #{MK_PRE}(?:you|him|her|it)#{MK_POST} in a ferocious bearhug!/].freeze),
+            # Mug (CMAN, rogues) - wiki: type Attack, "plunder your target's
+            # pockets as you distract them with an attack". The accost line
+            # OPENS the maneuver; the wrapped attack (any type, via
+            # CMAN MUG [attack] [target]) then resolves normally with its own
+            # AS/DS or UAF/UDF. The theft SMR prints AFTER that attack settles,
+            # followed by the pat-down announce, so the roll trails the swing
+            # it rode in on. Without a def both the accost and the theft roll
+            # orphaned into synthetic :unknown attacks (Rysk logs 2026-09-11:
+            # 71 accosts, 62 pat-downs, 62 orphaned SMR rolls).
+            # Theft outcomes: "In your hasty search, you don't find anything
+            # worth taking." / "You rifle his pockets and discover N silvers!"
+            # / "Your hasty search scatters the X's riches to the ground!"
+            # A creature that cannot be mugged prints "too wary" - per the
+            # wiki that is not a failure, the action is simply unavailable.
+            AttackDef.new(:mug, [
+              /You boldly accost (?<target>.+?), your attack masking your larcenous intent!/,
+              /Taking advantage of the scuffle, you roughly pat (?<target>.+?) down for hidden valuables!/
+            ].freeze),
             AttackDef.new(:charge, [
               /(?<attacker>.+?) rushes forward at (?<target>you|.+?) with #{MK_PRE}(?:his|her|its)#{MK_POST} .+? and attempts a charge!/,
               # 2p (logs/examples/weapon_charge.txt). The graded connect line
@@ -214,15 +232,42 @@ module Lich
             AttackDef.new(:shield_pin, [/You attempt to expose a vulnerability with a diversionary shield bash on (?<target>[^!]+)!/].freeze),
             AttackDef.new(:shield_push, [/You raise your (?<weapon>.+?) before you and attempt to push (?<target>.+?) away!/].freeze),
             AttackDef.new(:shield_strike, [/You launch a quick bash with your (?<weapon>.+?) at (?<target>[^!]+)!/].freeze),
-            AttackDef.new(:shield_charge, [/You raise your (?<weapon>.+?) before you and charge headlong towards (?<target>[^!]+)!/].freeze),
+            AttackDef.new(:shield_charge, [
+              /You raise your (?<weapon>.+?) before you and charge headlong towards (?<target>[^!]+)!/,
+              # Second 2p form (Dreadt log 2026-09-11: 15 occurrences, every
+              # one orphaning its SMR, damage and crits). Like :charge above,
+              # the graded connect line ("You lunge forward with an expert
+              # shield charge!") sits between the roll and the damage and is
+              # deliberately NOT a def - matching it would double-open the
+              # event. Ten grades observed (half-hearted..expert).
+              /You charge forward at (?<target>.+?) with your (?<weapon>.+?) and attempt a shield charge!/
+            ].freeze),
             # Assassinate (rogue): the uncoil line opens the event; the SMR
             # roll follows it directly, then the "carve into" hit line
             AttackDef.new(:eviscerate, [/You uncoil from the shadows, your (?<weapon>.+?) poised to eviscerate (?<target>[^!]+)!/].freeze),
             # Coup de Grace - messaging varies by weapon type; this is the
             # THW form, catalogue other weapon variants as they're observed
             AttackDef.new(:coup_de_grace, [/You lunge towards (?<target>.+?), intending to finish #{MK_PRE}(?:him|her|it)#{MK_POST} off!/].freeze),
-            # "dark wings" equipment proc (SMR attack); name pending
+            # Energy Wings (Dark), tier 1 offensive: Shadow Barb - a
+            # single-target SMR attack, disruption damage plus poison.
             AttackDef.new(:shadow_barb, [/Your umbrous wings twitch sharply, launching a barbed shard of shadow that hisses through the air toward (?<target>[^!]+)!/].freeze),
+            # Energy Wings (Dark), tier 2 offensive: Barbed Sweep - an AoE
+            # SMR attack over up to 5 targets. ONLY the per-target thrash
+            # line is the attack: it names its creature and is preceded by
+            # that creature's own SMR, so one row per target falls out of
+            # the normal switch path.
+            #
+            # The opener ("Your umbrous wings lash outward in a wide arc")
+            # is deliberately NOT matched. It carries no target, no roll and
+            # no damage, and including it double-counted the first creature:
+            # the opener adopted whichever target the first thrash line
+            # named, then that same thrash line fired as a second attack for
+            # the same creature - one row holding the roll, the next holding
+            # the damage (Rysk log 2026-09-11 7716). The cost is that a
+            # sweep which reaches nothing records nothing; it has no facts
+            # to record either way.
+            AttackDef.new(:barbed_sweep,
+                          [/The dark tendrils thrash across (?<target>.+?)'s#{MK_POST} skin in a devastating assault!/].freeze),
             # Whirlwind (THW AoE, single round - not a sequence). Known to
             # have ~4 message variants; two catalogued so far plus the
             # per-target strike line, all under one name.
@@ -388,7 +433,23 @@ module Lich
               # Ward-probe opener (CS/TD follows). "sneaking in an attack on
               # the magical wards" is the creature form of spell_thieve.
               /(?<attacker>.+?) hangs back for a moment and concentrates intently on (?<target>[^,]+), before sneaking in an attack/,
-              /(?<attacker>.+?) lifts a slender hand and points unerringly at (?<target>[^!]+)!/
+              /(?<attacker>.+?) lifts a slender hand and points unerringly at (?<target>[^!]+)!/,
+              # Round-8 inbound forms, mined the same way from the Rysk logs
+              # 2026-09-11: every one left its AS/DS roll, damage and crits
+              # orphaned. Treekin (root/sap/fist) and the Illoke jarl's
+              # CS/TD ward attack.
+              /(?<attacker>.+?) lashes a root out at (?<target>[^!]+)!/,
+              /(?<attacker>.+?) raises a large root and slams it down at (?<target>[^!]+)!/,
+              /(?<attacker>.+?) suddenly spits a gob of sap directly at (?<target>[^!]+)!/,
+              /(?<attacker>.+?) strikes out at (?<target>.+?) with all of #{MK_PRE}(?:his|her|its)#{MK_POST} might!/,
+              /(?<attacker>.+?) pounds at (?<target>.+?) with a leafy fist!/,
+              /(?<attacker>.+?) summons the wrath of #{MK_PRE}(?:his|her|its)#{MK_POST} god while pointing at (?<target>[^!]+)!/,
+              # Krolvin slaver subdue-and-kidnap (Dreadt log 2026-09-11 7280):
+              # one line - it bludgeons us "until your eyes glaze over" (the
+              # STUNNED indicator fires just before) and "drags you off into
+              # the dank hold", a room move. Its SMR PRECEDES the line,
+              # maneuver-style; the inbound held-roll exception claims it.
+              /(?<attacker>.+?) reaches outward, #{MK_PRE}(?:his|her|its)#{MK_POST} arm encircling (?<target>your) neck\./
             ].freeze),
             # ambush - "waylay" IS its own attack line (it names a target).
             # The bare "leaps from hiding" form is NOT here: it is a
@@ -480,7 +541,29 @@ module Lich
               /Blood weeps from (?<target>.+?)'s#{MK_POST} open .+? wound\./,
               /(?<target>.+?)'s#{MK_POST} .+? drips as #{MK_PRE}(?:he|she|it)#{MK_POST} continues to bleed\./,
               /Trickles of blood course from (?<target>.+?)'s#{MK_POST} .+?\./,
-              /(?<target>Your) .+? drips as you continue to bleed\./
+              /(?<target>Your) .+? drips as you continue to bleed\./,
+              # Further wound-tick phrasings (Rysk logs 2026-09-11; every
+              # occurrence carried a damage line, and all 14 orphaned).
+              /(?<target>.+?)'s#{MK_POST} wounded .+? oozes fresh blood\./,
+              /Fresh blood drips down (?<target>.+?)'s#{MK_POST} .+?\./,
+              /Blood continues to stream from (?<target>.+?)'s#{MK_POST} wounded .+?\./
+            ].freeze),
+            # Poison ticks from the weapon_poison flare (defs/flares.rb).
+            # Unlike :bleed these DO have an owner - our own envenomed
+            # weapon put them there - but the tick line itself names no
+            # weapon, so ownership is resolved the same way as the other
+            # ticks: unowned unless our cast is visible in the blob.
+            #
+            # Seven phrasings, all from the Rysk logs 2026-09-11, all
+            # carrying a damage line, all previously orphaned (24 hits).
+            AttackDef.new(:poison_tick, [
+              /Shuddering and twitching, (?<target>.+?) suffers visibly from the poison afflicting #{MK_PRE}(?:him|her|it)#{MK_POST}\./,
+              /A spasm of pain overtakes (?<target>.+?)\./,
+              /(?<target>.+?) is a study of agonized misery, #{MK_PRE}(?:his|her|its)#{MK_POST} every movement a torment\./,
+              /(?<target>.+?) sweats copiously and groans in pain\./,
+              /(?<target>.+?) wheezes out an agonized breath\./,
+              /(?<target>.+?) curls in on #{MK_PRE}(?:himself|herself|itself)#{MK_POST}, rigid with tension\./,
+              /(?<target>.+?) wavers with infirmity and pales slightly\./
             ].freeze),
             # Rot tick (a nearby player's curse on a creature; hunt log
             # 2026-09-07 23:36). Unowned like bleed.
@@ -562,22 +645,71 @@ module Lich
             /\AYou leap from hiding to (?:attack|strike)!/,
             /\AYou quickly leap from hiding to deliver your attack!/,
             /\AYou step from hiding and attack!/,
+            # Waylay (rogue CMAN) - weights damage rather than crits. Same
+            # prefix grammar: the swing that follows carries the target and
+            # the AS/DS roll (Rysk logs 2026-09-11: 44 waylays, every one
+            # followed by "You swing ... at <creature>!").
+            /\AYou step out of hiding to waylay /,
             # 3p, same grammar with an attacker
             /\A(?<attacker>.+?) leaps from hiding to (?:attack|strike)!/
           ].freeze
 
           AMBUSH_GATE, AMBUSH_ALWAYS_SCAN = PatternGate.build(AMBUSH_PREFIXES)
 
-          # True when the line is an ambush prefix; returns the attacker
+          # Which maneuver each prefix names, by its index in AMBUSH_PREFIXES.
+          # The bonuses differ - waylay weights damage, the bare hiding forms
+          # weight crits - so the kind is recorded alongside the ambush flag
+          # (attacks.attack_kind) to let the two be compared. Kept as a
+          # separate map so AMBUSH_PREFIXES stays the flat list PatternGate
+          # builds its gate from. Indices must track the list above.
+          AMBUSH_KINDS = %i[ambush ambush ambush waylay ambush].freeze
+          raise 'AMBUSH_KINDS must name every AMBUSH_PREFIXES entry' unless
+            AMBUSH_KINDS.length == AMBUSH_PREFIXES.length
+
+          # REACTION PREFIXES - same prefix grammar as the ambush forms, but
+          # the attack is triggered by a defensive event rather than made
+          # from hiding, so it sets attack_kind WITHOUT setting `ambush`.
+          #
+          # Reverse Strike (Two-Handed Weapons technique, 50 ranks): a parry
+          # offers it ("You could use this opportunity to Reverse Strike!"),
+          # and THIS line is the confirmation that it was taken - the offer
+          # fires whether or not the player uses it, so only the confirmation
+          # may tag an attack. The swing that follows is byte-identical to a
+          # normal swing and carries the target and the roll, so this line is
+          # the only thing distinguishing the attack (Rysk log 2026-09-11).
+          #
+          # Cannot co-occur with an ambush: a reverse strike requires a parry,
+          # which means engaged and visible. That is why one attack_kind
+          # column suffices rather than a per-family flag.
+          REACTION_PREFIXES = [
+            [/\ASpotting an opening in .+? defenses, you quickly reverse the direction of your .+? and strike from a different angle!/,
+             :reverse_strike]
+          ].freeze
+
+          REACTION_GATE, REACTION_ALWAYS_SCAN =
+            PatternGate.build(REACTION_PREFIXES.map(&:first))
+
+          # True when the line is an ambush or reaction prefix; returns the
+          # maneuver kind, whether it was made from hiding, and the attacker
           # capture when the 3p form carries one.
           def self.ambush_prefix(line)
-            return nil if PatternGate.rejects?(AMBUSH_GATE, AMBUSH_ALWAYS_SCAN, line)
+            unless PatternGate.rejects?(AMBUSH_GATE, AMBUSH_ALWAYS_SCAN, line)
+              AMBUSH_PREFIXES.each_with_index do |pattern, i|
+                next unless (m = pattern.match(line))
 
-            AMBUSH_PREFIXES.each do |pattern|
-              next unless (m = pattern.match(line))
-
-              return { attacker: m.names.include?('attacker') ? m[:attacker] : nil }
+                return { attacker: m.names.include?('attacker') ? m[:attacker] : nil,
+                         kind: AMBUSH_KINDS[i], hidden: true }
+              end
             end
+
+            unless PatternGate.rejects?(REACTION_GATE, REACTION_ALWAYS_SCAN, line)
+              REACTION_PREFIXES.each do |pattern, kind|
+                next unless pattern.match(line)
+
+                return { attacker: nil, kind: kind, hidden: false }
+              end
+            end
+
             nil
           end
 

--- a/lib/gemstone/combat/defs/flares.rb
+++ b/lib/gemstone/combat/defs/flares.rb
@@ -418,7 +418,11 @@ module Lich
               result[:target] = match[:target] if match.names.include?('target') && match[:target]
               # 3p forms name whose item flared; a 2p flare ("Your ...") has
               # no attacker and is ours - the recorder writes flares.ours off it
-              result[:attacker] = match[:attacker] if match.names.include?('attacker') && match[:attacker]
+              if match.names.include?('attacker') && (who = match[:attacker])
+                # a lazy capture can land on the FIRST-PERSON form ("from your
+                # hands" - boil_blood): that is ours, not an attacker
+                result[:attacker] = who unless who.gsub(/<[^>]*>/, '').strip =~ /\A(?:your?|yourself)\z/i
+              end
               if (weapon = WEAPON_LINK.match(line))
                 result[:weapon] = { id: weapon[:id].to_i, name: weapon[:name] }
               end

--- a/lib/gemstone/combat/defs/flares.rb
+++ b/lib/gemstone/combat/defs/flares.rb
@@ -154,8 +154,8 @@ module Lich
             FlareDef.new(:parasite, [/A slender .+? and black tendril lashes out from .+? and slashes (?<target>.+?) .+?!/].freeze, true, true, false),
             FlareDef.new(:physical_prowess, [/The vitality of nature bestows you with a burst of strength!/].freeze, false, true, false),
             FlareDef.new(:plasma, [
-              /\*\* Your .+? pulses with a burst of plasma energy! \*\*/,
-              /\*\* (?<attacker>.+?)'s#{MK_POST} .+? pulses with a burst of plasma energy! \*\*/
+              /\*\* Your .+? pulses with a burst of plasma energy(?: at (?<target>[^!]+))?! \*\*/,
+              /\*\* (?<attacker>.+?)'s#{MK_POST} .+? pulses with a burst of plasma energy(?: at (?<target>[^!]+))?! \*\*/
             ].freeze, true, true, false),
             # Glowbark / plasma weapon flare. Three lines, three roles (owner
             # breakdown 2026-09-06):
@@ -203,6 +203,22 @@ module Lich
               # the sigils, then the tendrils lash out in the same line
               /\*\* A bolt of energy leaps from (?<attacker>.+?)'s#{MK_POST} .+? and sets the sigils along .+? ablaze\.  Tendrils of .+? lash out at (?<target>.+?) and cage .+? within bands of concentric geometry/
             ].freeze, true, false, false),
+            # Holy Weapon (1625) infusion release: a paladin BESEECHes a
+            # bonded weapon to invoke its infused spell at the START of the
+            # next attack, so this line precedes the swing's roll (and, for a
+            # bare swing, the swing line itself - a pre-flare claimed by
+            # weapon). The spell it releases prints its own cast line and is
+            # its own attack; see SPELL_RELEASING_FLARES in the processor.
+            # Was an AttackDef: it then opened an event that swallowed BOTH
+            # the spell's CS/TD and the swing's AS/DS (Dreadt log 2026-09-11:
+            # 13 rows carrying cs_td, 10 of them also as_ds). Not damaging -
+            # the damage belongs to the spell. The wiki prints this in flare
+            # syntax (** ... **); the live feed omits the asterisks.
+            # Second pattern: the FAILED release - nothing follows it.
+            FlareDef.new(:weapon_cast, [
+              /(?:\*\* )?As (?:you attempt to strike with your|your) (?<weapon>.+?)(?: hits)?, it sends a surge of power through you that quickly leaps out at (?:the )?(?<target>[^!]+)!/,
+              /(?:\*\* )?As you attempt to strike with your (?<weapon>.+?), you briefly feel a surge of power, but it dissipates before reaching (?:the )?(?<target>[^!.]+)/
+            ].freeze, false, false, false),
             FlareDef.new(:sigil_cast, [
               /\*\* Numerous sigils along your .+? abruptly flare to brilliance!  .+? surges from each, twining into an echo of your last spell\.\.\. \*\*/,
               /\*\* Numerous sigils along (?<attacker>.+?)'s#{MK_POST} .+? abruptly flare to brilliance!  .+? surges from each, twining into an echo of .+? last spell\.\.\. \*\*/,

--- a/lib/gemstone/combat/defs/flares.rb
+++ b/lib/gemstone/combat/defs/flares.rb
@@ -416,6 +416,9 @@ module Lich
 
               result = { name: name, damaging: damaging, aoe: aoe, spawns: spawns }
               result[:target] = match[:target] if match.names.include?('target') && match[:target]
+              # 3p forms name whose item flared; a 2p flare ("Your ...") has
+              # no attacker and is ours - the recorder writes flares.ours off it
+              result[:attacker] = match[:attacker] if match.names.include?('attacker') && match[:attacker]
               if (weapon = WEAPON_LINK.match(line))
                 result[:weapon] = { id: weapon[:id].to_i, name: weapon[:name] }
               end

--- a/lib/gemstone/combat/defs/outcomes.rb
+++ b/lib/gemstone/combat/defs/outcomes.rb
@@ -211,7 +211,7 @@ module Lich
               /(?<target>.+?) harmlessly deflects the charge!/,
               /You gauge the attack and expertly deflect it with your .+?!/,
               /At the last moment, you block the missile with your .+?!/,
-              /In the nick of time, you interpose your .+? between yourself and the (?:missile|blow)!/,
+              /In the nick of time, you interpose your .+? between yourself and the (?:missile|blow|attack)!/,
               /Though dazed, you easily deflect the .+? with your .+?!/,
               /Although completely oblivious, you instinctively block the .+? with your .+?!/,
               /You skillfully block the missile with your .+?!/,

--- a/lib/gemstone/combat/defs/spells.rb
+++ b/lib/gemstone/combat/defs/spells.rb
@@ -172,7 +172,6 @@ module Lich
             # Excalibur-style weapon spell surge: opens its own CS/TD (the
             # patron-aura flavor rides between); the actual swing opens
             # separately after. The fizzle form is a prefix - no def.
-            AttackDef.new(:weapon_cast, [/As you attempt to strike with your (?<weapon>.+?), it sends a surge of power through you that quickly leaps out at (?:the )?(?<target>[^!]+)!/].freeze),
             AttackDef.new(:elemental_strike, [/A vortex of elemental energy suddenly strikes (?<target>[^!]+)!/].freeze),
             AttackDef.new(:fervent_reproach, [/With a quick flick of your wrists, the orbs dance through the air toward (?<target>[^!]+)!/].freeze),
             AttackDef.new(:force_projection, [/A translucent force moves outward from you and toward (?<target>[^.]+)\./].freeze),
@@ -267,7 +266,15 @@ module Lich
             # shared cast line of targeted bard attack songs (1008, 1016...)
             AttackDef.new(:spellsong, [/You weave another verse into your harmony, directing the sound of your voice at (?<target>[^.]+)\./].freeze),
             AttackDef.new(:sunburst, [/A sudden burst of bright light emanates from your hand toward (?<target>[^!]+)!/].freeze),
-            AttackDef.new(:templars_verdict, [/A column of violet flame envelops (?<target>.+?) in its searing embrace!/].freeze),
+            # 1603. The ERUPT line is the cast (wiki messaging: "You gesture
+            # at X. Violet flames erupt from beneath X." then the CS/TD roll);
+            # the envelops line that follows is its HIT line, deliberately
+            # not a def. On a paladin the spell is usually RELEASED by a Holy
+            # Weapon (1625) infusion mid-swing rather than gestured: the proc
+            # is a flare (:weapon_cast, defs/flares) and the processor treats
+            # the cast that follows it as an interruption of the swing - the
+            # swing resumes when its own AS/DS arrives (SPELL_RELEASING_FLARES).
+            AttackDef.new(:templars_verdict, [/Violet flames erupt from beneath (?<target>.+?)\./].freeze),
             AttackDef.new(:thought_lash, [/A crackling whip of energy lashes out at (?:the )?(?<target>[^!]+)!/].freeze),
             AttackDef.new(:web_bolt, [/You shoot strands of webbing at (?<target>[^!]+)!/].freeze),
             AttackDef.new(:wither, [/A nebulous haze shimmers into view around (?<target>[^,.]+)/].freeze),

--- a/lib/gemstone/combat/defs/statuses.rb
+++ b/lib/gemstone/combat/defs/statuses.rb
@@ -333,7 +333,23 @@ module Lich
                             # Evil Eye result (round-5)
                             /(?<target>.+?) is frightened into utter immobility!/
                           ].freeze,
-                          [/You regain control of your senses!/].freeze),
+                          [
+                            /You regain control of your senses!/,
+                            # Creature expiry (Rysk logs 2026-09-11). The self
+                            # line above never names a target, so without this
+                            # a creature's terror never cleared.
+                            /(?<target>.+?) gathers #{MK_PRE}(?:himself|herself|itself)#{MK_POST} and shakes off the fear\./
+                          ].freeze),
+
+            # Eviscerate (rogue CMAN) applies Terrified OR Demoralized with
+            # power 15 to every onlooker that witnesses the attack, each
+            # rolling its own SSR - so this is a SEPARATE status from
+            # :terrified, not flavor riding along with it. Both landed on
+            # both bystanders in the Rysk logs 2026-09-11 (11 occurrences),
+            # but the wiki's "or" means they can arrive apart.
+            StatusDef.new(:demoralized,
+                          [/Upon witnessing your vicious display, (?<target>.+?) appears profoundly unsettled\./].freeze,
+                          [/(?<target>.+?) composes #{MK_PRE}(?:himself|herself|itself)#{MK_POST}, shedding #{MK_PRE}(?:his|her|its)#{MK_POST} apparent demoralization\./].freeze),
 
             StatusDef.new(:silenced,
                           [/(?<target>.+?) chokes, momentarily unable to speak!/].freeze,

--- a/lib/gemstone/combat/parser.rb
+++ b/lib/gemstone/combat/parser.rb
@@ -268,10 +268,14 @@ module Lich
           # The weapon a swing line names, in plain text (swing lines do
           # not link the weapon):  "You swing a kelyn-edged slim short
           # sword at <pushBold/>..." - used to claim pre-flares by weapon.
-          SWING_WEAPON_PATTERN = /You(?: take aim and)? (?:swing|fire) (?:an? |your |some )?(?<weapon>[^<]+?) at </.freeze
+          # The weapon itself may be linked ("You swing a perfect <a ...>mithril
+          # mace</a> at ..."), so anchor tags are dropped before matching and
+          # the capture ends at the " at " that precedes the target (linked or
+          # plain) rather than at a literal "<".
+          SWING_WEAPON_PATTERN = /You(?: take aim and)? (?:swing|fire) (?:an? |your |some )?(?<weapon>[^<]+?) at (?=<|\S)/.freeze
 
           def parse_swing_weapon(line)
-            SWING_WEAPON_PATTERN.match(line)&.[](:weapon)
+            SWING_WEAPON_PATTERN.match(line.gsub(%r{</?a\b[^>]*>}, ''))&.[](:weapon)
           end
 
           # Parse status effects (optional - performance setting)

--- a/lib/gemstone/combat/parser.rb
+++ b/lib/gemstone/combat/parser.rb
@@ -341,8 +341,15 @@ module Lich
             target_text = match[:target]
             return nil if target_text.nil? || target_text.strip.empty?
 
-            # Look for creature in target text
-            if (target_match = TARGET_LINK_PATTERN.match(target_text))
+            # Look for creature in target text. A possessive capture ends at
+            # the apostrophe INSIDE the link text ("<a ...>human robber" + "'s"
+            # outside), so the closing tag falls beyond the capture and
+            # TARGET_LINK_PATTERN cannot match - bleed/trickle ticks were
+            # resolving to no target and recording as foreign (Rysk logs
+            # 2026-09-11: 10 bleed ticks on named creatures, all unattributed).
+            # Fall back to the open-tail form, as the attacker path does.
+            if (target_match = TARGET_LINK_PATTERN.match(target_text) ||
+                               OPEN_LINK_TAIL_PATTERN.match(target_text))
               id = target_match[:id].to_i
               return nil if id < 0
 

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -748,7 +748,18 @@ module Lich
                 parse_state = :seeking_damage
                 respond "[Combat] Resumed interrupted #{current_event[:name]} for its flare" if Tracker.debug?(:verbose)
               end
-              if current_event && !flare_contradicts_weapon?(flare, current_event)
+              # A spell-RELEASING flare fires at the START of an attack. One
+              # arriving on a swing that has already landed (hits) or
+              # resolved (outcome) - or on a creature's inbound event - is
+              # the NEXT swing's, and must be held for it: attached to the
+              # finished swing it dragged the released cast under the wrong
+              # parent (review of 3c3f1bfe). A maneuver's own SMR does not
+              # settle it - pummel rolls its SMR before its release fires.
+              releasing_flare = SPELL_RELEASING_FLARES.include?(flare[:name])
+              settled_for_release = current_event &&
+                                    (current_event[:inbound] || current_event[:hits].any? || current_event[:outcomes].any?)
+              if current_event && !flare_contradicts_weapon?(flare, current_event) &&
+                 !(releasing_flare && settled_for_release)
                 current_event[:flares] << flare
               else
                 pending_flares << flare
@@ -1513,6 +1524,7 @@ module Lich
                       # ...and the cast that flare released, which printed
                       # before this swing, is this swing's child.
                       if releasing && pending_release_cast
+                        f[:_release_claimed] = true
                         cast = pending_release_cast
                         cast[:root_ref] = current_event[:root_ref] || current_event
                         cast[:parent_ref] = current_event

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -30,7 +30,26 @@ module Lich
         # 2026-09-06). A tick IS ours only when our own cast of that spell
         # is visible in the same blob (see cast_owner tracking below).
         # :bleed has no cast at all, so it is always unowned (owner 2026-09-07).
-        UNOWNED_TICK_ATTACKS = %i[pestilence web bleed rot spiritual_malady].freeze
+        # Flares that RELEASE a spell instead of dealing damage themselves
+        # (Holy Weapon 1625: the infused spell fires at the start of a
+        # swing). The cast that follows is the flare's spell, and it lands
+        # in the MIDDLE of the swing - before the swing's own AS/DS. It is
+        # handled like an inbound attack cutting in: the swing is saved as
+        # interrupted_own, the spell runs as its own event, and the first
+        # PHYSICAL roll (AS/DS, UAF/UDF - a warding cast never rolls one)
+        # resumes the swing, which then owns that roll and its damage.
+        # Before this the cast's event held the swing's roll and damage,
+        # and a pummel bracket was dropped as an "unexpected attack" by its
+        # own weapon's spell (Dreadt log 2026-09-11 594-613).
+        SPELL_RELEASING_FLARES = %i[weapon_cast].freeze
+
+        # Assaults whose per-round roll PRECEDES the round line (barrage:
+        # an aim SMR before each arrow, claimed at the arrow's creation -
+        # see the roll-routing notes). While one is open a held maneuver
+        # roll is ours; every other assault rolls after its round line.
+        ROLL_BEFORE_ROUND_ASSAULTS = %i[barrage].freeze
+
+        UNOWNED_TICK_ATTACKS = %i[pestilence web bleed rot spiritual_malady poison_tick].freeze
 
         # Initiations whose inline "causing N points of damage!" restates the
         # "... N points of damage!" line that follows (that line carries the
@@ -301,7 +320,17 @@ module Lich
           events = []
           # Identity-guarded push: an event RESUMED after an inbound
           # interruption (see interrupted_own) was already saved once.
-          save_event = ->(ev) { events << ev unless events.any? { |e| e.equal?(ev) } }
+          save_event = lambda do |ev|
+            next if events.any? { |e| e.equal?(ev) }
+
+            events << ev
+            # A cast this swing's Holy Weapon proc released that PRINTED
+            # BEFORE the swing (proc -> spell -> swing) was pulled out of the
+            # emit order when the swing adopted it: the recorder resolves
+            # lineage at insert time and a parent must emit first, so the
+            # child follows its parent here.
+            Array(ev.delete(:_released_children)).each { |c| events << c unless events.any? { |e| e.equal?(c) } }
+          end
           # Our own event that an inbound attack cut into mid-swing. A
           # creature's reactive cast (cloak of shadows: our arrow lands, its
           # tendril lashes back, CS/TD, "Warded off!") prints BETWEEN our hit
@@ -310,6 +339,18 @@ module Lich
           # log 2026-09-07 23:18, flayed gigas disciple). Our next own flare
           # line resumes the interrupted event.
           interrupted_own = nil
+          # The own swing a flare-released spell cut into (see
+          # SPELL_RELEASING_FLARES): stashed at the cast's open so the fresh
+          # event can be parented to it, then cleared.
+          released_parent = nil
+          # The other ordering: the release line prints FIRST (pre-flare,
+          # no swing open yet), the spell casts, THEN the swing line prints.
+          # The cast is remembered here and parented to the swing that
+          # claims the pending release flare (see the pre-flare claim).
+          pending_release_cast = nil
+          # Every cast deferred behind its swing (see save_event); flushed
+          # at the end in case the swing itself never got saved.
+          deferred_casts = []
           # Attacker of the last inbound event saved this blob. A creature's
           # warding spell that lands prints its effect as an attackerless
           # spell-result line right after the cast's "Warding failed!"
@@ -698,7 +739,7 @@ module Lich
                 current_target = current_event[:target] if current_event[:target] && current_event[:target][:id]
                 respond "[Combat] Resumed #{current_event[:name]} after its one-hit side effect (flare)" if Tracker.debug?(:verbose)
               end
-              if current_event && current_event[:inbound] && interrupted_own &&
+              if current_event && (current_event[:inbound] || current_event[:_released]) && interrupted_own &&
                  !flare_contradicts_weapon?(flare, interrupted_own)
                 save_event.call(current_event)
                 current_event = interrupted_own
@@ -879,6 +920,20 @@ module Lich
                 # already dealt its damage is complete - an acid proc must
                 # not steal the next swing's AS/DS (real-feed replay,
                 # logs/examples/weapon_pulverize.txt).
+                # A PHYSICAL roll arriving on a flare-released spell is the
+                # interrupted swing's (a warding cast never rolls AS/DS):
+                # resume the swing first so the routing below lands the roll
+                # and its damage on it (see SPELL_RELEASING_FLARES).
+                if current_event && current_event[:_released] && interrupted_own &&
+                   %i[as_ds uaf_udf].include?(resolution[:type])
+                  save_event.call(current_event)
+                  current_event = interrupted_own
+                  interrupted_own = nil
+                  current_target = current_event[:target] if current_event[:target] && current_event[:target][:id]
+                  parse_state = :seeking_damage
+                  flare_ctx = nil
+                  respond "[Combat] Resumed interrupted #{current_event[:name]} for its #{resolution[:type]} roll" if Tracker.debug?(:verbose)
+                end
                 settled_flare = flare_ctx if flare_ctx && flare_ctx[:hits].any?
                 flare_ctx = nil if settled_flare
                 sink = flare_ctx
@@ -911,8 +966,18 @@ module Lich
                     # switch-born event an outcome settles too - a volley
                     # miss's roll came BEFORE its outcome, so one arriving
                     # after belongs to the next arrow.
+                    #
+                    # A STATUS settles a switch-born event the same way: an
+                    # AoE status effect rolls once PER onlooker, each roll
+                    # printed BEFORE the creature it applies to (eviscerate:
+                    # ssr -> freeze -> unsettled, twice). Without this the
+                    # second roll fell into the first bystander's still-open
+                    # event - which had no hits and no outcome to settle it -
+                    # and the second bystander recorded no roll at all
+                    # (Rysk logs 2026-09-11, fixture eviscerate.txt).
                     settled = current_event[:hits].any? ||
-                              (!born && current_event[:outcomes].any?)
+                              (!born && (current_event[:outcomes].any? ||
+                                         current_event[:_had_status]))
                     sink = current_event unless settled
                   elsif born || (current_event[:hits].empty? && current_event[:outcomes].empty?)
                     sink = current_event
@@ -961,10 +1026,11 @@ module Lich
                     # (a creature's wholly-negated ambush on us is this shape
                     # too: prefix, then the intercept, no attack line)
                     current_event = {
-                      name: pending_ambush ? :ambush : :unknown, target: {}, inbound: true,
+                      name: (pending_ambush && pending_ambush[:hidden]) ? :ambush : :unknown, target: {}, inbound: true,
                       attacker: line_target, weapon: nil, parent: nil,
                       hits: [], statuses: [], flares: [], outcomes: [outcome],
-                      ambush: !pending_ambush.nil?,
+                      ambush: !!(pending_ambush && pending_ambush[:hidden]),
+                      attack_kind: pending_ambush && pending_ambush[:kind],
                       resolutions: pending_resolutions
                     }
                     pending_ambush = nil
@@ -977,16 +1043,17 @@ module Lich
                     round_name = SEQUENCE_ROUND_NAMES.include?(active_sequence) ? active_sequence : nil
                     # a nocked bow with no fire line printed: the outcome IS
                     # the fire (pre-emptive evade, see nocked decl)
-                    nock_fire = nocked && !pending_ambush && round_name.nil?
+                    nock_fire = nocked && !(pending_ambush && pending_ambush[:hidden]) && round_name.nil?
                     current_event = {
-                      name: pending_ambush ? :ambush : (round_name || (nock_fire ? :fire : :unknown)),
+                      name: (pending_ambush && pending_ambush[:hidden]) ? :ambush : (round_name || (nock_fire ? :fire : :unknown)),
                       target: line_target, attacker: nil,
                       weapon: nock_fire ? nocked : nil, parent: nil, hits: [],
                       statuses: [], flares: [], outcomes: [outcome],
                       # A wholly-negated ambush prints its prefix and then an
                       # intercept, with no attack line between - this is the
                       # only record that the ambush was attempted.
-                      ambush: !pending_ambush.nil?,
+                      ambush: !!(pending_ambush && pending_ambush[:hidden]),
+                      attack_kind: pending_ambush && pending_ambush[:kind],
                       resolutions: pending_resolutions
                     }
                     if round_name
@@ -1017,7 +1084,7 @@ module Lich
             # line follows and carries the target and the roll. Arm the flag
             # and move on; the next attack claims it.
             if (amb = Definitions::Attacks.ambush_prefix(line))
-              pending_ambush = { attacker: amb[:attacker] }
+              pending_ambush = { attacker: amb[:attacker], kind: amb[:kind], hidden: amb[:hidden] }
               respond '[Combat] Ambush prefix armed' if Tracker.debug?(:verbose)
             end
 
@@ -1112,6 +1179,13 @@ module Lich
                 if attack[:inbound] && !(current_event[:inbound] || current_event[:foreign_caster] || current_event[:foreign_target])
                   interrupted_own = current_event
                 end
+                # our own swing carrying a spell-releasing flare: the cast
+                # opening now is that flare's spell, cutting into the swing
+                if !attack[:inbound] && !(current_event[:inbound] || current_event[:foreign_caster] || current_event[:foreign_target]) &&
+                   (rel = (current_event[:flares] || []).find { |f| SPELL_RELEASING_FLARES.include?(f[:name]) })
+                  interrupted_own = current_event
+                  released_parent = { event: current_event, flare: rel }
+                end
                 last_inbound_attacker = current_event[:attacker] if current_event[:inbound] && current_event[:attacker]
               end
               # A same-line artifact event may have claimed held rolls in
@@ -1188,7 +1262,11 @@ module Lich
                 # Struck from hiding: this attack carries the ambush
                 # bonuses (DS pushdown + crit weighting). A modifier on the
                 # attack, not an attack of its own.
-                ambush: !pending_ambush.nil?,
+                ambush: !!(pending_ambush && pending_ambush[:hidden]),
+                # Which hiding maneuver armed it (:waylay weights damage,
+                # :ambush weights crits) - see AMBUSH_KINDS. Reaction
+                # prefixes set the kind but leave `ambush` false.
+                attack_kind: pending_ambush && pending_ambush[:kind],
                 # A guardian stepped in front of the creature we struck at
                 # and this attack resolved against the guardian instead:
                 # { interceptor: {id?, name}, intended: <victim noun> }.
@@ -1277,6 +1355,17 @@ module Lich
                 current_event[:root_ref] = spawn_root
                 current_event[:parent_ref] = spawn_root
                 current_event[:parent_confidence] = :bracket
+              elsif released_parent && !not_ours
+                # A spell released by the swing's own flare: child of that
+                # swing. Asserted by adjacency (one releasing flare, one
+                # cast), the same count constraint an echo uses.
+                owner = released_parent[:event]
+                current_event[:root_ref] = owner[:root_ref] || owner
+                current_event[:parent_ref] = owner
+                current_event[:parent_confidence] = :count
+                current_event[:parent] = { flare: released_parent[:flare][:name], weapon: released_parent[:flare][:weapon] }
+                current_event[:_released] = true
+                released_parent = nil
               elsif !not_ours && spawn_root && !pending_echoes.empty? && line.match?(/\AYou\b/) &&
                     current_event[:name] == (pending_echoes.first[:owner] || spawn_root)[:name]
                 echo = pending_echoes.shift
@@ -1288,6 +1377,15 @@ module Lich
               else
                 spawn_root = current_event unless not_ours
                 current_event[:root_ref] = current_event
+              end
+              # A weaponless cast opening while a spell-releasing pre-flare
+              # is still unclaimed IS that flare's spell (proc -> spell ->
+              # swing ordering). Mark it so the assault guard leaves the
+              # bracket alone, and hold it for the swing to adopt.
+              if !not_ours && !current_event[:_released] && current_event[:weapon].nil? &&
+                 pending_flares.any? { |f| SPELL_RELEASING_FLARES.include?(f[:name]) }
+                current_event[:_released] = true
+                pending_release_cast = current_event
               end
 
               # Record ownership of a DoT/effect spell from its CAST line so
@@ -1331,7 +1429,8 @@ module Lich
                     @active_assault[:target] = current_target
                   end
                 elsif current_event[:attacker].nil? &&
-                      !%i[unknown companion].include?(current_event[:name])
+                      !%i[unknown companion].include?(current_event[:name]) &&
+                      !current_event[:_released]
                   # Only OUR OWN attacks are impossible mid-assault. A third
                   # party's are normal and must not disturb the bracket:
                   # :companion defs capture (?<companion>) not (?<attacker>)
@@ -1378,12 +1477,39 @@ module Lich
                   # Sequential so the first claimed flare guards the second.
                   still_pending = []
                   pending_flares.each do |f|
-                    if flare_matches_weapon?(f, current_event[:weapon]) || !flare_contradicts_weapon?(f, current_event)
+                    # A spell-RELEASING pre-flare (Holy Weapon) rode a swing,
+                    # never the spell it released: only an attack that names
+                    # a weapon may claim it. Left to the generic rule the
+                    # Templar's Verdict cast took it, which then read as the
+                    # swing that released the spell and pulled the real
+                    # swing's AS/DS onto the cast (Dreadt log 2026-09-11
+                    # 12274, 12715).
+                    releasing = SPELL_RELEASING_FLARES.include?(f[:name])
+                    claim = if releasing
+                              current_event[:weapon] && !flare_contradicts_weapon?(f, current_event)
+                            else
+                              flare_matches_weapon?(f, current_event[:weapon]) || !flare_contradicts_weapon?(f, current_event)
+                            end
+                    if claim
                       # fired BEFORE the swing line (dispel-on-nock, ensorcell's
                       # veil): never the cause of a status the swing's own crit
                       # inflicts afterwards (see status_flare_seq)
                       f[:_pre] = true
                       current_event[:flares] << f
+                      # ...and the cast that flare released, which printed
+                      # before this swing, is this swing's child.
+                      if releasing && pending_release_cast
+                        cast = pending_release_cast
+                        cast[:root_ref] = current_event[:root_ref] || current_event
+                        cast[:parent_ref] = current_event
+                        cast[:parent_confidence] = :count
+                        cast[:parent] = { flare: f[:name], weapon: f[:weapon] }
+                        # re-emit it after the swing (recorder needs parent first)
+                        events.delete_if { |e| e.equal?(cast) }
+                        (current_event[:_released_children] ||= []) << cast
+                        deferred_casts << cast
+                        pending_release_cast = nil
+                      end
                     else
                       still_pending << f
                     end
@@ -1395,11 +1521,27 @@ module Lich
                   pending_resolutions = []
                 end
               end
-              # Exception: an inbound maneuver whose initiation IS its result
-              # line (3p feint: "[SMR] X feints high, but you aren't fooled")
-              # rolled BEFORE it printed - that held maneuver roll is its own,
-              # not our next swing's.
-              if current_event[:inbound] && same_line_outcome && !pending_resolutions.empty?
+              # Exception: a creature MANEUVER rolls before its line prints
+              # (3p feint: "[SMR] X feints high, but you aren't fooled"; sap
+              # spit whose miss prints on the NEXT line; a grapple that lands
+              # and prints no outcome at all) - that held maneuver roll is its
+              # own, not our next swing's. This used to key on the line
+              # carrying its own outcome, which only covered the feint shape
+              # and left the other two orphaned (Rysk/Dreadt logs 2026-09-11).
+              # The roll IS ours only when we are mid-sequence: volley (a
+              # sequence) and barrage (an assault) print our SMR before our
+              # arrow line, and both announce themselves, so those states keep
+              # the hold. Every OTHER assault (pummel, flurry, thrash, guardant
+              # thrust) rolls AFTER its round line - fixture-verified - so an
+              # open one must not block the claim: a pummel was open when a
+              # slaver's subdue cut in, and the blanket guard orphaned that
+              # roll (Dreadt log 2026-09-11 7280). Corpus census 2026-09-12:
+              # 5 maneuver-SMR -> inbound-line shapes, 0 with our own attack
+              # following in the chunk. Maneuver-class rolls only - AS/DS
+              # never precedes.
+              if current_event[:inbound] && !pending_resolutions.empty? &&
+                 active_sequence.nil? && !nocked &&
+                 !(@active_assault && ROLL_BEFORE_ROUND_ASSAULTS.include?(@active_assault[:name]))
                 mine, pending_resolutions = pending_resolutions.partition { |r| %i[smr ssr maneuver_roll].include?(r[:type]) }
                 current_event[:resolutions].concat(mine)
               end
@@ -1582,6 +1724,8 @@ module Lich
             }
           end
 
+          # a deferred cast whose swing never saved still carries its facts
+          deferred_casts.each { |c| events << c unless events.any? { |e| e.equal?(c) } }
           events
         end
 

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -920,12 +920,19 @@ module Lich
                 # already dealt its damage is complete - an acid proc must
                 # not steal the next swing's AS/DS (real-feed replay,
                 # logs/examples/weapon_pulverize.txt).
-                # A PHYSICAL roll arriving on a flare-released spell is the
-                # interrupted swing's (a warding cast never rolls AS/DS):
-                # resume the swing first so the routing below lands the roll
-                # and its damage on it (see SPELL_RELEASING_FLARES).
+                # A PHYSICAL roll arriving on a flare-released spell that has
+                # ALREADY resolved is the interrupted swing's: resume the swing
+                # first so the routing below lands the roll and its damage on
+                # it (see SPELL_RELEASING_FLARES). "Already resolved" matters:
+                # Holy Weapon can release a BOLT, whose own AS/DS is the first
+                # roll after its cast line - that one is the bolt's, and only
+                # the roll after it belongs to the swing. Keying on roll type
+                # alone gave the bolt's roll and damage to the swing (review
+                # of 056ff899). A warding cast resolves on its CS/TD first
+                # either way, so this is a no-op for Templar's Verdict.
                 if current_event && current_event[:_released] && interrupted_own &&
-                   %i[as_ds uaf_udf].include?(resolution[:type])
+                   %i[as_ds uaf_udf].include?(resolution[:type]) &&
+                   (current_event[:resolutions].any? || current_event[:hits].any? || current_event[:outcomes].any?)
                   save_event.call(current_event)
                   current_event = interrupted_own
                   interrupted_own = nil
@@ -1179,10 +1186,17 @@ module Lich
                 if attack[:inbound] && !(current_event[:inbound] || current_event[:foreign_caster] || current_event[:foreign_target])
                   interrupted_own = current_event
                 end
-                # our own swing carrying a spell-releasing flare: the cast
-                # opening now is that flare's spell, cutting into the swing
+                # our own swing carrying an UNCLAIMED spell-releasing flare:
+                # a weaponless CAST opening now is that flare's spell, cutting
+                # into the swing. One flare releases one spell - claiming it
+                # marks the flare consumed, and a weapon-bearing swing line is
+                # never the released spell - otherwise a second swing later in
+                # the chunk read as "released" too and handed its roll and
+                # damage back to the first swing (review of 056ff899).
                 if !attack[:inbound] && !(current_event[:inbound] || current_event[:foreign_caster] || current_event[:foreign_target]) &&
-                   (rel = (current_event[:flares] || []).find { |f| SPELL_RELEASING_FLARES.include?(f[:name]) })
+                   attack[:weapon].nil? && Parser.parse_swing_weapon(line).nil? &&
+                   (rel = (current_event[:flares] || []).find { |f| SPELL_RELEASING_FLARES.include?(f[:name]) && !f[:_release_claimed] })
+                  rel[:_release_claimed] = true
                   interrupted_own = current_event
                   released_parent = { event: current_event, flare: rel }
                 end

--- a/lib/gemstone/combat/processor.rb
+++ b/lib/gemstone/combat/processor.rb
@@ -699,7 +699,7 @@ module Lich
               # around X flares causing 58 points of damage!") - the same
               # shape as inline attack damage (replay 2026-09-05)
               if (inline = Parser.parse_damage(line))
-                flare[:hits] << { damage: inline, crit: nil }
+                flare[:hits] << { damage: inline, crit: nil, line: index }
                 respond "[Combat] Found inline flare damage: #{inline}" if Tracker.debug?(:verbose)
               end
 
@@ -1481,7 +1481,7 @@ module Lich
               # gating only here made inline-damage events vanish under
               # configs that omit the key (replay 2026-09-05, pestilence)
               if !SUMMARY_DAMAGE_ATTACKS.include?(current_event[:name]) && (inline = Parser.parse_damage(line))
-                current_event[:hits] << { damage: inline, crit: nil }
+                current_event[:hits] << { damage: inline, crit: nil, line: index }
                 respond "[Combat] Found inline damage: #{inline}" if Tracker.debug?(:verbose)
               end
               current_event[:outcomes] << same_line_outcome if same_line_outcome
@@ -1587,7 +1587,7 @@ module Lich
               # 2026-09-07); the room-feed death that follows agrees.
               if current_event && current_event[:name] == :coup_de_grace &&
                  (coup_loc = Definitions::Attacks.coup_kill_location(line))
-                current_event[:hits] << { damage: 0, crit: { location: coup_loc, type: 'coup_de_grace', rank: nil,
+                current_event[:hits] << { damage: 0, line: index, crit: { location: coup_loc, type: 'coup_de_grace', rank: nil,
                                                              wound_rank: nil, fatal: true } }
                 chunk_deaths << current_event[:target][:id] if current_event[:target] && current_event[:target][:id]
                 respond '[Combat] Coup de grace kill' if Tracker.debug?(:verbose)
@@ -1615,7 +1615,7 @@ module Lich
                 # "... 5 points of damage!"; the 65 is concussion and takes no
                 # crit (the lookahead breaks on the next damage line), the 5
                 # carries the fire crit.
-                hit = { damage: damage, crit: nil }
+                hit = { damage: damage, crit: nil, line: index }
                 sink[:hits] << hit
                 respond "[Combat] Found damage: #{damage}#{flare_ctx ? " (flare: #{flare_ctx[:name]})" : ''}" if Tracker.debug?(:verbose)
 
@@ -1670,7 +1670,7 @@ module Lich
               # Damage while seeking an attack: its initiation had no def
               # (or lived in a prior chunk we cannot see). Orphan-sink it
               # rather than dropping the fact.
-              orphan_hits << { damage: orphan_dmg, crit: nil }
+              orphan_hits << { damage: orphan_dmg, crit: nil, line: index }
               respond "[Combat] Orphan damage: #{orphan_dmg}" if Tracker.debug?(:verbose)
             end
 

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -202,7 +202,8 @@ module Lich
             fatal       INTEGER NOT NULL DEFAULT 0,
             amputated   INTEGER NOT NULL DEFAULT 0,
             secondary_location TEXT,
-            secondary_rank     INTEGER                    -- secondary wound severity (:wound_rank)
+            secondary_rank     INTEGER,                   -- secondary wound severity (:wound_rank)
+            line_seq    INTEGER                           -- feed position of the damage line within its chunk: COMBAT order. Row id is insertion order, which a released cast (emitted after its swing) breaks; attacks.occurred_at orders across chunks
           );
           CREATE INDEX IF NOT EXISTS idx_hits_attack ON hits(attack_id);
           CREATE INDEX IF NOT EXISTS idx_hits_creature ON hits(session_id, creature_id);
@@ -551,6 +552,7 @@ module Lich
           'attacks'   => { 'redirected_from' => 'TEXT', 'attack_kind' => 'TEXT',
                            'ours' => 'INTEGER NOT NULL DEFAULT 0' },
           'flares'    => { 'ours' => 'INTEGER NOT NULL DEFAULT 0' },
+          'hits'      => { 'line_seq' => 'INTEGER' },
           'creatures' => { 'kill_credit' => 'TEXT' },
           'statuses'  => { 'flare_id' => 'INTEGER REFERENCES flares(id)' }
         }.freeze
@@ -840,12 +842,13 @@ module Lich
                     hit[:damage].to_i, crit[:location], map_body_part(crit[:location]),
                     crit[:type]&.to_s, crit[:rank], crit[:wound_rank], fatal,
                     crit[:amputated] ? 1 : 0,
-                    secondary[:location], secondary[:wound_rank] || secondary[:rank]]
+                    secondary[:location], secondary[:wound_rank] || secondary[:rank],
+                    hit[:line]]
           @db.execute(<<~SQL, params)
             INSERT INTO hits (attack_id, flare_id, session_id, creature_id, seq, damage, location,
                               body_part, crit_type, crit_rank, wound_rank, fatal, amputated,
-                              secondary_location, secondary_rank)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                              secondary_location, secondary_rank, line_seq)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           SQL
 
           return unless fatal == 1 && creature_row
@@ -975,8 +978,13 @@ module Lich
                   JOIN attacks a ON a.id = h.attack_id
                   LEFT JOIN flares f ON f.id = h.flare_id
                   WHERE h.creature_id = ? AND a.session_id = ? AND h.damage > 0
-                  ORDER BY h.id DESC LIMIT 1
+                  ORDER BY a.occurred_at DESC, COALESCE(h.line_seq, -1) DESC, h.id DESC LIMIT 1
                 SQL
+                # ordering: the chunk's time, then the damage line's position
+                # in the chunk (COMBAT order), then insertion. Row id alone
+                # credited a released spell over the swing that landed after
+                # it - the cast is emitted after its swing for lineage
+                # (review of cb68bb90).
                 if last
                   credit_id = last[0]
                   credit = last[1] == 1 ? 'last_own_hit' : 'last_hit'

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -113,6 +113,7 @@ module Lich
             last_seen   REAL,
             killed_at   REAL,
             killed_by_attack_id INTEGER,
+            kill_credit TEXT,                             -- how killed_by_attack_id was chosen: 'crit' (fatal crit, ground truth) | 'window' (room-feed death inside an attack window) | 'last_own_hit' (no window: our last damaging attack on it) | NULL (unknown / pre-migration)
             UNIQUE (session_id, exist_id)
           );
 
@@ -142,6 +143,7 @@ module Lich
             orphan      INTEGER NOT NULL DEFAULT 0,
             foreign_caster INTEGER NOT NULL DEFAULT 0, -- a nearby player's attack (observed, not ours)
             unowned     INTEGER NOT NULL DEFAULT 0,    -- effect tick, no owning cast: applied to creature, not our deal
+            ours        INTEGER NOT NULL DEFAULT 0,    -- decided at write time: our own OUTBOUND attack - not inbound, not a nearby player's, not on a foreign target, not an unowned tick, not an orphan sink
             redirected_from TEXT                       -- guardian redirect: noun of the creature we struck AT; the row's creature is the guardian that took it
           );
           CREATE INDEX IF NOT EXISTS idx_attacks_session ON attacks(session_id, seq);
@@ -178,7 +180,8 @@ module Lich
             damaging    INTEGER NOT NULL DEFAULT 0,
             creature_id INTEGER REFERENCES creatures(id), -- AoE: may differ from swing
             weapon      TEXT,
-            outcome     TEXT
+            outcome     TEXT,
+            ours        INTEGER NOT NULL DEFAULT 0     -- 2p flare (our item fired). On an INBOUND row ours=1 is our REACTIVE flare (shield spike, thorns); ours=0 there is the creature's own weapon proc striking us
           );
           CREATE INDEX IF NOT EXISTS idx_flares_attack ON flares(attack_id);
           CREATE INDEX IF NOT EXISTS idx_flares_name ON flares(name);
@@ -205,6 +208,8 @@ module Lich
           CREATE INDEX IF NOT EXISTS idx_hits_creature ON hits(session_id, creature_id);
           CREATE INDEX IF NOT EXISTS idx_hits_location ON hits(location);
           CREATE INDEX IF NOT EXISTS idx_hits_crit ON hits(crit_rank);
+          CREATE INDEX IF NOT EXISTS idx_hits_creature_only ON hits(creature_id);  -- per-creature damage subqueries (the composite needs session_id first)
+          CREATE INDEX IF NOT EXISTS idx_hits_flare ON hits(flare_id);
 
           -- kind: status (action add/remove), stun (value=rounds),
           --       roundtime (value=seconds), spell_loss (spell/spell_name/cause),
@@ -258,6 +263,13 @@ module Lich
           @character = character
           @source = source
           @idle_timeout = idle_timeout
+          # Session-finished hook (see on_session_finished / drain_finished_sessions).
+          # Every close path funnels through finish_session_locked, which
+          # queues the id; callbacks run OUTSIDE the mutex after the public
+          # call that caused the close returns.
+          @session_finished_callbacks = []
+          @finished_sessions = []
+          @finished_to_notify = []
           @last_event_at = nil
           # record fires on the AsyncProcessor worker thread; check_idle!/close
           # are documented as driven from the consuming script's own periodic
@@ -308,7 +320,41 @@ module Lich
 
         # @return [Integer, nil] the id of the session just closed
         def finish_session(at: Time.now)
-          @mutex.synchronize { finish_session_locked(at: at) }
+          result = @mutex.synchronize { finish_session_locked(at: at) }
+          notify_finished_sessions!
+          result
+        end
+
+        # Session-finished hook. Fires for EVERY close path - the idle poll
+        # (check_idle!), the next event's own idle check inside record, and
+        # close - so a subscriber sees each hunt end without polling. A
+        # session the idle gap closed and a trailing death then re-opened
+        # closes again later and fires again with the same id; dedupe if
+        # that matters. Callbacks run outside the recorder's mutex.
+        # @yieldparam session_id [Integer]
+        def on_session_finished(&blk)
+          @session_finished_callbacks << blk
+          self
+        end
+
+        # Drainable alternative to the callback: every session id finished
+        # since the last drain, oldest first.
+        # @return [Array<Integer>]
+        def drain_finished_sessions
+          @mutex.synchronize do
+            ids = @finished_sessions.dup
+            @finished_sessions.clear
+            ids
+          end
+        end
+
+        def notify_finished_sessions!
+          ids = @mutex.synchronize do
+            pending = @finished_to_notify.dup
+            @finished_to_notify.clear
+            pending
+          end
+          ids.each { |id| @session_finished_callbacks.each { |cb| cb.call(id) } }
         end
 
         def finish_session_locked(at: Time.now)
@@ -316,6 +362,8 @@ module Lich
 
           @db.execute('UPDATE sessions SET ended_at = ? WHERE id = ?', [at.to_f, @session_id])
           finished = @session_id
+          @finished_sessions << finished
+          @finished_to_notify << finished
           # Remember what the closed session fought. A death confirmed by the
           # room feed can arrive after the idle gap has already closed the
           # hunt, and that kill belongs to THIS session's creature rows - see
@@ -352,7 +400,9 @@ module Lich
         # Cheap; call it from a periodic loop so a finished hunt closes even
         # when no further event ever arrives.
         def check_idle!(now = Time.now)
-          @mutex.synchronize { check_idle_locked!(now) }
+          result = @mutex.synchronize { check_idle_locked!(now) }
+          notify_finished_sessions!
+          result
         end
 
         def check_idle_locked!(now = Time.now)
@@ -369,10 +419,13 @@ module Lich
             finish_session_locked(at: @last_event_at || Time.now) if @session_id
             @db.close
           end
+          notify_finished_sessions!
         end
 
         def record(type, data)
-          @mutex.synchronize { record_locked(type, data) }
+          result = @mutex.synchronize { record_locked(type, data) }
+          notify_finished_sessions!
+          result
         end
 
         # An event that is not ours: a nearby player's attack, a creature
@@ -489,20 +542,63 @@ module Lich
         # be nullable, since existing rows cannot supply a value. Anything the
         # SCHEMA gained but this map did not would fail on the first INSERT
         # that names it (statuses.flare_id did exactly that).
+        # Seconds within which a crit-table stun and its messaging twin are
+        # the same swing's (both are emitted while one event persists).
+        STUN_PAIR_WINDOW = 2.0
+
         ADDED_COLUMNS = {
-          'attacks'  => { 'redirected_from' => 'TEXT', 'attack_kind' => 'TEXT' },
-          'statuses' => { 'flare_id' => 'INTEGER REFERENCES flares(id)' }
+          'attacks'   => { 'redirected_from' => 'TEXT', 'attack_kind' => 'TEXT',
+                           'ours' => 'INTEGER NOT NULL DEFAULT 0' },
+          'flares'    => { 'ours' => 'INTEGER NOT NULL DEFAULT 0' },
+          'creatures' => { 'kill_credit' => 'TEXT' },
+          'statuses'  => { 'flare_id' => 'INTEGER REFERENCES flares(id)' }
         }.freeze
 
+        # Ownership of an attack row, decided ONCE here and persisted as
+        # attacks.ours so no reader re-derives it from five flags. The script
+        # kept five SQL fragments for this and two shapes slipped through:
+        # orphan sink rows (no flags set) passed every predicate, and a
+        # creature's weapon flare on an inbound row counted as our reactive
+        # flare (see flares.ours).
+        def own_attack?(event)
+          !(event[:inbound] || event[:foreign_caster] || event[:foreign_target] ||
+            event[:unowned] || event[:_orphan])
+        end
+
         def migrate!
+          added = Hash.new { |h, k| h[k] = [] }
           ADDED_COLUMNS.each do |table, cols|
             present = @db.execute("PRAGMA table_info(#{table})").map { |r| r[1] }
             cols.each do |col, type|
               next if present.include?(col)
 
               @db.execute("ALTER TABLE #{table} ADD COLUMN #{col} #{type}")
+              added[table] << col
             end
           end
+          # Backfills for databases written before a column existed. Each is
+          # derivable from what the row already stores, so they run only when
+          # the column was just added.
+          if added['attacks'].include?('ours')
+            @db.execute(<<~SQL)
+              UPDATE attacks SET ours = 1
+              WHERE inbound = 0 AND foreign_caster = 0 AND unowned = 0 AND orphan = 0 AND target_kind <> 'foreign'
+            SQL
+          end
+          if added['flares'].include?('ours')
+            # 2p/3p is not stored on old rows: a flare on our own outbound
+            # attack is ours; one on an inbound row is unknowable and stays 0.
+            @db.execute(<<~SQL)
+              UPDATE flares SET ours = 1
+              WHERE attack_id IN (SELECT id FROM attacks WHERE ours = 1)
+            SQL
+          end
+          # A flare-spawned child with no asserted parent row: the script
+          # derived "(echo)" two different ways - now one column read.
+          @db.execute(<<~SQL)
+            UPDATE attacks SET parent_confidence = 'unbound'
+            WHERE parent IS NOT NULL AND parent_attack_id IS NULL AND parent_confidence IS NULL
+          SQL
         end
 
         # -- creatures -----------------------------------------------------------
@@ -631,6 +727,10 @@ module Lich
           root_row = (root_uid && chunk_row(root_uid))
           parent_row = (parent_uid && chunk_row(parent_uid))
           parent_conf = event[:parent_confidence]&.to_s
+          # flare-spawned but the spawner row could not be asserted: say so
+          # in the column instead of leaving readers to infer it
+          parent_conf = 'unbound' if parent && parent_row.nil? && parent_conf.nil?
+          ours = own_attack?(event) ? 1 : 0
 
           in_txn do
             @seq += 1
@@ -646,15 +746,16 @@ module Lich
                       # only an HONORED redirect changes who the row is about;
                       # an announced-but-unhonored one (UAC shape) resolved on
                       # the intended creature, which the row already names
-                      (event[:redirect] && event[:redirect][:honored] != false) ? event[:redirect][:intended] : nil]
+                      (event[:redirect] && event[:redirect][:honored] != false) ? event[:redirect][:intended] : nil,
+                      ours]
             @db.execute(<<~SQL, params)
               INSERT INTO attacks (session_id, seq, occurred_at, name, parent, parent_weapon,
                                    root_attack_id, parent_attack_id, parent_confidence,
                                    via, creature_id,
                                    target_kind, attacker, attacker_exist_id, weapon, outcome,
                                    outcomes_all, aimed, ambush, attack_kind, inbound, orphan,
-                                   foreign_caster, unowned, redirected_from)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                   foreign_caster, unowned, redirected_from, ours)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             SQL
             attack_id = @db.last_insert_row_id
             # stage the uid -> row mapping; published to @chunk_rows only when
@@ -684,11 +785,15 @@ module Lich
               touched << f_target[:id].to_i if f_target && f_target[:id]
               f_outcomes = (flare[:outcomes] || []).map(&:to_s)
               weapon = flare[:weapon].is_a?(Hash) ? flare[:weapon][:name] : flare[:weapon]
+              # A 2p flare (no attacker capture) is our item firing - on an
+              # inbound row that is our REACTIVE flare; a 3p flare names the
+              # creature's or a nearby player's item. Decided here, once.
+              f_ours = flare[:attacker].nil? && !event[:foreign_caster] ? 1 : 0
               f_params = [attack_id, i + 1, flare[:name].to_s, flare[:damaging] ? 1 : 0,
-                          f_creature, txt(weapon), f_outcomes.first]
+                          f_creature, txt(weapon), f_outcomes.first, f_ours]
               @db.execute(<<~SQL, f_params)
-                INSERT INTO flares (attack_id, seq, name, damaging, creature_id, weapon, outcome)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO flares (attack_id, seq, name, damaging, creature_id, weapon, outcome, ours)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
               SQL
               flare_id = @db.last_insert_row_id
               flare_ids << flare_id
@@ -746,7 +851,7 @@ module Lich
           # credit even when a room-feed death already stamped killed_at
           # (that stamp can land under an earlier attack when the worker
           # lags the stream), but never moves an earlier killed_at.
-          @db.execute('UPDATE creatures SET killed_at = COALESCE(killed_at, ?), killed_by_attack_id = ? WHERE id = ?',
+          @db.execute("UPDATE creatures SET killed_at = COALESCE(killed_at, ?), killed_by_attack_id = ?, kill_credit = 'crit' WHERE id = ?",
                       [at, attack_id, creature_row])
         end
 
@@ -801,13 +906,42 @@ module Lich
               source = 'window'
             end
 
-            params = [@session_id, creature_row, txt(name), attack_id, flare_id, at, kind,
-                      txt(status), action, value, spell, txt(spell_name), cause, source]
-            @db.execute(<<~SQL, params)
-              INSERT INTO statuses (session_id, creature_id, subject, attack_id, flare_id, occurred_at,
-                                    kind, status, action, value, spell, spell_name, cause, source)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            SQL
+            # One swing's stun arrives twice: the crit table's kind='stun' row
+            # (with the round count) and the messaging "X is stunned!" row
+            # (kind='status'). Readers folded them inconsistently, so they
+            # merge here into ONE row - kind 'stun', the round count kept,
+            # the better attack link kept - whichever arrives first.
+            stun_add = (kind == 'stun') || (kind == 'status' && status == 'stunned' && action == 'add')
+            merged = false
+            if stun_add && creature_row
+              twin = @db.get_first_row(<<~SQL, [@session_id, creature_row, kind == 'stun' ? 'status' : 'stun', at - STUN_PAIR_WINDOW])
+                SELECT id FROM statuses
+                WHERE session_id = ? AND creature_id = ? AND kind = ? AND status = 'stunned' AND action = 'add'
+                  AND occurred_at >= ?
+                ORDER BY id DESC LIMIT 1
+              SQL
+              if twin
+                @db.execute(<<~SQL, [kind == 'stun' ? value : nil, attack_id, flare_id, source, twin[0]])
+                  UPDATE statuses
+                  SET kind = 'stun',
+                      value = COALESCE(?, value),
+                      attack_id = COALESCE(attack_id, ?),
+                      flare_id = COALESCE(flare_id, ?),
+                      source = CASE WHEN attack_id IS NULL THEN ? ELSE source END
+                  WHERE id = ?
+                SQL
+                merged = true
+              end
+            end
+            unless merged
+              params = [@session_id, creature_row, txt(name), attack_id, flare_id, at, kind,
+                        txt(status), action, value, spell, txt(spell_name), cause, source]
+              @db.execute(<<~SQL, params)
+                INSERT INTO statuses (session_id, creature_id, subject, attack_id, flare_id, occurred_at,
+                                      kind, status, action, value, spell, spell_name, cause, source)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              SQL
+            end
 
             # A death confirmed by the room feed (processor death watch) rather
             # than a fatal crit: stamp the kill and credit the attack whose
@@ -815,8 +949,27 @@ module Lich
             # Ownership (kill vs assist) is judged later from that attack's
             # flags, so crediting a foreign caster's attack here is correct.
             if status == 'dead' && action == 'add' && creature_row
-              @db.execute(<<~SQL, [at, attack_id, creature_row])
-                UPDATE creatures SET killed_at = ?, killed_by_attack_id = COALESCE(killed_by_attack_id, ?)
+              credit_id = attack_id
+              credit = attack_id ? 'window' : nil
+              if credit_id.nil?
+                # No window and no event link (the death message lagged past
+                # the swing): credit our last damaging attack on it - an own
+                # swing, or our reactive flare on an inbound row - so a kill
+                # we clearly made is not reported as an assist.
+                credit_id = @db.get_first_value(<<~SQL, [creature_row, @session_id])
+                  SELECT a.id FROM hits h
+                  JOIN attacks a ON a.id = h.attack_id
+                  LEFT JOIN flares f ON f.id = h.flare_id
+                  WHERE h.creature_id = ? AND a.session_id = ? AND h.damage > 0
+                    AND (a.ours = 1 OR f.ours = 1)
+                  ORDER BY h.id DESC LIMIT 1
+                SQL
+                credit = 'last_own_hit' if credit_id
+              end
+              @db.execute(<<~SQL, [at, credit_id, credit, creature_row])
+                UPDATE creatures
+                SET killed_at = ?, killed_by_attack_id = COALESCE(killed_by_attack_id, ?),
+                    kill_credit = COALESCE(kill_credit, ?)
                 WHERE id = ? AND killed_at IS NULL
               SQL
             end

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -144,6 +144,7 @@ module Lich
             foreign_caster INTEGER NOT NULL DEFAULT 0, -- a nearby player's attack (observed, not ours)
             unowned     INTEGER NOT NULL DEFAULT 0,    -- effect tick, no owning cast: applied to creature, not our deal
             ours        INTEGER NOT NULL DEFAULT 0,    -- decided at write time: our own OUTBOUND attack - not inbound, not a nearby player's, not on a foreign target, not an unowned tick, not an orphan sink
+            chunk_seq   INTEGER,                       -- the recorder's own count of chunks seen (monotonic for its lifetime): orders chunks that share a whole-second occurred_at, where hits.line_seq restarts
             redirected_from TEXT                       -- guardian redirect: noun of the creature we struck AT; the row's creature is the guardian that took it
           );
           CREATE INDEX IF NOT EXISTS idx_attacks_session ON attacks(session_id, seq);
@@ -270,6 +271,10 @@ module Lich
           # call that caused the close returns.
           @session_finished_callbacks = []
           @merged_stun_rows = Set.new # status ids that already absorbed their stun twin
+          # Chunks seen by this recorder, counted at each chunk boundary
+          # (a fresh per-chunk uid sequence). Persisted as attacks.chunk_seq
+          # so two chunks inside the same prompt second still order.
+          @chunk_seq = 0
           @finished_sessions = []
           @finished_to_notify = []
           @last_event_at = nil
@@ -550,7 +555,7 @@ module Lich
 
         ADDED_COLUMNS = {
           'attacks'   => { 'redirected_from' => 'TEXT', 'attack_kind' => 'TEXT',
-                           'ours' => 'INTEGER NOT NULL DEFAULT 0' },
+                           'ours' => 'INTEGER NOT NULL DEFAULT 0', 'chunk_seq' => 'INTEGER' },
           'flares'    => { 'ours' => 'INTEGER NOT NULL DEFAULT 0' },
           'hits'      => { 'line_seq' => 'INTEGER' },
           'creatures' => { 'kill_credit' => 'TEXT' },
@@ -720,6 +725,7 @@ module Lich
           if new_chunk
             @chunk_rows = {}
             @chunk_flares = {}
+            @chunk_seq += 1
           end
           @chunk_batch = batch
           root_uid = event[:root_uid]
@@ -750,15 +756,15 @@ module Lich
                       # an announced-but-unhonored one (UAC shape) resolved on
                       # the intended creature, which the row already names
                       (event[:redirect] && event[:redirect][:honored] != false) ? event[:redirect][:intended] : nil,
-                      ours]
+                      ours, @chunk_seq]
             @db.execute(<<~SQL, params)
               INSERT INTO attacks (session_id, seq, occurred_at, name, parent, parent_weapon,
                                    root_attack_id, parent_attack_id, parent_confidence,
                                    via, creature_id,
                                    target_kind, attacker, attacker_exist_id, weapon, outcome,
                                    outcomes_all, aimed, ambush, attack_kind, inbound, orphan,
-                                   foreign_caster, unowned, redirected_from, ours)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                   foreign_caster, unowned, redirected_from, ours, chunk_seq)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             SQL
             attack_id = @db.last_insert_row_id
             # stage the uid -> row mapping; published to @chunk_rows only when
@@ -978,10 +984,12 @@ module Lich
                   JOIN attacks a ON a.id = h.attack_id
                   LEFT JOIN flares f ON f.id = h.flare_id
                   WHERE h.creature_id = ? AND a.session_id = ? AND h.damage > 0
-                  ORDER BY a.occurred_at DESC, COALESCE(h.line_seq, -1) DESC, h.id DESC LIMIT 1
+                  ORDER BY a.occurred_at DESC, COALESCE(a.chunk_seq, -1) DESC, COALESCE(h.line_seq, -1) DESC, h.id DESC LIMIT 1
                 SQL
-                # ordering: the chunk's time, then the damage line's position
-                # in the chunk (COMBAT order), then insertion. Row id alone
+                # ordering: the chunk's time, then which chunk (prompt times
+                # are whole seconds, so two chunks can share one), then the
+                # damage line's position in the chunk (COMBAT order), then
+                # insertion. Row id alone
                 # credited a released spell over the swing that landed after
                 # it - the cast is emitted after its swing for lineage
                 # (review of cb68bb90).

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -113,7 +113,7 @@ module Lich
             last_seen   REAL,
             killed_at   REAL,
             killed_by_attack_id INTEGER,
-            kill_credit TEXT,                             -- how killed_by_attack_id was chosen: 'crit' (fatal crit, ground truth) | 'window' (room-feed death inside an attack window) | 'last_own_hit' (no window: our last damaging attack on it) | NULL (unknown / pre-migration)
+            kill_credit TEXT,                             -- how killed_by_attack_id was chosen: 'crit' (fatal crit, ground truth) | 'window' (room-feed death inside an attack window) | 'last_own_hit' (no window: the last damaging attack on it was ours) | 'last_hit' (no window: the last damaging attack on it was someone else's) | NULL (unknown / pre-migration)
             UNIQUE (session_id, exist_id)
           );
 
@@ -268,6 +268,7 @@ module Lich
           # queues the id; callbacks run OUTSIDE the mutex after the public
           # call that caused the close returns.
           @session_finished_callbacks = []
+          @merged_stun_rows = Set.new # status ids that already absorbed their stun twin
           @finished_sessions = []
           @finished_to_notify = []
           @last_event_at = nil
@@ -785,10 +786,12 @@ module Lich
               touched << f_target[:id].to_i if f_target && f_target[:id]
               f_outcomes = (flare[:outcomes] || []).map(&:to_s)
               weapon = flare[:weapon].is_a?(Hash) ? flare[:weapon][:name] : flare[:weapon]
-              # A 2p flare (no attacker capture) is our item firing - on an
-              # inbound row that is our REACTIVE flare; a 3p flare names the
-              # creature's or a nearby player's item. Decided here, once.
-              f_ours = flare[:attacker].nil? && !event[:foreign_caster] ? 1 : 0
+              # A 2p flare (no attacker capture, or a first-person capture such
+              # as the "your" in "spirals from your hands") is our item firing -
+              # on an inbound row that is our REACTIVE flare; a 3p flare names
+              # the creature's or a nearby player's item. Decided here, once.
+              first_person = flare[:attacker].to_s.strip.match?(/\A(?:you|your)\z/i)
+              f_ours = (flare[:attacker].nil? || first_person) && !event[:foreign_caster] ? 1 : 0
               f_params = [attack_id, i + 1, flare[:name].to_s, flare[:damaging] ? 1 : 0,
                           f_creature, txt(weapon), f_outcomes.first, f_ours]
               @db.execute(<<~SQL, f_params)
@@ -914,13 +917,22 @@ module Lich
             stun_add = (kind == 'stun') || (kind == 'status' && status == 'stunned' && action == 'add')
             merged = false
             if stun_add && creature_row
-              twin = @db.get_first_row(<<~SQL, [@session_id, creature_row, kind == 'stun' ? 'status' : 'stun', at - STUN_PAIR_WINDOW])
+              # The twin must be the SAME swing's: same attack when both sides
+              # know theirs, no stun removal in between (a fresh application
+              # after a removal is a new stun), and a row that has already
+              # absorbed its twin is not reused for a later application.
+              twin = @db.get_first_row(<<~SQL, [@session_id, creature_row, kind == 'stun' ? 'status' : 'stun', at - STUN_PAIR_WINDOW, attack_id, attack_id, @session_id, creature_row])
                 SELECT id FROM statuses
                 WHERE session_id = ? AND creature_id = ? AND kind = ? AND status = 'stunned' AND action = 'add'
                   AND occurred_at >= ?
+                  AND (attack_id IS NULL OR ? IS NULL OR attack_id = ?)
+                  AND id > COALESCE((SELECT MAX(id) FROM statuses
+                                     WHERE session_id = ? AND creature_id = ? AND status = 'stunned' AND action = 'remove'), 0)
                 ORDER BY id DESC LIMIT 1
               SQL
+              twin = nil if twin && @merged_stun_rows.include?(twin[0])
               if twin
+                @merged_stun_rows << twin[0]
                 @db.execute(<<~SQL, [kind == 'stun' ? value : nil, attack_id, flare_id, source, twin[0]])
                   UPDATE statuses
                   SET kind = 'stun',
@@ -953,18 +965,22 @@ module Lich
               credit = attack_id ? 'window' : nil
               if credit_id.nil?
                 # No window and no event link (the death message lagged past
-                # the swing): credit our last damaging attack on it - an own
-                # swing, or our reactive flare on an inbound row - so a kill
-                # we clearly made is not reported as an assist.
-                credit_id = @db.get_first_value(<<~SQL, [creature_row, @session_id])
-                  SELECT a.id FROM hits h
+                # the swing): credit the LAST damaging attack on it from ANY
+                # source, then say whether that was ours - an own swing, or
+                # our reactive flare on an inbound row ('last_own_hit') - or
+                # someone else's ('last_hit'). Filtering to our hits first
+                # would credit our earlier hit over another player's later one.
+                last = @db.get_first_row(<<~SQL, [creature_row, @session_id])
+                  SELECT a.id, (a.ours = 1 OR COALESCE(f.ours, 0) = 1) FROM hits h
                   JOIN attacks a ON a.id = h.attack_id
                   LEFT JOIN flares f ON f.id = h.flare_id
                   WHERE h.creature_id = ? AND a.session_id = ? AND h.damage > 0
-                    AND (a.ours = 1 OR f.ours = 1)
                   ORDER BY h.id DESC LIMIT 1
                 SQL
-                credit = 'last_own_hit' if credit_id
+                if last
+                  credit_id = last[0]
+                  credit = last[1] == 1 ? 'last_own_hit' : 'last_hit'
+                end
               end
               @db.execute(<<~SQL, [at, credit_id, credit, creature_row])
                 UPDATE creatures

--- a/lib/gemstone/combat/recorder.rb
+++ b/lib/gemstone/combat/recorder.rb
@@ -137,6 +137,7 @@ module Lich
             outcomes_all TEXT,                        -- comma-joined when >1
             aimed       INTEGER NOT NULL DEFAULT 0,
             ambush      INTEGER NOT NULL DEFAULT 0,
+            attack_kind TEXT,                         -- named maneuver: 'waylay'/'ambush' (from hiding, also sets ambush=1) or 'reverse_strike' (parry reaction, ambush=0); NULL when not an ambush, or recorded before this column existed
             inbound     INTEGER NOT NULL DEFAULT 0,
             orphan      INTEGER NOT NULL DEFAULT 0,
             foreign_caster INTEGER NOT NULL DEFAULT 0, -- a nearby player's attack (observed, not ours)
@@ -278,11 +279,20 @@ module Lich
         # creatures.noun blob=196, text=0), so `WHERE noun = 'berserker'` never
         # matched and text functions saw bytes, not words. Re-tag as UTF-8 at
         # the boundary; game text is ASCII/Latin-1 so scrub only guards junk.
+        # Whitespace is normalised here too. A creature revealed from hiding
+        # sometimes arrives with a space injected into BOTH attributes of its
+        # link - real line 2026-09-11: noun=" rogue" name="human  rogue", the
+        # same creature being plain "rogue"/"human rogue" on its other 34
+        # mentions. The game sends it; it is intermittent, and the reveal line
+        # is never trustworthy. Untouched, " rogue" is a noun distinct from
+        # "rogue" and the creature reports as its own kind forever.
         def txt(value)
           return nil if value.nil?
 
           s = value.to_s
-          s.encoding == Encoding::ASCII_8BIT ? s.dup.force_encoding('UTF-8').scrub('?') : s
+          s = s.dup.force_encoding('UTF-8').scrub('?') if s.encoding == Encoding::ASCII_8BIT
+          s = s.strip.squeeze(' ')
+          s.empty? ? nil : s
         end
 
         def start_session_locked(character: nil, source: nil, at: Time.now)
@@ -480,7 +490,7 @@ module Lich
         # SCHEMA gained but this map did not would fail on the first INSERT
         # that names it (statuses.flare_id did exactly that).
         ADDED_COLUMNS = {
-          'attacks'  => { 'redirected_from' => 'TEXT' },
+          'attacks'  => { 'redirected_from' => 'TEXT', 'attack_kind' => 'TEXT' },
           'statuses' => { 'flare_id' => 'INTEGER REFERENCES flares(id)' }
         }.freeze
 
@@ -630,6 +640,7 @@ module Lich
                       txt(attacker[:name]), attacker[:id],
                       txt(event[:weapon]), outcomes.first, (outcomes.size > 1 ? outcomes.join(',') : nil),
                       event[:aimed] ? 1 : 0, event[:ambush] ? 1 : 0,
+                      event[:attack_kind]&.to_s,
                       event[:inbound] ? 1 : 0, event[:_orphan] ? 1 : 0,
                       event[:foreign_caster] ? 1 : 0, event[:unowned] ? 1 : 0,
                       # only an HONORED redirect changes who the row is about;
@@ -641,9 +652,9 @@ module Lich
                                    root_attack_id, parent_attack_id, parent_confidence,
                                    via, creature_id,
                                    target_kind, attacker, attacker_exist_id, weapon, outcome,
-                                   outcomes_all, aimed, ambush, inbound, orphan, foreign_caster, unowned,
-                                   redirected_from)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                   outcomes_all, aimed, ambush, attack_kind, inbound, orphan,
+                                   foreign_caster, unowned, redirected_from)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             SQL
             attack_id = @db.last_insert_row_id
             # stage the uid -> row mapping; published to @chunk_rows only when

--- a/spec/fixtures/replay/eviscerate.txt
+++ b/spec/fixtures/replay/eviscerate.txt
@@ -1,5 +1,5 @@
 ##### eviscerate 15aea6f22534cf2c
-# expect: attacks=eviscerate | res=smr,ssr | flares=none | outcomes=none | dmg=3 | statuses=terrified/add
+# expect: attacks=eviscerate | res=smr,ssr | flares=none | outcomes=none | dmg=3 | statuses=terrified/add,demoralized/add
 You uncoil from the shadows, your mithril dagger poised to eviscerate <pushBold/>an <a exist="86648608" noun="bandit">elven bandit</a><popBold/>!
 [SMR result: 177 (Open d100: 76, Bonus: 6)]
 Catching him unaware, you carve into <pushBold/>an <a exist="86648608" noun="bandit">elven bandit</a><popBold/> with a ruthlessness calculated to terrorize onlookers!

--- a/spec/fixtures/replay/weapon_cast.txt
+++ b/spec/fixtures/replay/weapon_cast.txt
@@ -1,6 +1,21 @@
 ##### weapon_cast 47a49e78552be40a
-# expect: attacks=weapon_cast | res=none | flares=none | outcomes=none | dmg=0 | statuses=
-As you attempt to strike with your Excalibur, it sends a surge of power through you that quickly leaps out at <pushBold/>the <a exist="49036992" noun="ghast">ghast</a><popBold/>!
-You summon forth additional strength to aid your spell in penetrating the defenses surrounding the tatterdemalion <pushBold/><a exist="49036992" noun="ghast">ghast</a><popBold/>.
-Calling upon your patron to aid your cause, a brilliant aura begins to radiate from you!
-
+# expect: attacks=pummel,templars_verdict | res=smr,cs_td,as_ds | flares=weapon_cast | outcomes=ward_failed | dmg=5 | statuses=vulnerable/add
+<dialogData id='minivitals'><skin id='manaSkin' name='manaBar' controls='mana' left='25%' top='0%' width='25%' height='100%'/><progressBar id='mana' value='100' text='mana 212/212' left='25%' customText='t' top='0%' width='25%' height='100%'/></dialogData><castTime value='1789190400'/><dialogData id='minivitals'><skin id='staminaSkin' name='staminaBar' controls='stamina' left='50%' top='0%' width='25%' height='100%'/><progressBar id='stamina' value='72' text='stamina 78/107' left='50%' customText='t' top='0%' width='25%' height='100%'/></dialogData>You take a menacing step toward <pushBold/>a <a exist="212657781" noun="troll">bog troll</a><popBold/>, sweeping your <a exist="212333157" noun="mace">mithril mace</a> out low to your side in your advance.
+[SMR result: 165 (Open d100: 43, Bonus: 65)]
+With deliberate brutality, you bring your <a exist="212333157" noun="mace">mace</a> around to pummel <pushBold/>a <a exist="212657781" noun="troll">bog troll</a><popBold/>!
+As you attempt to strike with your <a exist="212333157" noun="mace">mithril mace</a>, it sends a surge of power through you that quickly leaps out at <pushBold/>the <a exist="212657781" noun="troll">troll</a><popBold/>!
+Violet flames erupt from beneath <pushBold/>a <a exist="212657781" noun="troll">bog troll</a><popBold/>.
+  CS: +149 - TD: +120 + CvA: +17 + d100: +85 == +131
+  Warding failed!
+A column of seething violet flame envelops <pushBold/>a <a exist="212657781" noun="troll">bog troll</a><popBold/> in its searing embrace!
+   ... 5 points of damage!
+   Minor burns to <pushBold/>the <a exist="212657781" noun="troll">bog troll</a><popBold/>'s weapon arm.
+   ... 20 points of damage!
+<pushBold/>A <a exist="212657781" noun="troll">bog troll's</a><popBold/> defenses are diminished in the wake of the flames.
+  <pushBold/>The <a exist="212657781" noun="troll">bog troll</a><popBold/> suffers an additional 3 damage!
+A wisp of smoke rises up from your <a exist="212333157" noun="mace">mithril mace</a> as the violet flames surrounding it are extinguished.
+  AS: +273 vs DS: +80 with AvD: +35 + d100 roll: +2 = +230
+   ... and hit for 79 points of damage!
+   Crushing blow to head closes that eye for good.
+  <pushBold/>The <a exist="212657781" noun="troll">bog troll</a><popBold/> suffers an additional 2 damage!
+Roundtime: 2 sec.

--- a/spec/lib/gemstone/combat/holy_weapon_release_spec.rb
+++ b/spec/lib/gemstone/combat/holy_weapon_release_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe 'Holy Weapon release' do
   it 'parents the released spell to the swing and returns the swing its roll' do
     events = processor.parse_events(pummel_with_verdict + ['<prompt time="1">&gt;</prompt>'])
     expect(summary(events)).to eq([
-      [:pummel, %i[smr as_ds], [79], nil],
-      [:templars_verdict, %i[cs_td], [20], :pummel]
-    ])
+                                    [:pummel, %i[smr as_ds], [79], nil],
+                                    [:templars_verdict, %i[cs_td], [20], :pummel]
+                                  ])
   end
 
   it 'does not read a later swing in the chunk as another released spell' do
@@ -69,10 +69,10 @@ RSpec.describe 'Holy Weapon release' do
     ]
     events = processor.parse_events(chunk)
     expect(summary(events)).to eq([
-      [:pummel, %i[smr as_ds], [79], nil],
-      [:templars_verdict, %i[cs_td], [20], :pummel],
-      [:attack, %i[as_ds], [40], nil]
-    ])
+                                    [:pummel, %i[smr as_ds], [79], nil],
+                                    [:templars_verdict, %i[cs_td], [20], :pummel],
+                                    [:attack, %i[as_ds], [40], nil]
+                                  ])
     expect(events.last[:_released]).to be_falsey
   end
 
@@ -97,9 +97,9 @@ RSpec.describe 'Holy Weapon release' do
     ]
     events = processor.parse_events(chunk)
     expect(summary(events)).to eq([
-      [:attack, %i[as_ds], [79], nil],
-      [:templars_verdict, %i[cs_td], [20], :attack]
-    ])
+                                    [:attack, %i[as_ds], [79], nil],
+                                    [:templars_verdict, %i[cs_td], [20], :attack]
+                                  ])
     expect(events.first[:flares].map { |f| f[:name] }).to eq([:weapon_cast])
     expect(events.first[:weapon]).to eq('perfect mithril mace')
   end
@@ -116,10 +116,10 @@ RSpec.describe 'Holy Weapon release' do
     ]
     events = processor.parse_events(chunk)
     expect(summary(events)).to eq([
-      [:attack, %i[as_ds], [79], nil],
-      [:templars_verdict, %i[cs_td], [20], :attack],
-      [:bolt, %i[as_ds], [15], nil]
-    ])
+                                    [:attack, %i[as_ds], [79], nil],
+                                    [:templars_verdict, %i[cs_td], [20], :attack],
+                                    [:bolt, %i[as_ds], [15], nil]
+                                  ])
     expect(events.last[:_released]).to be_falsey
   end
 
@@ -136,10 +136,10 @@ RSpec.describe 'Holy Weapon release' do
     ]
     events = processor.parse_events(chunk)
     expect(summary(events)).to eq([
-      [:attack, %i[as_ds], [10], nil],
-      [:attack, %i[as_ds], [79], nil],
-      [:templars_verdict, %i[cs_td], [20], :attack]
-    ])
+                                    [:attack, %i[as_ds], [10], nil],
+                                    [:attack, %i[as_ds], [79], nil],
+                                    [:templars_verdict, %i[cs_td], [20], :attack]
+                                  ])
     expect(events[0][:flares]).to be_empty
     expect(events[1][:flares].map { |f| f[:name] }).to eq([:weapon_cast])
     expect(events[2][:parent_ref]).to equal(events[1])
@@ -160,8 +160,8 @@ RSpec.describe 'Holy Weapon release' do
     ]
     events = processor.parse_events(chunk)
     expect(summary(events)).to eq([
-      [:pummel, %i[smr as_ds], [79], nil],
-      [:bolt, %i[as_ds], [15], :pummel]
-    ])
+                                    [:pummel, %i[smr as_ds], [79], nil],
+                                    [:bolt, %i[as_ds], [15], :pummel]
+                                  ])
   end
 end

--- a/spec/lib/gemstone/combat/holy_weapon_release_spec.rb
+++ b/spec/lib/gemstone/combat/holy_weapon_release_spec.rb
@@ -76,6 +76,75 @@ RSpec.describe 'Holy Weapon release' do
     expect(events.last[:_released]).to be_falsey
   end
 
+  # Second review round (3c3f1bfe): the release -> spell -> swing ordering.
+  let(:release_then_verdict) do
+    [
+      "As you attempt to strike with your #{mace}, it sends a surge of power through you that quickly leaps out at #{troll}!",
+      "Violet flames erupt from beneath #{troll}.",
+      '  CS: +149 - TD: +120 + CvA: +17 + d100: +85 == +131',
+      '  Warding failed!',
+      "A column of seething violet flame envelops #{troll} in its searing embrace!",
+      '   ... 20 points of damage!'
+    ]
+  end
+
+  it 'lets a swing with a LINKED weapon claim the pending release and adopt the cast' do
+    chunk = release_then_verdict + [
+      "You swing a perfect #{mace} at #{troll}!",
+      '  AS: +273 vs DS: +80 with AvD: +35 + d100 roll: +2 = +230',
+      '   ... and hit for 79 points of damage!',
+      '<prompt time="1">&gt;</prompt>'
+    ]
+    events = processor.parse_events(chunk)
+    expect(summary(events)).to eq([
+      [:attack, %i[as_ds], [79], nil],
+      [:templars_verdict, %i[cs_td], [20], :attack]
+    ])
+    expect(events.first[:flares].map { |f| f[:name] }).to eq([:weapon_cast])
+    expect(events.first[:weapon]).to eq('perfect mithril mace')
+  end
+
+  it 'consumes the release on the release-before-swing path so a later bolt is not adopted' do
+    chunk = release_then_verdict + [
+      "You swing a perfect mithril mace at #{troll}!",
+      '  AS: +273 vs DS: +80 with AvD: +35 + d100 roll: +2 = +230',
+      '   ... and hit for 79 points of damage!',
+      "You hurl a fiery bolt at #{troll}!",
+      '  AS: +120 vs DS: +80 with AvD: +25 + d100 roll: +60 = +125',
+      '   ... and hit for 15 points of damage!',
+      '<prompt time="1">&gt;</prompt>'
+    ]
+    events = processor.parse_events(chunk)
+    expect(summary(events)).to eq([
+      [:attack, %i[as_ds], [79], nil],
+      [:templars_verdict, %i[cs_td], [20], :attack],
+      [:bolt, %i[as_ds], [15], nil]
+    ])
+    expect(events.last[:_released]).to be_falsey
+  end
+
+  it 'holds a release that follows a settled swing for the NEXT swing' do
+    chunk = [
+      "You swing a perfect mithril mace at #{troll}!",
+      '  AS: +260 vs DS: +80 with AvD: +35 + d100 roll: +10 = +225',
+      '   ... and hit for 10 points of damage!'
+    ] + release_then_verdict + [
+      "You swing a perfect mithril mace at #{troll}!",
+      '  AS: +273 vs DS: +80 with AvD: +35 + d100 roll: +2 = +230',
+      '   ... and hit for 79 points of damage!',
+      '<prompt time="1">&gt;</prompt>'
+    ]
+    events = processor.parse_events(chunk)
+    expect(summary(events)).to eq([
+      [:attack, %i[as_ds], [10], nil],
+      [:attack, %i[as_ds], [79], nil],
+      [:templars_verdict, %i[cs_td], [20], :attack]
+    ])
+    expect(events[0][:flares]).to be_empty
+    expect(events[1][:flares].map { |f| f[:name] }).to eq([:weapon_cast])
+    expect(events[2][:parent_ref]).to equal(events[1])
+  end
+
   it 'lets a released BOLT keep its own AS/DS and damage' do
     chunk = [
       "You take a menacing step toward #{troll}, sweeping your #{mace} out low to your side in your advance.",

--- a/spec/lib/gemstone/combat/holy_weapon_release_spec.rb
+++ b/spec/lib/gemstone/combat/holy_weapon_release_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require 'gemstone/combat/parser'
+require 'gemstone/combat/processor'
+
+# Holy Weapon (1625) infusion release: the proc line is a pre-flare on the
+# swing, the spell it releases runs as the swing's child, and the swing
+# resumes for its own roll. Two shapes a review of 056ff899 caught:
+#   1. one flare releases ONE spell - a later swing in the same chunk must
+#      not be read as "released" (it stole the swing's roll and damage);
+#   2. the released spell may be a BOLT, whose own AS/DS arrives before the
+#      swing's - the swing must resume on the SECOND physical roll.
+RSpec.describe 'Holy Weapon release' do
+  processor = Lich::Gemstone::Combat::Processor
+  troll = '<pushBold/>a <a exist="212657781" noun="troll">bog troll</a><popBold/>'
+  mace  = '<a exist="212333157" noun="mace">mithril mace</a>'
+
+  before do
+    stub_const('Lich::Gemstone::Combat::Tracker', Module.new)
+    allow(Lich::Gemstone::Combat::Tracker).to receive(:settings).and_return(
+      emit_attacks: true, track_statuses: true, track_ucs: true, track_wounds: true
+    )
+    allow(Lich::Gemstone::Combat::Tracker).to receive(:debug?).and_return(false)
+    stub_const('Lich::Gemstone::Combat::Observers', Module.new)
+    allow(processor).to receive(:apply_status_to_target)
+    allow(processor).to receive(:apply_ucs_to_target)
+    allow(Lich::Gemstone::Combat::Observers).to receive(:emit)
+    processor.instance_variable_set(:@active_assault, nil)
+  end
+
+  def summary(events)
+    events.map do |e|
+      [e[:name], e[:resolutions].map { |r| r[:type] }, e[:hits].map { |h| h[:damage] },
+       e[:parent_ref] ? e[:parent_ref][:name] : nil]
+    end
+  end
+
+  let(:pummel_with_verdict) do
+    [
+      "You take a menacing step toward #{troll}, sweeping your #{mace} out low to your side in your advance.",
+      '[SMR result: 165 (Open d100: 43, Bonus: 65)]',
+      "With deliberate brutality, you bring your #{mace} around to pummel #{troll}!",
+      "As you attempt to strike with your #{mace}, it sends a surge of power through you that quickly leaps out at #{troll}!",
+      "Violet flames erupt from beneath #{troll}.",
+      '  CS: +149 - TD: +120 + CvA: +17 + d100: +85 == +131',
+      '  Warding failed!',
+      "A column of seething violet flame envelops #{troll} in its searing embrace!",
+      '   ... 20 points of damage!',
+      '  AS: +273 vs DS: +80 with AvD: +35 + d100 roll: +2 = +230',
+      '   ... and hit for 79 points of damage!'
+    ]
+  end
+
+  it 'parents the released spell to the swing and returns the swing its roll' do
+    events = processor.parse_events(pummel_with_verdict + ['<prompt time="1">&gt;</prompt>'])
+    expect(summary(events)).to eq([
+      [:pummel, %i[smr as_ds], [79], nil],
+      [:templars_verdict, %i[cs_td], [20], :pummel]
+    ])
+  end
+
+  it 'does not read a later swing in the chunk as another released spell' do
+    chunk = pummel_with_verdict + [
+      "You swing a perfect #{mace} at #{troll}!",
+      '  AS: +280 vs DS: +90 with AvD: +35 + d100 roll: +50 = +275',
+      '   ... and hit for 40 points of damage!',
+      '<prompt time="1">&gt;</prompt>'
+    ]
+    events = processor.parse_events(chunk)
+    expect(summary(events)).to eq([
+      [:pummel, %i[smr as_ds], [79], nil],
+      [:templars_verdict, %i[cs_td], [20], :pummel],
+      [:attack, %i[as_ds], [40], nil]
+    ])
+    expect(events.last[:_released]).to be_falsey
+  end
+
+  it 'lets a released BOLT keep its own AS/DS and damage' do
+    chunk = [
+      "You take a menacing step toward #{troll}, sweeping your #{mace} out low to your side in your advance.",
+      '[SMR result: 165 (Open d100: 43, Bonus: 65)]',
+      "With deliberate brutality, you bring your #{mace} around to pummel #{troll}!",
+      "As you attempt to strike with your #{mace}, it sends a surge of power through you that quickly leaps out at #{troll}!",
+      "You hurl a fiery bolt at #{troll}!",
+      '  AS: +120 vs DS: +80 with AvD: +25 + d100 roll: +60 = +125',
+      '   ... and hit for 15 points of damage!',
+      '  AS: +273 vs DS: +80 with AvD: +35 + d100 roll: +2 = +230',
+      '   ... and hit for 79 points of damage!',
+      '<prompt time="1">&gt;</prompt>'
+    ]
+    events = processor.parse_events(chunk)
+    expect(summary(events)).to eq([
+      [:pummel, %i[smr as_ds], [79], nil],
+      [:bolt, %i[as_ds], [15], :pummel]
+    ])
+  end
+end

--- a/spec/lib/gemstone/combat/processor_inbound_spec.rb
+++ b/spec/lib/gemstone/combat/processor_inbound_spec.rb
@@ -434,17 +434,26 @@ RSpec.describe Lich::Gemstone::Combat::Processor do
       expect(Lich::Gemstone::Combat::Observers).to have_received(:emit).with(:attack, event)
     end
 
+    # The Holy Weapon (1625) release line is a pre-FLARE on our swing, not
+    # an attack of its own (it used to be, and then swallowed the swing's
+    # roll). "through you" is what keeps it ours rather than a nearby
+    # player's; the swing line that follows carries the target.
     it 'keeps our OWN weapon infusion (through you) as ours' do
       chunk = [
         "As you attempt to strike with your star, it sends a surge of power through you that quickly leaps out at #{maiden}!",
+        "You swing a spiked star at #{maiden}!",
         '  AS: +400 vs DS: +200 with AvD: +30 + d100 roll: +50 = +280',
         '   ... and hits for 30 points of damage!',
         '<prompt time="1757183316">&gt;</prompt>'
       ]
 
-      event = described_class.parse_events(chunk).first
+      events = described_class.parse_events(chunk)
+      expect(events.size).to eq(1)
+      event = events.first
       expect(event[:foreign_caster]).to be_falsey
       expect(event[:target][:id]).to eq(555001)
+      expect(event[:flares].map { |f| f[:name] }).to eq([:weapon_cast])
+      expect(event[:hits].size).to eq(1)
     end
   end
 

--- a/spec/lib/gemstone/combat/recorder_combat_order_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_combat_order_spec.rb
@@ -120,6 +120,28 @@ RSpec.describe 'Recorder kill credit follows combat order' do
     expect(row['kill_credit']).to eq('last_own_hit')
   end
 
+  it 'orders two chunks that share a whole-second timestamp by chunk, not by line position' do
+    rec = Lich::Gemstone::Combat::Recorder.new(@db_path, character: 'Tester', source: 'test', idle_timeout: 60)
+    same_second = Time.at(1_000_000)
+    lizard = { id: 101, name: 'a cave lizard', noun: nil }
+    # earlier chunk: our damage late in the chunk (line 30)
+    rec.record(:attack, { name: 'mine', at: same_second, target: lizard, _uid: 0,
+                          hits: [{ damage: 40, crit: nil, line: 30 }], resolutions: [] })
+    # later chunk, same prompt second: a nearby player's damage early in it (line 2)
+    rec.record(:attack, { name: 'theirs', at: same_second, target: lizard, _uid: 0, foreign_caster: true,
+                          hits: [{ damage: 5, crit: nil, line: 2 }], resolutions: [] })
+    rec.finish_session(at: same_second + 100)
+    rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: 'add')
+    rec.close
+
+    theirs = query("SELECT id, chunk_seq FROM attacks WHERE name = 'theirs'").first
+    mine   = query("SELECT chunk_seq FROM attacks WHERE name = 'mine'").first
+    expect(theirs['chunk_seq']).to be > mine['chunk_seq']
+    row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
+    expect(row['killed_by_attack_id']).to eq(theirs['id'])
+    expect(row['kill_credit']).to eq('last_hit')
+  end
+
   it 'records the feed position of every hit' do
     rec = Lich::Gemstone::Combat::Recorder.new(@db_path, character: 'Tester', source: 'test', idle_timeout: 60)
     chunk = [release] + verdict + ["You swing a perfect #{mace} at #{troll}!"] + swing_roll + prompt

--- a/spec/lib/gemstone/combat/recorder_combat_order_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_combat_order_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require 'gemstone/combat/parser'
+require 'gemstone/combat/processor'
+require 'gemstone/combat/recorder'
+require 'tmpdir'
+require 'fileutils'
+
+# Parser -> recorder: the delayed-death fallback must credit the attack that
+# dealt the LAST damage in COMBAT order. Insertion order is not that: a
+# Holy Weapon release re-emits the released cast AFTER the swing it belongs
+# to (so the recorder's parent-first lineage resolves), and a pummel opens
+# before its released spell but lands its own damage after it. Only the
+# damage line's feed position (hits.line_seq) says which hit was last.
+RSpec.describe 'Recorder kill credit follows combat order' do
+  processor = Lich::Gemstone::Combat::Processor
+  troll = '<pushBold/>a <a exist="212657781" noun="troll">bog troll</a><popBold/>'
+  mace  = '<a exist="212333157" noun="mace">mithril mace</a>'
+
+  before do
+    stub_const('Lich::Gemstone::Combat::Tracker', Module.new)
+    allow(Lich::Gemstone::Combat::Tracker).to receive(:settings).and_return(
+      emit_attacks: true, track_statuses: true, track_ucs: true, track_wounds: true
+    )
+    allow(Lich::Gemstone::Combat::Tracker).to receive(:debug?).and_return(false)
+    observers = Module.new do
+      def self.on(*, **, &_blk); end
+      def self.off(*); end
+      def self.emit(*); end
+    end
+    stub_const('Lich::Gemstone::Combat::Observers', observers)
+    allow(processor).to receive(:apply_status_to_target)
+    allow(processor).to receive(:apply_ucs_to_target)
+    processor.instance_variable_set(:@active_assault, nil)
+    @tmpdir = Dir.mktmpdir('combat-order')
+    @db_path = File.join(@tmpdir, 'test.db')
+  end
+
+  after do
+    GC.start
+    FileUtils.remove_entry(@tmpdir)
+  rescue StandardError
+    # leftover WAL sidecar still locked on Windows - harmless
+  end
+
+  def query(sql, *params)
+    db = SQLite3::Database.new(@db_path)
+    db.results_as_hash = true
+    db.execute(sql, params)
+  ensure
+    db&.close
+  end
+
+  # What Processor.process does after parse_events: resolve the object refs
+  # into per-chunk uids the recorder maps to rows, and stamp the chunk time.
+  def stamp(events, at:)
+    uids = {}.compare_by_identity
+    events.each_with_index { |ev, i| uids[ev] = i }
+    events.each_with_index do |ev, i|
+      ev[:_uid] = i
+      ev[:root_uid] = ev[:root_ref] ? (uids[ev[:root_ref]] || i) : i
+      ev[:parent_uid] = ev[:parent_ref] ? uids[ev[:parent_ref]] : nil
+      ev[:at] = at
+    end
+    events
+  end
+
+  def record_chunk(rec, lines, at:)
+    events = stamp(Lich::Gemstone::Combat::Processor.parse_events(lines), at: at)
+    events.each { |ev| rec.record(:attack, ev) }
+    events
+  end
+
+  let(:verdict) do
+    [
+      "Violet flames erupt from beneath #{troll}.",
+      '  CS: +149 - TD: +120 + CvA: +17 + d100: +85 == +131',
+      '  Warding failed!',
+      "A column of seething violet flame envelops #{troll} in its searing embrace!",
+      '   ... 20 points of damage!'
+    ]
+  end
+  let(:release) { "As you attempt to strike with your #{mace}, it sends a surge of power through you that quickly leaps out at #{troll}!" }
+  let(:swing_roll) { ['  AS: +273 vs DS: +80 with AvD: +35 + d100 roll: +2 = +230', '   ... and hit for 79 points of damage!'] }
+  let(:prompt) { ['<prompt time="1">&gt;</prompt>'] }
+
+  it 'credits the swing when the released spell landed first (release -> Verdict -> swing)' do
+    rec = Lich::Gemstone::Combat::Recorder.new(@db_path, character: 'Tester', source: 'test', idle_timeout: 60)
+    chunk = [release] + verdict + ["You swing a perfect #{mace} at #{troll}!"] + swing_roll + prompt
+    events = record_chunk(rec, chunk, at: Time.at(1_000_000))
+    expect(events.map { |e| e[:name] }).to eq(%i[attack templars_verdict]) # cast re-emitted AFTER its swing
+    rec.finish_session(at: Time.at(1_000_100))
+    rec.record(:status, id: 212_657_781, name: 'bog troll', status: 'dead', action: 'add')
+    rec.close
+
+    swing = query("SELECT id FROM attacks WHERE name = 'attack'").first['id']
+    row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
+    expect(row['killed_by_attack_id']).to eq(swing)
+    expect(row['kill_credit']).to eq('last_own_hit')
+  end
+
+  it 'credits the pummel when its own damage lands after the spell it released (pummel -> release -> Verdict -> AS/DS)' do
+    rec = Lich::Gemstone::Combat::Recorder.new(@db_path, character: 'Tester', source: 'test', idle_timeout: 60)
+    chunk = [
+      "You take a menacing step toward #{troll}, sweeping your #{mace} out low to your side in your advance.",
+      '[SMR result: 165 (Open d100: 43, Bonus: 65)]',
+      "With deliberate brutality, you bring your #{mace} around to pummel #{troll}!",
+      release
+    ] + verdict + swing_roll + prompt
+    events = record_chunk(rec, chunk, at: Time.at(1_000_000))
+    expect(events.map { |e| e[:name] }).to eq(%i[pummel templars_verdict])
+    rec.finish_session(at: Time.at(1_000_100))
+    rec.record(:status, id: 212_657_781, name: 'bog troll', status: 'dead', action: 'add')
+    rec.close
+
+    pummel = query("SELECT id FROM attacks WHERE name = 'pummel'").first['id']
+    row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
+    expect(row['killed_by_attack_id']).to eq(pummel)
+    expect(row['kill_credit']).to eq('last_own_hit')
+  end
+
+  it 'records the feed position of every hit' do
+    rec = Lich::Gemstone::Combat::Recorder.new(@db_path, character: 'Tester', source: 'test', idle_timeout: 60)
+    chunk = [release] + verdict + ["You swing a perfect #{mace} at #{troll}!"] + swing_roll + prompt
+    record_chunk(rec, chunk, at: Time.at(1_000_000))
+    rec.close
+    rows = query('SELECT a.name, h.damage, h.line_seq FROM hits h JOIN attacks a ON a.id = h.attack_id ORDER BY h.line_seq')
+    expect(rows.map { |r| [r['name'], r['damage']] }).to eq([['templars_verdict', 20], ['attack', 79]])
+    expect(rows.map { |r| r['line_seq'] }).to all(be_a(Integer))
+  end
+end

--- a/spec/lib/gemstone/combat/recorder_schema_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_schema_spec.rb
@@ -112,9 +112,9 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       rec.close
       rows = query('SELECT a.name AS atk, f.name AS flare, f.ours FROM flares f JOIN attacks a ON a.id = f.attack_id ORDER BY f.id')
       expect(rows.map { |r| [r['atk'], r['flare'], r['ours']] }).to eq([
-        ['own', 'fire', 1], ['own', 'acid', 0],
-        ['claw', 'shield_spike', 1], ['claw', 'acid', 0]
-      ])
+                                                                         ['own', 'fire', 1], ['own', 'acid', 0],
+                                                                         ['claw', 'shield_spike', 1], ['claw', 'acid', 0]
+                                                                       ])
     end
   end
 

--- a/spec/lib/gemstone/combat/recorder_schema_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_schema_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require 'gemstone/combat/recorder'
+require 'tmpdir'
+require 'fileutils'
+
+# The recorder as the single place that decides what a reader used to
+# re-derive: session end (a hook), ownership (attacks.ours / flares.ours),
+# kill credit when the death lands outside an attack window, the stun pair
+# merged to one row, and 'unbound' for a flare-spawned child whose spawner
+# row could not be asserted. Plus the two hit indexes.
+RSpec.describe Lich::Gemstone::Combat::Recorder do
+  before do
+    observers = Module.new do
+      def self.on(*, **, &_blk); end
+      def self.off(*); end
+      def self.emit(*); end
+    end
+    stub_const('Lich::Gemstone::Combat::Observers', observers)
+    @tmpdir = Dir.mktmpdir('combat-recorder-schema')
+    @db_path = File.join(@tmpdir, 'test.db')
+  end
+
+  after do
+    GC.start
+    FileUtils.remove_entry(@tmpdir)
+  rescue StandardError
+    # leftover WAL sidecar still locked on Windows - harmless
+  end
+
+  def new_recorder(**opts)
+    described_class.new(@db_path, character: 'Tester', source: 'test', **opts)
+  end
+
+  def query(sql, *params)
+    db = SQLite3::Database.new(@db_path)
+    db.results_as_hash = true
+    db.execute(sql, params)
+  ensure
+    db&.close
+  end
+
+  def attack_event(name: 'fire', target_id: 101, target_name: 'a cave lizard', damage: 42,
+                   at: Time.at(1_000_000), **extra)
+    {
+      name: name, at: at,
+      target: { id: target_id, name: target_name, noun: nil },
+      hits: [{ damage: damage, crit: nil }],
+      resolutions: [{ type: :ranged, as: 300, ds: 120, roll: 55, result: 235 }]
+    }.merge(extra)
+  end
+
+  describe 'session-finished hook' do
+    it 'fires from finish_session, from the idle poll, and from close, and is drainable' do
+      rec = new_recorder(idle_timeout: 60)
+      seen = []
+      rec.on_session_finished { |id| seen << id }
+
+      rec.record(:attack, attack_event)                        # opens session 1 lazily
+      first = rec.finish_session(at: Time.at(1_000_100))
+      expect(seen).to eq([first])
+
+      rec.record(:attack, attack_event)                        # session 2
+      expect(rec.check_idle!(Time.now + 3600)).to eq(first + 1) # idle poll closes it
+      expect(seen).to eq([first, first + 1])
+
+      rec.record(:attack, attack_event)                        # session 3
+      rec.close                                                # close path
+      expect(seen).to eq([first, first + 1, first + 2])
+      expect(rec.drain_finished_sessions).to eq([first, first + 1, first + 2])
+      expect(rec.drain_finished_sessions).to eq([])
+    end
+
+    it "fires when the NEXT event's own idle check closes the previous session" do
+      rec = new_recorder(idle_timeout: 0.05)
+      seen = []
+      rec.on_session_finished { |id| seen << id }
+      rec.record(:attack, attack_event)
+      sleep 0.1
+      rec.record(:attack, attack_event) # record's own check_idle_locked! closes session 1 first
+      expect(seen.size).to eq(1)
+      expect(query('SELECT COUNT(*) AS n FROM sessions').first['n']).to eq(2)
+      rec.close
+    end
+  end
+
+  describe 'ownership decided at write time' do
+    it 'stamps attacks.ours from the event flags, orphans and foreign targets included' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      rec.record(:attack, attack_event(name: 'own'))
+      rec.record(:attack, attack_event(name: 'claw', target: nil, inbound: true))
+      rec.record(:attack, attack_event(name: 'cast', foreign_caster: true))
+      rec.record(:attack, attack_event(name: 'spell', target: nil, foreign_target: true))
+      rec.record(:attack, attack_event(name: 'bleed', unowned: true))
+      rec.record(:attack, attack_event(name: 'unknown', target: {}, _orphan: true))
+      rec.close
+      rows = query('SELECT name, ours FROM attacks ORDER BY id').to_h { |r| [r['name'], r['ours']] }
+      expect(rows).to eq('own' => 1, 'claw' => 0, 'cast' => 0, 'spell' => 0, 'bleed' => 0, 'unknown' => 0)
+    end
+
+    it 'stamps flares.ours: 2p flares are ours even on an inbound row, 3p flares are not' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      mine   = { name: :fire, damaging: true, hits: [{ damage: 5, crit: nil }] }
+      theirs = { name: :acid, damaging: true, attacker: 'a cave lizard', hits: [{ damage: 5, crit: nil }] }
+      rec.record(:attack, attack_event(name: 'own', flares: [mine, theirs]))
+      rec.record(:attack, attack_event(name: 'claw', target: nil, inbound: true,
+                                       attacker: { id: 101, name: 'a cave lizard' },
+                                       flares: [mine.merge(name: :shield_spike), theirs]))
+      rec.close
+      rows = query('SELECT a.name AS atk, f.name AS flare, f.ours FROM flares f JOIN attacks a ON a.id = f.attack_id ORDER BY f.id')
+      expect(rows.map { |r| [r['atk'], r['flare'], r['ours']] }).to eq([
+        ['own', 'fire', 1], ['own', 'acid', 0],
+        ['claw', 'shield_spike', 1], ['claw', 'acid', 0]
+      ])
+    end
+  end
+
+  describe 'indexes' do
+    it 'indexes hits by creature alone and by flare' do
+      rec = new_recorder
+      rec.close
+      names = query("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'hits'").map { |r| r['name'] }
+      expect(names).to include('idx_hits_creature_only', 'idx_hits_flare')
+    end
+  end
+
+  describe 'kill credit' do
+    it "is 'window' when the room-feed death lands inside the attack window" do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      rec.record(:attack, attack_event)
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: 'add')
+      rec.close
+      row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
+      expect(row['killed_by_attack_id']).to eq(1)
+      expect(row['kill_credit']).to eq('window')
+    end
+
+    it "falls back to our last damaging attack and says 'last_own_hit' when there is no window" do
+      rec = new_recorder(idle_timeout: 60)
+      rec.record(:attack, attack_event(name: 'theirs', foreign_caster: true, damage: 500))
+      rec.record(:attack, attack_event(name: 'mine', damage: 40))
+      rec.finish_session(at: Time.at(1_000_100)) # clears the attack window
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: 'add') # trailing death
+      rec.close
+      row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
+      mine = query("SELECT id FROM attacks WHERE name = 'mine'").first['id']
+      expect(row['killed_by_attack_id']).to eq(mine)
+      expect(row['kill_credit']).to eq('last_own_hit')
+    end
+  end
+
+  describe 'stun pair' do
+    it 'merges the crit-table stun and the messaging status into one row, either order' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      rec.record(:attack, attack_event)
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'stunned', action: 'add')
+      rec.record(:stun, id: 101, name: 'a cave lizard', rounds: 3)
+      rec.record(:attack, attack_event(target_id: 102, target_name: 'a rolton'))
+      rec.record(:stun, id: 102, name: 'a rolton', rounds: 2)
+      rec.record(:status, id: 102, name: 'a rolton', status: 'stunned', action: 'add')
+      rec.close
+      rows = query("SELECT c.exist_id AS who, s.kind, s.value FROM statuses s JOIN creatures c ON c.id = s.creature_id WHERE s.status = 'stunned' ORDER BY s.id")
+      expect(rows.map { |r| [r['who'], r['kind'], r['value']] }).to eq([[101, 'stun', 3], [102, 'stun', 2]])
+    end
+  end
+
+  describe 'unbound children' do
+    it "marks a flare-spawned child with no asserted parent row as parent_confidence 'unbound'" do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      rec.record(:attack, attack_event(name: 'fire'))
+      rec.record(:attack, attack_event(name: 'fire', parent: { flare: :mirror_image, weapon: nil }))
+      rec.close
+      rows = query('SELECT parent, parent_attack_id, parent_confidence FROM attacks ORDER BY id')
+      expect(rows[0].values_at('parent', 'parent_confidence')).to eq([nil, nil])
+      expect(rows[1].values_at('parent', 'parent_attack_id', 'parent_confidence')).to eq(['mirror_image', nil, 'unbound'])
+    end
+  end
+end

--- a/spec/lib/gemstone/combat/recorder_schema_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_schema_spec.rb
@@ -129,15 +129,6 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
   end
 
   describe 'first-person flare captures' do
-    it 'treats an attacker capture of "your" as ours (boil_blood: "from your hands")' do
-      rec = new_recorder
-      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
-      boil = { name: :boil_blood, damaging: true, attacker: 'your', hits: [{ damage: 9, crit: nil }] }
-      rec.record(:attack, attack_event(name: 'own', flares: [boil]))
-      rec.close
-      expect(query("SELECT ours FROM flares WHERE name = 'boil_blood'").first['ours']).to eq(1)
-    end
-
     it 'drops the first-person capture at parse time too' do
       line = '** A fiery aura spirals from your hands into <pushBold/>a <a exist="101" noun="lizard">cave lizard</a><popBold/> body, roiling its blood to a boil! **'
       flare = Lich::Gemstone::Combat::Definitions::Flares.parse(line)
@@ -178,20 +169,6 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       mine = query("SELECT id FROM attacks WHERE name = 'mine'").first['id']
       expect(row['killed_by_attack_id']).to eq(mine)
       expect(row['kill_credit']).to eq('last_own_hit')
-    end
-
-    it 'credits a later FOREIGN hit over our earlier one - the last damage wins, whoever dealt it' do
-      rec = new_recorder(idle_timeout: 60)
-      rec.record(:attack, attack_event(name: 'mine', damage: 40))
-      rec.record(:attack, attack_event(name: 'theirs', foreign_caster: true, damage: 5))
-      rec.finish_session(at: Time.at(1_000_100))
-      rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: 'add')
-      rec.close
-      row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
-      theirs = query("SELECT id, ours FROM attacks WHERE name = 'theirs'").first
-      expect(row['killed_by_attack_id']).to eq(theirs['id'])
-      expect(theirs['ours']).to eq(0) # the row's flag says assist, not the credit path
-      expect(row['kill_credit']).to eq('last_hit')
     end
 
     it "credits another player's LATER hit over our earlier one and says 'last_hit'" do

--- a/spec/lib/gemstone/combat/recorder_schema_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_schema_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../../spec_helper'
 require 'gemstone/combat/recorder'
+require 'gemstone/combat/defs/flares'
 require 'tmpdir'
 require 'fileutils'
 
@@ -116,6 +117,33 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
                                                                          ['claw', 'shield_spike', 1], ['claw', 'acid', 0]
                                                                        ])
     end
+
+    it "treats a first-person attacker capture ('your hands') as our flare" do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      boil = { name: :boil_blood, damaging: true, attacker: 'your', hits: [{ damage: 9, crit: nil }] }
+      rec.record(:attack, attack_event(name: 'punch', flares: [boil]))
+      rec.close
+      expect(query('SELECT ours FROM flares').first['ours']).to eq(1)
+    end
+  end
+
+  describe 'first-person flare captures' do
+    it 'treats an attacker capture of "your" as ours (boil_blood: "from your hands")' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      boil = { name: :boil_blood, damaging: true, attacker: 'your', hits: [{ damage: 9, crit: nil }] }
+      rec.record(:attack, attack_event(name: 'own', flares: [boil]))
+      rec.close
+      expect(query("SELECT ours FROM flares WHERE name = 'boil_blood'").first['ours']).to eq(1)
+    end
+
+    it 'drops the first-person capture at parse time too' do
+      line = '** A fiery aura spirals from your hands into <pushBold/>a <a exist="101" noun="lizard">cave lizard</a><popBold/> body, roiling its blood to a boil! **'
+      flare = Lich::Gemstone::Combat::Definitions::Flares.parse(line)
+      expect(flare[:name]).to eq(:boil_blood)
+      expect(flare[:attacker]).to be_nil
+    end
   end
 
   describe 'indexes' do
@@ -139,7 +167,7 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       expect(row['kill_credit']).to eq('window')
     end
 
-    it "falls back to our last damaging attack and says 'last_own_hit' when there is no window" do
+    it "falls back to the LAST damaging attack and says 'last_own_hit' when that was ours" do
       rec = new_recorder(idle_timeout: 60)
       rec.record(:attack, attack_event(name: 'theirs', foreign_caster: true, damage: 500))
       rec.record(:attack, attack_event(name: 'mine', damage: 40))
@@ -150,6 +178,33 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       mine = query("SELECT id FROM attacks WHERE name = 'mine'").first['id']
       expect(row['killed_by_attack_id']).to eq(mine)
       expect(row['kill_credit']).to eq('last_own_hit')
+    end
+
+    it 'credits a later FOREIGN hit over our earlier one - the last damage wins, whoever dealt it' do
+      rec = new_recorder(idle_timeout: 60)
+      rec.record(:attack, attack_event(name: 'mine', damage: 40))
+      rec.record(:attack, attack_event(name: 'theirs', foreign_caster: true, damage: 5))
+      rec.finish_session(at: Time.at(1_000_100))
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: 'add')
+      rec.close
+      row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
+      theirs = query("SELECT id, ours FROM attacks WHERE name = 'theirs'").first
+      expect(row['killed_by_attack_id']).to eq(theirs['id'])
+      expect(theirs['ours']).to eq(0) # the row's flag says assist, not the credit path
+      expect(row['kill_credit']).to eq('last_hit')
+    end
+
+    it "credits another player's LATER hit over our earlier one and says 'last_hit'" do
+      rec = new_recorder(idle_timeout: 60)
+      rec.record(:attack, attack_event(name: 'mine', damage: 40))
+      rec.record(:attack, attack_event(name: 'theirs', foreign_caster: true, damage: 500))
+      rec.finish_session(at: Time.at(1_000_100)) # clears the attack window
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'dead', action: 'add') # trailing death
+      rec.close
+      row = query('SELECT killed_by_attack_id, kill_credit FROM creatures').first
+      theirs = query("SELECT id FROM attacks WHERE name = 'theirs'").first['id']
+      expect(row['killed_by_attack_id']).to eq(theirs)
+      expect(row['kill_credit']).to eq('last_hit')
     end
   end
 
@@ -166,6 +221,44 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
       rec.close
       rows = query("SELECT c.exist_id AS who, s.kind, s.value FROM statuses s JOIN creatures c ON c.id = s.creature_id WHERE s.status = 'stunned' ORDER BY s.id")
       expect(rows.map { |r| [r['who'], r['kind'], r['value']] }).to eq([[101, 'stun', 3], [102, 'stun', 2]])
+    end
+
+    it 'does not fold a second swing\'s stun into a pair that already merged, even inside the window' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      rec.record(:attack, attack_event(name: 'first'))
+      rec.record(:stun, id: 101, name: 'a cave lizard', rounds: 3)
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'stunned', action: 'add')    # merges into the pair
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'stunned', action: 'remove') # stun wore off
+      rec.record(:attack, attack_event(name: 'second'))
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'stunned', action: 'add')    # a NEW application
+      rec.close
+      rows = query("SELECT s.kind, s.action, s.value, a.name AS atk FROM statuses s LEFT JOIN attacks a ON a.id = s.attack_id WHERE s.status = 'stunned' ORDER BY s.id")
+      expect(rows.map { |r| [r['kind'], r['action'], r['value'], r['atk']] }).to eq([
+                                                                                      ['stun', 'add', 3, 'first'],
+                                                                                      ['status', 'remove', nil, 'first'],
+                                                                                      ['status', 'add', nil, 'second']
+                                                                                    ])
+    end
+  end
+
+  describe 'stun re-application' do
+    it 'does not fold a second attack\'s stun into a pair that a removal already ended' do
+      rec = new_recorder
+      rec.start_session(character: 'Tester', source: 'test', at: Time.at(1_000_000))
+      rec.record(:attack, attack_event(name: 'first'))
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'stunned', action: 'add')
+      rec.record(:stun, id: 101, name: 'a cave lizard', rounds: 3)
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'stunned', action: 'remove')
+      rec.record(:attack, attack_event(name: 'second'))
+      rec.record(:status, id: 101, name: 'a cave lizard', status: 'stunned', action: 'add') # all within 2s
+      rec.close
+      rows = query("SELECT s.kind, s.action, s.value, a.name AS atk FROM statuses s LEFT JOIN attacks a ON a.id = s.attack_id WHERE s.status = 'stunned' ORDER BY s.id")
+      expect(rows.map { |r| [r['kind'], r['action'], r['value'], r['atk']] }).to eq([
+                                                                                      ['stun', 'add', 3, 'first'],
+                                                                                      ['status', 'remove', nil, 'first'],
+                                                                                      ['status', 'add', nil, 'second']
+                                                                                    ])
     end
   end
 

--- a/spec/lib/gemstone/combat/recorder_spec.rb
+++ b/spec/lib/gemstone/combat/recorder_spec.rb
@@ -403,8 +403,14 @@ RSpec.describe Lich::Gemstone::Combat::Recorder do
   describe 'statuses.flare_id migration' do
     def legacy_database_without_flare_id
       legacy = SQLite3::Database.new(@db_path)
-      pre = described_class::SCHEMA.gsub(/\n\s*flare_id    INTEGER REFERENCES flares\(id\),[^\n]*/, '')
-      expect(pre).not_to include('flare_id')
+      # drop ONLY the statuses column: hits and resolutions have always had a
+      # flare_id (and hits is indexed on it), so a blanket strip built a
+      # legacy table the shipped index could not be created on
+      statuses_ddl = /CREATE TABLE IF NOT EXISTS statuses \(.*?\);/m
+      pre = described_class::SCHEMA.sub(statuses_ddl) do |ddl|
+        ddl.gsub(/\n\s*flare_id    INTEGER REFERENCES flares\(id\),[^\n]*/, '')
+      end
+      expect(pre[statuses_ddl]).not_to include('flare_id')
       legacy.execute_batch(pre)
       cols = legacy.execute('PRAGMA table_info(statuses)').map { |r| r[1] }
       legacy.close


### PR DESCRIPTION
> **Stacked on #1593.** This branch is one commit on top of `combat-hunt-audit`; until #1593 merges the diff here shows both. Review only the top commit, `056ff899`. Once #1593 is in, this fast-forwards onto it.

## Summary

Follow-up to #1593, same method: the recorder's database compared line by line against two characters' raw XML logs (a rogue with a greatsword and Energy Wings; a paladin with a shield, mace and Holy Weapon), every divergence traced to a parser or def defect and fixed with the offending lines as evidence. Scope is `lib/gemstone/combat/**` and its specs only.

## Parser / processor

- **Holy Weapon (1625) infusion release is a pre-flare on the swing, not an attack.** `:weapon_cast` moves from spells to flares (release and failed-release forms). The spell it releases (Templar's Verdict, cast line `Violet flames erupt from beneath X.`) runs as its own event, parented to the swing; the first physical roll resumes the swing (`SPELL_RELEASING_FLARES`). Both orderings handled: maneuver → proc → spell → swing's AS/DS, and proc → spell → "You swing". Before this, one pummel recorded as a single `weapon_cast` row holding the spell's CS/TD *and* the swing's AS/DS, and the pummel bracket was dropped by its own spell. A releasing pre-flare may only be claimed by a weapon-bearing attack; a cast that printed before its swing is re-emitted after it so the recorder's parent-first lineage resolution holds.
- **A status settles a switch-born event** like an outcome does, so an AoE status effect that rolls once per onlooker (eviscerate: SSR → freeze → unsettled, twice) gives each bystander its own roll instead of piling both on the first.
- **An inbound creature maneuver claims the held maneuver roll that preceded its line** (sap spit whose miss prints on the next line; a subdue that lands and prints no outcome), generalising the same-line-outcome feint exception. The hold stays while a volley sequence, a barrage (the one assault whose aim SMR precedes each arrow) or a nock is open; every other assault rolls after its round line, fixture-verified. AS/DS is never claimed. Corpus census: 5 maneuver-SMR → inbound-line shapes, 0 with our own attack following in the chunk.
- **`attacks.attack_kind`** (was `ambush_kind`, never shipped): `'waylay'` / `'ambush'` (from hiding, `ambush=1`) or `'reverse_strike'` (parry reaction, `ambush=0`). Reverse Strike's confirmation line is a prefix on the swing that follows; the offer line is deliberately not matched (it prints whether or not the technique is used). Reaction prefixes set the kind without the ambush flag; a load-time guard keeps `AMBUSH_KINDS` aligned with `AMBUSH_PREFIXES`.

## Defs (all from the logs, evidence in comments)

- **Statuses:** `demoralized` (eviscerate's second onlooker effect, wiki-named) with its expiry; `terrified` gains its creature-side expiry line — it only had the 2p one, so a creature's terror never cleared.
- **Attacks:** Barbed Sweep (Energy Wings tier 2, per-target line only — the opener double-counted the first creature); a second shield-charge opener form (every one of 15 orphaned roll+damage+crits, 200 damage dropped outright); six inbound forms (treekin root/sap/fist, Illoke jarl ward attack, krolvin slaver subdue); Templar's Verdict on its erupt line.
- **Ticks:** three more bleed phrasings and seven poison phrasings as `:poison_tick` (unowned like bleed) — 31 orphaned tick rows.
- **Flares:** shield plasma with its target clause. **Outcomes:** shield block `...between yourself and the attack!`.

## Recorder

- `attack_kind` column + migration entry.

## Result on the two log sets

Orphaned damage 818 → 110 (the remainder is another player's item flavor naming no creature) and 423 → 0; no Templar row carries an AS/DS; total damage and hit counts unchanged throughout.

## Tests

- `eviscerate` fixture asserts both statuses; `weapon_cast` fixture replaced with the real pummel exchange (the old blob was a truncated fragment — note the fixture loader treats a blank line as a blob boundary); the inbound infusion spec asserts the pre-flare shape.
- `bundle exec rspec spec/lib/gemstone/combat`: 296 examples, 0 failures on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
