### PR TITLE
ci(all): format-body harvests the last #NNN reference, not the first

### DIFF
--- a/.github/actions/format-body/action.yaml
+++ b/.github/actions/format-body/action.yaml
@@ -57,10 +57,11 @@ runs:
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         MODE: ${{ inputs.mode }}
-        # Bumped for the pull-link-vs-issue-link harvest fix below; this invalidates the
-        # sentinel on any already-formatted, still-open RP PR so it gets reformatted with
-        # the fix instead of being skipped by the old, matching sentinel.
-        CONTRACT_SHA: "2aa1c6bdb379fa50f77ca249ac4a19f7eef93e606f77d61dcbf1fc14107891a5"
+        # Bumped again: the prior fix assumed the real PR used a "/pull/" link, but RP renders
+        # every reference (issue or PR) as "/issues/"; taking the LAST "#NNN" match is the
+        # correct signal. Bump invalidates the sentinel on any already-formatted, still-open
+        # RP PR so it gets reformatted with the fix instead of being skipped.
+        CONTRACT_SHA: "699e8e7e66d93612c64757d672ffcca2db94e9c051060144e7c1a1d3fc29d2f6"
         BREAK_AUTO: ${{ inputs.break_autolinks_in_bullets }}
         PR_NUMBER: ${{ inputs.pr_number }}
       with:
@@ -125,16 +126,21 @@ runs:
           // ---------------------------------------------------------
 
           // Harvest PR numbers from existing RP bullets (lines starting with '* ' and containing '#NNN').
