### PR TITLE
feat(all): prototype bounded read-only session coordination

### DIFF
--- a/docs/coordinated-readiness-prototype.md
+++ b/docs/coordinated-readiness-prototype.md
@@ -1,0 +1,190 @@
+# Coordinated readiness: bounded A/B prototype
+
+Date: 2026-09-13. Status: experimental implementation and synthetic verification;
+not a published API, live installation, or approval of write-capable coordination.
+
+## Scope and pinned foundations
+
+Implements the first read-only experiment from the reviewed independent-session
+proposal; the bounded implementation contract is recorded here. Each character retains its
+own Ruby process. No game commands, scripts, permissions/grants for execution,
+receipts, broker replacement, Redis requirement, or native frontend input path
+are introduced. No automatic runtime registration or profile enablement.
+
+Source baselines:
+
+- [Lich 3342837fe78cd8965d20525464913c66218ea853](https://github.com/elanthia-online/lich-5/tree/3342837fe78cd8965d20525464913c66218ea853).
+- [EOHunter 6f15eb02c6376c4e9330d940e7f1c6f8da18eb3a](https://github.com/elanthia-online/eohunter/tree/6f15eb02c6376c4e9330d940e7f1c6f8da18eb3a).
+
+| Existing facility | Missing behavior | Owner in this experiment | Verification |
+| --- | --- | --- | --- |
+| ActiveSessions file lock, atomic rename, registry | Publish an optional character endpoint descriptor | Explicit discovery adapter; no extra daemon | Actual owner death, competing successors, reader, cleanup-race tests |
+| ActiveSessions Server/Client JSON transport | Bounded optional read-only route, exchange and frame limits | Native transport with opt-in arguments, unchanged legacy defaults | Old transport specs plus bounded I/O/capacity/auth tests |
+| Native Script lifecycle | None for read-only observations | No Script launch or supervisor added | No write routes accepted |
+| Group.report and Leader movement predicate | Copy diagnostics after owner progression | EOHunter adapter on completed engine tick | Existing policy consumed, no second policy engine |
+| Native state readers | Atomic room, vitals, ownership projection | Unresolved native source contract | Unknown readiness cannot pass the barrier |
+| LAB identity and admission | Demonstrated reusable deletion, not a wrapper | Deferred second-consumer evidence gate | Not claimed or implemented |
+
+MahtraDR's [plugin guide](https://github.com/elanthia-online/dr-scripts/wiki/Script-Plugin-System)
+already describes optional Ruby objects receiving host notifications, with no
+backend dependency in the host. We reuse that separation of responsibility:
+an explicitly attached adapter consumes a host callback. EOHunter already has
+callbacks and World readers; this does not copy DR's script-specific loader or
+invent a second plugin registry. One completed-tick notification is added because
+the existing `on_tick` fires before the action, not after it.
+
+## Contract
+
+`Lich::InternalAPI::Coordination` is explicitly required by the pilot, never by
+normal startup. `Session.new(..., enabled: false)` is inert. An enabled owner
+calls `start`, publishes a plain immutable projection from its own thread, and
+calls `close` at teardown. No network worker reads World or invokes an owner.
+
+Identity is `(game, character, incarnation, connection_generation, run_id)`.
+Incarnation is random per Session; reconnect increments the generation and
+invalidates the old snapshot. Peers must use the complete expected identity.
+The read credential is separate from discovery credentials and is never included
+in the advertised descriptor or diagnostics. Under same-host/same-user trust,
+this is a cooperative safety boundary, not protection from malicious same-user
+code able to inspect process memory/files.
+
+Only `ping` and `snapshot` exist. Snapshot fields are the fixed `room` and
+`readiness` projection. Unknown keys, versions, identities and operations fail.
+No raw commands, eval, method invocation, subscriptions or remote mutation.
+
+Owner publications carry a strictly advancing publication sequence and completed
+tick, connected state, room ID/epoch, readiness/coherence and source metadata for
+each field. A source has its own version, age, room epoch and connection
+generation; polling is not a new observation. Equal source versions cannot
+change value or gain a younger age. Missing source metadata stays unknown.
+The store and reader retain source watermarks even across unavailable samples.
+
+The server measures snapshot and source age on its own monotonic clock. The
+client adds its entire measured round trip conservatively; clocks are never
+compared between processes. An endpoint replying promptly does not refresh the
+owner tick or source age. The derived `ready` is permission-to-proceed for this
+read barrier, not the underlying tri-state fact: it is false for unknown, stale,
+mixed, disconnected or missing-source observations. The raw readiness remains
+nil when not established. Default accepted age is 1 second.
+
+The reader also retains receiver-local aging anchors. Replaying an unchanged
+response ten seconds later cannot reset its age, even if the reported wire ages
+are unchanged. These anchors survive unavailable-source gaps and faster later
+round trips. Concurrent calls on the same Client fail promptly with `snapshot
+busy` rather than queue behind an exchange outside the deadline.
+
+Limits: 16 KiB frames including newline, JSON nesting depth 16, four admitted
+clients per endpoint, 250 ms monotonic connect/write/read exchange deadline.
+There is no application request queue. Callback code must remain nonblocking;
+the transport deadline does not promise to preempt arbitrary Ruby computation.
+Over-capacity peers are closed, not queued without bound. Native discovery uses
+its existing transport defaults; this does not claim its entire failover path
+has acquired the endpoint's 250 ms deadline.
+
+## What the Hunter adapter can honestly prove
+
+It calls existing `Group.report` and, when supplied, `Leader#movement_ready?`.
+It rejects captures crossing a known room/connection/owner change. Nevertheless,
+these readers independently sample native state: a matching generation fence
+does not prove atomic vitals and controller ownership. Therefore the actual
+adapter deliberately publishes unknown coherence and cannot enable a new
+movement barrier. This is a discovery from slice A, not a reason to fabricate
+positive readiness. Synthetic fixtures exercise coherent true/false cases in
+the core without claiming those fixtures are an available game-state API.
+
+No existing hunting movement, DRb group behavior, LAB admission or recovery
+policy is replaced. Reading diagnostic state is the usable result of this
+prototype; production coordinated readiness needs the native writer contract
+resolved before promotion.
+
+## Discovery ownership finding
+
+The native shutdown released its advisory flock before checking and unlinking
+discovery. A successor could publish after that check and have its live file
+deleted by the retiring owner. A real-process barrier test reproduced this
+exact order. Shutdown now retains the existing flock through cleanup and only
+unlinks when it holds that lock. The existing unit fixture now acquires real
+ownership instead of treating matching PID metadata as ownership. This small
+prerequisite fix should be reviewed separately from the experimental endpoint.
+
+Discovery publication remains opt-in and explicit. No clearing-by-PID is added:
+the registry lacks conditional metadata removal, so an old session must not
+erase a new session's descriptor. A retired endpoint refuses access; readers
+validate identity, and a successor discovery service needs explicit republishing.
+Read tokens are supplied separately, not placed in shared discovery metadata.
+
+## Verification and next gates
+
+Run native ActiveSessions, coordination, multiprocess and transport specs. Run
+the full Hunter suite and gated cross-repository adapter test using the real
+Lich module. `spec/support/coordination_benchmark.rb` starts only independent
+synthetic owners on loopback; it must never be loaded as a game script.
+
+Initial local throughput baseline (Ruby 4.0.5, 200 reads per owner, unpaced
+concurrent clients; not a production load or idle-CPU estimate):
+
+| Owners | Reads | p50 ms | p95 ms | p99 ms | Reads/sec |
+| --- | --- | --- | --- | --- | --- |
+| 2 | 400 | 0.310 | 0.554 | 1.638 | 5,711 |
+| 5 | 1,000 | 0.812 | 1.162 | 1.657 | 5,845 |
+| 10 | 2,000 | 1.689 | 2.158 | 2.452 | 5,716 |
+
+These short runs establish a reproducible baseline, not a latency guarantee.
+Follow-up local regression targets: ten-owner p99 below 25 ms and endpoint
+incremental RSS below 16 MiB per owner in this harness. Initial RSS deltas were
+about 2.9-3.5 MiB. The harness reports parent/owner CPU and owner ticks; its
+unpaced flood is intentionally not representative of a one-Hz client. Game-loop
+overhead and long-run CPU/memory stability still need measurement before any
+live pilot. Four admitted clients are the enforced concurrency bound, not a
+measured claim about the kernel's listen backlog.
+
+Before slice C: maintainer agreement on coherent native projections, longer
+stalled-publisher/availability measurements, separately reviewed operation
+contracts and authorization. Before generic core promotion: a real LAB contract
+test plus code deletion demonstrating the second-consumer benefit. No writes or
+live trial are silently enabled by completing this prototype.
+
+Rollback: do not require/attach the optional module. The live installation has
+not been changed; both worktrees remain separate from running game sessions.
+
+## Acceptance record
+
+- Root reproduced the discovery-cleanup race before modifying production code;
+  the exact same multiprocess regression passed afterward.
+- Independent review reproduced stale-replay and concurrent-client admission
+  defects. Four new regressions pass after fixes; the independent reviewer
+  reran all four and found neither issue remaining.
+- Final targeted Lich internal API suite: 118 examples, zero failures, seed 719.
+- Final full Lich suite: 7,596 examples, zero failures, seed 719.
+- Hunter full suite with actual Lich transport integration: 864 examples, zero
+  failures, seed 719. Single-file build and documentation generation passed.
+- Lich scoped lint: all 13 changed/new Ruby files passed. Hunter changed-file
+  lint and both worktree whitespace checks passed.
+- Post-fix benchmark p99: 1.892 ms (two owners), 1.894 ms (five), 2.786 ms (ten).
+  This run overlapped regression work; it is a local sanity check, not an SLA.
+
+Reproduction commands, from the appropriate repository with Ruby 4.0.5 and the
+project test gems on PATH/GEM_PATH:
+
+```sh
+# Lich worktree: offline tests and Linux fork-based microbenchmark
+rspec spec/lib/internal_api --seed 719
+rspec --format progress --seed 719
+ruby spec/support/coordination_benchmark.rb
+
+# Hunter worktree: explicit cross-repository test opt-in
+LICH_COORDINATION_ROOT='/path/to/lich-coordination-checkout' rspec --format progress --seed 719
+```
+
+Known unverified boundaries: live source coherence, production game-loop cost,
+long-run resource stability, Windows/macOS process-handoff execution, forced
+numeric PID/port reuse, and a production discovery-availability deadline. The
+five-second subprocess-test deadline is test orchestration, not a claimed native
+failover SLA. No coordination command can be executed in this implementation.
+
+Review split: native discovery cleanup regression/fix; this optional bounded
+transport plus experimental read-only core; separate Hunter callback and
+diagnostic adapter. The cleanup regression/fix is not bundled here. The full
+suite counts above describe the combined prototype; per-PR checks are reported
+in the corresponding PR descriptions. The subsequently installed local build
+also includes pre-existing integration changes, not just these PRs.

--- a/lib/internal_api/active_sessions/bounded_frame.rb
+++ b/lib/internal_api/active_sessions/bounded_frame.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Lich
+  module InternalAPI
+    module ActiveSessions
+      # Optional newline framing with one monotonic deadline for all socket I/O.
+      # Frame limits include the terminating newline. This helper never extends
+      # a deadline when a peer supplies another partial chunk.
+      # @api private
+      module BoundedFrame
+        # @return [Integer] default frame limit when only a timeout is supplied
+        DEFAULT_MAX_BYTES = 65_536
+
+        # @return [Float] current monotonic time in seconds
+        def self.now
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+
+        # @param deadline [Numeric] absolute local monotonic deadline
+        # @return [Numeric] remaining seconds
+        # @raise [IOError] if the deadline has elapsed
+        def self.remaining(deadline)
+          seconds = deadline - now
+          raise IOError, 'transport timeout' unless seconds.positive?
+
+          seconds
+        end
+
+        # @param socket [IO] connected nonblocking-capable socket
+        # @param deadline [Numeric] absolute local monotonic deadline
+        # @param max_bytes [Integer] maximum frame size including newline
+        # @return [String] complete frame
+        # @raise [IOError] for incomplete, oversized, or timed-out frames
+        def self.read(socket, deadline:, max_bytes:)
+          buffer = +''.b
+          loop do
+            raise IOError, 'transport timeout' unless IO.select([socket], nil, nil, remaining(deadline))
+
+            chunk = socket.read_nonblock([4096, max_bytes + 1 - buffer.bytesize].min, exception: false)
+            next if chunk == :wait_readable
+            raise IOError, 'incomplete frame' unless chunk
+
+            buffer << chunk
+            newline = buffer.index("\n")
+            size = newline ? newline + 1 : buffer.bytesize
+            raise IOError, 'frame too large' if size > max_bytes
+
+            return buffer.byteslice(0, size) if newline
+          end
+        end
+
+        # @param socket [IO] connected nonblocking-capable socket
+        # @param frame [String] complete newline-terminated frame
+        # @param deadline [Numeric] absolute local monotonic deadline
+        # @param max_bytes [Integer] maximum frame size including newline
+        # @return [void]
+        # @raise [IOError] for oversized frames or elapsed deadlines
+        def self.write(socket, frame, deadline:, max_bytes:)
+          raise IOError, 'frame too large' if frame.bytesize > max_bytes
+
+          offset = 0
+          while offset < frame.bytesize
+            remaining(deadline)
+            count = socket.write_nonblock(frame.byteslice(offset, frame.bytesize - offset), exception: false)
+            if count == :wait_writable
+              raise IOError, 'transport timeout' unless IO.select(nil, [socket], nil, remaining(deadline))
+            else
+              raise IOError, 'socket write failed' unless count.positive?
+
+              offset += count
+            end
+          end
+        end
+
+        # @param timeout [Numeric] total exchange duration
+        # @param max_bytes [Integer] frame cap
+        # @return [void]
+        # @raise [ArgumentError] unless the supplied bounds are positive and finite
+        def self.validate!(timeout, max_bytes)
+          unless timeout.is_a?(Numeric) && timeout.real? && timeout.finite? && timeout.positive?
+            raise ArgumentError, 'timeout must be positive and finite'
+          end
+          raise ArgumentError, 'max_frame_bytes must be a positive integer' unless max_bytes.is_a?(Integer) && max_bytes.positive?
+        end
+      end
+    end
+  end
+end

--- a/lib/internal_api/active_sessions/client.rb
+++ b/lib/internal_api/active_sessions/client.rb
@@ -2,6 +2,9 @@
 
 require 'json'
 require 'socket'
+require 'ipaddr'
+
+require_relative 'bounded_frame'
 
 module Lich
   module InternalAPI
@@ -22,13 +25,21 @@ module Lich
         # @param host [String]
         # @param port [Integer]
         # @param auth_token [String]
-        # @param socket_factory [#call] builds a connected client socket
+        # @param socket_factory [#call] builds a connected client socket; in
+        #   bounded mode must honor the supplied absolute monotonic deadline:
+        #   keyword and close any socket it cannot return
+        # @param max_frame_bytes [Integer, nil] optional request/response byte cap
+        # @param timeout [Numeric, nil] total connect/write/read deadline seconds
         # @return [void]
-        def initialize(host:, port:, auth_token:, socket_factory: nil)
+        def initialize(host:, port:, auth_token:, socket_factory: nil, max_frame_bytes: nil, timeout: nil)
           @host = host
           @port = port
           @auth_token = auth_token
-          @socket_factory = socket_factory || ->(connect_host, connect_port) { TCPSocket.new(connect_host, connect_port) }
+          @bounded = !max_frame_bytes.nil? || !timeout.nil?
+          @max_frame_bytes = max_frame_bytes.nil? ? BoundedFrame::DEFAULT_MAX_BYTES : max_frame_bytes
+          @timeout = timeout.nil? ? READ_TIMEOUT : timeout
+          BoundedFrame.validate!(@timeout, @max_frame_bytes) if @bounded
+          @socket_factory = socket_factory || (@bounded ? method(:connect_bounded) : ->(connect_host, connect_port) { TCPSocket.new(connect_host, connect_port) })
         end
 
         # Sends a raw command payload to the active sessions service.
@@ -37,6 +48,8 @@ module Lich
         # @param payload [Hash] request-specific payload
         # @return [Hash] parsed response payload or a normalized error hash
         def request(command, payload = {})
+          return bounded_request(command, payload) if @bounded
+
           socket = @socket_factory.call(@host, @port)
           socket.write(JSON.dump(command: command, auth: @auth_token, payload: payload) + "\n")
           raw = read_response(socket)
@@ -83,6 +96,52 @@ module Lich
         end
 
         private
+
+        # Connects only to a numeric address, avoiding unbounded DNS resolution.
+        # Coordination supplies a loopback address; legacy hostname support is
+        # unchanged when bounds are absent.
+        # @param host [String] numeric IP address
+        # @param port [Integer] TCP port
+        # @param deadline [Numeric] absolute local monotonic deadline
+        # @return [Socket] connected socket
+        def connect_bounded(host, port, deadline:)
+          address = Addrinfo.tcp(IPAddr.new(host).to_s, port)
+          socket = Socket.new(address.afamily, Socket::SOCK_STREAM, 0)
+          result = socket.connect_nonblock(address, exception: false)
+          if result == :wait_writable
+            raise IOError, 'transport timeout' unless IO.select(nil, [socket], nil, BoundedFrame.remaining(deadline))
+
+            error = socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR).int
+            raise SystemCallError.new('connect', error) unless error.zero?
+          end
+          BoundedFrame.remaining(deadline)
+          socket
+        rescue StandardError
+          socket&.close rescue nil
+          raise
+        end
+
+        # Sends one request with a deadline shared by connection, write and read.
+        # @param command [String] protocol command
+        # @param payload [Hash] request data
+        # @return [Hash] protocol response or normalized error
+        def bounded_request(command, payload)
+          deadline = BoundedFrame.now + @timeout
+          frame = JSON.dump(command: command, auth: @auth_token, payload: payload) + "\n"
+          raise IOError, 'frame too large' if frame.bytesize > @max_frame_bytes
+
+          socket = @socket_factory.call(@host, @port, deadline: deadline)
+          BoundedFrame.write(socket, frame, deadline: deadline, max_bytes: @max_frame_bytes)
+          raw = BoundedFrame.read(socket, deadline: deadline, max_bytes: @max_frame_bytes)
+          response = JSON.parse(raw, symbolize_names: true, max_nesting: 16)
+          return { ok: false, error: 'invalid response type' } unless response.is_a?(Hash)
+
+          response
+        rescue StandardError => e
+          { ok: false, error: e.message }
+        ensure
+          socket&.close rescue nil
+        end
 
         # Reads a single newline-terminated JSON response without allowing
         # partial frames to block indefinitely.

--- a/lib/internal_api/active_sessions/server.rb
+++ b/lib/internal_api/active_sessions/server.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'socket'
 
 require_relative '../../common/shutdown_log'
+require_relative 'bounded_frame'
 
 module Lich
   module InternalAPI
@@ -31,12 +32,28 @@ module Lich
         # @param server_factory [#call] builds a listening server
         # @param accept_thread_factory [#call] builds the accept-loop thread
         # @param client_thread_factory [#call] builds per-client threads
+        # @param request_handler [#call, nil] optional authenticated request router;
+        #   must return a JSON response without blocking or performing game I/O
+        # @param max_frame_bytes [Integer, nil] optional request/response byte cap
+        # @param max_clients [Integer, nil] optional simultaneous client cap
+        # @param timeout [Numeric, nil] total read/write deadline in seconds;
+        #   enables bounded transport, as does either cap
         # @return [void]
-        def initialize(host:, port:, registry:, auth_token:, server_factory: nil, accept_thread_factory: nil, client_thread_factory: nil)
+        def initialize(host:, port:, registry:, auth_token:, server_factory: nil, accept_thread_factory: nil, client_thread_factory: nil,
+                       request_handler: nil, max_frame_bytes: nil, max_clients: nil, timeout: nil)
           @host = host
           @port = port
           @registry = registry
           @auth_token = auth_token
+          @request_handler = request_handler
+          @bounded = !max_frame_bytes.nil? || !max_clients.nil? || !timeout.nil?
+          @max_frame_bytes = max_frame_bytes.nil? ? BoundedFrame::DEFAULT_MAX_BYTES : max_frame_bytes
+          @timeout = timeout.nil? ? READ_TIMEOUT : timeout
+          @max_clients = max_clients
+          BoundedFrame.validate!(@timeout, @max_frame_bytes) if @bounded
+          if !max_clients.nil? && (!max_clients.is_a?(Integer) || !max_clients.positive?)
+            raise ArgumentError, 'max_clients must be a positive integer'
+          end
           @server_factory = server_factory || ->(bind_host, bind_port) { TCPServer.new(bind_host, bind_port) }
           @accept_thread_factory = accept_thread_factory || ->(&block) { Thread.new(&block) }
           @client_thread_factory = client_thread_factory || ->(socket, &block) { Thread.new(socket, &block) }
@@ -44,6 +61,7 @@ module Lich
           @thread = nil
           @mutex = Mutex.new
           @client_threads = []
+          @client_sockets = {}
           @stopping = false
         end
 
@@ -79,25 +97,31 @@ module Lich
           thread = nil
           server = nil
           client_threads = []
+          client_sockets = []
           @mutex.synchronize do
             thread = @thread
             server = @server
             client_threads = @client_threads.dup
             @client_threads.clear
+            client_sockets = @client_sockets.keys
+            @client_sockets.clear
             @stopping = true
             @thread = nil
             @server = nil
           end
 
           server&.close rescue nil
+          client_sockets.each { |socket| socket.close rescue nil }
           if thread&.alive?
             thread.join(0.1)
             thread.kill if thread.alive?
           end
+          shutdown_deadline = BoundedFrame.now + 0.25 if @bounded
           client_threads.each do |client_thread|
             next unless client_thread.respond_to?(:join)
 
-            client_thread.join(0.25)
+            wait = @bounded ? [shutdown_deadline - BoundedFrame.now, 0].max : 0.25
+            client_thread.join(wait)
             client_thread.kill if client_thread.respond_to?(:alive?) && client_thread.alive?
           end
         end
@@ -132,8 +156,12 @@ module Lich
             socket = nil
             begin
               socket = server.accept
-              client_thread = @client_thread_factory.call(socket) { |client| handle_tracked_client(client) }
-              track_client_thread(client_thread)
+              if @bounded
+                dispatch_bounded_client(socket)
+              else
+                client_thread = @client_thread_factory.call(socket) { |client| handle_tracked_client(client) }
+                track_client_thread(client_thread)
+              end
             rescue IOError, Errno::EBADF => e
               Lich.log("warning: ActiveSessions accept_loop closed unexpectedly: #{e.class} pid=#{Process.pid}") if !stopping? && defined?(Lich) && Lich.respond_to?(:log)
               break
@@ -154,6 +182,47 @@ module Lich
           end
         end
 
+        # Reserves capacity before spawning so unfinished thread creation counts
+        # toward the cap. Shutdown closes even reserved, not-yet-started sockets.
+        # @param socket [IO] accepted client
+        # @return [void]
+        def dispatch_bounded_client(socket)
+          admitted = @mutex.synchronize do
+            next false if @stopping || (@max_clients && @client_sockets.size >= @max_clients)
+
+            @client_sockets[socket] = nil
+            true
+          end
+          unless admitted
+            socket.close rescue nil
+            return
+          end
+
+          thread = @client_thread_factory.call(socket) do |client|
+            handle_client(client) unless stopping?
+          ensure
+            client.close rescue nil
+            @mutex.synchronize do
+              @client_sockets.delete(client)
+              @client_threads.delete(Thread.current)
+            end
+          end
+          stopped = @mutex.synchronize do
+            if @stopping
+              true
+            elsif @client_sockets.key?(socket)
+              @client_sockets[socket] = thread
+              @client_threads << thread
+              false
+            end
+          end
+          thread.kill if stopped && thread&.alive?
+        rescue StandardError
+          @mutex.synchronize { @client_sockets.delete(socket) }
+          socket.close rescue nil
+          raise
+        end
+
         # Wraps client handling so finished client threads can be removed from
         # the tracked thread set regardless of request outcome.
         #
@@ -171,6 +240,8 @@ module Lich
         # @param socket [IO]
         # @return [void]
         def handle_client(socket)
+          return handle_bounded_client(socket) if @bounded
+
           raw = read_request(socket)
           unless raw
             Lich.log('warning: ActiveSessions client read timed out') if defined?(Lich) && Lich.respond_to?(:log)
@@ -180,7 +251,24 @@ module Lich
           response = process_request(raw)
           socket.puts(JSON.dump(response))
         rescue StandardError => e
-          socket.puts(JSON.dump(ok: false, error: e.message)) rescue nil
+          unless @bounded
+            socket.puts(JSON.dump(ok: false, error: e.message)) rescue nil
+          end
+        ensure
+          socket.close rescue nil
+        end
+
+        # Runs one bounded exchange. Failed writes are never retried with a
+        # blocking error response. JSON parsing uses a depth cap of 16.
+        # @param socket [IO] accepted client
+        # @return [void]
+        def handle_bounded_client(socket)
+          deadline = BoundedFrame.now + @timeout
+          raw = BoundedFrame.read(socket, deadline: deadline, max_bytes: @max_frame_bytes)
+          response = process_request(raw)
+          BoundedFrame.write(socket, JSON.dump(response) + "\n", deadline: deadline, max_bytes: @max_frame_bytes)
+        rescue StandardError
+          nil
         ensure
           socket.close rescue nil
         end
@@ -222,8 +310,10 @@ module Lich
         # @param raw [String, nil] one request line encoded as JSON
         # @return [Hash] normalized protocol response
         def process_request(raw)
-          request = JSON.parse(raw.to_s, symbolize_names: true)
+          request = JSON.parse(raw.to_s, symbolize_names: true, max_nesting: @bounded ? 16 : 100)
+          return { ok: false, error: 'invalid request type' } unless request.is_a?(Hash)
           return unauthorized_response unless authorized?(request)
+          return @request_handler.call(request) if @request_handler
 
           case request[:command]
           when 'ping'

--- a/lib/internal_api/coordination.rb
+++ b/lib/internal_api/coordination.rb
@@ -1,0 +1,433 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require_relative 'active_sessions/server'
+require_relative 'active_sessions/client'
+
+module Lich
+  module InternalAPI
+    # Experimental, explicitly loaded read-only prototype. No runtime hooks or
+    # discovery registration occur on require or construction. The owner must
+    # publish a completed tick; transport workers only read that frozen copy.
+    module Coordination
+      PROTOCOL_VERSION = 1
+      MAX_FRAME_BYTES = 16_384
+      FIELDS = %w[room readiness].freeze
+      IDENTITY_KEYS = %i[game character incarnation connection_generation run_id].freeze
+
+      # Strict projection schema shared by owner admission and peer validation.
+      # Source versions describe the real contributing observations, not polls.
+      # All hashes use symbol keys; field names in protocol requests are strings.
+      # Validation predicates return Boolean and never invoke game-state readers.
+      module Schema
+        module_function
+
+        def exact_keys?(value, required, optional = [])
+          value.is_a?(Hash) && (required - value.keys).empty? && (value.keys - required - optional).empty?
+        end
+
+        def string?(value)
+          value.is_a?(String) && !value.empty? && value.bytesize <= 256
+        end
+
+        def count?(value)
+          value.is_a?(Integer) && value >= 0
+        end
+
+        def age?(value)
+          value.is_a?(Numeric) && value.finite? && value >= 0
+        end
+
+        def boolean?(value)
+          value == true || value == false || value.nil?
+        end
+
+        def identity?(value)
+          exact_keys?(value, IDENTITY_KEYS) &&
+            %i[game character incarnation run_id].all? { |key| string?(value[key]) } &&
+            count?(value[:connection_generation])
+        end
+
+        # @param value [Object] optional native discovery metadata
+        # @return [Boolean] whether this is an exact token-free loopback descriptor
+        def descriptor?(value)
+          exact_keys?(value, %i[protocol_version host port identity]) &&
+            value[:protocol_version] == PROTOCOL_VERSION && value[:host] == '127.0.0.1' &&
+            value[:port].is_a?(Integer) && value[:port].between?(1, 65_535) && identity?(value[:identity])
+        end
+
+        def room?(value)
+          exact_keys?(value, %i[id epoch]) &&
+            (value[:id].nil? || string?(value[:id]) || count?(value[:id])) &&
+            (value[:epoch].nil? || count?(value[:epoch]))
+        end
+
+        def readiness?(value)
+          return false unless exact_keys?(value, %i[ready coherence], %i[limitations owner roundtime looting movement_ready])
+          return false unless boolean?(value[:ready]) && %w[coherent unknown mixed].include?(value[:coherence])
+          return false unless %i[roundtime looting movement_ready].all? { |key| boolean?(value[key]) }
+          if value.key?(:limitations)
+            return false unless value[:limitations].is_a?(Array) && value[:limitations].size <= 8 && value[:limitations].all? { |item| string?(item) }
+          end
+          if value.key?(:owner)
+            owner = value[:owner]
+            return false unless exact_keys?(owner, %i[state behavior]) && string?(owner[:state]) && (owner[:behavior].nil? || string?(owner[:behavior]))
+          end
+          true
+        end
+
+        def source?(value)
+          value.nil? || (exact_keys?(value, %i[version age room_epoch connection_generation]) &&
+            count?(value[:version]) && age?(value[:age]) && count?(value[:room_epoch]) && count?(value[:connection_generation]))
+        end
+
+        # @param value [Object] owner publication, without wire version or age
+        # @return [Boolean] whether selected values have the supported strict shape
+        def projection?(value)
+          exact_keys?(value, %i[identity sequence owner_tick connected room readiness sources]) &&
+            identity?(value[:identity]) && count?(value[:sequence]) && count?(value[:owner_tick]) &&
+            boolean?(value[:connected]) && room?(value[:room]) && readiness?(value[:readiness]) &&
+            exact_keys?(value[:sources], %i[room readiness]) && value[:sources].values.all? { |source| source?(source) }
+        end
+
+        # Checks declared source bindings; it cannot establish source atomicity.
+        # @param value [Hash] validated projection or wire snapshot
+        # @return [Boolean, nil] truthy only for connected, declared coherent sources
+        def coherent?(value)
+          value[:connected] && !value[:room][:id].nil? && value[:readiness][:coherence] == 'coherent' &&
+            value[:sources].values.all? do |source|
+              source && source[:room_epoch] == value[:room][:epoch] &&
+                source[:connection_generation] == value[:identity][:connection_generation]
+            end
+        end
+
+        # @param value [Hash, Array, String, Numeric, Boolean, nil] validated data
+        # @return [Object] recursively frozen copy, without writable owner references
+        def immutable(value)
+          case value
+          when Hash
+            value.to_h { |key, item| [key, immutable(item)] }.freeze
+          when Array
+            value.map { |item| immutable(item) }.freeze
+          when String
+            value.dup.freeze
+          else
+            value.freeze
+          end
+        end
+      end
+
+      class Session
+        # Identity and explicit read credential are separate from native discovery
+        # credentials. Callers exchange this token outside the public descriptor.
+        # @param game [String] game instance identifier
+        # @param character [String] character name
+        # @param run_id [String] owning controller run identifier
+        # @param read_token [String] explicitly supplied per-endpoint read credential
+        # @param enabled [Boolean] opt-in switch; false creates no listener/workers
+        # @param clock [#call, nil] local monotonic seconds, injectable for tests
+        # @return [Session]
+        def initialize(game:, character:, run_id:, read_token:, enabled: false, clock: nil)
+          raise ArgumentError, 'read token required' unless Schema.string?(read_token)
+
+          @identity = Schema.immutable(game: game, character: character, run_id: run_id,
+                                       incarnation: SecureRandom.hex(16), connection_generation: 0)
+          raise ArgumentError, 'invalid identity' unless Schema.identity?(@identity)
+
+          @read_token = read_token.dup.freeze
+          @enabled = enabled == true
+          @clock = clock || -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+          @mutex = Mutex.new
+          @server = nil
+          @retired = false
+          @snapshot = nil
+          @source_times = {}
+        end
+
+        # @return [Hash] immutable current incarnation, connection and run identity
+        def identity
+          @mutex.synchronize { @identity }
+        end
+
+        # @return [Boolean] whether the explicitly enabled loopback listener started
+        def start
+          @mutex.synchronize do
+            return false unless @enabled && !@retired
+            return true if @server&.running?
+
+            @server = ActiveSessions::Server.new(
+              host: '127.0.0.1', port: 0, registry: nil, auth_token: @read_token,
+              request_handler: method(:route),
+              max_frame_bytes: MAX_FRAME_BYTES, max_clients: 4, timeout: 0.25
+            )
+            @server.start
+          end
+        end
+
+        # @return [Hash, nil] immutable token-free endpoint metadata, or unavailable
+        def descriptor
+          @mutex.synchronize do
+            return nil unless @server&.running? && !@retired
+
+            Schema.immutable(protocol_version: PROTOCOL_VERSION, host: @server.host,
+                             port: @server.port, identity: @identity)
+          end
+        end
+
+        # Runs only on the owner path. A room/connection fence is insufficient
+        # evidence of atomic vitals or ownership: callers must report unknown
+        # coherence unless their contributing source actually guarantees it.
+        # @param identity [Hash] identity captured with the owner's observations
+        # @param sequence [Integer] strictly increasing publication sequence
+        # @param owner_tick [Integer] strictly increasing completed owner tick
+        # @param connected [Boolean, nil] actual connection state, nil if unknown
+        # @param room [Hash] selected room id and native room epoch, nil if unknown
+        # @param readiness [Hash] readiness, coherence and selected owner diagnostics
+        # @param sources [Hash] room/readiness metadata or nil per unknown source;
+        #   each known source has version, age in seconds at publication, room_epoch
+        #   and connection_generation. Repeated versions retain their earlier age.
+        # @return [Boolean] whether this immutable owner publication was admitted
+        def publish(identity:, sequence:, owner_tick:, connected:, room:, readiness:, sources:)
+          candidate = { identity: identity, sequence: sequence, owner_tick: owner_tick,
+                        connected: connected, room: room, readiness: readiness, sources: sources }
+          return false unless Schema.projection?(candidate)
+
+          candidate = Schema.immutable(candidate)
+          @mutex.synchronize do
+            return false unless @enabled && !@retired && candidate[:identity] == @identity
+            if @snapshot
+              return false unless sequence > @snapshot[:sequence] && owner_tick > @snapshot[:owner_tick]
+            end
+            now = @clock.call
+            times = {}
+            candidate[:sources].each do |field, source|
+              next unless source
+
+              previous = @source_times[field]
+              return false if previous && source[:version] < previous[:version]
+
+              observed_at = now - source[:age]
+              if previous && source[:version] == previous[:version]
+                # A repeated observation cannot change its value or acquire a
+                # younger age simply because an owner tick completed again.
+                return false unless candidate[field] == previous[:value] &&
+                                    source[:room_epoch] == previous[:room_epoch] &&
+                                    source[:connection_generation] == previous[:connection_generation]
+
+                observed_at = [observed_at, previous[:observed_at]].min
+              end
+              times[field] = { version: source[:version], value: candidate[field], observed_at: observed_at,
+                               room_epoch: source[:room_epoch], connection_generation: source[:connection_generation] }
+            end
+            @source_times.merge!(times)
+            @snapshot = candidate
+            @published_at = now
+            true
+          end
+        end
+
+        # Called explicitly by the connection owner on reconnect. An old peer
+        # descriptor cannot read even an empty snapshot from the new generation.
+        # @return [Hash, false] new immutable identity, or false if disabled/retired
+        def reconnect
+          @mutex.synchronize do
+            return false if @retired || !@enabled
+
+            @identity = Schema.immutable(@identity.merge(connection_generation: @identity[:connection_generation] + 1))
+            @snapshot = nil
+            @source_times.clear
+            @identity
+          end
+        end
+
+        # Retires the listener and published data permanently for this Session.
+        # @return [nil]
+        def close
+          server = @mutex.synchronize do
+            @retired = true
+            @snapshot = nil
+            @source_times.clear
+            current = @server
+            @server = nil
+            current
+          end
+          server&.stop
+          nil
+        end
+
+        private
+
+        def route(request)
+          return failure('invalid request') unless Schema.exact_keys?(request, %i[command auth payload]) &&
+                                                   Schema.string?(request[:auth])
+
+          handle(request[:command], request[:payload])
+        end
+
+        def handle(command, payload)
+          @mutex.synchronize do
+            return failure('unavailable') if @retired || !@enabled
+            return failure('unsupported command') unless %w[ping snapshot].include?(command)
+            required = %i[protocol_version expected_identity]
+            required += [:fields] if command == 'snapshot'
+            return failure('invalid request') unless Schema.exact_keys?(payload, required)
+            return failure('protocol mismatch') unless payload[:protocol_version] == PROTOCOL_VERSION
+            return failure('identity mismatch') unless payload[:expected_identity] == @identity
+            if command == 'ping'
+              return { ok: true, payload: { protocol_version: PROTOCOL_VERSION, identity: @identity } }
+            end
+            return failure('unsupported fields') unless payload[:fields] == FIELDS
+            return failure('snapshot unavailable') unless @snapshot
+
+            now = @clock.call
+            sources = @snapshot[:sources].to_h do |field, source|
+              [field, source && source.merge(age: [now - @source_times.fetch(field)[:observed_at], 0.0].max)]
+            end
+            result = @snapshot.merge(protocol_version: PROTOCOL_VERSION,
+                                     age: [now - @published_at, 0.0].max, sources: sources)
+            unless Schema.coherent?(result)
+              result = result.merge(readiness: result[:readiness].merge(ready: nil))
+            end
+            { ok: true, payload: result }
+          end
+        end
+
+        def failure(message)
+          { ok: false, error: message }
+        end
+      end
+
+      # Pure consumer: no game globals, controller callbacks or remote writes.
+      # It measures only its own round trip, never subtracts a peer's clock.
+      class Client
+        # @param descriptor [Hash] strict endpoint metadata from explicit discovery
+        # @param read_token [String] read credential exchanged separately
+        # @param max_age [Numeric] maximum conservative observation age in seconds
+        # @param timeout [Numeric] shared connect/write/read deadline in seconds
+        # @param clock [#call, nil] receiver-local monotonic seconds
+        # @param transport [#request, nil] bounded transport injection for tests
+        # @return [Client]
+        def initialize(descriptor:, read_token:, max_age: 1.0, timeout: 0.25, clock: nil, transport: nil)
+          raise ArgumentError, 'invalid descriptor' unless Schema.descriptor?(descriptor)
+          raise ArgumentError, 'read token required' unless Schema.string?(read_token)
+          raise ArgumentError, 'invalid maximum age' unless Schema.age?(max_age) && max_age.positive?
+
+          @identity = Schema.immutable(descriptor[:identity])
+          @max_age = max_age
+          @clock = clock || -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+          @transport = transport || ActiveSessions::Client.new(
+            host: descriptor[:host], port: descriptor[:port], auth_token: read_token,
+            max_frame_bytes: MAX_FRAME_BYTES, timeout: timeout
+          )
+          @mutex = Mutex.new
+          @last = nil
+          @source_history = {}
+        end
+
+        # Proves endpoint identity/version only; does not freshen any observation.
+        # @return [Boolean] whether the exact endpoint answered within its deadline
+        def ping
+          response = @transport.request('ping', protocol_version: PROTOCOL_VERSION, expected_identity: @identity)
+          response.is_a?(Hash) && response[:ok] == true &&
+            Schema.exact_keys?(response[:payload], %i[protocol_version identity]) &&
+            response[:payload][:protocol_version] == PROTOCOL_VERSION && response[:payload][:identity] == @identity
+        rescue StandardError
+          false
+        end
+
+        # No calls queue behind another snapshot: a busy client fails immediately.
+        # Wire ages include server-local elapsed time; consumer ages additionally
+        # include full RTT and receiver-local age floors for repeated observations.
+        # @return [Hash] {ok: true, payload: frozen_snapshot} with conservative ready
+        #   Boolean, or {ok: false, error: String}; unknown/stale/mixed is never ready
+        def snapshot
+          return failure('snapshot busy') unless @mutex.try_lock
+
+          begin
+            started = @clock.call
+            response = @transport.request('snapshot', protocol_version: PROTOCOL_VERSION,
+                                                      expected_identity: @identity, fields: FIELDS)
+            received_at = @clock.call
+            elapsed = [received_at - started, 0.0].max
+            return failure('snapshot unavailable') unless response.is_a?(Hash) && response[:ok] == true
+
+            value = response[:payload]
+            return failure('invalid snapshot') unless valid_snapshot?(value)
+            return failure('out of order snapshot') unless advancing?(value)
+
+            # Keep wire watermarks separate from local age bounds. Repeating
+            # an accepted sequence/version cannot erase elapsed local time or
+            # a previous slower round trip, including across unavailable gaps.
+            observed_at = received_at - value[:age] - elapsed
+            if @last && value[:sequence] == @last[:sequence]
+              observed_at = [observed_at, @snapshot_observed_at].min
+            end
+            @snapshot_observed_at = observed_at
+            wire = Schema.immutable(value)
+            sources = wire[:sources].to_h do |field, source|
+              next [field, nil] unless source
+
+              history = @source_history[field]
+              source_observed_at = received_at - source[:age] - elapsed
+              if history && source[:version] == history[:source][:version]
+                source_observed_at = [source_observed_at, history[:observed_at]].min
+              end
+              @source_history[field] = { source: source, value: wire[field], observed_at: source_observed_at }
+              [field, source.merge(age: [received_at - source_observed_at, 0.0].max)]
+            end
+            @last = wire
+            value = value.merge(age: [received_at - observed_at, 0.0].max, sources: sources)
+            fresh = value[:age] <= @max_age && sources.values.all? { |source| source && source[:age] <= @max_age }
+            ready = !!(Schema.coherent?(value) && fresh && value[:readiness][:ready] == true)
+            { ok: true, payload: Schema.immutable(value.merge(ready: ready)) }
+          rescue StandardError
+            failure('snapshot unavailable')
+          ensure
+            @mutex.unlock
+          end
+        end
+
+        private
+
+        def valid_snapshot?(value)
+          return false unless value.is_a?(Hash) && value[:protocol_version] == PROTOCOL_VERSION &&
+                              value[:identity] == @identity && Schema.age?(value[:age])
+
+          projection = value.reject { |key, _| %i[protocol_version age].include?(key) }
+          Schema.projection?(projection)
+        end
+
+        def advancing?(value)
+          return true unless @last
+          return false if value[:sequence] < @last[:sequence] || value[:owner_tick] < @last[:owner_tick]
+          return false if value[:sequence] > @last[:sequence] && value[:owner_tick] <= @last[:owner_tick]
+
+          value[:sources].each do |field, source|
+            history = @source_history[field]
+            previous = history && history[:source]
+            next unless source && previous
+            return false if source[:version] < previous[:version]
+            if source[:version] == previous[:version]
+              return false if source[:age] < previous[:age] || value[field] != history[:value] ||
+                              source[:room_epoch] != previous[:room_epoch] ||
+                              source[:connection_generation] != previous[:connection_generation]
+            end
+          end
+          return true if value[:sequence] > @last[:sequence]
+
+          without_ages(value) == without_ages(@last) && value[:age] >= @last[:age]
+        end
+
+        def without_ages(value)
+          value.reject { |key, _| key == :age }.merge(
+            sources: value[:sources].transform_values { |source| source&.reject { |key, _| key == :age } }
+          )
+        end
+
+        def failure(message)
+          { ok: false, error: message }
+        end
+      end
+    end
+  end
+end

--- a/lib/internal_api/coordination/discovery.rb
+++ b/lib/internal_api/coordination/discovery.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative '../active_sessions'
+require_relative '../coordination'
+
+module Lich
+  module InternalAPI
+    module Coordination
+      # Explicit bridge to the native process registry. Publication merges only
+      # this metadata key into this process's existing character registration.
+      # Native lifecycle heartbeats do not republish it after discovery loss.
+      #
+      # There is deliberately no unregister/close hook: the native API cannot
+      # conditionally clear an old incarnation without racing its replacement.
+      # A closed endpoint's retained descriptor is only a hint; resolution must
+      # authenticate and check its complete identity before returning a client.
+      class Discovery
+        # @param enabled [Boolean] explicit opt-in for publication and resolution
+        # @param active_sessions [#register_session, #query_snapshot] native registry API
+        # @return [void]
+        def initialize(enabled: false, active_sessions: ActiveSessions)
+          @enabled = enabled == true
+          @active_sessions = active_sessions
+        end
+
+        # @param session [Session] local started session whose descriptor is published
+        # @return [Boolean] whether the native registry accepted the metadata
+        def publish(session)
+          return false unless @enabled
+
+          descriptor = session.descriptor
+          return false unless Schema.descriptor?(descriptor)
+
+          @active_sessions.register_session(pid: Process.pid, coordination: descriptor) == true
+        rescue StandardError
+          false
+        end
+
+        # Credentials are supplied separately and never enter public metadata.
+        # A caller pins the complete expected identity; PID/port/name matching
+        # alone is insufficient. Each call queries current native discovery.
+        # timeout bounds the endpoint handshake; the native registry query
+        # retains ActiveSessions' existing transport behavior and timeout policy.
+        # @param identity [Hash] complete expected peer identity, including incarnation and generation
+        # @param read_token [String] separately supplied peer read credential
+        # @param max_age [Numeric] maximum accepted snapshot and source age in seconds
+        # @param timeout [Numeric] coordination endpoint request deadline in seconds
+        # @return [Client, nil] authenticated identity-checked client, or nil when unavailable
+        def resolve(identity:, read_token:, max_age: 1.0, timeout: 0.25)
+          return nil unless @enabled && Schema.identity?(identity)
+
+          snapshot = @active_sessions.query_snapshot
+          return nil unless snapshot.is_a?(Hash) && !snapshot[:error] &&
+                            snapshot[:source] == 'ActiveSessionsAPI' && snapshot[:sessions].is_a?(Array)
+
+          matches = snapshot[:sessions].filter_map do |record|
+            next unless record.is_a?(Hash) && record[:pid].is_a?(Integer) && record[:pid].positive?
+
+            descriptor = record[:coordination]
+            descriptor if Schema.descriptor?(descriptor) && descriptor[:identity] == identity
+          end
+          return nil unless matches.length == 1
+
+          client = Client.new(descriptor: matches.first, read_token: read_token, max_age: max_age, timeout: timeout)
+          client.ping ? client : nil
+        rescue StandardError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/internal_api/active_sessions/bounded_transport_spec.rb
+++ b/spec/lib/internal_api/active_sessions/bounded_transport_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+require_relative '../../../../lib/internal_api/active_sessions/server'
+require_relative '../../../../lib/internal_api/active_sessions/client'
+
+RSpec.describe 'Optional bounded ActiveSessions transport' do
+  let(:server_class) { Lich::InternalAPI::ActiveSessions::Server }
+  let(:client_class) { Lich::InternalAPI::ActiveSessions::Client }
+  let(:frame) { Lich::InternalAPI::ActiveSessions::BoundedFrame }
+
+  after do
+    @sockets&.each { |socket| socket.close rescue nil }
+    @server&.stop
+    @worker&.kill
+    @listener&.close
+  end
+
+  # @param options [Hash] server constructor overrides
+  # @return [Lich::InternalAPI::ActiveSessions::Server]
+  def start_server(**options)
+    @server = server_class.new(host: '127.0.0.1', port: 0, registry: nil,
+                               auth_token: 'secret', max_frame_bytes: 1024,
+                               max_clients: 2, timeout: 0.15, **options)
+    expect(@server.start).to be(true)
+    @server
+  end
+
+  # @return [TCPSocket] connected socket tracked for cleanup
+  def connect
+    socket = TCPSocket.new('127.0.0.1', @server.port)
+    (@sockets ||= []) << socket
+    socket
+  end
+
+  # @param block [Proc] condition to await within a fixed deadline
+  # @return [void]
+  def await(&block)
+    deadline = frame.now + 1
+    until block.call
+      raise 'condition timed out' if frame.now >= deadline
+
+      sleep 0.005
+    end
+  end
+
+  # @return [Integer] active or reserved client count
+  def client_count
+    @server.instance_variable_get(:@mutex).synchronize do
+      @server.instance_variable_get(:@client_sockets).size
+    end
+  end
+
+  it 'routes authenticated requests exclusively through the optional handler' do
+    handler = spy('request handler')
+    allow(handler).to receive(:call).and_return(ok: true, payload: { mode: 'read-only' })
+    start_server(request_handler: handler)
+    client = client_class.new(host: '127.0.0.1', port: @server.port, auth_token: 'secret', timeout: 0.5)
+    expect(client.snapshot).to eq(ok: true, payload: { mode: 'read-only' })
+    expect(handler).to have_received(:call).with(command: 'snapshot', auth: 'secret', payload: {})
+
+    denied = client_class.new(host: '127.0.0.1', port: @server.port, auth_token: 'wrong', timeout: 0.5)
+    expect(denied.snapshot).to eq(ok: false, error: 'unauthorized')
+    expect(handler).to have_received(:call).once
+  end
+
+  it 'rejects oversized, non-object and excessively nested requests before routing' do
+    handler = spy('request handler')
+    start_server(request_handler: handler)
+    requests = ["x" * 1025, "[]\n", JSON.dump(auth: 'secret', payload: Array.new(1, [[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]])) + "\n"]
+    requests.each do |request|
+      socket = connect
+      socket.write(request)
+      expect(IO.select([socket], nil, nil, 0.5)).not_to be_nil
+      socket.read
+    end
+    expect(handler).not_to have_received(:call)
+  end
+
+  it 'expires partial frames without allowing slow arrivals to extend the deadline' do
+    start_server
+    socket = connect
+    socket.write('{')
+    started = frame.now
+    await { client_count == 1 }
+    sleep 0.08
+    socket.write('"')
+    expect(IO.select([socket], nil, nil, 0.4)).not_to be_nil
+    expect(socket.read).to eq('')
+    expect(frame.now - started).to be < 0.35
+  end
+
+  it 'reserves the client slot before a handler thread is created and releases it on failure' do
+    entered = Queue.new
+    release = Queue.new
+    calls = 0
+    factory = lambda do |socket, &block|
+      calls += 1
+      if calls == 1
+        entered << true
+        release.pop
+        raise 'factory failed'
+      end
+      Thread.new(socket, &block)
+    end
+    start_server(max_clients: 1, client_thread_factory: factory)
+    first = connect
+    await { !entered.empty? }
+    expect(client_count).to eq(1)
+    release << true
+    expect(IO.select([first], nil, nil, 0.5)).not_to be_nil
+    expect(first.read).to eq('')
+    second = connect
+    await { client_count == 1 && calls == 2 }
+    rejected = connect
+    expect(IO.select([rejected], nil, nil, 0.5)).not_to be_nil
+    expect(rejected.read).to eq('')
+    expect(calls).to eq(2)
+    second.close
+    await { client_count.zero? }
+  ensure
+    release << true
+  end
+
+  it 'bounds a server write when the peer never reads the response' do
+    factory = lambda do |socket, &block|
+      socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 1024)
+      Thread.new(socket, &block)
+    end
+    start_server(max_frame_bytes: 8_000_000, client_thread_factory: factory,
+                 request_handler: ->(_request) { { ok: true, payload: 'x' * 4_000_000 } })
+    socket = connect
+    socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, 1024)
+    socket.write("{\"auth\":\"secret\",\"command\":\"snapshot\"}\n")
+    await { client_count == 1 }
+    started = frame.now
+    await { client_count.zero? }
+    expect(frame.now - started).to be < 0.6
+    expect(@server.instance_variable_get(:@client_threads)).to be_empty
+  end
+
+  it 'closes reserved sockets during shutdown even before thread creation returns' do
+    entered = Queue.new
+    release = Queue.new
+    factory = lambda do |socket, &block|
+      entered << true
+      release.pop
+      Thread.new(socket, &block)
+    end
+    start_server(client_thread_factory: factory)
+    socket = connect
+    await { !entered.empty? }
+    started = frame.now
+    @server.stop
+    expect(frame.now - started).to be < 0.5
+    expect(IO.select([socket], nil, nil, 0.5)).not_to be_nil
+    expect(socket.read).to eq('')
+    expect(client_count).to eq(0)
+  ensure
+    release << true
+  end
+
+  it 'caps client responses and rejects incomplete frames' do
+    ["x" * 1025, '{"ok":true}'].each do |response|
+      @listener = TCPServer.new('127.0.0.1', 0)
+      @worker = Thread.new do
+        socket = @listener.accept
+        socket.gets
+        socket.write(response)
+      ensure
+        socket&.close
+      end
+      client = client_class.new(host: '127.0.0.1', port: @listener.addr[1], auth_token: 'secret', timeout: 0.3, max_frame_bytes: 1024)
+      expect(client.snapshot).to eq(ok: false, error: response.size > 1024 ? 'frame too large' : 'incomplete frame')
+      @worker.join(0.5)
+      @listener.close
+    end
+  end
+
+  it 'bounds client writes when the peer never reads the request' do
+    @listener = TCPServer.new('127.0.0.1', 0)
+    accepted = Queue.new
+    @worker = Thread.new { accepted << @listener.accept }
+    factory = lambda do |host, port, deadline:|
+      expect(deadline).to be > frame.now
+      socket = TCPSocket.new(host, port)
+      socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 1024)
+      socket
+    end
+    client = client_class.new(host: '127.0.0.1', port: @listener.addr[1], auth_token: 'secret',
+                              socket_factory: factory, timeout: 0.1, max_frame_bytes: 8_000_000)
+    started = frame.now
+    expect(client.request('snapshot', data: 'x' * 4_000_000)).to eq(ok: false, error: 'transport timeout')
+    expect(frame.now - started).to be < 0.5
+    await { !accepted.empty? }
+    (@sockets ||= []) << accepted.pop
+  end
+
+  it 'uses the same client deadline for connect, write, and response waits' do
+    socket = instance_double(Socket, close: nil)
+    observed = []
+    factory = lambda do |_host, _port, deadline:|
+      observed << deadline
+      socket
+    end
+    allow(frame).to receive(:write) { |_socket, _request, deadline:, **_options| observed << deadline }
+    allow(frame).to receive(:read) do |_socket, deadline:, **_options|
+      observed << deadline
+      "{\"ok\":true}\n"
+    end
+    client = client_class.new(host: '127.0.0.1', port: 1, auth_token: 'secret', timeout: 0.2, socket_factory: factory)
+    expect(client.ping).to be(true)
+    expect(observed.size).to eq(3)
+    expect(observed.uniq.size).to eq(1)
+    expect(socket).to have_received(:close)
+  end
+
+  it 'closes a socket when the nonblocking connection exceeds its deadline' do
+    socket = instance_double(Socket, connect_nonblock: :wait_writable, close: nil)
+    allow(Socket).to receive(:new).and_return(socket)
+    allow(IO).to receive(:select).with(nil, [socket], nil, kind_of(Numeric)).and_return(nil)
+    expect(socket).not_to receive(:write_nonblock)
+    client = client_class.new(host: '127.0.0.1', port: 1, auth_token: 'secret', timeout: 0.2)
+
+    expect(client.snapshot).to eq(ok: false, error: 'transport timeout')
+    expect(socket).to have_received(:close)
+  end
+
+  it 'rejects a failed nonblocking connection before attempting a request' do
+    socket = instance_double(Socket, connect_nonblock: :wait_writable, close: nil)
+    allow(Socket).to receive(:new).and_return(socket)
+    allow(IO).to receive(:select).and_return([socket])
+    allow(socket).to receive(:getsockopt)
+      .with(Socket::SOL_SOCKET, Socket::SO_ERROR)
+      .and_return(instance_double(Socket::Option, int: Errno::ECONNREFUSED::Errno))
+    expect(socket).not_to receive(:write_nonblock)
+    client = client_class.new(host: '127.0.0.1', port: 1, auth_token: 'secret', timeout: 0.2)
+
+    expect(client.snapshot).to include(ok: false, error: a_string_matching(/refused/i))
+    expect(socket).to have_received(:close)
+  end
+
+  it 'refuses oversized outgoing requests without opening a connection' do
+    factory = spy('socket factory')
+    client = client_class.new(host: '127.0.0.1', port: 1, auth_token: 'secret',
+                              timeout: 0.2, max_frame_bytes: 64, socket_factory: factory)
+    expect(client.request('snapshot', data: 'x' * 65)).to eq(ok: false, error: 'frame too large')
+    expect(factory).not_to have_received(:call)
+  end
+
+  it 'rejects invalid bounds before opening sockets' do
+    [0, -1, Float::INFINITY, Float::NAN, '1', false].each do |timeout|
+      expect { client_class.new(host: '127.0.0.1', port: 1, auth_token: 'secret', timeout: timeout) }.to raise_error(ArgumentError)
+    end
+    [0, -1, 0.5, false].each do |max_bytes|
+      expect { client_class.new(host: '127.0.0.1', port: 1, auth_token: 'secret', max_frame_bytes: max_bytes) }.to raise_error(ArgumentError)
+    end
+    expect { server_class.new(host: '127.0.0.1', port: 0, registry: nil, auth_token: 'secret', max_clients: 0) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/lib/internal_api/coordination_discovery_spec.rb
+++ b/spec/lib/internal_api/coordination_discovery_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/internal_api/coordination/discovery'
+
+RSpec.describe Lich::InternalAPI::Coordination::Discovery do
+  let(:coordination) { Lich::InternalAPI::Coordination }
+  let(:native) { Lich::InternalAPI::ActiveSessions }
+  let(:identity) { { game: 'GS3', character: 'Synthetic', incarnation: 'synthetic-incarnation', connection_generation: 0, run_id: 'test-run' } }
+  let(:descriptor) { { protocol_version: 1, host: '127.0.0.1', port: 12_345, identity: identity } }
+  let(:session) { instance_double(coordination::Session, descriptor: descriptor) }
+  let(:registry) { native::Registry.new(process_checker: ->(_pid) { true }) }
+  let(:api) { double('native active sessions') }
+  let(:discovery) { described_class.new(enabled: true, active_sessions: api) }
+  let(:character_record) do
+    { pid: Process.pid, session_name: 'Synthetic', role: 'detachable', connected: true,
+      hidden: true, started_at: 123, listener_host: '127.0.0.1', listener_port: 4567, unrelated: 'preserved' }
+  end
+
+  before do
+    allow(api).to receive(:register_session) do |payload|
+      registry.upsert(payload)
+      true
+    end
+    allow(api).to receive(:query_snapshot) { registry.snapshot }
+  end
+
+  it 'is inert unless explicitly enabled' do
+    disabled = described_class.new(active_sessions: api)
+    expect(session).not_to receive(:descriptor)
+    expect(api).not_to receive(:register_session)
+    expect(api).not_to receive(:query_snapshot)
+
+    expect(disabled.publish(session)).to be(false)
+    expect(disabled.resolve(identity: identity, read_token: 'read-secret')).to be_nil
+  end
+
+  it 'merges only endpoint metadata and preserves unrelated native character fields' do
+    registry.upsert(character_record)
+    expect(discovery.publish(session)).to be(true)
+    expect(api).to have_received(:register_session).with(pid: Process.pid, coordination: descriptor)
+    expect(registry.session(Process.pid)).to include(character_record.merge(coordination: descriptor))
+
+    # Ordinary native lifecycle updates continue to preserve this opt-in key.
+    registry.upsert(pid: Process.pid, connected: false)
+    expect(registry.session(Process.pid)).to include(coordination: descriptor, connected: false)
+  end
+
+  it 'refuses absent or malformed descriptors, including accidentally included credentials' do
+    [nil, descriptor.merge(read_token: 'secret'), descriptor.merge(host: '192.0.2.1'),
+     descriptor.merge(port: 0), descriptor.merge(identity: identity.merge(incarnation: nil))].each do |value|
+      allow(session).to receive(:descriptor).and_return(value)
+      expect(discovery.publish(session)).to be(false)
+    end
+    expect(api).not_to have_received(:register_session)
+  end
+
+  it 'reports native publication failure without assuming discovery is enabled' do
+    allow(api).to receive(:register_session).and_return(false)
+    expect(discovery.publish(session)).to be(false)
+  end
+
+  it 'returns unavailable for missing, malformed, or unavailable native discovery' do
+    [nil, {}, { source: 'ActiveSessionsAPI', sessions: [], error: 'unavailable' },
+     { source: 'other', sessions: [] }, { source: 'ActiveSessionsAPI', sessions: nil }].each do |value|
+      allow(api).to receive(:query_snapshot).and_return(value)
+      expect(discovery.resolve(identity: identity, read_token: 'read-secret')).to be_nil
+    end
+  end
+
+  it 'requires full identity and one unambiguous matching registration before connecting' do
+    registry.upsert(pid: Process.pid, coordination: descriptor)
+    expect(coordination::Client).not_to receive(:new)
+    identity.keys.each do |key|
+      changed = identity.merge(key => (key == :connection_generation ? 1 : 'different'))
+      expect(discovery.resolve(identity: changed, read_token: 'read-secret')).to be_nil
+    end
+    registry.upsert(pid: Process.pid + 1, coordination: descriptor)
+    expect(discovery.resolve(identity: identity, read_token: 'read-secret')).to be_nil
+  end
+
+  it 'refuses untrusted malformed registration metadata without connecting' do
+    expect(coordination::Client).not_to receive(:new)
+    [nil, false, 'invalid', descriptor.merge(auth_token: 'secret'), descriptor.merge(port: -1)].each do |value|
+      registry.upsert(pid: Process.pid, coordination: value)
+      expect(discovery.resolve(identity: identity, read_token: 'read-secret')).to be_nil
+    end
+  end
+
+  it 'requires an authenticated identity check and re-queries discovery on each resolution' do
+    registry.upsert(pid: Process.pid, coordination: descriptor)
+    client = instance_double(coordination::Client, ping: true)
+    allow(coordination::Client).to receive(:new).with(descriptor: descriptor, read_token: 'read-secret', max_age: 1.0, timeout: 0.25).and_return(client)
+    expect(discovery.resolve(identity: identity, read_token: 'read-secret')).to equal(client)
+    allow(client).to receive(:ping).and_return(false)
+    expect(discovery.resolve(identity: identity, read_token: 'read-secret')).to be_nil
+    allow(api).to receive(:query_snapshot).and_return(source: 'ActiveSessionsAPI', sessions: [], error: 'owner lost')
+    expect(discovery.resolve(identity: identity, read_token: 'read-secret')).to be_nil
+    expect(api).to have_received(:query_snapshot).exactly(3).times
+  end
+
+  context 'with native registry and endpoint transports' do
+    let(:discovery) { described_class.new(enabled: true) }
+
+    before do
+      @directory = Dir.mktmpdir('coordination-discovery')
+      stub_const('ACTIVE_SESSION_DIR', @directory)
+      @endpoint = coordination::Session.new(game: 'GS3', character: 'Synthetic', run_id: 'test-run', read_token: 'read-secret', enabled: true)
+      expect(@endpoint.start).to be(true)
+      expect(native.register_session(character_record)).to be(true)
+    end
+
+    after do
+      @endpoint&.close
+      native.stop_service!
+      FileUtils.remove_entry(@directory)
+    end
+
+    it 'authenticates discovery, rejects reconnect and close staleness, and preserves native registration' do
+      first_identity = @endpoint.identity
+      expect(discovery.publish(@endpoint)).to be(true)
+      expect(discovery.resolve(identity: first_identity, read_token: 'wrong-secret')).to be_nil
+      expect(discovery.resolve(identity: first_identity, read_token: 'read-secret')).to be_a(coordination::Client)
+      @endpoint.reconnect
+      expect(discovery.resolve(identity: first_identity, read_token: 'read-secret')).to be_nil
+      expect(discovery.resolve(identity: @endpoint.identity, read_token: 'read-secret')).to be_nil
+      expect(discovery.publish(@endpoint)).to be(true)
+      expect(discovery.resolve(identity: @endpoint.identity, read_token: 'read-secret')).to be_a(coordination::Client)
+
+      @endpoint.close
+      expect(discovery.publish(@endpoint)).to be(false)
+      expect(discovery.resolve(identity: @endpoint.identity, read_token: 'read-secret')).to be_nil
+      record = native.query_snapshot.fetch(:sessions).find { |entry| entry[:pid] == Process.pid }
+      expect(record).to include(character_record)
+      expect(record[:coordination].keys).to contain_exactly(:protocol_version, :host, :port, :identity)
+    end
+
+    it 'requires explicit republication after native owner restart while an existing peer remains direct' do
+      expect(discovery.publish(@endpoint)).to be(true)
+      verified_peer = discovery.resolve(identity: @endpoint.identity, read_token: 'read-secret')
+      expect(verified_peer).to be_a(coordination::Client)
+      native.stop_service!
+      expect(discovery.resolve(identity: @endpoint.identity, read_token: 'read-secret')).to be_nil
+      expect(verified_peer.ping).to be(true)
+
+      expect(native.register_session(character_record)).to be(true)
+      expect(discovery.resolve(identity: @endpoint.identity, read_token: 'read-secret')).to be_nil
+      expect(discovery.publish(@endpoint)).to be(true)
+      expect(discovery.resolve(identity: @endpoint.identity, read_token: 'read-secret')).to be_a(coordination::Client)
+      expect(native.query_snapshot.fetch(:sessions).first).to include(character_record)
+    end
+  end
+end

--- a/spec/lib/internal_api/coordination_spec.rb
+++ b/spec/lib/internal_api/coordination_spec.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../lib/internal_api/coordination'
+require 'timeout'
+
+RSpec.describe Lich::InternalAPI::Coordination do
+  let(:now) { [100.0] }
+  let(:session) do
+    described_class::Session.new(game: 'GS3', character: 'Example', run_id: 'hunt-1',
+                                 read_token: 'explicit-read-token', enabled: true, clock: -> { now.first })
+  end
+  let(:projection) do
+    { identity: session.identity, sequence: 1, owner_tick: 1, connected: true,
+      room: { id: 42, epoch: 7 }, readiness: { ready: true, coherence: 'coherent' },
+      sources: { room: { version: 3, age: 0.1, room_epoch: 7, connection_generation: 0 },
+                 readiness: { version: 8, age: 0.2, room_epoch: 7, connection_generation: 0 } } }
+  end
+  let(:descriptor) do
+    { protocol_version: 1, host: '127.0.0.1', port: 12_345, identity: session.identity }
+  end
+  let(:transport) do
+    double('existing JSON transport').tap do |instance|
+      allow(instance).to receive(:request) { |command, payload| session.send(:handle, command, payload) }
+    end
+  end
+  let(:client) do
+    described_class::Client.new(descriptor: descriptor, read_token: 'explicit-read-token',
+                                clock: -> { now.first }, transport: transport)
+  end
+
+  after { session.close }
+
+  it 'does not create a listener or threads by default' do
+    expect(Lich::InternalAPI::ActiveSessions::Server).not_to receive(:new)
+    disabled = described_class::Session.new(game: 'GS3', character: 'Example', run_id: 'run', read_token: 'token')
+    expect(disabled.start).to be(false)
+    expect(disabled.descriptor).to be_nil
+    expect(disabled.publish(**projection.merge(identity: disabled.identity))).to be(false)
+  ensure
+    disabled&.close
+  end
+
+  it 'reuses the bounded native transport and advertises no credential' do
+    server = instance_double(Lich::InternalAPI::ActiveSessions::Server, start: true, running?: true,
+                             host: '127.0.0.1', port: 34_567, stop: nil)
+    expect(Lich::InternalAPI::ActiveSessions::Server).to receive(:new).with(
+      host: '127.0.0.1', port: 0, registry: nil, auth_token: 'explicit-read-token',
+      request_handler: kind_of(Method), max_frame_bytes: 16_384, max_clients: 4, timeout: 0.25
+    ).and_return(server)
+    expect(session.start).to be(true)
+    expect(session.descriptor).to eq(descriptor.merge(port: 34_567))
+    expect(session.descriptor.keys).to contain_exactly(:protocol_version, :host, :port, :identity)
+    expect(server).to receive(:stop)
+    session.close
+    expect(session.start).to be(false)
+  end
+
+  it 'copies owner data into an immutable published snapshot' do
+    expect(session.publish(**projection)).to be(true)
+    projection[:room][:id] = 999
+    snapshot = client.snapshot[:payload]
+    expect(snapshot[:room][:id]).to eq(42)
+    expect(snapshot[:ready]).to be(true)
+    expect { snapshot[:room][:id] = 123 }.to raise_error(FrozenError)
+  end
+
+  it 'requires a completed advancing owner tick as well as an advancing sequence' do
+    expect(session.publish(**projection)).to be(true)
+    expect(session.publish(**projection.merge(sequence: 2))).to be(false)
+    expect(session.publish(**projection.merge(owner_tick: 2))).to be(false)
+    expect(session.publish(**projection.merge(sequence: 0, owner_tick: 0))).to be(false)
+  end
+
+  it 'does not freshen old observations on a new owner tick or ping' do
+    session.publish(**projection)
+    now[0] += 2.0
+    expect(client.ping).to be(true)
+    projection[:sources].each_value { |source| source[:age] = 0.0 }
+    expect(session.publish(**projection.merge(sequence: 2, owner_tick: 2))).to be(true)
+    result = client.snapshot[:payload]
+    expect(result[:age]).to eq(0.0)
+    expect(result[:sources][:readiness][:age]).to be_within(0.00001).of(2.2)
+    expect(result[:ready]).to be(false)
+  end
+
+  it 'rejects regressing sources and changes disguised as the same observation' do
+    session.publish(**projection)
+    projection[:sequence] = projection[:owner_tick] = 2
+    projection[:sources][:room][:version] -= 1
+    expect(session.publish(**projection)).to be(false)
+    projection[:sources][:room][:version] += 1
+    projection[:room][:id] = 99
+    expect(session.publish(**projection)).to be(false)
+  end
+
+  it 'remembers source versions across unavailable publications' do
+    session.publish(**projection)
+    unknown = projection.merge(sequence: 2, owner_tick: 2, sources: { room: nil, readiness: nil })
+    expect(session.publish(**unknown)).to be(true)
+    projection[:sources][:room][:version] -= 1
+    expect(session.publish(**projection.merge(sequence: 3, owner_tick: 3))).to be(false)
+  end
+
+  it 'expires an unchanged published copy even while the endpoint answers' do
+    session.publish(**projection)
+    expect(client.snapshot[:payload][:ready]).to be(true)
+    now[0] += 2.0
+    expect(client.ping).to be(true)
+    expect(client.snapshot[:payload][:ready]).to be(false)
+  end
+
+  it 'never treats unknown, mixed, missing, disconnected or mismatched sources as ready' do
+    cases = [
+      { readiness: { ready: true, coherence: 'unknown' } },
+      { readiness: { ready: true, coherence: 'mixed' } },
+      { readiness: { ready: nil, coherence: 'coherent' } },
+      { sources: { room: nil, readiness: nil } },
+      { connected: false }, { connected: nil },
+      { room: { id: nil, epoch: nil } },
+      { sources: projection[:sources].merge(room: projection[:sources][:room].merge(room_epoch: 8)) },
+      { sources: projection[:sources].merge(room: projection[:sources][:room].merge(connection_generation: 9)) }
+    ]
+    cases.each do |change|
+      isolated = described_class::Session.new(game: 'GS3', character: 'Example', run_id: 'hunt-1', read_token: 'token', enabled: true)
+      expect(isolated.publish(**projection.merge(change).merge(identity: isolated.identity))).to be(true)
+      response = isolated.send(:handle, 'snapshot', protocol_version: 1, expected_identity: isolated.identity, fields: %w[room readiness])
+      peer = described_class::Client.new(descriptor: descriptor.merge(identity: isolated.identity), read_token: 'token',
+                                         transport: double(request: response))
+      expect(peer.snapshot[:payload][:ready]).to be(false)
+      isolated.close
+    end
+  end
+
+  it 'adds its whole local round trip to reported ages without comparing clocks' do
+    session.publish(**projection)
+    ticks = [5_000.0, 5_000.9]
+    peer = described_class::Client.new(descriptor: descriptor, read_token: 'token', clock: -> { ticks.shift }, transport: transport)
+    result = peer.snapshot[:payload]
+    expect(result[:sources][:readiness][:age]).to be_within(0.00001).of(1.1)
+    expect(result[:ready]).to be(false)
+  end
+
+  it 'ages a replayed snapshot by receiver-local elapsed time' do
+    session.publish(**projection)
+    response = session.send(:handle, 'snapshot', protocol_version: 1, expected_identity: session.identity, fields: %w[room readiness])
+    allow(transport).to receive(:request).and_return(response)
+    expect(client.snapshot[:payload][:ready]).to be(true)
+    now[0] += 10.0
+    replay = client.snapshot[:payload]
+    expect(replay[:age]).to eq(10.0)
+    expect(replay[:sources][:readiness][:age]).to be_within(0.00001).of(10.2)
+    expect(replay[:ready]).to be(false)
+  end
+
+  it 'preserves source age floors across new owner ticks and unavailable sources' do
+    session.publish(**projection)
+    response = session.send(:handle, 'snapshot', protocol_version: 1, expected_identity: session.identity, fields: %w[room readiness])
+    allow(transport).to receive(:request).and_return(response)
+    expect(client.snapshot[:payload][:ready]).to be(true)
+    unknown = response[:payload].merge(sequence: 2, owner_tick: 2, sources: { room: nil, readiness: nil })
+    allow(transport).to receive(:request).and_return(ok: true, payload: unknown)
+    now[0] += 0.5
+    expect(client.snapshot[:payload][:ready]).to be(false)
+    repeated_sources = response[:payload].merge(sequence: 3, owner_tick: 3)
+    allow(transport).to receive(:request).and_return(ok: true, payload: repeated_sources)
+    now[0] += 9.5
+    stale = client.snapshot[:payload]
+    expect(stale[:age]).to eq(0.0)
+    expect(stale[:sources][:readiness][:age]).to be_within(0.00001).of(10.2)
+    expect(stale[:ready]).to be(false)
+
+    fresh_sources = repeated_sources[:sources].transform_values { |source| source.merge(version: source[:version] + 1, age: 0.0) }
+    fresh = repeated_sources.merge(sequence: 4, owner_tick: 4, sources: fresh_sources)
+    allow(transport).to receive(:request).and_return(ok: true, payload: fresh)
+    expect(client.snapshot[:payload][:ready]).to be(true)
+  end
+
+  it 'retains the previous round-trip age bound when a later replay is faster' do
+    session.publish(**projection)
+    response = session.send(:handle, 'snapshot', protocol_version: 1, expected_identity: session.identity, fields: %w[room readiness])
+    allow(transport).to receive(:request).and_return(response)
+    ticks = [5_000.0, 5_000.7, 5_000.9, 5_000.9]
+    peer = described_class::Client.new(descriptor: descriptor, read_token: 'token', clock: -> { ticks.shift }, transport: transport)
+    expect(peer.snapshot[:payload][:ready]).to be(true)
+    replay = peer.snapshot[:payload]
+    expect(replay[:sources][:readiness][:age]).to be_within(0.00001).of(1.1)
+    expect(replay[:ready]).to be(false)
+  end
+
+  it 'rejects a concurrent snapshot promptly instead of queuing behind transport I/O' do
+    session.publish(**projection)
+    entered = Queue.new
+    release = Queue.new
+    expect(transport).to receive(:request).once do |command, payload|
+      entered << true
+      release.pop
+      session.send(:handle, command, payload)
+    end
+    first = Thread.new { client.snapshot }
+    Timeout.timeout(1) { entered.pop }
+    busy = Timeout.timeout(0.25) { client.snapshot }
+    expect(busy).to eq(ok: false, error: 'snapshot busy')
+    release << true
+    expect(first.value[:ok]).to be(true)
+  ensure
+    release << true if release
+    first&.join(1)
+    first&.kill if first&.alive?
+  end
+
+  it 'requires the exact protocol, identity, and selected field set on every route' do
+    session.publish(**projection)
+    base = { protocol_version: 1, expected_identity: session.identity }
+    expect(session.send(:handle, 'ping', base)[:ok]).to be(true)
+    expect(session.send(:handle, 'ping', base.merge(protocol_version: 2))[:ok]).to be(false)
+    expect(session.send(:handle, 'ping', base.merge(expected_identity: session.identity.merge(run_id: 'other')))[:ok]).to be(false)
+    expect(session.send(:handle, 'snapshot', base.merge(fields: ['world']))[:ok]).to be(false)
+    expect(session.send(:handle, 'snapshot', base.merge(fields: %w[room readiness], eval: 'anything'))[:ok]).to be(false)
+    expect(session.send(:route, command: 'ping', auth: 'token', payload: base, eval: 'anything')[:ok]).to be(false)
+    %w[upsert remove hold release request result eval execute].each do |command|
+      expect(session.send(:handle, command, base)[:ok]).to be(false)
+    end
+  end
+
+  it 'invalidates the previous generation and published copy on reconnect' do
+    session.publish(**projection)
+    expect(client.snapshot[:ok]).to be(true)
+    old_identity = session.identity
+    session.reconnect
+    expect(session.identity[:incarnation]).to eq(old_identity[:incarnation])
+    expect(session.identity[:connection_generation]).to eq(1)
+    expect(client.ping).to be(false)
+    expect(client.snapshot[:ok]).to be(false)
+    expect(session.publish(**projection.merge(sequence: 2, owner_tick: 2))).to be(false)
+    expect(session.send(:handle, 'snapshot', protocol_version: 1, expected_identity: session.identity, fields: %w[room readiness])[:ok]).to be(false)
+  end
+
+  it 'rejects malformed, identity-mismatched, and version-mismatched responses' do
+    session.publish(**projection)
+    response = session.send(:handle, 'snapshot', protocol_version: 1, expected_identity: session.identity, fields: %w[room readiness])
+    invalid = [response[:payload].merge(protocol_version: 99), response[:payload].merge(extra: 'world'),
+               response[:payload].merge(identity: session.identity.merge(character: 'Other')),
+               response[:payload].merge(age: -1), response[:payload].merge(age: Float::NAN),
+               response[:payload].merge(sources: { room: 'bad', readiness: nil })]
+    invalid.each do |payload|
+      allow(transport).to receive(:request).and_return(ok: true, payload: payload)
+      expect(client.snapshot[:ok]).to be(false)
+    end
+  end
+
+  it 'accepts repeated reads but rejects rollback and non-advancing owner ticks' do
+    session.publish(**projection)
+    expect(client.snapshot[:ok]).to be(true)
+    expect(client.snapshot[:ok]).to be(true)
+    response = session.send(:handle, 'snapshot', protocol_version: 1, expected_identity: session.identity, fields: %w[room readiness])
+    [response[:payload].merge(sequence: 0), response[:payload].merge(sequence: 2, owner_tick: 1),
+     response[:payload].merge(sequence: 2, owner_tick: 2, sources: projection[:sources].merge(room: projection[:sources][:room].merge(version: 0)))].each do |payload|
+      allow(transport).to receive(:request).and_return(ok: true, payload: payload)
+      expect(client.snapshot[:ok]).to be(false)
+    end
+  end
+
+  it 'rejects unknown or oversized owner fields instead of exporting arbitrary state' do
+    expect(session.publish(**projection.merge(room: { id: 1, epoch: 1, world: {} }))).to be(false)
+    expect(session.publish(**projection.merge(readiness: { ready: true, coherence: 'coherent', arbitrary: 'data' }))).to be(false)
+    expect(session.publish(**projection.merge(room: { id: 'x' * 257, epoch: 1 }))).to be(false)
+  end
+
+  it 'rejects non-loopback descriptors and missing explicit read credentials' do
+    expect { described_class::Client.new(descriptor: descriptor.merge(host: 'example.org'), read_token: 'token') }.to raise_error(ArgumentError)
+    expect { described_class::Client.new(descriptor: descriptor, read_token: '') }.to raise_error(ArgumentError)
+  end
+
+  it 'serves only authenticated read snapshots over the reused loopback transport', :real_socket do
+    expect(session.start).to be(true)
+    expect(session.publish(**projection)).to be(true)
+    peer = described_class::Client.new(descriptor: session.descriptor, read_token: 'explicit-read-token')
+    expect(peer.ping).to be(true)
+    expect(peer.snapshot[:payload][:ready]).to be(true)
+    unauthorized = described_class::Client.new(descriptor: session.descriptor, read_token: 'native-discovery-token')
+    expect(unauthorized.ping).to be(false)
+    expect(unauthorized.snapshot[:ok]).to be(false)
+    raw = Lich::InternalAPI::ActiveSessions::Client.new(
+      host: session.descriptor[:host], port: session.descriptor[:port], auth_token: 'explicit-read-token',
+      max_frame_bytes: 16_384, timeout: 0.25
+    )
+    expect(raw.request('upsert', pid: 123)[:ok]).to be(false)
+    session.reconnect
+    expect(peer.ping).to be(false)
+    session.close
+    expect(peer.ping).to be(false)
+  end
+end

--- a/spec/support/coordination_benchmark.rb
+++ b/spec/support/coordination_benchmark.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Offline only: independent synthetic owners, no game runtime or credentials.
+# Run with Ruby directly; prints summaries, never endpoint tokens.
+require 'json'
+require 'securerandom'
+require_relative '../../lib/internal_api/coordination'
+
+module CoordinationBenchmark
+  Core = Lich::InternalAPI::Coordination
+
+  def self.now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def self.cpu
+    times = Process.times
+    times.utime + times.stime
+  end
+
+  def self.rss_kib
+    match = File.read('/proc/self/status').match(/^VmRSS:\s+(\d+)/)
+    match && match[1].to_i
+  end
+
+  def self.receive(io)
+    raise 'benchmark child deadline exceeded' unless IO.select([io], nil, nil, 5)
+
+    JSON.parse(io.gets || raise('benchmark child exited'), symbolize_names: true)
+  end
+
+  def self.child(input, output, token, index)
+    output.sync = true
+    before = rss_kib
+    session = Core::Session.new(game: 'SYNTHETIC', character: "fixture-#{index}",
+                                run_id: 'benchmark', read_token: token, enabled: true)
+    raise 'endpoint failed' unless session.start
+
+    started_cpu = cpu
+    ticks = 0
+    loop do
+      ticks += 1
+      source = { version: ticks, age: 0.0, room_epoch: 1, connection_generation: 0 }
+      raise 'publication failed' unless session.publish(
+        identity: session.identity, sequence: ticks, owner_tick: ticks, connected: true,
+        room: { id: 1, epoch: 1 }, readiness: { ready: true, coherence: 'coherent' },
+        sources: { room: source, readiness: source }
+      )
+      output.puts(JSON.generate(descriptor: session.descriptor)) if ticks == 1
+      next unless IO.select([input], nil, nil, 0.05)
+      break unless input.gets == "continue\n"
+    end
+    session.close
+    output.puts(JSON.generate(cpu_seconds: cpu - started_cpu, rss_delta_kib: rss_kib - before, ticks: ticks))
+  ensure
+    session&.close
+  end
+
+  def self.run(count, rounds: 200)
+    token = SecureRandom.hex(32)
+    children = []
+    count.times do |index|
+      input, writer = IO.pipe
+      reader, output = IO.pipe
+      pid = fork do
+        children.each { |entry| entry[:writer].close; entry[:reader].close }
+        writer.close
+        reader.close
+        begin
+          child(input, output, token, index)
+          exit! 0
+        rescue StandardError => e
+          warn "benchmark child failed: #{e.class}"
+          exit! 1
+        end
+      end
+      input.close
+      output.close
+      entry = { pid: pid, writer: writer, reader: reader }
+      children << entry
+      entry[:client] = Core::Client.new(descriptor: receive(reader)[:descriptor], read_token: token, max_age: 1.0)
+    end
+    # Warm up independently of the reported interval.
+    children.each { |entry| raise 'warmup failed' unless entry[:client].snapshot[:ok] }
+    started = now
+    started_cpu = cpu
+    workers = children.map do |entry|
+      Thread.new do
+        Array.new(rounds) do
+          sent = now
+          answer = entry[:client].snapshot
+          raise 'invalid benchmark response' unless answer[:ok] && answer[:payload][:ready]
+
+          (now - sent) * 1000
+        end
+      end
+    end
+    samples = workers.flat_map(&:value).sort
+    elapsed = now - started
+    parent_cpu = cpu - started_cpu
+    children.each { |entry| entry[:writer].puts('stop') }
+    owners = children.map { |entry| receive(entry[:reader]) }
+    { sessions: count, requests: samples.size, elapsed_seconds: elapsed.round(4),
+      requests_per_second: (samples.size / elapsed).round,
+      latency_ms: [50, 95, 99].to_h { |p| ["p#{p}", samples[((samples.size - 1) * p / 100.0).ceil].round(3)] },
+      parent_cpu_seconds: parent_cpu.round(4), owner_cpu_seconds: owners.sum { |entry| entry[:cpu_seconds] }.round(4),
+      owner_rss_delta_kib: owners.map { |entry| entry[:rss_delta_kib] },
+      owner_ticks: owners.map { |entry| entry[:ticks] } }
+  ensure
+    children&.each do |entry|
+      entry[:writer].close unless entry[:writer].closed?
+      entry[:reader].close unless entry[:reader].closed?
+      deadline = now + 2
+      until Process.waitpid(entry[:pid], Process::WNOHANG)
+        if now >= deadline
+          Process.kill('KILL', entry[:pid])
+          Process.waitpid(entry[:pid])
+          break
+        end
+        sleep 0.01
+      end
+    rescue Errno::ECHILD, Errno::ESRCH
+      nil
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  [2, 5, 10].each { |count| puts JSON.generate(CoordinationBenchmark.run(count)) }
+end


### PR DESCRIPTION
## Summary

Draft implementation of the reviewed coordinated-independent-sessions proposal,
read-only slices A/B. Each character keeps its own Ruby process. This is not
Sessionize, a new broker, a hunting engine, or a write-capable control interface.

## Reuse and scope

- Reuse native ActiveSessions Server/Client with optional bounded framing,
  deadlines and authenticated handler dispatch. Legacy defaults stay unchanged.
- Explicitly loaded `Coordination::Session`, `Client` and `Discovery` expose
  fixed room/readiness snapshots, complete incarnation/connection/run identity,
  immutable owner publications and conservative source freshness.
- Reads cannot refresh owner progression. Replayed response ages retain local
  elapsed time and prior RTT; concurrent calls on one client fail busy rather
  than wait outside their budget.
- Discovery is metadata only. Tokens are not advertised. Closed/replaced
  endpoints cannot be adopted by PID, port or character name alone.
- No commands, eval, Script launches, automatic initialization, profile changes
  or modifications to LAB's existing policy authority.

## Cross-consumer architecture boundary

The contract has now been pressure-tested against three distinct consumers:
EOHunter readiness barriers, LAB operation admission, and a production-tested DR
claim/lease allocator.

That DR input sharpens the boundaries rather than expanding this PR:

- The fixed `room`/`readiness` projection here is an EOHunter experiment, **not**
  the future game-neutral observation schema.
- A promotable envelope must describe producer/session incarnation, source name,
  source generation and sequence, capture boundary, freshness and per-field
  coherence without requiring GemStone room/combat concepts.
- Loopback ActiveSessions is this prototype's transport adapter, not the semantic
  definition of coordination. Existing DR cross-host transports should be able
  to implement the eventual contract without becoming Lich dependencies.
- Long-lived resource leases are distinct from observations and discrete
  operations. Lease lifecycle, atomic arbitration and fencing require a separate
  design/approval slice; Redis, remote transport and lease code remain out of
  scope here.
- Every contender for one logical resource pool must use the same lease-store
  authority. Durable participant identity may survive restart, but the ephemeral
  holder incarnation must be replaced atomically under a newly advanced fence.
- Discrete Operations cannot be declared stable/public before a game-free lease
  conformance harness proves composition or records that Leases need a separate
  surface. The stacked operations PR now includes that executable gate.

These constraints are now recorded in
`docs/coordinated-readiness-prototype.md` before any public interface is frozen.

## Deliberate limitations / review gates

The actual Hunter adapter cannot yet prove a coherent atomic snapshot from
independently sampled World readers. It reports unknown, not positive readiness.
These drafts provide diagnostics and test the contract; they do not enable
coordinated movement. The native game-neutral writer contract and a genuine
second-consumer benefit must be established before core promotion.

Same-host/same-user credentials are a cooperative safety boundary, not defense
against malicious code running as the same user. Endpoint exchange deadline is
250 ms, frame cap 16 KiB, nesting cap 16, concurrency cap four. Native discovery
retains its existing timeout behavior; no end-to-end discovery SLA is claimed.

## Stack and companions

- Discovery ownership and Windows `EACCES` handoff fix: #1612
- Bounded coordinated operations, stacked on this PR: #1618
- EOHunter read-only adapter: elanthia-online/eohunter#110

## Verification

- Core, native bounded transport, discovery and paired Hunter tests passed locally.
- Independent review reproduced then verified fixes for replay freshness and
  concurrent client admission; four dedicated regressions.
- Synthetic 2/5/10 independent-process benchmark: final ten-owner p99 2.786 ms.
  Short local microbenchmark, not a production latency or resource guarantee.
- Full exact-branch suite: 7,591 examples, zero failures, seed 719, run serially.
  An earlier concurrent run failed an unrelated DR map fixture; the serial
  rerun passed. No map code changed in this PR.
- The DR-informed follow-up is documentation-only; no tested runtime behavior was
  changed in this read-only slice. The executable conformance test lives in the
  separately reviewed operations PR.
- Live read-only validation follows submission; no live result is claimed yet.

See `docs/coordinated-readiness-prototype.md` for contracts, proof limitations,
reproducible commands and the combined-prototype acceptance record.
