### PR TITLE
ci(all): format-body harvests PR number, not issue number, from RP bullets

### DIFF
--- a/.github/actions/format-body/action.yaml
+++ b/.github/actions/format-body/action.yaml
@@ -57,7 +57,10 @@ runs:
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         MODE: ${{ inputs.mode }}
-        CONTRACT_SHA: "95f8f517411f9058bc92706310677db8cbba97fbd296bc853f2181274cb0e8bb"
+        # Bumped for the pull-link-vs-issue-link harvest fix below; this invalidates the
+        # sentinel on any already-formatted, still-open RP PR so it gets reformatted with
+        # the fix instead of being skipped by the old, matching sentinel.
+        CONTRACT_SHA: "2aa1c6bdb379fa50f77ca249ac4a19f7eef93e606f77d61dcbf1fc14107891a5"
         BREAK_AUTO: ${{ inputs.break_autolinks_in_bullets }}
         PR_NUMBER: ${{ inputs.pr_number }}
       with:
@@ -121,11 +124,16 @@ runs:
           const headerLine = versionStr ? `Lich ${versionStr} (${dateStr})` : `Lich (${dateStr})`;
           // ---------------------------------------------------------
 
-          // Harvest PR numbers from existing RP bullets (lines starting with '* ' and containing '#NNN')
+          // Harvest PR numbers from existing RP bullets (lines starting with '* ' and containing '#NNN').
+          // RP bullets that close an issue link BOTH the issue and the merging PR, e.g.:
+          //   * **all:** desc ([#1596](.../issues/1596)) ([#1599](.../pull/1599)) ([sha](...))
+          // Prefer a "/pull/<N>" link (the actual PR, which pulls.get() below can resolve) over
+          // a bare "#<N>" match, which would grab the issue number first and 404 on pulls.get().
           const prNums = [];
           for (const l of body.split(/\r?\n/)) {
             if (/^\s*\*\s+/.test(l)) {
-              const m = l.match(/#(\d+)/);
+              const pullLink = l.match(/\(https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)\)/);
+              const m = pullLink || l.match(/#(\d+)/);
               if (m) prNums.push(parseInt(m[1], 10));
             }
           }


### PR DESCRIPTION
## Summary

- The Release PR body formatter (`.github/actions/format-body`, used by both `format-pr-body-stable.yaml` and `format-pr-body-prerelease.yaml`) silently drops changelog bullets that close an issue.
- When a Release Please bullet links both the closed issue and the merging PR — e.g. `([#1596](.../issues/1596)) ([#1599](.../pull/1599))` — the harvest step's `l.match(/#(\d+)/)` grabbed the **first** `#NNN` on the line, which is the issue number, not the PR number.
- It then calls `pulls.get(1596)`, which 404s (1596 is an issue, not a PR), the error is swallowed (`// skip unverifiable PRs`), and the whole bullet is dropped from the formatted body.
- This is exactly what happened to [#1599](https://github.com/elanthia-online/lich-5/pull/1599) (closing [#1596](https://github.com/elanthia-online/lich-5/issues/1596)) in the current stable release PR: [run 34720162282](https://github.com/elanthia-online/lich-5/actions/runs/34720162282/job/103624441771) formatted every other bullet correctly but dropped that one.

## Change

- Harvest step now prefers a `.../pull/<N>` link match over a bare `#<N>` match, so it grabs the actual merging PR number instead of an issue number that happens to appear first in the bullet.
- Bumped `CONTRACT_SHA` in `action.yaml` so the fix takes effect on any RP PR that's already been stamped with the old sentinel (otherwise the formatter would just skip it as "already formatted").

## Scope checked

- `.github/workflows/format-pr-body-stable.yaml` and `.github/workflows/format-pr-body-prerelease.yaml` both delegate entirely to `.github/actions/format-body` — no duplicated harvest logic there, so this one fix covers both channels.
- `.github/workflows/format-release-notes.yaml` was also checked: it consumes the already-formatted PR/release body and converts `[#123](url)` → `#123` with a single global regex — it doesn't do a per-number `pulls.get()` lookup, so it isn't exposed to this bug.

## Note

The currently open stable Release Please PR is already stamped with the pre-fix sentinel. Bumping `CONTRACT_SHA` here means the next `workflow_run` trigger (from "Prepare Stable Release") will reformat it with the fix; if that doesn't fire on its own, it can be nudged with a label/edit event or a manual re-run.

## Test plan

- [x] Verified the new regex against the actual dropped bullet (extracts `1599`, not `1596`) and against a normal single-link bullet (unaffected, extracts `1603`).
- [ ] Confirm the next stable RP PR reformat includes the `setup_files uses content hash for cache freshness` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Existing pull request entries are now reformatted when formatting rules are updated.
  - Pull request references are identified more accurately, reducing incorrect links to unrelated issues.
  - Improved handling of existing release note bullets helps prevent invalid pull request links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->