-          // RP bullets that close an issue link BOTH the issue and the merging PR, e.g.:
-          //   * **all:** desc ([#1596](.../issues/1596)) ([#1599](.../pull/1599)) ([sha](...))
-          // Prefer a "/pull/<N>" link (the actual PR, which pulls.get() below can resolve) over
-          // a bare "#<N>" match, which would grab the issue number first and 404 on pulls.get().
+          // RP renders every "#NNN" it finds in the merge commit subject as an "/issues/NNN"
+          // link -- it never distinguishes issues from PRs by URL shape, so both look identical.
+          // When a PR's own title references the issue it closes (e.g. "fix(all): ... (#1596)"),
+          // GitHub's squash-merge appends the *real* merging PR number as the final "(#NNN)"
+          // token in the commit subject: "fix(all): ... (#1596) (#1599)". RP then emits both as
+          // links in that same left-to-right order:
+          //   * **all:** desc ([#1596](.../issues/1596)) ([#1599](.../issues/1599)) ([sha](...))
+          // The commit-sha link has no leading "#" so it never matches here. Taking the LAST
+          // "#NNN" match (not the first) reliably gets the real PR number, since GitHub always
+          // appends it last; pulls.get() below then resolves it instead of 404ing on the issue.
           const prNums = [];
           for (const l of body.split(/\r?\n/)) {
             if (/^\s*\*\s+/.test(l)) {
-              const pullLink = l.match(/\(https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)\)/);
-              const m = pullLink || l.match(/#(\d+)/);
-              if (m) prNums.push(parseInt(m[1], 10));
+              const matches = [...l.matchAll(/#(\d+)/g)];
+              if (matches.length) prNums.push(parseInt(matches[matches.length - 1][1], 10));
             }
           }
           // De-dupe in encounter order

--- a/.github/tests/test-format-body-harvest.sh
+++ b/.github/tests/test-format-body-harvest.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test-format-body-harvest.sh - Tests for the RP-bullet PR-number harvest logic
+# in .github/actions/format-body/action.yaml (the "Compose prerelease body" step).
+#
+# The logic under test lives inside a `script:` block in that action.yaml and
+# can't be required/sourced directly, so it is mirrored here for standalone
+# testing (same approach as test-union-merge.sh's parse_and_resolve_conflicts).
+# If the harvest logic in action.yaml changes, update the JS below to match.
+# =============================================================================
+
+set -euo pipefail
+
+echo "Testing format-body PR-number harvest..."
+echo
+
+# Mirrors the harvest loop body in .github/actions/format-body/action.yaml
+# (the "Harvest PR numbers from existing RP bullets" section).
+harvest_last_ref() {
+  local line="$1"
+  node -e '
+    const l = process.argv[1];
+    const matches = [...l.matchAll(/#(\d+)/g)];
+    if (matches.length) process.stdout.write(matches[matches.length - 1][1]);
+  ' "$line"
+}
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+  local expected="$1" actual="$2" test_name="$3"
+  ((++TESTS_RUN))
+
+  if [[ "$expected" == "$actual" ]]; then
+    echo "✓ $test_name"
+    ((++TESTS_PASSED))
+  else
+    echo "✗ $test_name"
+    echo "  Expected: $expected"
+    echo "  Got: $actual"
+    ((++TESTS_FAILED))
+  fi
+}
+
+# Test 1: squash-merge bullet where the PR's own title referenced the issue
+# it closes, so RP renders BOTH numbers as "/issues/" links, issue first,
+# real PR last (this is the exact regression from PR #1596/#1599).
+squash_merge_line='* **all:** setup_files uses content hash for cache freshness ([#1596](https://github.com/elanthia-online/lich-5/issues/1596)) ([#1599](https://github.com/elanthia-online/lich-5/issues/1599)) ([4968e45](https://github.com/elanthia-online/lich-5/commit/4968e45e92a239a375677e0f4767a67085925089))'
+assert_equals "1599" "$(harvest_last_ref "$squash_merge_line")" \
+  "squash-merge bullet (issue + PR refs) selects the real PR number"
+
+# Test 2: normal bullet with a single reference.
+single_ref_line='* creatures registry housekeeping independent of Combat::Tracker ([#1603](https://github.com/elanthia-online/lich-5/issues/1603))'
+assert_equals "1603" "$(harvest_last_ref "$single_ref_line")" \
+  "single-reference bullet selects that reference"
+
+# Test 3: reference followed by a trailing commit-SHA link. The SHA link has
+# no leading "#" and must not be mistaken for (or shift) the selected number.
+ref_plus_sha_line='* infomon - a spells start message refreshes a refreshable timer ([#1585](https://github.com/elanthia-online/lich-5/issues/1585)) ([abc1234](https://github.com/elanthia-online/lich-5/commit/abc1234def))'
+assert_equals "1585" "$(harvest_last_ref "$ref_plus_sha_line")" \
+  "reference + trailing commit-SHA bullet selects the reference, not the SHA"
+
+echo
+echo "Tests passed: $TESTS_PASSED/$TESTS_RUN"
+echo "Tests failed: $TESTS_FAILED/$TESTS_RUN"
+
+[[ $TESTS_FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

Follow-up to #1609, which was a wrong fix for the right symptom (confirmed by [run 34727595165](https://github.com/elanthia-online/lich-5/actions/runs/34727595165) still 404ing on `pulls/1596` after that fix merged).

#1609 assumed release-please distinguishes the merging PR from a referenced issue by URL shape (`/pull/<N>` vs `/issues/<N>`). It doesn't — RP's changelog writer renders **every** `#NNN` it finds in the merge commit subject as an `/issues/<N>` link, with no distinction. Confirmed by pulling the actual squash-merge commit for #1599:

```
fix(all): setup_files uses content hash for cache freshness (#1596) (#1599)
```

The PR's own title referenced the issue it closes (`(#1596)`, typed by the author), and GitHub's squash-merge appended the real merging PR number last (`(#1599)`). RP renders both as `/issues/` links in that same left-to-right order:

```
* **all:** setup_files uses content hash for cache freshness ([#1596](.../issues/1596)) ([#1599](.../issues/1599)) ([4968e45](.../commit/...))
```

So #1609's `/pull/` check never matched anything and silently fell back to the old first-match behavior — still grabbing 1596, still 404ing on `pulls.get()`, still dropping the bullet.

## Change

- Harvest step now takes the **last** `#NNN` match per bullet line instead of the first. GitHub always appends the real merging PR number last when squash-merging, so this is the reliable signal (not URL shape). The commit-sha link (`[abc1234](.../commit/...)`) has no leading `#`, so it's never a false match either way.
- Bumped `CONTRACT_SHA` again so the currently open, already-sentineled stable Release Please PR gets reformatted with this fix instead of short-circuiting on #1609's sentinel.

## Test plan

- [x] Verified against the actual squash-merge commit subject for #1599 (extracts `1599`, not `1596`).
- [x] Verified a normal single-reference bullet is unaffected (extracts `1603`).
- [x] Verified a bullet with a reference + trailing commit-sha link still extracts the reference number, not something from the sha link (sha link has no `#`).
- [ ] Confirm the next stable RP PR reformat includes the `setup_files uses content hash for cache freshness` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request reference detection in automatically formatted content, ensuring the correct PR number is retained when multiple references appear on a line.
  - Existing open pull requests that were previously formatted may now be refreshed to reflect the corrected reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->